### PR TITLE
Fix typo in manual link code string

### DIFF
--- a/syncs-kserver/src/main/res/values/strings.xml
+++ b/syncs-kserver/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="sync_kserver_link_host_option_nfc">Link device via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">A new device was linked to your account.</string>
     <string name="sync_kserver_link_host_nfc_action">Looking for NFC client. Hold this device close to the device you want link to your account.</string>
-    <string name="sync_kserver_link_client_option_direct">Manually copy and paste a  link code</string>
+    <string name="sync_kserver_link_client_option_direct">Manually copy and paste a link code</string>
     <string name="sync_kserver_link_client_option_qrcode">Scan a QR code from another device</string>
     <string name="sync_kserver_link_client_option_nfc">Use two devices with NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Start camera</string>


### PR DESCRIPTION
The string resource `sync_kserver_link_client_option_direct` had an extra space.