### PR TITLE
Fix display cutout and edge-to-edge insets in landscape mode

### DIFF
--- a/app/src/main/java/eu/darken/octi/common/EdgeToEdgeHelper.kt
+++ b/app/src/main/java/eu/darken/octi/common/EdgeToEdgeHelper.kt
@@ -25,11 +25,12 @@ class EdgeToEdgeHelper(activity: Activity) {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v: View, insets: WindowInsetsCompat ->
             if (Bugs.isDebug) log(tag, VERBOSE) { "Applying padding insets to $v" }
             val systemBars: Insets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            val displayCutout: Insets = insets.getInsets(WindowInsetsCompat.Type.displayCutout())
             v.setPadding(
-                if (left) systemBars.left else v.paddingLeft,
-                if (top) systemBars.top else v.paddingTop,
-                if (right) systemBars.right else v.paddingRight,
-                if (bottom) systemBars.bottom else v.paddingBottom,
+                if (left) maxOf(systemBars.left, displayCutout.left) else v.paddingLeft,
+                if (top) maxOf(systemBars.top, displayCutout.top) else v.paddingTop,
+                if (right) maxOf(systemBars.right, displayCutout.right) else v.paddingRight,
+                if (bottom) maxOf(systemBars.bottom, displayCutout.bottom) else v.paddingBottom,
             )
             insets
         }

--- a/app/src/main/res/layout/onboarding_privacy_fragment.xml
+++ b/app/src/main/res/layout/onboarding_privacy_fragment.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipToPadding="false">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/onboarding_welcome_fragment.xml
+++ b/app/src/main/res/layout/onboarding_welcome_fragment.xml
@@ -2,7 +2,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:clipToPadding="false">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -86,6 +87,7 @@
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="32dp"
             android:layout_marginTop="32dp"
+            android:layout_marginBottom="32dp"
             android:text="@string/general_continue"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## Summary
- Fix `EdgeToEdgeHelper.insetsPadding()` to account for display cutout insets (camera notches/punch holes) in addition to system bars
- Fix onboarding screens not scrolling far enough to show the continue button in landscape mode

## Changes
- **EdgeToEdgeHelper.kt**: Use `maxOf()` to apply the larger of `systemBars` or `displayCutout` insets for each side
- **onboarding_welcome_fragment.xml**: Add `clipToPadding="false"` and bottom margin to button
- **onboarding_privacy_fragment.xml**: Add `clipToPadding="false"`

## Test plan
- [x] Test on device with display cutout in landscape mode - UI content should not be obscured
- [x] Test onboarding flow in landscape - continue button should be fully visible when scrolled
- [x] Verify portrait mode still works correctly (no regression)