### PR TITLE
Remove deprecated lifecycle-extensions and update test dependencies

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -124,7 +124,6 @@ fun DependencyHandlerScope.addAndroidUI() {
     implementation("androidx.activity:activity-ktx:1.9.1")
     implementation("androidx.fragment:fragment-ktx:1.8.2")
 
-    implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
     implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:2.8.4")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.8.4")
@@ -138,33 +137,33 @@ fun DependencyHandlerScope.addAndroidUI() {
 fun DependencyHandlerScope.addTesting() {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.junit.vintage:junit-vintage-engine:5.8.2")
-    testImplementation("androidx.test:core-ktx:1.4.0")
+    testImplementation("androidx.test:core-ktx:1.6.1")
 
-    testImplementation("io.mockk:mockk:1.12.4")
-    androidTestImplementation("io.mockk:mockk-android:1.12.4")
+    testImplementation("io.mockk:mockk:1.13.13")
+    androidTestImplementation("io.mockk:mockk-android:1.13.13")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.8.2")
 
 
-    testImplementation("io.kotest:kotest-runner-junit5:5.3.0")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:5.3.0")
-    testImplementation("io.kotest:kotest-property-jvm:5.3.0")
-    androidTestImplementation("io.kotest:kotest-assertions-core-jvm:5.3.0")
-    androidTestImplementation("io.kotest:kotest-property-jvm:5.3.0")
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    testImplementation("io.kotest:kotest-property-jvm:5.9.1")
+    androidTestImplementation("io.kotest:kotest-assertions-core-jvm:5.9.1")
+    androidTestImplementation("io.kotest:kotest-property-jvm:5.9.1")
 
     testImplementation("android.arch.core:core-testing:1.1.1")
     androidTestImplementation("android.arch.core:core-testing:1.1.1")
-    debugImplementation("androidx.test:core-ktx:1.4.0")
+    debugImplementation("androidx.test:core-ktx:1.6.1")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 
-    androidTestImplementation("androidx.test:runner:1.4.0")
-    androidTestImplementation("androidx.test:rules:1.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-intents:3.4.0")
-    androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:3.4.0")
+    androidTestImplementation("androidx.test:runner:1.6.2")
+    androidTestImplementation("androidx.test:rules:1.6.2")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.6.1")
+    androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")
+    androidTestImplementation("androidx.test.espresso.idling:idling-concurrent:3.6.1")
 }


### PR DESCRIPTION
## Summary
- Remove deprecated `lifecycle-extensions:2.2.0` (newer lifecycle libs already included)
- Update test dependencies to latest versions:
  - mockk: 1.12.4 → 1.13.13
  - kotest: 5.3.0 → 5.9.1
  - androidx.test:core-ktx: 1.4.0 → 1.6.1
  - androidx.test.ext:junit: 1.1.3 → 1.2.1
  - androidx.test.espresso: 3.4.0 → 3.6.1
  - androidx.test:runner/rules: 1.4.0 → 1.6.2

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes