### PR TITLE
Fix navigation bar color in bottom sheets for light mode

### DIFF
--- a/app-common/src/main/res/values-night/themes.xml
+++ b/app-common/src/main/res/values-night/themes.xml
@@ -1,3 +1,0 @@
-<resources>
-
-</resources>

--- a/app-common/src/main/res/values/colors.xml
+++ b/app-common/src/main/res/values/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-</resources>

--- a/app-common/src/main/res/values/themes.xml
+++ b/app-common/src/main/res/values/themes.xml
@@ -1,3 +1,0 @@
-<resources>
-
-</resources>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -66,6 +66,13 @@
         <item name="dynamicColorThemeOverlay">@style/Theme.Material3.DynamicColors.Dark.NoActionBar</item>
     </style>
 
+    <style name="AppTheme" parent="BaseAppTheme">
+        <item name="windowActionModeOverlay">true</item>
+        <item name="actionModeCloseDrawable">@drawable/ic_baseline_close_24</item>
+        <item name="android:statusBarColor">?colorSurface</item>
+        <item name="android:navigationBarColor">?colorSurface</item>
+    </style>
+
     <style name="AppThemeFloating" parent="BaseAppTheme">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <style name="Theme.Material3.DynamicColors.Light.NoActionBar" parent="Theme.Material3.DynamicColors.Light">
         <item name="windowActionBar">false</item>
@@ -70,6 +70,10 @@
     <style name="AppTheme" parent="BaseAppTheme">
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeCloseDrawable">@drawable/ic_baseline_close_24</item>
+        <item name="android:statusBarColor">?colorSurface</item>
+        <item name="android:navigationBarColor">?colorSurface</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>
 
     <style name="AppThemeSplash" parent="Theme.SplashScreen">


### PR DESCRIPTION
Sets proper navigation bar colors and light mode flags in app themes to ensure correct contrast between navigation bar icons and background in both light and dark themes. Addresses issue where bottom sheets showed light icons on light backgrounds in light mode.

Closes #118