### PR TITLE
Upgrade AGP from 8.12.2 to 8.13.2

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,8 +8,8 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:8.12.2")
+    implementation("com.android.tools.build:gradle:8.13.2")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
     implementation("com.squareup:javapoet:1.13.0")
-    implementation("com.android.tools:common:31.12.2")
+    implementation("com.android.tools:common:31.13.2")
 }


### PR DESCRIPTION
## Summary
- Upgrade Android Gradle Plugin from 8.12.2 to 8.13.2
- Update `com.android.tools:common` from 31.12.2 to 31.13.2 to match AGP version

## Test plan
- [x] Debug build succeeds
- [x] Unit tests pass