### PR TITLE
Add dashboard UI improvements for device states and interactions

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/flow/FlowCombineExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/flow/FlowCombineExtensions.kt
@@ -151,6 +151,34 @@ inline fun <T1, T2, T3, T4, T5, T6, T7, T8, R> combine(
 }
 
 @Suppress("UNCHECKED_CAST", "LongParameterList")
+inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    flow5: Flow<T5>,
+    flow6: Flow<T6>,
+    flow7: Flow<T7>,
+    flow8: Flow<T8>,
+    flow9: Flow<T9>,
+    crossinline transform: suspend (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R
+): Flow<R> = kotlinx.coroutines.flow.combine(
+    flow, flow2, flow3, flow4, flow5, flow6, flow7, flow8, flow9
+) { args: Array<*> ->
+    transform(
+        args[0] as T1,
+        args[1] as T2,
+        args[2] as T3,
+        args[3] as T4,
+        args[4] as T5,
+        args[5] as T6,
+        args[6] as T7,
+        args[7] as T8,
+        args[8] as T9
+    )
+}
+
+@Suppress("UNCHECKED_CAST", "LongParameterList")
 inline fun <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,

--- a/app/src/main/java/eu/darken/octi/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/octi/main/core/GeneralSettings.kt
@@ -18,6 +18,7 @@ import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.theming.ThemeMode
 import eu.darken.octi.common.theming.ThemeStyle
 import eu.darken.octi.main.core.updater.UpdateChecker
+import eu.darken.octi.main.ui.dashboard.DashboardConfig
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -55,9 +56,29 @@ class GeneralSettings @Inject constructor(
         writer = { perms -> perms.joinToString(",") { it.permissionId } }
     )
 
+    val dashboardConfig = dataStore.createValue(
+        "dashboard.ui.config", 
+        DashboardConfig(),
+        moshi
+    )
+
     suspend fun addDismissedPermission(permission: Permission) {
         log(TAG) { "addDismissedPermission(permission=$permission)" }
         dismissedPermissions.update { it + permission }
+    }
+
+    suspend fun toggleDeviceCollapsed(deviceId: String) {
+        log(TAG) { "toggleDeviceCollapsed(deviceId=$deviceId)" }
+        dashboardConfig.update { config ->
+            config.toToggledCollapsed(deviceId)
+        }
+    }
+
+    suspend fun updateDeviceOrder(newOrder: List<String>) {
+        log(TAG) { "updateDeviceOrder(newOrder=$newOrder)" }
+        dashboardConfig.update { config ->
+            config.toUpdatedOrder(newOrder)
+        }
     }
 
     override val mapper = PreferenceStoreMapper(

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardConfig.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardConfig.kt
@@ -1,0 +1,53 @@
+package eu.darken.octi.main.ui.dashboard
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class DashboardConfig(
+    @Json(name = "collapsedDevices") val collapsedDevices: Set<String> = emptySet(),
+    @Json(name = "deviceOrder") val deviceOrder: List<String> = emptyList(),
+) {
+    
+    fun isCollapsed(deviceId: String): Boolean = collapsedDevices.contains(deviceId)
+    
+    fun toToggledCollapsed(deviceId: String): DashboardConfig = copy(
+        collapsedDevices = if (isCollapsed(deviceId)) {
+            collapsedDevices - deviceId
+        } else {
+            collapsedDevices + deviceId
+        }
+    )
+    
+    fun toUpdatedOrder(newOrder: List<String>): DashboardConfig = copy(
+        deviceOrder = newOrder
+    )
+    
+    fun toCleaned(existingDeviceIds: Set<String>): DashboardConfig = copy(
+        collapsedDevices = collapsedDevices.intersect(existingDeviceIds),
+        deviceOrder = deviceOrder.filter { existingDeviceIds.contains(it) }
+    )
+    
+    fun applyCustomOrdering(deviceIds: List<String>): List<String> {
+        if (deviceOrder.isEmpty()) return deviceIds
+        
+        val deviceSet = deviceIds.toSet()
+        val ordered = mutableListOf<String>()
+        
+        // Add devices in custom order
+        deviceOrder.forEach { deviceId ->
+            if (deviceSet.contains(deviceId)) {
+                ordered.add(deviceId)
+            }
+        }
+        
+        // Add any remaining devices not in the custom order
+        deviceIds.forEach { deviceId ->
+            if (!ordered.contains(deviceId)) {
+                ordered.add(deviceId)
+            }
+        }
+        
+        return ordered
+    }
+}

--- a/app/src/main/res/drawable/ic_baseline_expand_less_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_expand_less_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8l-6,6 1.41,1.41L12,10.83l4.59,4.58L18,14z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_expand_more_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_expand_more_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_home_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_home_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnSurface">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/layout/dashboard_device_apps_item.xml
+++ b/app/src/main/res/layout/dashboard_device_apps_item.xml
@@ -13,7 +13,7 @@
         android:id="@+id/tap_indicator"
         android:layout_width="16dp"
         android:layout_height="16dp"
-        android:src="@drawable/ic_chevron_right_24"
+        android:src="@drawable/ic_gesture_tap_24"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/dashboard_device_item.xml
+++ b/app/src/main/res/layout/dashboard_device_item.xml
@@ -11,13 +11,24 @@
         android:layout_height="wrap_content">
 
         <ImageView
+            android:id="@+id/expand_chevron"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginStart="8dp"
+            android:src="@drawable/ic_chevron_right_24"
+            app:layout_constraintBottom_toBottomOf="@id/device_subtitle"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/device_label"
+            tools:ignore="ContentDescription" />
+
+        <ImageView
             android:id="@+id/device_icon"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            android:layout_marginStart="16dp"
+            android:layout_marginStart="8dp"
             android:src="@drawable/ic_baseline_phone_android_24"
             app:layout_constraintBottom_toBottomOf="@id/device_subtitle"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintStart_toEndOf="@id/expand_chevron"
             app:layout_constraintTop_toTopOf="@id/device_label"
             tools:ignore="ContentDescription" />
 


### PR DESCRIPTION
- Add expand/collapse chevron at start of device rows with rotation animation
- Replace chevron with touch icon in apps row to differentiate actions
- Use home icon for current device instead of regular device type icon
- Add drag-and-drop reordering functionality with long press
- Implement persistent device ordering and collapse state via DashboardConfig
- Support automatic stale device cleanup in stored preferences
- Add Material Design icons: expand_more, expand_less, home
- Hide chevrons for devices without modules or limited devices
- Enable device limit enforcement based on post-reordering position

Improvements provide clear visual feedback:
- Chevron indicates expandable devices (rotates when expanded)
- Touch icon differentiates clickable from expandable items
- Home icon immediately identifies current device
- Drag handles allow intuitive reordering with persistence

Closes https://github.com/d4rken-org/octi/issues/112