### PR TITLE
Add high battery notification alert for charging devices

### DIFF
--- a/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
@@ -59,10 +59,34 @@ class PowerAlertsFragment : Fragment3(R.layout.module_power_alerts_fragment) {
             valueTo = 0.95f
         }
 
+        ui.highbatteryThresholdSlider.apply {
+            addOnChangeListener { _, value, _ ->
+                ui.highbatteryThresholdSliderCaption.text = when (value) {
+                    0f -> getString(R.string.module_power_alerts_highbattery_disabled_caption)
+                    else -> getString(
+                        R.string.module_power_alerts_highbattery_slider_value_caption,
+                        "${(value * 100).toInt()}%"
+                    )
+                }
+            }
+            addOnSliderTouchListener(object : Slider.OnSliderTouchListener {
+                override fun onStartTrackingTouch(slider: Slider) {}
+
+                override fun onStopTrackingTouch(slider: Slider) {
+                    vm.setBatteryHighAlert(slider.value)
+                }
+            })
+            stepSize = 0.05f
+            valueFrom = 0f
+            valueTo = 1f
+        }
+
         vm.state.observe2(this@PowerAlertsFragment, ui) { state ->
             ui.toolbar.subtitle = getString(R.string.device_x_label, state.deviceLabel)
             lowbatteryThresholdSlider.value = state.batteryLowAlert?.rule?.threshold ?: 0f
             lowbatteryTitle.isBold = state.batteryLowAlert != null
+            highbatteryThresholdSlider.value = state.batteryHighAlert?.rule?.threshold ?: 0f
+            highbatteryTitle.isBold = state.batteryHighAlert != null
         }
 
         vm.events.observe2 { event ->

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.common.uix.ViewModel3
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.modules.meta.core.MetaRepo
+import eu.darken.octi.modules.power.core.alert.BatteryHighAlertRule
 import eu.darken.octi.modules.power.core.alert.BatteryLowAlertRule
 import eu.darken.octi.modules.power.core.alert.PowerAlert
 import eu.darken.octi.modules.power.core.alert.PowerAlertManager
@@ -42,6 +43,7 @@ class PowerAlertsVM @Inject constructor(
     data class State(
         val deviceLabel: String = "",
         val batteryLowAlert: PowerAlert<BatteryLowAlertRule>? = null,
+        val batteryHighAlert: PowerAlert<BatteryHighAlertRule>? = null,
     )
 
     val state = combine(
@@ -58,7 +60,8 @@ class PowerAlertsVM @Inject constructor(
 
         State(
             deviceLabel = metaData.data.deviceLabel ?: metaData.data.deviceName,
-            batteryLowAlert = alerts.find { it.rule is BatteryLowAlertRule } as PowerAlert<BatteryLowAlertRule>?
+            batteryLowAlert = alerts.find { it.rule is BatteryLowAlertRule } as PowerAlert<BatteryLowAlertRule>?,
+            batteryHighAlert = alerts.find { it.rule is BatteryHighAlertRule } as PowerAlert<BatteryHighAlertRule>?,
         )
     }.asLiveData2()
 
@@ -70,6 +73,16 @@ class PowerAlertsVM @Inject constructor(
         }
         val cleanThreshold = String.format(Locale.ROOT, "%.2f", threshold.coerceIn(0f, 95f)).toFloat()
         alertsManager.setBatteryLowAlert(navArgs.deviceId, cleanThreshold.takeIf { it > 0f })
+    }
+
+    fun setBatteryHighAlert(threshold: Float) = launch {
+        log(TAG) { "setBatteryHighAlert($threshold)" }
+        if (!upgradeRepo.isPro()) {
+            PowerAlertsFragmentDirections.goToUpgradeFragment().navigate()
+            return@launch
+        }
+        val cleanThreshold = String.format(Locale.ROOT, "%.2f", threshold.coerceIn(0f, 100f)).toFloat()
+        alertsManager.setBatteryHighAlert(navArgs.deviceId, cleanThreshold.takeIf { it > 0f })
     }
 
     companion object {

--- a/app/src/main/res/layout/module_power_alerts_fragment.xml
+++ b/app/src/main/res/layout/module_power_alerts_fragment.xml
@@ -37,8 +37,7 @@
                 style="Widget.Material3.CardView.Elevated"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="8dp"
-                android:layout_marginBottom="32dp">
+                android:layout_margin="8dp">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -99,6 +98,77 @@
                         app:layout_constraintEnd_toEndOf="@id/lowbattery_threshold_slider"
                         app:layout_constraintStart_toStartOf="@id/lowbattery_threshold_slider"
                         app:layout_constraintTop_toBottomOf="@id/lowbattery_threshold_slider" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.google.android.material.card.MaterialCardView
+                style="Widget.Material3.CardView.Elevated"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="8dp"
+                android:layout_marginBottom="32dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp">
+
+                    <ImageView
+                        android:id="@+id/highbattery_icon"
+                        android:layout_width="20dp"
+                        android:layout_height="20dp"
+                        android:src="@drawable/ic_baseline_battery_full_24"
+                        app:layout_constraintBottom_toBottomOf="@id/highbattery_title"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/highbattery_title" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/highbattery_title"
+                        style="@style/TextAppearance.Material3.TitleMedium"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="8dp"
+                        android:text="@string/module_power_alerts_highbattery_title"
+                        android:textColor="?colorOnSecondaryContainer"
+                        app:layout_constraintStart_toEndOf="@id/highbattery_icon"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintVertical_chainStyle="packed" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/highbattery_body"
+                        style="@style/TextAppearance.Material3.BodyMedium"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/module_power_alerts_highbattery_description"
+                        android:textColor="?colorOnSecondaryContainer"
+                        app:layout_constraintBottom_toTopOf="@id/highbattery_threshold_slider"
+                        app:layout_constraintEnd_toEndOf="@id/highbattery_title"
+                        app:layout_constraintStart_toStartOf="@id/highbattery_title"
+                        app:layout_constraintTop_toBottomOf="@id/highbattery_title" />
+
+                    <com.google.android.material.slider.Slider
+                        android:id="@+id/highbattery_threshold_slider"
+                        style="@style/Widget.Material3.Slider"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="8dp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/highbattery_body" />
+
+                    <com.google.android.material.textview.MaterialTextView
+                        android:id="@+id/highbattery_threshold_slider_caption"
+                        style="@style/TextAppearance.Material3.LabelMedium"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="32dp"
+                        android:gravity="center"
+                        android:text="@string/module_power_alerts_highbattery_disabled_caption"
+                        app:layout_constraintEnd_toEndOf="@id/highbattery_threshold_slider"
+                        app:layout_constraintStart_toStartOf="@id/highbattery_threshold_slider"
+                        app:layout_constraintTop_toBottomOf="@id/highbattery_threshold_slider" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
@@ -98,6 +98,23 @@ class PowerAlertNotifications @Inject constructor(
                         )
                     )
                 }
+
+                is BatteryHighAlertRule -> {
+                    setContentTitle(
+                        context.getString(
+                            R.string.module_power_alerts_notification_battery_high_title,
+                            label
+                        )
+                    )
+                    setContentText(
+                        context.getString(
+                            R.string.module_power_alerts_notification_battery_high_body,
+                            label,
+                            (rule.threshold * 100).toInt(),
+                            (power.battery.percent * 100).toInt(),
+                        )
+                    )
+                }
             }
         }
 

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
@@ -20,6 +20,7 @@ sealed interface PowerAlertRule {
         val moshiFactory: PolymorphicJsonAdapterFactory<PowerAlertRule>
             get() = PolymorphicJsonAdapterFactory.of(PowerAlertRule::class.java, "type")
                 .withSubtype(BatteryLowAlertRule::class.java, "BATTERY_LOW")
+                .withSubtype(BatteryHighAlertRule::class.java, "BATTERY_HIGH")
     }
 }
 
@@ -33,4 +34,14 @@ data class BatteryLowAlertRule(
 
     override val id: PowerAlertRuleId
         get() = "${deviceId.id}-batterlow"
+}
+
+@JsonClass(generateAdapter = true)
+data class BatteryHighAlertRule(
+    override val deviceId: DeviceId,
+    val threshold: Float,
+) : PowerAlertRule {
+
+    override val id: PowerAlertRuleId
+        get() = "${deviceId.id}-batterhigh"
 }

--- a/modules-power/src/main/res/values/strings.xml
+++ b/modules-power/src/main/res/values/strings.xml
@@ -25,4 +25,11 @@
     <string name="module_power_alerts_notification_channel_label">Battery alerts</string>
     <string name="module_power_alerts_notification_battery_low_title">Low battery: %s</string>
     <string name="module_power_alerts_notification_battery_low_body">%1$s is at %3$d%% battery (&lt;%2$d%%) and not charging.</string>
+
+    <string name="module_power_alerts_highbattery_title">High battery</string>
+    <string name="module_power_alerts_highbattery_description">Get notified when this device\'s battery reaches your specified threshold while charging. Useful for preserving battery health.</string>
+    <string name="module_power_alerts_highbattery_slider_value_caption">Notify when battery is above %s</string>
+    <string name="module_power_alerts_highbattery_disabled_caption">Don\'t notify when battery is high</string>
+    <string name="module_power_alerts_notification_battery_high_title">High battery: %s</string>
+    <string name="module_power_alerts_notification_battery_high_body">%1$s is at %3$d%% battery (>%2$d%%) and still charging.</string>
 </resources>


### PR DESCRIPTION
Adds a new battery alert option that notifies users when a device's battery reaches a specified upper threshold while charging. This helps preserve battery health by reminding users to stop charging at their preferred level (e.g., 80-85%).

Closes #125