### PR TITLE
Add BATTERY_LOW and BATTERY_OKAY events for immediate sync

### DIFF
--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoSource.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoSource.kt
@@ -37,12 +37,6 @@ import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
-/*
-    TODO
-    Trigger worker and update for these events
-    <action android:name="android.intent.action.BATTERY_LOW"/>
-    <action android:name="android.intent.action.BATTERY_OKAY"/>
- */
 @Singleton
 class PowerInfoSource @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
@@ -94,6 +88,8 @@ class PowerInfoSource @Inject constructor(
         log(TAG) { "batteryState receiver: $receiver" }
         val filter = IntentFilter().apply {
             addAction(Intent.ACTION_BATTERY_CHANGED)
+            addAction(Intent.ACTION_BATTERY_LOW)
+            addAction(Intent.ACTION_BATTERY_OKAY)
         }
         context.registerReceiver(receiver, filter)
         isRegistered = true


### PR DESCRIPTION
## Summary
- Add `ACTION_BATTERY_LOW` and `ACTION_BATTERY_OKAY` intent actions to `PowerInfoSource.kt`
- This enables immediate sync/update when battery level drops critically low or recovers
- Removes the TODO comment that requested this feature

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew :modules-power:testDebugUnitTest` passes
- [x] Manual test with ADB battery simulation:
  ```bash
  adb shell dumpsys battery set level 10  # Should trigger update
  adb shell dumpsys battery set level 50  # Should trigger update
  adb shell dumpsys battery reset
  ```