### PR TITLE
Warn of stale devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /fastlane/report.xml
 /fastlane/Appfile
 /fastlane/README.md
+.kotlin

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -251,18 +251,17 @@ class DashboardVM @Inject constructor(
                     now = now,
                     meta = metaModule,
                     moduleItems = moduleItems,
+                    onUpgrade = { DashboardFragmentDirections.goToUpgradeFragment().navigate() },
+                    onManageStaleDevice = {
+                        DashboardFragmentDirections.actionDashFragmentToSyncListFragment().navigate()
+                    }
                 )
             }
             .sortedBy { it.meta.data.deviceLabel ?: it.meta.data.deviceName }
             .sortedByDescending { it.meta.deviceId == syncSettings.deviceId }
             .mapIndexed { index, item ->
                 val isLimited = !upgradeInfo.isPro && index >= DEVICE_LIMIT
-                item.copy(
-                    isLimited = isLimited,
-                    onUpgrade = if (isLimited) {
-                        { DashboardFragmentDirections.goToUpgradeFragment().navigate() }
-                    } else null
-                )
+                item.copy(isLimited = isLimited)
             }
     }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/PerDeviceModuleAdapter.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/PerDeviceModuleAdapter.kt
@@ -28,6 +28,7 @@ class PerDeviceModuleAdapter @Inject constructor() :
 
     init {
         modules.add(DataBinderMod(data))
+        modules.add(TypedVHCreatorMod({ data[it] is StaleDeviceVH.Item }) { StaleDeviceVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is DevicePowerVH.Item }) { DevicePowerVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is DeviceWifiVH.Item }) { DeviceWifiVH(it) })
         modules.add(TypedVHCreatorMod({ data[it] is DeviceAppsVH.Item }) { DeviceAppsVH(it) })

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/StaleDeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/StaleDeviceVH.kt
@@ -1,0 +1,36 @@
+package eu.darken.octi.main.ui.dashboard.items.perdevice
+
+import android.view.ViewGroup
+import eu.darken.octi.R
+import eu.darken.octi.databinding.DashboardDeviceStaleItemBinding
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.StalenessUtil
+import java.time.Instant
+
+
+class StaleDeviceVH(parent: ViewGroup) :
+    PerDeviceModuleAdapter.BaseVH<StaleDeviceVH.Item, DashboardDeviceStaleItemBinding>(
+        R.layout.dashboard_device_stale_item,
+        parent
+    ) {
+
+    override val viewBinding = lazy { DashboardDeviceStaleItemBinding.bind(itemView) }
+
+    override val onBindData: DashboardDeviceStaleItemBinding.(
+        item: Item,
+        payloads: List<Any>
+    ) -> Unit = { item, _ ->
+        val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSyncTime)
+        staleWarningText.text = getString(R.string.sync_device_stale_warning_text, stalePeriod)
+        manageDeviceAction.setOnClickListener { item.onManageDevice() }
+    }
+
+    data class Item(
+        val deviceId: DeviceId,
+        val lastSyncTime: Instant,
+        val onManageDevice: () -> Unit,
+    ) : PerDeviceModuleAdapter.Item {
+        override val stableId: Long = this.javaClass.hashCode().toLong() + deviceId.hashCode()
+    }
+
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DefaultSyncDeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DefaultSyncDeviceVH.kt
@@ -8,6 +8,7 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.databinding.SyncDevicesItemDefaultBinding
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.StalenessUtil
 import java.time.Instant
 
 
@@ -34,6 +35,14 @@ class DefaultSyncDeviceVH(parent: ViewGroup) :
         subtitle.text = item.deviceId.id
         octiVersion.text = item.metaInfo?.octiVersionName
         lastSeen.text = item.lastSeen?.let { DateUtils.getRelativeTimeSpanString(it.toEpochMilli()) }
+        staleWarning.apply {
+            val isStale = StalenessUtil.isStale(item.lastSeen)
+            text = if (isStale && item.lastSeen != null) {
+                val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSeen)
+                getString(R.string.sync_device_stale_warning_text, stalePeriod)
+            } else ""
+            isGone = text.isEmpty()
+        }
         errorDesc.apply {
             text = item.error?.asLog()
             isGone = text.isEmpty()

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveStateVH.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveStateVH.kt
@@ -69,6 +69,15 @@ class GDriveStateVH(parent: ViewGroup) :
             deviceString
         } ?: getString(R.string.general_na_label)
 
+        staleDevicesWarning.apply {
+            isGone = item.staleDevicesCount == 0
+            text = getQuantityString(
+                R.plurals.sync_stale_devices_info_message,
+                item.staleDevicesCount,
+                item.staleDevicesCount
+            )
+        }
+
         itemView.setOnClickListener { item.onManage() }
     }
 
@@ -77,6 +86,7 @@ class GDriveStateVH(parent: ViewGroup) :
         val ourState: SyncConnectorState,
         val otherStates: Collection<SyncConnectorState>,
         val isPaused: Boolean,
+        val staleDevicesCount: Int,
         val onManage: () -> Unit,
     ) : SyncListAdapter.Item {
         override val stableId: Long

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
@@ -73,6 +73,15 @@ class KServerStateVH(parent: ViewGroup) :
             deviceString
         } ?: getString(R.string.general_na_label)
 
+        staleDevicesWarning.apply {
+            isGone = item.staleDevicesCount == 0
+            text = getQuantityString(
+                R.plurals.sync_stale_devices_info_message,
+                item.staleDevicesCount,
+                item.staleDevicesCount
+            )
+        }
+
         itemView.setOnClickListener { item.onManage() }
     }
 
@@ -81,6 +90,7 @@ class KServerStateVH(parent: ViewGroup) :
         val ourState: SyncConnectorState,
         val otherStates: Collection<SyncConnectorState>,
         val isPaused: Boolean,
+        val staleDevicesCount: Int,
         val onManage: () -> Unit,
     ) : SyncListAdapter.Item {
         override val stableId: Long

--- a/app/src/main/res/layout/dashboard_device_stale_item.xml
+++ b/app/src/main/res/layout/dashboard_device_stale_item.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/colorErrorContainer">
+
+    <ImageView
+        android:id="@+id/stale_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="16dp"
+        android:src="@drawable/ic_baseline_warning_24"
+        app:tint="?attr/colorOnErrorContainer"
+        app:layout_constraintBottom_toBottomOf="@id/stale_warning_text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/stale_warning_text"
+        tools:ignore="ContentDescription" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/stale_warning_text"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginEnd="8dp"
+        android:textColor="?attr/colorOnErrorContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/manage_device_action"
+        app:layout_constraintStart_toEndOf="@id/stale_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Device hasn't synced in 2 months" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/manage_device_action"
+        style="@style/Widget.Material3.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:text="@string/general_manage_action"
+        android:textColor="?attr/colorOnErrorContainer"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sync_devices_fragment.xml
+++ b/app/src/main/res/layout/sync_devices_fragment.xml
@@ -12,7 +12,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:title="@string/sync_services_label" />
+        app:title="@string/sync_synced_devices_label" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/list"

--- a/app/src/main/res/layout/sync_devices_item_default.xml
+++ b/app/src/main/res/layout/sync_devices_item_default.xml
@@ -60,6 +60,20 @@
         tools:text="Last seen 123 123 123" />
 
     <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/stale_warning"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:textColor="?colorError"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/last_seen"
+        tools:text="Device hasn't synced in 2 months"
+        tools:visibility="visible" />
+
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/error_desc"
         style="@style/TextAppearance.Material3.BodySmall"
         android:layout_width="0dp"
@@ -70,7 +84,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/last_seen"
+        app:layout_constraintTop_toBottomOf="@id/stale_warning"
         tools:text="@tools:sample/lorem/random" />
 
 

--- a/app/src/main/res/layout/sync_list_item_gdrive.xml
+++ b/app/src/main/res/layout/sync_list_item_gdrive.xml
@@ -139,6 +139,20 @@
         app:layout_constraintTop_toBottomOf="@id/devices_label"
         tools:text="4 devices (2 unique)" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/stale_devices_warning"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:textColor="?colorError"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/devices_text"
+        tools:text="⚠ 2 devices haven't synced recently"
+        tools:visibility="visible" />
+
     <ImageView
         android:id="@+id/manage_hint_icon"
         android:layout_width="24dp"

--- a/app/src/main/res/layout/sync_list_item_kserver.xml
+++ b/app/src/main/res/layout/sync_list_item_kserver.xml
@@ -141,6 +141,20 @@
         app:layout_constraintTop_toBottomOf="@id/devices_label"
         tools:text="4 devices (2 unique)" />
 
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/stale_devices_warning"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:textColor="?colorError"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/devices_text"
+        tools:text="⚠ 2 devices haven't synced recently"
+        tools:visibility="visible" />
+
     <ImageView
         android:id="@+id/manage_hint_icon"
         android:layout_width="24dp"

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/StalenessUtil.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/StalenessUtil.kt
@@ -1,0 +1,58 @@
+package eu.darken.octi.sync.core
+
+import android.content.Context
+import eu.darken.octi.sync.R
+import java.time.Duration
+import java.time.Instant
+
+object StalenessUtil {
+    const val STALE_DEVICE_THRESHOLD_DAYS = 30L
+
+    fun isStale(lastSyncTime: Instant?): Boolean {
+        if (lastSyncTime == null) return false
+        val daysSinceLastSync = Duration.between(lastSyncTime, Instant.now()).toDays()
+        return daysSinceLastSync > STALE_DEVICE_THRESHOLD_DAYS
+    }
+
+    fun SyncRead.Device.isStale(): Boolean {
+        val mostRecentSync = modules.maxOfOrNull { it.modifiedAt }
+        return isStale(mostRecentSync)
+    }
+
+    fun SyncRead?.countStaleDevices(): Int {
+        if (this?.devices == null) return 0
+        return devices.count { it.isStale() }
+    }
+
+    fun formatStalePeriod(context: Context, lastSyncTime: Instant): String {
+        val daysSinceLastSync = Duration.between(lastSyncTime, Instant.now()).toDays().toInt()
+
+        return when {
+            daysSinceLastSync < 60 -> {
+                context.resources.getQuantityString(
+                    R.plurals.sync_stale_period_days,
+                    daysSinceLastSync,
+                    daysSinceLastSync
+                )
+            }
+
+            daysSinceLastSync < 365 -> {
+                val months = (daysSinceLastSync / 30).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.sync_stale_period_months,
+                    months,
+                    months
+                )
+            }
+
+            else -> {
+                val years = (daysSinceLastSync / 365).toInt()
+                context.resources.getQuantityString(
+                    R.plurals.sync_stale_period_years,
+                    years,
+                    years
+                )
+            }
+        }
+    }
+}

--- a/sync-core/src/main/res/values/strings.xml
+++ b/sync-core/src/main/res/values/strings.xml
@@ -1,2 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources />
+<resources>
+    <string name="sync_device_stale_warning_text">Device hasn\'t synced in %s</string>
+
+    <plurals name="sync_stale_devices_info_message">
+        <item quantity="one">%d device hasn\'t synced recently</item>
+        <item quantity="other">%d devices haven\'t synced recently</item>
+    </plurals>
+
+    <plurals name="sync_stale_period_days">
+        <item quantity="one">%d day</item>
+        <item quantity="other">%d days</item>
+    </plurals>
+
+    <plurals name="sync_stale_period_months">
+        <item quantity="one">%d month</item>
+        <item quantity="other">%d months</item>
+    </plurals>
+
+    <plurals name="sync_stale_period_years">
+        <item quantity="one">%d year</item>
+        <item quantity="other">%d years</item>
+    </plurals>
+</resources>


### PR DESCRIPTION
This commit introduces a warning for devices that haven't synced in over 30 days. The warning is displayed on the dashboard within the device's card. Users can now choose to remove these stale devices directly from the dashboard. This prompts a confirmation dialog before proceeding with the removal.

This feature helps users manage their device list by identifying and allowing the removal of inactive devices, which can be particularly useful for users approaching their device limit.

Implements #96