### PR TITLE
Add "Manage devices" action to device limit dashboard item

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -165,6 +165,8 @@ class DashboardVM @Inject constructor(
             DeviceLimitVH.Item(
                 current = deviceItems.size,
                 maximum = DEVICE_LIMIT,
+                onManageDevices = { DashboardFragmentDirections.actionDashFragmentToSyncListFragment().navigate() },
+                onUpgrade = { DashboardFragmentDirections.goToUpgradeFragment().navigate() },
             ).run { items.add(this) }
             items.addAll(deviceItems.drop(DEVICE_LIMIT))
         } else {

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/DeviceLimitVH.kt
@@ -1,7 +1,6 @@
 package eu.darken.octi.main.ui.dashboard.items
 
 import android.view.ViewGroup
-import androidx.core.view.isGone
 import eu.darken.octi.R
 import eu.darken.octi.common.lists.binding
 import eu.darken.octi.databinding.DashboardDeviceLimitItemBinding
@@ -25,12 +24,15 @@ class DeviceLimitVH(parent: ViewGroup) :
             append(" ")
             append(getQuantityString(R.plurals.pro_device_limit_maximum_description, item.maximum))
         }
-        upgradeAction.isGone = true
+        manageDevicesAction.setOnClickListener { item.onManageDevices() }
+        upgradeAction.setOnClickListener { item.onUpgrade() }
     }
 
     data class Item(
         val current: Int,
         val maximum: Int,
+        val onManageDevices: () -> Unit,
+        val onUpgrade: () -> Unit,
     ) : DashboardAdapter.Item {
         override val stableId: Long = this.javaClass.hashCode().toLong()
     }

--- a/app/src/main/res/layout/dashboard_device_limit_item.xml
+++ b/app/src/main/res/layout/dashboard_device_limit_item.xml
@@ -27,11 +27,24 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            app:layout_constraintBottom_toTopOf="@id/upgrade_action"
+            app:layout_constraintBottom_toTopOf="@id/manage_devices_action"
             app:layout_constraintEnd_toEndOf="@id/title"
             app:layout_constraintStart_toStartOf="@id/title"
             app:layout_constraintTop_toBottomOf="@id/title"
             tools:text="Device limit was reached. Upgrade to Pro." />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/manage_devices_action"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/general_manage_devices_action"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/upgrade_action"
+            app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/body" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/upgrade_action"
@@ -40,9 +53,11 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:text="@string/general_upgrade_action"
+            app:icon="@drawable/ic_baseline_stars_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_chainStyle="spread_inside"
+            app:layout_constraintStart_toEndOf="@id/manage_devices_action"
             app:layout_constraintTop_toBottomOf="@id/body" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="general_create_account_action">Create account</string>
     <string name="general_link_existing_action">Link to existing account</string>
     <string name="general_sync_action">Synchronize</string>
+    <string name="general_manage_devices_action">Manage devices</string>
     <string name="general_select_server_label">Select server</string>
 
     <string name="onboarding_welcome_subtitle">Your Device Buddy</string>


### PR DESCRIPTION
This commit introduces a "Manage devices" button to the device limit notification on the dashboard. This allows users to navigate directly to the device management screen.

Additionally, the "Upgrade" button is now always visible and an icon has been added to it.