### PR TITLE
Restyle limited devices

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.main.ui.dashboard.items
 
 import android.view.ViewGroup
+import androidx.core.view.isGone
 import eu.darken.octi.R
 import eu.darken.octi.common.lists.binding
 import eu.darken.octi.databinding.DashboardDeviceLimitItemBinding
@@ -24,13 +25,12 @@ class DeviceLimitVH(parent: ViewGroup) :
             append(" ")
             append(getQuantityString(R.plurals.pro_device_limit_maximum_description, item.maximum))
         }
-        upgradeAction.setOnClickListener { item.onUpgrade() }
+        upgradeAction.isGone = true
     }
 
     data class Item(
         val current: Int,
         val maximum: Int,
-        val onUpgrade: () -> Unit,
     ) : DashboardAdapter.Item {
         override val stableId: Long = this.javaClass.hashCode().toLong()
     }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/DeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/DeviceVH.kt
@@ -36,10 +36,14 @@ class DeviceVH(parent: ViewGroup) :
         val meta = item.meta.data
 
         deviceIcon.setImageResource(
-            when (meta.deviceType) {
-                MetaInfo.DeviceType.PHONE -> R.drawable.ic_baseline_phone_android_24
-                MetaInfo.DeviceType.TABLET -> R.drawable.ic_baseline_tablet_android_24
-                MetaInfo.DeviceType.UNKNOWN -> R.drawable.ic_baseline_question_mark_24
+            if (item.isLimited) {
+                R.drawable.ic_baseline_stars_24
+            } else {
+                when (meta.deviceType) {
+                    MetaInfo.DeviceType.PHONE -> R.drawable.ic_baseline_phone_android_24
+                    MetaInfo.DeviceType.TABLET -> R.drawable.ic_baseline_tablet_android_24
+                    MetaInfo.DeviceType.UNKNOWN -> R.drawable.ic_baseline_question_mark_24
+                }
             }
         )
         deviceLabel.text = meta.deviceLabel
@@ -59,14 +63,24 @@ class DeviceVH(parent: ViewGroup) :
         }
 
         lastSeen.text = DateUtils.getRelativeTimeSpanString(item.meta.modifiedAt.toEpochMilli())
-        moduleDataList.isGone = item.moduleItems.isEmpty()
+        moduleDataList.isGone = item.isLimited || item.moduleItems.isEmpty()
         moduleAdapter.update(item.moduleItems)
+
+        root.setOnClickListener {
+            if (item.isLimited) {
+                item.onUpgrade?.invoke()
+            } else {
+                null
+            }
+        }
     }
 
     data class Item(
         val now: Instant,
         val meta: eu.darken.octi.module.core.ModuleData<MetaInfo>,
         val moduleItems: List<PerDeviceModuleAdapter.Item>,
+        val isLimited: Boolean = false,
+        val onUpgrade: (() -> Unit)? = null,
     ) : DashboardAdapter.Item {
         override val stableId: Long = meta.deviceId.hashCode().toLong()
     }


### PR DESCRIPTION
Devices beyond the free limit are now displayed with a "limited" style, indicating that their module data is not visible. This change provides a clearer user experience by visually distinguishing between fully accessible devices and those restricted due to the device limit in the free version.

Closes #97