### PR TITLE
Fix device limit text in dashboard

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
@@ -22,7 +22,7 @@ class DeviceLimitVH(parent: ViewGroup) :
         body.text = buildString {
             append(getQuantityString(R.plurals.pro_device_limit_current_description, item.current))
             append(" ")
-            append(getQuantityString(R.plurals.pro_device_limit_current_description, item.maximum))
+            append(getQuantityString(R.plurals.pro_device_limit_maximum_description, item.maximum))
         }
         upgradeAction.setOnClickListener { item.onUpgrade() }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -111,8 +111,8 @@
         <item quantity="other">Sie haben derzeit %1$d synchronisierte Geräte.</item>
     </plurals>
     <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Um mehr als %2$d Gerät anzuzeigen, upgraden Sie auf Octi Pro oder entfernen Sie Geräte.</item>
-        <item quantity="other">Um mehr als %2$d Geräte anzuzeigen, upgraden Sie auf Octi Pro oder entfernen Sie Geräte.</item>
+        <item quantity="one">Um mehr als %1$d Gerät anzuzeigen, upgraden Sie auf Octi Pro oder entfernen Sie Geräte.</item>
+        <item quantity="other">Um mehr als %1$d Geräte anzuzeigen, upgraden Sie auf Octi Pro oder entfernen Sie Geräte.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Das Entfernen dieses Geräts löscht seine Daten, widerruft aber nicht den Zugriff. Um den Zugriff zu widerrufen, trennen Sie Octi auf dem Gerät.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Das Löschen dieses Geräts entfernt seine Daten und widerruft seinen Zugriff.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -112,8 +112,8 @@
         <item quantity="other">%1$d appareils sont synchronisés actuellement.</item>
     </plurals>
     <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Pour afficher plus de %2$d appareil, passez à Octi Pro ou supprimez des périphériques.</item>
-        <item quantity="other">Pour afficher plus de %2$d appareils, passez à Octi Pro ou supprimez des périphériques.</item>
+        <item quantity="one">Pour afficher plus de %1$d appareil, passez à Octi Pro ou supprimez des périphériques.</item>
+        <item quantity="other">Pour afficher plus de %1$d appareils, passez à Octi Pro ou supprimez des périphériques.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Supprimer cet appareil supprimera ses données, mais ne révoquera pas son accès. Pour révoquer l\'accès, déconnectez Octi sur l\'appareil en question.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Supprimer cet appareil supprimera ses données et révoquera son accès.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,8 +140,8 @@
         <item quantity="other">You currently have %1$d synced devices.</item>
     </plurals>
     <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">To view more than %2$d device, upgrade to Octi Pro or remove devices.</item>
-        <item quantity="other">To view more than %2$d devices, upgrade to Octi Pro or remove devices.</item>
+        <item quantity="one">To view more than %1$d device, upgrade to Octi Pro or remove devices.</item>
+        <item quantity="other">To view more than %1$d devices, upgrade to Octi Pro or remove devices.</item>
     </plurals>
 
     <string name="sync_delete_device_keepaccess_caveat">Removing this device will delete its data but won\'t revoke access. To revoke access, disconnect Octi on the device.</string>


### PR DESCRIPTION
The device limit text in the dashboard was incorrectly using the current device count for the maximum device count string. This change corrects the string formatting and updates the translations.