### PR TITLE
Refine wording and use plurals for app counts

### DIFF
--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -10,7 +10,7 @@
     <string name="general_cancel_action">Ακύρωση</string>
     <string name="general_thanks_action">Ευχαριστώ</string>
     <string name="general_gotit_action">Κατάλαβα</string>
-    <string name="general_na_label">Χ/Δ</string>
+    <string name="general_na_label">Μ/Δ</string>
     <string name="general_empty_label">Κενό</string>
     <string name="general_dismiss_action">Κλείσιμο</string>
     <string name="general_maybe_later_action">Ίσως αργότερα</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -15,7 +15,7 @@
     <string name="general_dismiss_action">Chiudi</string>
     <string name="general_maybe_later_action">Forse dopo</string>
     <string name="general_manage_action">Gestisci</string>
-    <string name="general_quota_label">Quota</string>
+    <string name="general_quota_label">Percentuale</string>
     <string name="general_upgrade_action">Aggiorna</string>
     <string name="general_update_action">Aggiorna</string>
     <string name="general_donate_action">Dona</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -12,7 +12,7 @@
     <string name="general_gotit_action">Anlaşıldı</string>
     <string name="general_na_label">Mevcut değil</string>
     <string name="general_empty_label">Boş</string>
-    <string name="general_dismiss_action">Kapat</string>
+    <string name="general_dismiss_action">Yoksay</string>
     <string name="general_maybe_later_action">Daha sonra</string>
     <string name="general_manage_action">Yönet</string>
     <string name="general_quota_label">Kota</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -13,5 +13,5 @@
     <string name="upgrade_screen_benefits_body">• Πάνω από 3 συσκευές 💯\n• Διαφορετικά θέματα 🎨\n• Περισσότερες επιλογές ⚙️\n• Πρόσθετοι servers συγχρονισμού🖥️\n• Συνεχής ανάπτυξη ανοιχτού κώδικα 🧙</string>
     <string name="upgrade_screen_sponsor_action">Χορηγήστε την ανάπτυξη</string>
     <string name="upgrade_screen_sponsor_action_hint">Η εναλλακτική είναι διαφημίσεις, αναλύσεις και Google Play 🙁</string>
-    <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που στηρίζετε την ανοιχτή ανάπτυξη ❤️</string>
+    <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που στηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
-    <string name="upgrade_feature_requires_pro">Nécessite Octi Pro</string>
+    <string name="app_name_upgraded">Octi, version libre</string>
+    <string name="upgrade_feature_requires_pro">Seulement avec Octi Pro</string>
     <string name="upgrades_dashcard_title">Obtenir Octi Pro</string>
-    <string name="upgrades_dashcard_body">Débloquez des fonctionnalités supplémentaires et devenez mécène pour soutenir le développement continu !</string>
-    <string name="upgrades_dashcard_upgrade_action">Améliorer</string>
+    <string name="upgrades_dashcard_body">Accédez à des fonctions supplémentaires et financez le développement permanent de l’appli</string>
+    <string name="upgrades_dashcard_upgrade_action">Surclasser</string>
     <string name="upgrade_screen_title">Passer à Octi Pro</string>
-    <string name="upgrade_screen_preamble">Octi n\'utilise pas de publicités et ne vend pas les données des utilisateurs. Mon travail est financé par vous ❤️</string>
+    <string name="upgrade_screen_preamble">Octi n’affiche pas de publicités et ne vend pas les données des utilisateurs. Vous financez mon travail ❤️.</string>
     <string name="upgrade_screen_how_title">Que faire</string>
-    <string name="upgrade_screen_how_body">Devenez mécène et sponsorisez le développement ! Touchez le bouton ci-dessous pour activer toutes les fonctionnalités supplémentaires et ouvrir mon profil GitHub Sponsors.</string>
+    <string name="upgrade_screen_how_body">Devenez mécène et commanditez le développement d’Octi. Touchez le bouton ci-dessous pour activer les fonctions supplémentaires et ouvrir mon profil « GitHub Sponsors ».</string>
     <string name="upgrade_screen_why_title">Avantages 🪄</string>
-    <string name="upgrade_screen_benefits_body">• Plus de 3 appareils 💯\n• Différents thèmes 🎨\n• Plus d\'options ⚙️\n• Serveurs de synchronisation supplémentaires 🖥️\n• Développement open source continu 🧙</string>
-    <string name="upgrade_screen_sponsor_action">Soutenir le développement</string>
-    <string name="upgrade_screen_sponsor_action_hint">L\'alternative, ce sont les publicités, les analyses et Google Play 🙁</string>
-    <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement open-source ❤️</string>
+    <string name="upgrade_screen_benefits_body">• Plus de 3 appareils 💯;\n• Plusieurs thèmes 🎨;\n• Plus d’options ⚙️;\n• Des serveurs de synchronisation supplémentaires ; 🖥️\n• Un développement libre permanent 🧙.</string>
+    <string name="upgrade_screen_sponsor_action">Commanditer le développement</string>
+    <string name="upgrade_screen_sponsor_action_hint">L’alternative est des publicités, des analyses et Google Play 🙁</string>
+    <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement libre ❤️</string>
 </resources>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -13,7 +13,7 @@
 
     <string name="upgrade_screen_title">Get Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
-    <string name="upgrade_screen_benefits_title">Advantages</string>
+    <string name="upgrade_screen_benefits_title">Benefits</string>
     <string name="upgrade_screen_benefits_body">• More than 3 devices 💯\n• Different themes 🎨\n• More options ⚙️\n• Extra sync servers🖥️️\n• Continued development ☕\n• A motivated developer 🧙</string>
     <string name="upgrade_screen_how_title">Options</string>
     <string name="upgrade_screen_how_body">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription starts with a free 14-day trial, after which you\'ll be charged once per year. Trial and subscription are cancellable at any time.\nSame features, just different pricing models.</string>

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
@@ -19,7 +19,11 @@ class DeviceLimitVH(parent: ViewGroup) :
         item: Item,
         payloads: List<Any>
     ) -> Unit = binding { item ->
-        body.text = getString(R.string.pro_device_limit_reached_description, item.current, item.maximum)
+        body.text = buildString {
+            append(getQuantityString(R.plurals.pro_device_limit_current_description, item.current))
+            append(" ")
+            append(getQuantityString(R.plurals.pro_device_limit_current_description, item.maximum))
+        }
         upgradeAction.setOnClickListener { item.onUpgrade() }
     }
 

--- a/app/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/DeviceAppsVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/DeviceAppsVH.kt
@@ -24,7 +24,11 @@ class DeviceAppsVH(parent: ViewGroup) :
         val apps = item.data.data
 
         appsPrimary.apply {
-            text = getString(R.string.module_apps_x_installed, apps.installedPackages.size)
+            text = resources.getQuantityString(
+                R.plurals.module_apps_x_installed,
+                apps.installedPackages.size,
+                apps.installedPackages.size
+            )
         }
         val last = apps.installedPackages.maxByOrNull { it.installedAt }
         appsSecondary.text =

--- a/app/src/main/res/layout/dashboard_device_limit_item.xml
+++ b/app/src/main/res/layout/dashboard_device_limit_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     style="@style/DashboardCardItem"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -26,11 +27,11 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:text="@string/pro_device_limit_reached_description"
             app:layout_constraintBottom_toTopOf="@id/upgrade_action"
             app:layout_constraintEnd_toEndOf="@id/title"
             app:layout_constraintStart_toStartOf="@id/title"
-            app:layout_constraintTop_toBottomOf="@id/title" />
+            app:layout_constraintTop_toBottomOf="@id/title"
+            tools:text="Device limit was reached. Upgrade to Pro." />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/upgrade_action"

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -105,7 +105,6 @@
     <string name="module_apps_category_label">Toepassings</string>
     <string name="device_x_label">Toestel: %s</string>
     <string name="pro_device_limit_reached_title">Toestel Beperking Bereik</string>
-    <string name="pro_device_limit_reached_description">Jy het tans %1$d gesinkroniseerde toestelle. Om meer as %2$d te sien, opgradeer na Octi Pro of verwyder toestelle.</string>
     <string name="sync_delete_device_keepaccess_caveat">As jy hierdie toestel verwyder, word sy data geskrap, maar toegang bly. Om toegang te herroep, ontkoppel Octi op die toestel.</string>
     <string name="sync_delete_device_revokeaccess_caveat">As jy hierdie toestel uitvee, word sy data verwyder en sy toegang herroep.</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -113,7 +113,6 @@
     <string name="module_apps_category_label">التطبيقات</string>
     <string name="device_x_label">الجهاز: %s</string>
     <string name="pro_device_limit_reached_title">تم الوصول إلى حد الأجهزة</string>
-    <string name="pro_device_limit_reached_description">لديك حاليًا %1$d أجهزة متزامنة. لعرض أكثر من %2$d أجهزة، قم بالترقية إلى أوكتي احترافي أو قم بإزالة الأجهزة.</string>
     <string name="sync_delete_device_keepaccess_caveat">إزالة هذا الجهاز ستحذف بياناته ولكن لن تلغي الوصول. لإلغاء الوصول، افصل أوكتي على الجهاز.</string>
     <string name="sync_delete_device_revokeaccess_caveat">حذف هذا الجهاز سيزيل بياناته ويلغي وصوله.</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -105,7 +105,6 @@
     <string name="module_apps_category_label">Aplicacions</string>
     <string name="device_x_label">Dispositiu: %s</string>
     <string name="pro_device_limit_reached_title">S\'ha assolit el límit de dispositius</string>
-    <string name="pro_device_limit_reached_description">Actualment teniu %1$d dispositius sincronitzats. Per veure més de %2$d dispositius, actualitzeu a l\'Octi Pro o elimineu dispositius.</string>
     <string name="sync_delete_device_keepaccess_caveat">En suprimir aquest dispositiu, se suprimiran les seves dades, però no se\'n revocarà l\'accés. Per revocar l\'accés, desconnecteu l\'Octi al dispositiu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">En suprimir aquest dispositiu, se n\'eliminaran les dades i se\'n revocarà l\'accés.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -109,7 +109,6 @@
     <string name="module_apps_category_label">Aplikace</string>
     <string name="device_x_label">Zařízení: %s</string>
     <string name="pro_device_limit_reached_title">Dosažen limit počtu zařízení</string>
-    <string name="pro_device_limit_reached_description">Aktuálně máte %1$d synchronizovaná zařízení. Chcete-li zobrazit více než %2$d zařízení, upgradujte na Octi Pro nebo odstraňte zařízení.</string>
     <string name="sync_delete_device_keepaccess_caveat">Odstraněním tohoto zařízení smažete jeho data, ale nebude odvolán přístup. Chcete-li odvolat přístup, odpojte aplikaci Octi na zařízení.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Smazáním tohoto zařízení se odstraní jeho data a zruší se jeho přístup.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -105,7 +105,6 @@
     <string name="module_apps_category_label">Apps</string>
     <string name="device_x_label">Enhed: %s</string>
     <string name="pro_device_limit_reached_title">Enhedsgrænse nået</string>
-    <string name="pro_device_limit_reached_description">Du har i øjeblikket %1$d synkroniserede enheder. For at se mere end %2$d, opgrader til Octi Pro eller fjern enheder.</string>
     <string name="sync_delete_device_keepaccess_caveat">Fjernelse af denne enhed sletter data, men fjerner ikke adgang. For at fjerne adgang, afbryd Octi på enheden.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Sletning af enheden fjerner både data og adgang.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -112,7 +112,6 @@
     <string name="module_apps_category_label">Apps</string>
     <string name="device_x_label">Gerät: %s</string>
     <string name="pro_device_limit_reached_title">Geräte Limit erreicht</string>
-    <string name="pro_device_limit_reached_description">Sie haben derzeit %1$d synchronisierte Geräte. Um mehr als %2$d Geräte anzuzeigen, upgraden Sie auf Octi Pro oder entfernen Sie Geräte.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Das Entfernen dieses Geräts löscht seine Daten, widerruft aber nicht den Zugriff. Um den Zugriff zu widerrufen, trennen Sie Octi auf dem Gerät.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Das Löschen dieses Geräts entfernt seine Daten und widerruft seinen Zugriff.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Εφαρμογές</string>
     <string name="device_x_label">Συσκευή: %s</string>
     <string name="pro_device_limit_reached_title">Έφτασε το όριο συσκευών</string>
-    <string name="pro_device_limit_reached_description">Έχετε %1$d συγχρονισμένες συσκευές. Για να δείτε πάνω από %2$d συσκευές, αναβαθμίστε σε Octi Pro ή αφαιρέστε συσκευές.</string>
     <string name="sync_delete_device_keepaccess_caveat">Η κατάργηση αυτής της συσκευής διαγράφει τα δεδομένα της αλλά δεν αφαιρεί την πρόσβαση. Για να αφαιρέσετε την πρόσβαση, αποσυνδέστε το Octi στη συσκευή.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Διαγράφοντας αυτή τη συσκευή διαγράφονται τα δεδομένα και ακυρώνεται η πρόσβαση.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -119,7 +119,6 @@
     <string name="module_apps_category_label">Aplicaciones</string>
     <string name="device_x_label">Dispositivo: %s</string>
     <string name="pro_device_limit_reached_title">Límite de dispositivo alcanzado</string>
-    <string name="pro_device_limit_reached_description">Actualmente tienes %1$d dispositivos sincronizados. Para ver más de %2$d dispositivos, actualiza a Octi Pro o elimina dispositivos.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Eliminar este dispositivo borrará sus datos pero no revocará el acceso. Para revocar el acceso, desconecta Octi en el dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminar este dispositivo removerá sus datos y revocará su acceso.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Sovellukset</string>
     <string name="device_x_label">Laite: %s</string>
     <string name="pro_device_limit_reached_title">Laitekatto saavutettu</string>
-    <string name="pro_device_limit_reached_description">Sinulla on nyt %1$d synkronoitua laitetta. Nähdäksesi enemmän kuin %2$d laitetta, päivitä Octi Prohon tai poista laitteita.</string>
     <string name="sync_delete_device_keepaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot, mutta ei poista käyttöoikeutta. Poistaaksesi käyttöoikeuden, irrota Octi laitteessa.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot ja käyttöoikeudet.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -136,7 +136,6 @@
     <string name="device_x_label">Appareil : %s</string>
 
     <string name="pro_device_limit_reached_title">Limite d\'appareils atteinte</string>
-    <string name="pro_device_limit_reached_description">Vous avez actuellement %1$d appareils synchronisés. Pour voir plus de %2$d appareils, passez à Octi Pro ou supprimez des appareils.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Supprimer cet appareil supprimera ses données mais ne révoquera pas l\'accès. Pour révoquer l\'accès, déconnectez Octi sur l\'appareil.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Supprimer cet appareil supprimera ses données et révoquera son accès.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Alkalmazások</string>
     <string name="device_x_label">Eszköz: %s</string>
     <string name="pro_device_limit_reached_title">Elérted az eszköz limitet</string>
-    <string name="pro_device_limit_reached_description">Jelenleg %1$d szinkronizált eszközöd van. Több, mint %2$d eszköz megtekintéséhez frissíts Octi Pro-ra vagy törölj eszközöket.</string>
     <string name="sync_delete_device_keepaccess_caveat">Az eszköz eltávolításakor annak adatai törlődnek, de a hozzáférést nem vonja vissza. A hozzáférés visszavonásához válaszd le az Octit az eszközön.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ez az eszköz törlésekor az adatait és a hozzáférését is törlöd.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -107,7 +107,6 @@ I dispositivi possono vedersi solo se hanno un servizio di sincronizzazione comu
     <string name="module_apps_category_label">Applicazioni</string>
     <string name="device_x_label">Dispositivo: %s</string>
     <string name="pro_device_limit_reached_title">Limite dispositivi raggiunto</string>
-    <string name="pro_device_limit_reached_description">Attualmente hai %1$d dispositivi sincronizzati. Per visualizzare più di %2$d dispositivi, esegui l\'upgrade a Octi Pro o rimuovi dei dispositivi.</string>
     <string name="sync_delete_device_keepaccess_caveat">Rimuovere questo dispositivo cancellerà i suoi dati, ma non revoca l\'accesso. Per revocare l\'accesso, disconnetti Octi dal dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminare questo dispositivo rimuoverà i suoi dati e revocerà il suo accesso.</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -109,7 +109,6 @@
     <string name="module_apps_category_label">יישומים</string>
     <string name="device_x_label">מכשיר: %s</string>
     <string name="pro_device_limit_reached_title">הגעת למגבלת המכשירים</string>
-    <string name="pro_device_limit_reached_description">יש לך כרגע %1$d מכשירים מסונכרנים.  כדי להציג יותר מ-%2$d מכשירים, שדרג ל-Octi פרמיום או הסר מכשירים.</string>
     <string name="sync_delete_device_keepaccess_caveat">הסרת מכשיר זה תמחק את הנתונים שלו אך לא תבטל את הגישה. כדי לבטל גישה, נתק את Octi במכשיר.</string>
     <string name="sync_delete_device_revokeaccess_caveat">מחיקת המכשיר הזה תסיר את הנתונים שלו ותבטל את הגישה שלו.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -103,7 +103,6 @@
     <string name="module_apps_category_label">アプリ</string>
     <string name="device_x_label">デバイス: %s</string>
     <string name="pro_device_limit_reached_title">デバイスの上限に達しました</string>
-    <string name="pro_device_limit_reached_description">現在、同期されたデバイスは %1$d 台あります。%2$d 台を超えるデバイスを表示するには、Octi Pro にアップグレードするか、デバイスを削除してください。</string>
     <string name="sync_delete_device_keepaccess_caveat">このデバイスを削除するとデータは削除されますが、アクセスは取り消されません。アクセスを取り消すにはデバイス上の Octi を切断してください。</string>
     <string name="sync_delete_device_revokeaccess_caveat">このデバイスを削除するとデータが削除され、アクセスが取り消されます。</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">앱</string>
     <string name="device_x_label">기기: %s</string>
     <string name="pro_device_limit_reached_title">기기 제한에 도달함</string>
-    <string name="pro_device_limit_reached_description">현재 %1$d개 동기화된 기기가 있습니다. %2$d개를 초과하여 보려면 Octi Pro로 업그레이드하거나 기기를 제거하세요.</string>
     <string name="sync_delete_device_keepaccess_caveat">이 기기를 삭제하면 데이터는 지워지나 접근 권한은 남아있습니다. 접근권한을 해제하려면 해당 기기에서 Octi 연결을 해제하세요.</string>
     <string name="sync_delete_device_revokeaccess_caveat">이 기기를 삭제하면 데이터와 접근 권한 모두 삭제됩니다.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Apper</string>
     <string name="device_x_label">Enhet: %s</string>
     <string name="pro_device_limit_reached_title">Enhetsgrense nådd</string>
-    <string name="pro_device_limit_reached_description">Du har for øyeblikket %1$d synkroniserte enheter. Oppgrader til Octi Pro eller fjern enheter for å se mer enn %2$d enheter.</string>
     <string name="sync_delete_device_keepaccess_caveat">Å fjerne denne enheten sletter dens data, men fjerner ikke tilgang. For å fjerne tilgang, koble Octi fra enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Å slette denne enheten fjerner både data og tilgang.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -136,7 +136,6 @@
     <string name="device_x_label">Apparaat: %s</string>
 
     <string name="pro_device_limit_reached_title">Apparaatlimiet bereikt</string>
-    <string name="pro_device_limit_reached_description">U heeft momenteel %1$d gesynchroniseerde apparaten. Om meer dan %2$d apparaten te bekijken, upgrade naar Octi Pro of verwijder apparaten.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Dit apparaat verwijderen zal de gegevens wissen maar toegang niet intrekken. Om toegang in te trekken, koppel Octi los op het apparaat.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Dit apparaat verwijderen zal de gegevens verwijderen en toegang intrekken.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -140,7 +140,6 @@
     <string name="device_x_label">Urządzenie: %s</string>
 
     <string name="pro_device_limit_reached_title">Osiągnięto limit urządzeń</string>
-    <string name="pro_device_limit_reached_description">Obecnie masz %1$d zsynchronizowanych urządzeń. Aby wyświetlić więcej niż %2$d urządzeń, uaktualnij do Octi Pro lub usuń urządzenia.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Usunięcie tego urządzenia usunie jego dane, ale nie cofnie dostępu. Aby cofnąć dostęp, rozłącz Octi na urządzeniu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Usunięcie tego urządzenia usunie jego dane i cofnie jego dostęp.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Aplicativos</string>
     <string name="device_x_label">Dispositivo: %s</string>
     <string name="pro_device_limit_reached_title">Limite de dispositivos atingido</string>
-    <string name="pro_device_limit_reached_description">Você tem atualmente %1$d dispositivos sincronizados. Para ver mais que %2$d dispositivos, atualize para Octi Pro ou remova dispositivos.</string>
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo apagará seus dados, mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Apagar este dispositivo removerá seus dados e revogará o acesso.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -136,7 +136,6 @@
     <string name="device_x_label">Dispositivo: %s</string>
 
     <string name="pro_device_limit_reached_title">Limite de dispositivos atingido</string>
-    <string name="pro_device_limit_reached_description">Você atualmente tem %1$d dispositivos sincronizados. Para ver mais de %2$d dispositivos, atualize para Octi Pro ou remova dispositivos.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo deletará seus dados mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Deletar este dispositivo removerá seus dados e revogará seu acesso.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Aplicații</string>
     <string name="device_x_label">Dispozitiv: %s</string>
     <string name="pro_device_limit_reached_title">Limită dispozitive atinsă</string>
-    <string name="pro_device_limit_reached_description">Ai acum %1$d dispozitive sincronizate. Pentru a vedea mai mult de %2$d dispozitive, treci la Octi Pro sau elimină dispozitive.</string>
     <string name="sync_delete_device_keepaccess_caveat">Eliminarea acestui dispozitiv îi va șterge datele, dar nu va revoca accesul. Pentru a revoca accesul, deconectează Octi pe acel dispozitiv.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ștergând acest dispozitiv îi elimini datele și îi revoci accesul.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -140,7 +140,6 @@
     <string name="device_x_label">Устройство: %s</string>
 
     <string name="pro_device_limit_reached_title">Достигнут лимит устройств</string>
-    <string name="pro_device_limit_reached_description">У вас сейчас %1$d синхронизированных устройств. Чтобы просматривать более %2$d устройств, обновитесь до Octi Pro или удалите устройства.</string>
 
     <string name="sync_delete_device_keepaccess_caveat">Удаление этого устройства удалит его данные, но не отзовет доступ. Чтобы отозвать доступ, отключите Octi на устройстве.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Удаление этого устройства удалит его данные и отзовет его доступ.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Апликације</string>
     <string name="device_x_label">Уређај: %s</string>
     <string name="pro_device_limit_reached_title">Достигнут лимит уређаја</string>
-    <string name="pro_device_limit_reached_description">Тренутно имаш %1$d синхронизованих уређаја. Да видиш више од %2$d, надогради на Octi Pro или уклони уређаје.</string>
     <string name="sync_delete_device_keepaccess_caveat">Уклањањем овог уређаја ће се обрисати његови подаци, али приступ ће остати. Да укинеш приступ, одјави Octi на овом уређају.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Брисањем овог уређаја ће се обрисати његови подаци и потпуно укинути приступ.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Appar</string>
     <string name="device_x_label">Enhet: %s</string>
     <string name="pro_device_limit_reached_title">Enhetsgräns uppnådd</string>
-    <string name="pro_device_limit_reached_description">Du har för närvarande %1$d synkroniserade enheter. För att se fler än %2$d, uppgradera till Octi Pro eller ta bort enheter.</string>
     <string name="sync_delete_device_keepaccess_caveat">Att ta bort denna enhet tar bort dess data men tar inte bort åtkomst. För att ta bort åtkomst måste du koppla loss Octi på enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ta bort denna enhet raderar dess data och tar bort dess åtkomst.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -105,7 +105,6 @@
     <string name="module_apps_category_label">Uygulamalar</string>
     <string name="device_x_label">Cihaz: %s</string>
     <string name="pro_device_limit_reached_title">Cihaz sınırına ulaşıldı</string>
-    <string name="pro_device_limit_reached_description">Şu anda %1$d senkronize cihazınız var. %2$d\'den fazla cihaz görüntülemek için Octi Pro\'ya yükseltin veya cihazları kaldırın.</string>
     <string name="sync_delete_device_keepaccess_caveat">Bu cihazın kaldırılması verilerini silecek ancak erişimi iptal etmeyecektir. Erişimi iptal etmek için cihazdaki Octi bağlantısını kesin.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Bu cihazın silinmesi, verilerini kaldıracak ve erişimini iptal edecektir.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Додатки</string>
     <string name="device_x_label">Пристрій: %s</string>
     <string name="pro_device_limit_reached_title">Досягнуто ліміту пристроїв</string>
-    <string name="pro_device_limit_reached_description">Зараз у вас %1$d синхронізованих пристроїв. Щоб побачити більше ніж %2$d — оновіть до Octi Pro або видаліть зайві пристрої.</string>
     <string name="sync_delete_device_keepaccess_caveat">Видалення пристрою видалить його дані, але не скасує доступ. Щоб скасувати доступ, від’єднайте Octi на пристрої.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Видалення пристрою також видалить дані та скасує доступ.</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">Ứng dụng</string>
     <string name="device_x_label">Thiết bị: %s</string>
     <string name="pro_device_limit_reached_title">Đã đạt giới hạn thiết bị</string>
-    <string name="pro_device_limit_reached_description">Bạn có %1$d thiết bị đồng bộ. Để xem nhiều hơn %2$d thiết bị, hãy nâng cấp lên Octi Pro hoặc xóa bớt thiết bị.</string>
     <string name="sync_delete_device_keepaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu nhưng không thu hồi quyền truy cập. Để thu hồi quyền, hãy ngắt Octi trên thiết bị.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu và thu hồi cả quyền truy cập.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,7 +105,6 @@
     <string name="module_apps_category_label">应用</string>
     <string name="device_x_label">设备: %s</string>
     <string name="pro_device_limit_reached_title">设备达到极限</string>
-    <string name="pro_device_limit_reached_description">您当前有%1$d同步设备。要查看超过%2$d的设备，请升级到Octi Pro或删除设备。</string>
     <string name="sync_delete_device_keepaccess_caveat">删除此设备将删除其数据，但不会撤销访问权限。要撤销访问权限，请断开设备上的Octi连接。</string>
     <string name="sync_delete_device_revokeaccess_caveat">删除此设备将删除其数据并撤销其访问权限。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -107,7 +107,6 @@
     <string name="module_apps_category_label">應用</string>
     <string name="device_x_label">設備：%s</string>
     <string name="pro_device_limit_reached_title">已達設備上限</string>
-    <string name="pro_device_limit_reached_description">你目前有 %1$d 台同步設備。要查看超過 %2$d 台，請升級到 Octi Pro 或刪除一些裝置。</string>
     <string name="sync_delete_device_keepaccess_caveat">移除本設備將刪除數據但不影響訪問權限。欲撤銷請於該設備上斷開 Octi。</string>
     <string name="sync_delete_device_revokeaccess_caveat">刪除本設備將移除其數據並撤銷訪問權限。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,7 +10,7 @@
     <string name="onboarding_welcome_subtitle">Your Device Buddy</string>
     <string name="onboarding_welcome_body1">Octi is a tool for people with multiple Android devices.</string>
     <string name="onboarding_welcome_body2">It keeps you in the loop with all your devices. Whether it\'s your phone, tablet or any other gadget with Octi installed, you\'ll get key details at a glance.</string>
-    <string name="onboarding_welcome_body3">You can upgrade to Octi Pro to gain extra features and support development.</string>
+    <string name="onboarding_welcome_body3">Upgrade to Octi Pro to gain extra features and support development.</string>
     <string name="onboarding_welcome_beta_hint">Just a heads-up, this is a beta version, so thanks for your patience as I keep improving the app!</string>
 
     <string name="onboarding_privacy_subtitle">Privacy policy</string>
@@ -25,8 +25,8 @@
     <string name="debug_debuglog_file_label">Recorded log file</string>
     <string name="debug_debuglog_record_action">Record debug log</string>
 
-    <string name="onboarding_setupsync_title">Setup synchronization</string>
-    <string name="onboarding_setupsync_message">Currently you are only seeing this device. To connect your Octi installations, setup a common synchronization service.</string>
+    <string name="onboarding_setupsync_title">Set up synchronization</string>
+    <string name="onboarding_setupsync_message">Currently you are only seeing this device. To connect your Octi installations, set up a common synchronization service.</string>
 
     <string name="settings_privacy_policy_label">Privacy policy</string>
     <string name="settings_privacy_policy_desc">Handling data responsibly.</string>
@@ -44,7 +44,7 @@
     <string name="help_translate_description">Help translate this app into your favorite language.</string>
 
     <string name="ui_theme_mode_setting_label">Theme mode</string>
-    <string name="ui_theme_mode_setting_explanation">The mode used when theming the app (e.g. night or day).</string>
+    <string name="ui_theme_mode_setting_explanation">The mode used when theming the app (e.g. dark or light).</string>
     <string name="ui_theme_mode_dark_label">Dark</string>
     <string name="ui_theme_mode_light_label">Light</string>
     <string name="ui_theme_mode_system_label">System</string>
@@ -135,7 +135,14 @@
     <string name="device_x_label">Device: %s</string>
 
     <string name="pro_device_limit_reached_title">Device limit reached</string>
-    <string name="pro_device_limit_reached_description">You currently have %1$d  synced devices. To view more than %2$d devices, upgrade to Octi Pro or remove devices.</string>
+    <plurals name="pro_device_limit_current_description">
+        <item quantity="one">You currently have %1$d synced device.</item>
+        <item quantity="other">You currently have %1$d synced devices.</item>
+    </plurals>
+    <plurals name="pro_device_limit_maximum_description">
+        <item quantity="one">To view more than %2$d device, upgrade to Octi Pro or remove devices.</item>
+        <item quantity="other">To view more than %2$d devices, upgrade to Octi Pro or remove devices.</item>
+    </plurals>
 
     <string name="sync_delete_device_keepaccess_caveat">Removing this device will delete its data but won\'t revoke access. To revoke access, disconnect Octi on the device.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Deleting this device will remove its data and revoke its access.</string>

--- a/modules-apps/src/main/res/values/strings.xml
+++ b/modules-apps/src/main/res/values/strings.xml
@@ -3,10 +3,13 @@
     <string name="module_apps_label">Apps module</string>
     <string name="module_apps_desc">Information about installed apps.</string>
 
-    <string name="module_apps_x_installed">%d apps installed</string>
+    <plurals name="module_apps_x_installed">
+        <item quantity="one">%d app installed</item>
+        <item quantity="other">%d apps installed</item>
+    </plurals>
     <string name="module_apps_last_installed_x">Last installed app: %s</string>
     <string name="module_apps_list_title">Installed apps</string>
 
     <string name="module_apps_installer_label">App installation source</string>
-    <string name="module_apps_installer_desc">Sync and include information about the source from which each app was installed.</string>
+    <string name="module_apps_installer_desc">Sync and include information about each app’s installation source.</string>
 </resources>

--- a/modules-clipboard/src/main/res/values-fr/strings.xml
+++ b/modules-clipboard/src/main/res/values-fr/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="module_clipboard_label">Module presse-papiers</string>
-    <string name="module_clipboard_desc">Copier et coller du texte entre les appareils.</string>
-    <string name="module_clipboard_copied_octi_to_os">Copié d\'Octi vers le presse-papiers système</string>
-    <string name="module_clipboard_copied_os_to_octi">Copié du système vers le presse-papiers Octi</string>
+    <string name="module_clipboard_desc">Copier et coller du texte entre appareils.</string>
+    <string name="module_clipboard_copied_octi_to_os">Le presse-papiers d’Octi a été copié dans le presse-papiers du système</string>
+    <string name="module_clipboard_copied_os_to_octi">Le presse-papiers du système a été copié dans le presse-papiers d’Octi</string>
 </resources>

--- a/modules-power/src/main/res/values-de/strings.xml
+++ b/modules-power/src/main/res/values-de/strings.xml
@@ -14,9 +14,7 @@
     <string name="module_power_battery_full_in_x">Vollständig aufgeladen in: %s</string>
     <string name="module_power_battery_empty_in_x">Leer in: %s</string>
     <string name="module_power_battery_estimation_na">Schätzung nicht verfügbar</string>
-
     <string name="module_power_widget_description">Zeigt den Akkustatus Ihrer synchronisierten Geräte an.</string>
-
     <string name="module_power_alerts_title">Akku Warnung</string>
     <string name="module_power_alerts_lowbattery_title">Akkustand niedrig</string>
     <string name="module_power_alerts_lowbattery_description">Erhalten Sie eine Benachrichtigung, wenn der Akku dieses Geräts unter Ihren festgelegten Schwellenwert fällt. Stellen Sie Ihren bevorzugten Prozentsatz für Warnungen ein.</string>

--- a/modules-power/src/main/res/values-es/strings.xml
+++ b/modules-power/src/main/res/values-es/strings.xml
@@ -15,7 +15,6 @@
     <string name="module_power_battery_empty_in_x">Fuera de jugo: %s</string>
     <string name="module_power_battery_estimation_na">Estimación no disponible</string>
     <string name="module_power_widget_description">Muestra el estado de la batería de tus dispositivos sincronizados.</string>
-
     <string name="module_power_alerts_title">Alertas de batería</string>
     <string name="module_power_alerts_lowbattery_title">Batería baja</string>
     <string name="module_power_alerts_lowbattery_description">Recibe notificaciones cuando la batería de este dispositivo cae por debajo del umbral especificado. Establece tu porcentaje preferido para las alertas.</string>

--- a/modules-power/src/main/res/values-fr/strings.xml
+++ b/modules-power/src/main/res/values-fr/strings.xml
@@ -2,27 +2,25 @@
 <resources>
     <string name="module_power_label">Module d\'alimentation</string>
     <string name="module_power_desc">Batterie, charge, estimations, température, etc.</string>
-    <string name="module_power_battery_status_unknown">État inconnu</string>
-    <string name="module_power_battery_status_full">Pleine</string>
+    <string name="module_power_battery_status_unknown">L’éttat est inconnu</string>
+    <string name="module_power_battery_status_full">Chargée</string>
     <string name="module_power_battery_status_charging">En charge</string>
     <string name="module_power_battery_status_charging_slow">Charge lente</string>
     <string name="module_power_battery_status_charging_fast">Charge rapide</string>
-    <string name="module_power_battery_status_discharging">En décharge</string>
+    <string name="module_power_battery_status_discharging">Se décharge</string>
     <string name="module_power_battery_status_discharging_slow">Décharge lente</string>
     <string name="module_power_battery_status_discharging_fast">Décharge rapide</string>
-    <string name="module_power_battery_full_since_x">Charge terminée : %s</string>
-    <string name="module_power_battery_full_in_x">Entièrement chargée : %s</string>
-    <string name="module_power_battery_empty_in_x">Épuisée dans : %s</string>
-    <string name="module_power_battery_estimation_na">Estimation non disponible</string>
-
-    <string name="module_power_widget_description">Afficher l\'état de la batterie de vos appareils synchronisés.</string>
-
-    <string name="module_power_alerts_title">Alertes de batterie</string>
-    <string name="module_power_alerts_lowbattery_title">Batterie faible</string>
-    <string name="module_power_alerts_lowbattery_description">Recevez une notification lorsque la batterie de cet appareil tombe en dessous de votre seuil spécifié. Définissez votre pourcentage préféré pour les alertes.</string>
-    <string name="module_power_alerts_lowbattery_slider_value_caption">Notifier quand la batterie est en dessous de %s</string>
-    <string name="module_power_alerts_lowbattery_disabled_caption">Ne pas notifier quand la batterie est faible</string>
-    <string name="module_power_alerts_notification_channel_label">Alertes de batterie</string>
-    <string name="module_power_alerts_notification_battery_low_title">Batterie faible : %s</string>
-    <string name="module_power_alerts_notification_battery_low_body">%1$s est à %3$d%% de batterie (&lt;%2$d%%) et ne se charge pas.</string>
+    <string name="module_power_battery_full_since_x">Charge terminée : %s</string>
+    <string name="module_power_battery_full_in_x">Pleine charge : %s</string>
+    <string name="module_power_battery_empty_in_x">Épuisée dans : %s</string>
+    <string name="module_power_battery_estimation_na">Aucune estimation</string>
+    <string name="module_power_widget_description">Afficher l’état de la batterie de vos appareils synchronisés.</string>
+    <string name="module_power_alerts_title">Alertes de la batterie</string>
+    <string name="module_power_alerts_lowbattery_title">Le niveau de la batterie est faible</string>
+    <string name="module_power_alerts_lowbattery_description">Signalez un niveau de batterie de cet appareil inférieur au seuil que vous avez indiqué. Définissez votre pourcentage avant alerte.</string>
+    <string name="module_power_alerts_lowbattery_slider_value_caption">Signaler un niveau de batterie inférieur à %s</string>
+    <string name="module_power_alerts_lowbattery_disabled_caption">Ne pas signaler un niveau de batterie faible</string>
+    <string name="module_power_alerts_notification_channel_label">Alertes de la batterie</string>
+    <string name="module_power_alerts_notification_battery_low_title">Le niveau de la batterie est faible : %s</string>
+    <string name="module_power_alerts_notification_battery_low_body">Le niveau de la batterie de %1$s est à %3$d% % (&lt;%2$d% %) et elle n’est pas en charge.</string>
 </resources>

--- a/modules-power/src/main/res/values-ru/strings.xml
+++ b/modules-power/src/main/res/values-ru/strings.xml
@@ -14,9 +14,7 @@
     <string name="module_power_battery_full_in_x">Полностью заряжена: %s</string>
     <string name="module_power_battery_empty_in_x">Разрядится через: %s</string>
     <string name="module_power_battery_estimation_na">Оценка недоступна</string>
-
     <string name="module_power_widget_description">Отображать статус батареи ваших синхронизированных устройств.</string>
-
     <string name="module_power_alerts_title">Оповещения о батарее</string>
     <string name="module_power_alerts_lowbattery_title">Низкий заряд батареи</string>
     <string name="module_power_alerts_lowbattery_description">Получайте уведомления, когда батарея этого устройства опускается ниже указанного порога. Установите предпочтительный процент для оповещений.</string>

--- a/modules-power/src/main/res/values-sv/strings.xml
+++ b/modules-power/src/main/res/values-sv/strings.xml
@@ -3,7 +3,7 @@
     <string name="module_power_label">Strömmodul</string>
     <string name="module_power_desc">Batteri, laddning, uppskattningar, temperatur, etc.</string>
     <string name="module_power_battery_status_unknown">Okänd status</string>
-    <string name="module_power_battery_status_full">Full</string>
+    <string name="module_power_battery_status_full">Fullt</string>
     <string name="module_power_battery_status_charging">Laddar</string>
     <string name="module_power_battery_status_charging_slow">Laddar långsamt</string>
     <string name="module_power_battery_status_charging_fast">Laddar snabbt</string>

--- a/modules-wifi/src/main/res/values-el/strings.xml
+++ b/modules-wifi/src/main/res/values-el/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="module_wifi_label">Wi-Fi μονάδα</string>
-    <string name="module_wifi_desc">Ονόματα, λήψη, IP\'s, κ.λπ.</string>
+    <string name="module_wifi_label">Μονάδα Wi-Fi</string>
+    <string name="module_wifi_desc">Ονόματα, ισχύς σήματος, IP\'s, κ.λπ.</string>
     <string name="module_wifi_unknown_ssid_label">Άγνωστο SSID</string>
     <string name="module_wifi_unknown_ip_label">Άγνωστη IP</string>
     <string name="module_wifi_reception_good_label">Καλό σήμα</string>

--- a/modules-wifi/src/main/res/values-fr/strings.xml
+++ b/modules-wifi/src/main/res/values-fr/strings.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="module_wifi_label">Module Wi-Fi</string>
-    <string name="module_wifi_desc">Noms, réception, IPs, etc.</string>
-    <string name="module_wifi_unknown_ssid_label">SSID inconnu</string>
-    <string name="module_wifi_unknown_ip_label">IP inconnue</string>
-    <string name="module_wifi_reception_good_label">Bon signal</string>
-    <string name="module_wifi_reception_okay_label">Signal OK</string>
-    <string name="module_wifi_reception_bad_label">Mauvais signal</string>
+    <string name="module_wifi_desc">Noms, réception, IP, etc.</string>
+    <string name="module_wifi_unknown_ssid_label">Le SSID est inconnu</string>
+    <string name="module_wifi_unknown_ip_label">L’IP est inconnue</string>
+    <string name="module_wifi_reception_good_label">Le signal est bon</string>
+    <string name="module_wifi_reception_okay_label">Le signal est correct</string>
+    <string name="module_wifi_reception_bad_label">Le signal est mauvais</string>
 </resources>

--- a/syncs-gdrive/src/main/res/values/strings.xml
+++ b/syncs-gdrive/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="sync_gdrive_appdata_label">App-data scope</string>
     <string name="sync_gdrive_type_appdata_description">Data is placed in Google Drive. This specific variant uses the "app-data" scope. Access is only granted to a new folder just for this app. The folder is not visible in your drive. It is similar to how WhatsApp backups work.</string>
     <string name="sync_gdrive_add_label">Add new Google Drive</string>
-    <string name="sync_gdrive_add_description">Click the sign-in button below to setup Google Drive access.</string>
+    <string name="sync_gdrive_add_description">Click the sign-in button below to set up Google Drive access.</string>
     <string name="sync_gdrive_reset_confirmation_desc">Reset all Octi data stored on Google Drive. Your device stays logged into Google Drive.</string>
     <string name="sync_gdrive_disconnect_confirmation_desc">Log out from Google Drive and delete data related to this device.</string>
     <string name="sync_gdrive_error_no_account_on_device">This device is not signed into any Google account.</string>

--- a/syncs-kserver/src/main/res/values-de/strings.xml
+++ b/syncs-kserver/src/main/res/values-de/strings.xml
@@ -2,8 +2,8 @@
 <resources>
     <string name="sync_kserver_type_label">K-Server</string>
     <string name="sync_kserver_type_description">Ein Open-Source-Synchronisierungsserver für Octi, erstellt vom Entwickler dieser App. Daten werden clientseitig verschlüsselt, nur Ihre Geräte können sie entschlüsseln.\n\nDa sowohl die App als auch der Server noch verbessert werden, kann er weniger stabil sein als andere Synchronisierungsoptionen.</string>
-    <string name="sync_kserver_add_subtitle">K-Server Konto hinzufügen</string>
     <string name="sync_kserver_add_create_action_hint">Inaktive Konten werden nach einigen Wochen gelöscht.</string>
+    <string name="sync_kserver_add_subtitle">K-Server Konto hinzufügen</string>
     <string name="sync_kserver_add_link_action_hint">Sie benötigen Zugriff auf ein anderes Gerät, das bereits verbunden ist.</string>
     <string name="sync_kserver_about_title">Über KServer</string>
     <string name="sync_kserver_about_desc">KServer ist ein Open-Source-Synchronisierungsserver (in Kotlin) für Octi von darken.</string>


### PR DESCRIPTION
This commit introduces several string refinements and utilizes plurals for displaying application counts for better localization.

Specifically:
- "Advantages" is changed to "Benefits" in the upgrade screen.
- "setup" is corrected to "set up" in onboarding and Google Drive sync descriptions.
- "night or day" is changed to "dark or light" in theme mode settings.
- Plurals are now used to display the number of installed apps in the apps module and the device limit message. This ensures grammatically correct phrasing for singular and plural counts.
- Minor wording tweaks were made in the onboarding welcome message and app installer description for clarity.