### PR TITLE
Remove unimplemented NFC linking option

### DIFF
--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/KServerLinkOption.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/KServerLinkOption.kt
@@ -3,5 +3,4 @@ package eu.darken.octi.syncs.kserver.ui.link
 enum class KServerLinkOption {
     DIRECT,
     QRCODE,
-    NFC
 }

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
@@ -51,7 +51,6 @@ class KServerLinkClientFragment : Fragment3(R.layout.sync_kserver_link_client_fr
             when (checkedId) {
                 R.id.link_option_direct -> vm.onLinkOptionSelected(KServerLinkOption.DIRECT)
                 R.id.link_option_qrcode -> vm.onLinkOptionSelected(KServerLinkOption.QRCODE)
-                R.id.link_option_nfc -> vm.onLinkOptionSelected(KServerLinkOption.NFC)
             }
         }
 
@@ -79,7 +78,6 @@ class KServerLinkClientFragment : Fragment3(R.layout.sync_kserver_link_client_fr
         vm.state.observe2(ui) { state ->
             linkContainerDirect.isGone = state.linkOption != KServerLinkOption.DIRECT
             linkContainerQrcode.isGone = state.linkOption != KServerLinkOption.QRCODE
-            linkContainerNfc.isGone = state.linkOption != KServerLinkOption.NFC
 
             when (state.linkOption) {
                 KServerLinkOption.DIRECT -> {
@@ -89,11 +87,6 @@ class KServerLinkClientFragment : Fragment3(R.layout.sync_kserver_link_client_fr
 
                 KServerLinkOption.QRCODE -> {
                     linkOptions.check(R.id.link_option_qrcode)
-                }
-
-                KServerLinkOption.NFC -> {
-                    linkOptions.check(R.id.link_option_nfc)
-                    // TODO NOOP?
                 }
             }
             busyContainer.isVisible = state.isBusy

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
@@ -40,7 +40,6 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
             when (checkedId) {
                 R.id.link_option_direct -> vm.onLinkOptionSelected(KServerLinkOption.DIRECT)
                 R.id.link_option_qrcode -> vm.onLinkOptionSelected(KServerLinkOption.QRCODE)
-                R.id.link_option_nfc -> vm.onLinkOptionSelected(KServerLinkOption.NFC)
             }
         }
 
@@ -49,7 +48,6 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
         vm.state.observe2(ui) { state ->
             linkContainerDirect.isGone = state.linkOption != KServerLinkOption.DIRECT
             linkContainerQrcode.isGone = state.linkOption != KServerLinkOption.QRCODE
-            linkContainerNfc.isGone = state.linkOption != KServerLinkOption.NFC
 
             when (state.linkOption) {
                 KServerLinkOption.DIRECT -> {
@@ -68,11 +66,6 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
                     } catch (e: Exception) {
                         e.asErrorDialogBuilder(requireActivity()).show()
                     }
-                }
-
-                KServerLinkOption.NFC -> {
-                    linkOptions.check(R.id.link_option_nfc)
-                    // TODO NOOP?
                 }
             }
         }

--- a/app/src/main/res/layout/sync_kserver_link_client_fragment.xml
+++ b/app/src/main/res/layout/sync_kserver_link_client_fragment.xml
@@ -46,14 +46,6 @@
                 android:layout_height="wrap_content"
                 android:text="@string/sync_kserver_link_client_option_direct" />
 
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_nfc"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
-                android:layout_width="match_parent"
-                android:visibility="gone"
-                android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_client_option_nfc" />
-
         </RadioGroup>
 
     </com.google.android.material.card.MaterialCardView>
@@ -120,25 +112,6 @@
             android:layout_marginTop="16dp"
             android:text="@string/sync_kserver_link_client_link_action" />
 
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/link_container_nfc"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="32dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card">
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/TextAppearance.Material3.HeadlineMedium"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/sync_kserver_link_client_nfc_action" />
     </LinearLayout>
 
     <FrameLayout

--- a/app/src/main/res/layout/sync_kserver_link_host_fragment.xml
+++ b/app/src/main/res/layout/sync_kserver_link_host_fragment.xml
@@ -47,13 +47,6 @@
                 android:layout_height="wrap_content"
                 android:text="@string/sync_kserver_link_host_option_direct" />
 
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_nfc"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_host_option_nfc"
-                android:visibility="gone" />
         </RadioGroup>
     </com.google.android.material.card.MaterialCardView>
 
@@ -138,28 +131,5 @@
 
         </LinearLayout>
     </ScrollView>
-
-
-    <LinearLayout
-        android:id="@+id/link_container_nfc"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="32dp"
-        android:layout_marginVertical="32dp"
-        android:orientation="vertical"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card">
-
-        <com.google.android.material.textview.MaterialTextView
-            style="@style/TextAppearance.Material3.HeadlineMedium"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center"
-            android:text="@string/sync_kserver_link_host_nfc_action" />
-    </LinearLayout>
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/syncs-kserver/src/main/res/values-af-rZA/strings.xml
+++ b/syncs-kserver/src/main/res/values-af-rZA/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Koppel kode</string>
     <string name="sync_kserver_link_host_option_direct">Skep \'n tekskode wat jy via ander programme kan stuur</string>
     <string name="sync_kserver_link_host_option_qrcode">Wys \'n QR-kode</string>
-    <string name="sync_kserver_link_host_option_nfc">Koppel toestel via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">\'n Nuwe toestel is aan jou rekening gekoppel.</string>
-    <string name="sync_kserver_link_host_nfc_action">Soek NFC-kliënt. Hou hierdie toestel naby aan die toestel wat jy aan jou rekening wil koppel.</string>
     <string name="sync_kserver_link_client_option_qrcode">Skandeer \'n QR-kode van \'n ander toestel</string>
-    <string name="sync_kserver_link_client_option_nfc">Gebruik twee toestelle met NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Begin kamera</string>
     <string name="sync_kserver_link_client_link_action">Koppel toestel</string>
-    <string name="sync_kserver_link_client_nfc_action">Soek na NFC-gasheer. Hou dit naby aan die toestel wat toegang wil deel.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ar/strings.xml
+++ b/syncs-kserver/src/main/res/values-ar/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">رمز الربط</string>
     <string name="sync_kserver_link_host_option_direct">إنشاء رمز نصي يمكنك إرساله عبر تطبيقات أخرى</string>
     <string name="sync_kserver_link_host_option_qrcode">عرض رمز استجابة سريعة (QR)</string>
-    <string name="sync_kserver_link_host_option_nfc">ربط الجهاز عبر NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">تم ربط جهاز جديد بحسابك.</string>
-    <string name="sync_kserver_link_host_nfc_action">جاري البحث عن عميل NFC. قرّب هذا الجهاز من الجهاز الذي تريد ربطه بحسابك.</string>
     <string name="sync_kserver_link_client_option_qrcode">مسح رمز استجابة سريعة (QR) من جهاز آخر</string>
-    <string name="sync_kserver_link_client_option_nfc">استخدام جهازين يدعمان NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">تشغيل الكاميرا</string>
     <string name="sync_kserver_link_client_link_action">ربط الجهاز</string>
-    <string name="sync_kserver_link_client_nfc_action">جاري البحث عن مضيف NFC. قرّبه من الجهاز الذي يعرض مشاركة الوصول إلى الحساب.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ca/strings.xml
+++ b/syncs-kserver/src/main/res/values-ca/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">Codi d\'enllaç</string>
     <string name="sync_kserver_link_host_option_direct">Crea un codi de text que podeu enviar mitjançant altres aplicacions</string>
     <string name="sync_kserver_link_host_option_qrcode">Mostra un codi QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Enllaça el dispositiu mitjançant NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">S\'ha enllaçat un dispositiu nou al vostre compte.</string>
-    <string name="sync_kserver_link_host_nfc_action">S\'està cercant un client NFC. Manteniu aquest dispositiu a prop del dispositiu que voleu enllaçar al vostre compte.</string>
     <string name="sync_kserver_link_client_option_qrcode">Escaneja un codi QR des d\'un altre dispositiu</string>
-    <string name="sync_kserver_link_client_option_nfc">Utilitza dos dispositius amb NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Inicieu la càmera</string>
     <string name="sync_kserver_link_client_link_action">Enllaça el dispositiu</string>
-    <string name="sync_kserver_link_client_nfc_action">S\'està cercant un amfitrió NFC. Manteniu-lo a prop del dispositiu que ofereix compartir accés al compte.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-cs/strings.xml
+++ b/syncs-kserver/src/main/res/values-cs/strings.xml
@@ -15,13 +15,9 @@
     <string name="sync_kserver_link_code_label">Kód propojení</string>
     <string name="sync_kserver_link_host_option_direct">Vytvoření textového kódu, který můžete odeslat prostřednictvím jiných aplikací</string>
     <string name="sync_kserver_link_host_option_qrcode">Zobrazit QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Propojit zařízení skrze NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">S vaším účtem bylo propojeno nové zařízení.</string>
-    <string name="sync_kserver_link_host_nfc_action">Vyhledávání klienta NFC. Přiložte toto zařízení k zařízení, které chcete propojit se svým účtem.</string>
     <string name="sync_kserver_link_client_option_direct">Ručně kopírovat a vložit kód propojení</string>
     <string name="sync_kserver_link_client_option_qrcode">Naskenovat QR kód z jiného zařízení</string>
-    <string name="sync_kserver_link_client_option_nfc">Použít dvě zařízení s NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Spustit fotoaparát</string>
     <string name="sync_kserver_link_client_link_action">Propojit zařížení</string>
-    <string name="sync_kserver_link_client_nfc_action">Vyhledávání NFC hostitele. Držte se blízko zařízení, které nabízí sdílení přístupu k účtu.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-da/strings.xml
+++ b/syncs-kserver/src/main/res/values-da/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Linkkode</string>
     <string name="sync_kserver_link_host_option_direct">Opret en tekstkode, som du kan sende via andre apps</string>
     <string name="sync_kserver_link_host_option_qrcode">Vis en QR-kode</string>
-    <string name="sync_kserver_link_host_option_nfc">Link enhed via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">En ny enhed blev linket til din konto.</string>
-    <string name="sync_kserver_link_host_nfc_action">Søger efter NFC-klient. Hold denne enhed tæt på den enhed, du vil linke til din konto.</string>
     <string name="sync_kserver_link_client_option_qrcode">Scan en QR-kode fra en anden enhed</string>
-    <string name="sync_kserver_link_client_option_nfc">Brug to enheder med NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Start kamera</string>
     <string name="sync_kserver_link_client_link_action">Link enhed</string>
-    <string name="sync_kserver_link_client_nfc_action">Søger efter NFC-vært. Hold den tæt på enheden, der tilbyder at dele konto-adgang.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-de/strings.xml
+++ b/syncs-kserver/src/main/res/values-de/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">Verbindungscode</string>
     <string name="sync_kserver_link_host_option_direct">Einen Textcode erstellen, den Sie über andere Apps senden können</string>
     <string name="sync_kserver_link_host_option_qrcode">Zeige einen QR-Code</string>
-    <string name="sync_kserver_link_host_option_nfc">Verbinde Gerät per NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Ein neues Gerät wurde mit deinem Konto verbunden.</string>
-    <string name="sync_kserver_link_host_nfc_action">Suche nach NFC-Client. Halten Sie dieses Gerät nah an das Gerät, das Sie mit Ihrem Konto verbinden möchten.</string>
     <string name="sync_kserver_link_client_option_qrcode">Einen QR-Code von einem anderen Gerät scannen</string>
-    <string name="sync_kserver_link_client_option_nfc">Benutze zwei Geräte mit NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Starte Kamera</string>
     <string name="sync_kserver_link_client_link_action">Gerät verbinden</string>
-    <string name="sync_kserver_link_client_nfc_action">Suche nach NFC-Host. Halten Sie es nah an das Gerät, das anbietet, den Kontozugriff zu teilen.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-el/strings.xml
+++ b/syncs-kserver/src/main/res/values-el/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">Κωδικός σύνδεσης</string>
     <string name="sync_kserver_link_host_option_direct">Δημιουργία κειμενικού κωδικού που μπορείτε να στείλετε με άλλες εφαρμογές</string>
     <string name="sync_kserver_link_host_option_qrcode">Εμφάνιση QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Σύνδεση συσκευής μέσω NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Μια νέα συσκευή συνδέθηκε στον λογαριασμό σας.</string>
-    <string name="sync_kserver_link_host_nfc_action">Αναζήτηση πελάτη NFC. Κρατήστε αυτή τη συσκευή κοντά στη συσκευή που θέλετε να συνδέσετε στον λογαριασμό σας.</string>
     <string name="sync_kserver_link_client_option_qrcode">Σάρωση QR κωδικού από άλλη συσκευή</string>
-    <string name="sync_kserver_link_client_option_nfc">Χρησιμοποιήστε δύο συσκευές με NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Έναρξη κάμερας</string>
     <string name="sync_kserver_link_client_link_action">Σύνδεση συσκευής</string>
-    <string name="sync_kserver_link_client_nfc_action">Αναζήτηση διακομιστή NFC. Κρατήστε το κοντά στη συσκευή που προσφέρει κοινή χρήση πρόσβασης λογαριασμού.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-es/strings.xml
+++ b/syncs-kserver/src/main/res/values-es/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Código de vinculación</string>
     <string name="sync_kserver_link_host_option_direct">Crear un código de texto que puedes enviar a través de otras aplicaciones</string>
     <string name="sync_kserver_link_host_option_qrcode">Mostrar un código QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Vincular dispositivo vía NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Un nuevo dispositivo ha sido vinculado a tu cuenta.</string>
-    <string name="sync_kserver_link_host_nfc_action">Buscando cliente NFC. Mantén este dispositivo cerca del dispositivo que quieres vincular a tu cuenta.</string>
     <string name="sync_kserver_link_client_option_qrcode">Escanear un código QR desde otro dispositivo</string>
-    <string name="sync_kserver_link_client_option_nfc">Usar dos dispositivos con NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Iniciar cámara</string>
     <string name="sync_kserver_link_client_link_action">Vincular dispositivo</string>
-    <string name="sync_kserver_link_client_nfc_action">Buscando host NFC. Mantenlo cerca del dispositivo que ofrece compartir acceso a la cuenta.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-fi/strings.xml
+++ b/syncs-kserver/src/main/res/values-fi/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Yhdistämiskoodi</string>
     <string name="sync_kserver_link_host_option_direct">Luo tekstikoodi, jonka voi lähettää muiden sovellusten kautta</string>
     <string name="sync_kserver_link_host_option_qrcode">Näytä QR-koodi</string>
-    <string name="sync_kserver_link_host_option_nfc">Yhdistä laite NFC:llä</string>
     <string name="sync_kserver_link_host_device_linked_message">Uusi laite yhdistetty tilillesi.</string>
-    <string name="sync_kserver_link_host_nfc_action">Etsitään NFC-asiakasta. Pidä laitetta lähellä laitetta, jonka haluat liittää tiliin.</string>
     <string name="sync_kserver_link_client_option_qrcode">Skannaa QR-koodi toisesta laitteesta</string>
-    <string name="sync_kserver_link_client_option_nfc">Käytä kahta laitetta NFC:llä</string>
     <string name="sync_kserver_link_client_startcamera_action">Käynnistä kamera</string>
     <string name="sync_kserver_link_client_link_action">Yhdistä laite</string>
-    <string name="sync_kserver_link_client_nfc_action">Etsitään NFC-isäntää. Pidä lähellä laitetta, joka on jakamassa tilin käyttöoikeuden.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-fr/strings.xml
+++ b/syncs-kserver/src/main/res/values-fr/strings.xml
@@ -15,13 +15,9 @@
     <string name="sync_kserver_link_code_label">Code de liaison</string>
     <string name="sync_kserver_link_host_option_direct">Créer un code texte que vous pouvez envoyer avec d’autres applis</string>
     <string name="sync_kserver_link_host_option_qrcode">Afficher un code QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Relier l’appareil par CCP</string>
     <string name="sync_kserver_link_host_device_linked_message">Un nouvel appareil a été relié à votre compte.</string>
-    <string name="sync_kserver_link_host_nfc_action">Recherche d’un client CCP. Tenez cet appareil proche de celui que vous voulez relier à votre compte.</string>
     <string name="sync_kserver_link_client_option_direct">Copier et coller manuellement un code de liaison</string>
     <string name="sync_kserver_link_client_option_qrcode">Lire le code QR d’un autre appareil</string>
-    <string name="sync_kserver_link_client_option_nfc">Utiliser deux appareils avec la CCP</string>
     <string name="sync_kserver_link_client_startcamera_action">Démarrer l’appareil photo</string>
     <string name="sync_kserver_link_client_link_action">Relier l’appareil</string>
-    <string name="sync_kserver_link_client_nfc_action">Recherche d\'un hôte CCP. Tenez votre appareil proche de celui qui propose de partager l’accès au compte.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-hu/strings.xml
+++ b/syncs-kserver/src/main/res/values-hu/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Összekapcsolási kód</string>
     <string name="sync_kserver_link_host_option_direct">Hozz létre egy szöveges kódot, amit más alkalmazásokon keresztül küldhetsz el</string>
     <string name="sync_kserver_link_host_option_qrcode">QR kód megjelenítése</string>
-    <string name="sync_kserver_link_host_option_nfc">Eszköz összekapcsolása NFC-vel</string>
     <string name="sync_kserver_link_host_device_linked_message">Új eszköz lett kapcsolva a fiókodhoz.</string>
-    <string name="sync_kserver_link_host_nfc_action">NFC kliens keresése. Tartsd ezt az eszközt közel ahhoz, amit hozzá akarsz kapcsolni a fiókodhoz.</string>
     <string name="sync_kserver_link_client_option_qrcode">QR kód leolvasása másik eszközről</string>
-    <string name="sync_kserver_link_client_option_nfc">Két eszköz használata NFC-vel</string>
     <string name="sync_kserver_link_client_startcamera_action">Kamera indítása</string>
     <string name="sync_kserver_link_client_link_action">Eszköz összekapcsolása</string>
-    <string name="sync_kserver_link_client_nfc_action">NFC szerver keresése. Tartsd közel ahhoz az eszközhöz, ami hozzáférést kínál a fiókhoz.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-it/strings.xml
+++ b/syncs-kserver/src/main/res/values-it/strings.xml
@@ -17,12 +17,8 @@ Poiché sia l\'app che il server sono ancora in fase di miglioramento, potrebber
     <string name="sync_kserver_link_code_label">Codice di collegamento</string>
     <string name="sync_kserver_link_host_option_direct">Crea un codice da inviare alle diverse app</string>
     <string name="sync_kserver_link_host_option_qrcode">Mostra QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Collega via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Un nuovo dispositivo è stato collegato al tuo account.</string>
-    <string name="sync_kserver_link_host_nfc_action">In cerca di un client NFC. Tieni questo dispositivo vicino al dispositivo che vuoi collegare al tuo account.</string>
     <string name="sync_kserver_link_client_option_qrcode">Scansiona il QRCode con un altro dispositivo</string>
-    <string name="sync_kserver_link_client_option_nfc">Usa due dispositivi con NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Apri fotocamera</string>
     <string name="sync_kserver_link_client_link_action">Collega dispositivo</string>
-    <string name="sync_kserver_link_client_nfc_action">In cerca di un host NFC. Tieni il dispositivo vicino a quello che sta offrendo di condividere l\'accesso all\'account.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-iw/strings.xml
+++ b/syncs-kserver/src/main/res/values-iw/strings.xml
@@ -15,13 +15,9 @@
     <string name="sync_kserver_link_code_label">קוד קישור</string>
     <string name="sync_kserver_link_host_option_direct">צור קוד טקסט שתוכל לשלוח דרך אפליקציות אחרות</string>
     <string name="sync_kserver_link_host_option_qrcode">הצג QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">קשר מכשיר באמצעות NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">מכשיר חדש קושר לחשבון שלך.</string>
-    <string name="sync_kserver_link_host_nfc_action">מחפש לקוח NFC. החזק את המכשירים שברצונך לקשר קרובים אחד לשני.</string>
     <string name="sync_kserver_link_client_option_direct">העתק והדבק ידנית קוד קישור</string>
     <string name="sync_kserver_link_client_option_qrcode">סרוק קוד QR ממכשיר אחר</string>
-    <string name="sync_kserver_link_client_option_nfc">השתמש בשני מכשירים עם NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">הפעל מצלמה</string>
     <string name="sync_kserver_link_client_link_action">קשר מכשיר</string>
-    <string name="sync_kserver_link_client_nfc_action">מחפש מארח NFC. החזק אותו קרוב למכשיר המציע לשתף גישה לחשבון.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ja/strings.xml
+++ b/syncs-kserver/src/main/res/values-ja/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">リンクコード</string>
     <string name="sync_kserver_link_host_option_direct">他のアプリから送信できるテキストコードを作成します</string>
     <string name="sync_kserver_link_host_option_qrcode">QR コードを表示</string>
-    <string name="sync_kserver_link_host_option_nfc">NFC でデバイスをリンク</string>
     <string name="sync_kserver_link_host_device_linked_message">新しいデバイスがアカウントにリンクされました</string>
-    <string name="sync_kserver_link_host_nfc_action">NFC クライアントを探しています。このデバイスをアカウントにリンクするデバイスを近づけてください。</string>
     <string name="sync_kserver_link_client_option_qrcode">別のデバイスから QR コードをスキャン</string>
-    <string name="sync_kserver_link_client_option_nfc">NFC で 2 台のデバイスを使用する</string>
     <string name="sync_kserver_link_client_startcamera_action">カメラを起動</string>
     <string name="sync_kserver_link_client_link_action">デバイスをリンク</string>
-    <string name="sync_kserver_link_client_nfc_action">NFC ホストを探しています。アカウントアクセスの共有を提供するデバイスに近づけてください。</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ko/strings.xml
+++ b/syncs-kserver/src/main/res/values-ko/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">연결 코드</string>
     <string name="sync_kserver_link_host_option_direct">다른 앱을 통해 보낼 수 있는 텍스트 코드를 생성하기</string>
     <string name="sync_kserver_link_host_option_qrcode">QR코드 표시</string>
-    <string name="sync_kserver_link_host_option_nfc">NFC로 기기 연결</string>
     <string name="sync_kserver_link_host_device_linked_message">새 기기가 계정에 연결되었습니다.</string>
-    <string name="sync_kserver_link_host_nfc_action">NFC 클라이언트 검색 중. 이 기기를 계정에 연결할 기기 근처에 두세요.</string>
     <string name="sync_kserver_link_client_option_qrcode">다른 기기의 QR 코드 스캔하기</string>
-    <string name="sync_kserver_link_client_option_nfc">NFC로 두 기기 사용</string>
     <string name="sync_kserver_link_client_startcamera_action">카메라 시작</string>
     <string name="sync_kserver_link_client_link_action">기기 연결</string>
-    <string name="sync_kserver_link_client_nfc_action">NFC 호스트 검색 중. 계정 접근 공유를 제공하는 기기 근처에 두세요.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-nb/strings.xml
+++ b/syncs-kserver/src/main/res/values-nb/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Koblingskode</string>
     <string name="sync_kserver_link_host_option_direct">Lag en tekstkode du kan sende via andre apper</string>
     <string name="sync_kserver_link_host_option_qrcode">Vis en QR-kode</string>
-    <string name="sync_kserver_link_host_option_nfc">Koble enhet via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">En ny enhet er koblet til kontoen din.</string>
-    <string name="sync_kserver_link_host_nfc_action">Søker etter NFC-klient. Hold denne enheten nær enheten du vil koble til kontoen din.</string>
     <string name="sync_kserver_link_client_option_qrcode">Skann en QR-kode fra en annen enhet</string>
-    <string name="sync_kserver_link_client_option_nfc">Bruk to enheter med NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Start kamera</string>
     <string name="sync_kserver_link_client_link_action">Koble enhet</string>
-    <string name="sync_kserver_link_client_nfc_action">Søker etter NFC-vert. Hold den nær enheten som tilbyr å dele konto-tilgang.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-nl/strings.xml
+++ b/syncs-kserver/src/main/res/values-nl/strings.xml
@@ -14,11 +14,7 @@
     <string name="sync_kserver_link_code_label">Koppelcode</string>
     <string name="sync_kserver_link_host_option_direct">Maak een tekstcode die je via andere apps kunt versturen</string>
     <string name="sync_kserver_link_host_option_qrcode">Toon een QR-code</string>
-    <string name="sync_kserver_link_host_option_nfc">Koppel apparaat via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Er is een nieuw apparaat gekoppeld aan je account.</string>
-    <string name="sync_kserver_link_host_nfc_action">Op zoek naar NFC-client. Houd dit apparaat dicht bij het apparaat dat je aan je account wilt koppelen.</string>
     <string name="sync_kserver_link_client_option_qrcode">Scan een QR-code van een ander apparaat</string>
-    <string name="sync_kserver_link_client_option_nfc">Gebruik twee apparaten met NFC</string>
     <string name="sync_kserver_link_client_link_action">Koppel apparaat</string>
-    <string name="sync_kserver_link_client_nfc_action">Op zoek naar een NFC-host. Houd deze dicht bij het apparaat dat aanbiedt om accounttoegang te delen.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-pl/strings.xml
+++ b/syncs-kserver/src/main/res/values-pl/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Kod powiązania</string>
     <string name="sync_kserver_link_host_option_direct">Utwórz kod tekstowy, który możesz przesłać przez inne aplikacje</string>
     <string name="sync_kserver_link_host_option_qrcode">Pokaż kod QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Powiąż urządzenie przez NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Nowe urządzenie zostało powiązane z twoim kontem.</string>
-    <string name="sync_kserver_link_host_nfc_action">Wyszukiwanie klienta NFC. Przytrzymaj to urządzenie blisko urządzenia, które chcesz powiązać z kontem.</string>
     <string name="sync_kserver_link_client_option_qrcode">Zeskanuj kod QR z innego urządzenia</string>
-    <string name="sync_kserver_link_client_option_nfc">Użyj dwóch urządzeń z NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Uruchom aparat</string>
     <string name="sync_kserver_link_client_link_action">Powiąż urządzenie</string>
-    <string name="sync_kserver_link_client_nfc_action">Wyszukiwanie hosta NFC. Przytrzymaj blisko urządzenia udostępniającego dostęp do konta.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-pt-rBR/strings.xml
+++ b/syncs-kserver/src/main/res/values-pt-rBR/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Código de vinculação</string>
     <string name="sync_kserver_link_host_option_direct">Criar um código de texto que você pode enviar por outros aplicativos</string>
     <string name="sync_kserver_link_host_option_qrcode">Mostrar um QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Vincular dispositivo via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Um novo dispositivo foi vinculado à sua conta.</string>
-    <string name="sync_kserver_link_host_nfc_action">Procurando cliente NFC. Mantenha este dispositivo próximo do dispositivo que você deseja vincular à sua conta.</string>
     <string name="sync_kserver_link_client_option_qrcode">Escanear um QR code de outro dispositivo</string>
-    <string name="sync_kserver_link_client_option_nfc">Use dois dispositivos com NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Iniciar câmera</string>
     <string name="sync_kserver_link_client_link_action">Vincular dispositivo</string>
-    <string name="sync_kserver_link_client_nfc_action">Procurando host NFC. Mantenha próximo do dispositivo que oferece compartilhar o acesso à conta.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-pt/strings.xml
+++ b/syncs-kserver/src/main/res/values-pt/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Código de vinculação</string>
     <string name="sync_kserver_link_host_option_direct">Criar um código de texto que você pode enviar por outros aplicativos</string>
     <string name="sync_kserver_link_host_option_qrcode">Mostrar um QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Vincular dispositivo via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Um novo dispositivo foi vinculado à sua conta.</string>
-    <string name="sync_kserver_link_host_nfc_action">Procurando cliente NFC. Mantenha este dispositivo próximo do dispositivo que você deseja vincular à sua conta.</string>
     <string name="sync_kserver_link_client_option_qrcode">Escanear um QR code de outro dispositivo</string>
-    <string name="sync_kserver_link_client_option_nfc">Use dois dispositivos com NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Iniciar câmera</string>
     <string name="sync_kserver_link_client_link_action">Vincular dispositivo</string>
-    <string name="sync_kserver_link_client_nfc_action">Procurando host NFC. Mantenha próximo do dispositivo que oferece compartilhar o acesso à conta.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ro/strings.xml
+++ b/syncs-kserver/src/main/res/values-ro/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Cod de conectare</string>
     <string name="sync_kserver_link_host_option_direct">Creează un cod text pe care îl poți trimite prin alte aplicații</string>
     <string name="sync_kserver_link_host_option_qrcode">Afișează un cod QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Conectează dispozitivul prin NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Un dispozitiv nou a fost conectat la contul tău.</string>
-    <string name="sync_kserver_link_host_nfc_action">Caută client NFC. Ține acest dispozitiv aproape de cel pe care vrei să-l conectezi la contul tău.</string>
     <string name="sync_kserver_link_client_option_qrcode">Scanează un cod QR de pe alt dispozitiv</string>
-    <string name="sync_kserver_link_client_option_nfc">Folosește două dispozitive cu NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Pornește camera</string>
     <string name="sync_kserver_link_client_link_action">Conectează dispozitiv</string>
-    <string name="sync_kserver_link_client_nfc_action">Caută gazdă NFC. Ține aproape de dispozitivul care dorește să partajeze accesul la cont.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-ru/strings.xml
+++ b/syncs-kserver/src/main/res/values-ru/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Код связи</string>
     <string name="sync_kserver_link_host_option_direct">Создать текстовый код, который можно отправить через другие приложения</string>
     <string name="sync_kserver_link_host_option_qrcode">Показать QR-код</string>
-    <string name="sync_kserver_link_host_option_nfc">Связать устройство через NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Новое устройство было связано с вашей учетной записью.</string>
-    <string name="sync_kserver_link_host_nfc_action">Поиск NFC-клиента. Держите это устройство рядом с устройством, которое вы хотите связать с вашей учетной записью.</string>
     <string name="sync_kserver_link_client_option_qrcode">Сканировать QR-код с другого устройства</string>
-    <string name="sync_kserver_link_client_option_nfc">Использовать два устройства с NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Запустить камеру</string>
     <string name="sync_kserver_link_client_link_action">Связать устройство</string>
-    <string name="sync_kserver_link_client_nfc_action">Поиск NFC-хоста. Держите его рядом с устройством, предлагающим поделиться доступом к учетной записи.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-sr/strings.xml
+++ b/syncs-kserver/src/main/res/values-sr/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Код за повезивање</string>
     <string name="sync_kserver_link_host_option_direct">Креирај текстуални код који можете послати преко других апликација</string>
     <string name="sync_kserver_link_host_option_qrcode">Прикажи QR код</string>
-    <string name="sync_kserver_link_host_option_nfc">Повежи уређај преко NFC-а</string>
     <string name="sync_kserver_link_host_device_linked_message">Нови уређај је повезан са вашим налогом.</string>
-    <string name="sync_kserver_link_host_nfc_action">Тражим NFC клијента. Држите овај уређај близу уређаја који желите да повежете на налог.</string>
     <string name="sync_kserver_link_client_option_qrcode">Скенирај QR код са другог уређаја</string>
-    <string name="sync_kserver_link_client_option_nfc">Користите два уређаја са NFC-ом</string>
     <string name="sync_kserver_link_client_startcamera_action">Покрени камеру</string>
     <string name="sync_kserver_link_client_link_action">Повежи уређај</string>
-    <string name="sync_kserver_link_client_nfc_action">Тражим NFC домаћина. Држите га поред уређаја који дели приступ налогу.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-sv/strings.xml
+++ b/syncs-kserver/src/main/res/values-sv/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Länkkod</string>
     <string name="sync_kserver_link_host_option_direct">Skapa en textkod som du kan skicka via andra appar</string>
     <string name="sync_kserver_link_host_option_qrcode">Visa en QR-kod</string>
-    <string name="sync_kserver_link_host_option_nfc">Länka enhet via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">En ny enhet har länkats till ditt konto.</string>
-    <string name="sync_kserver_link_host_nfc_action">Söker efter NFC-klient. Håll den här enheten nära den enhet du vill länka till ditt konto.</string>
     <string name="sync_kserver_link_client_option_qrcode">Skanna en QR-kod från en annan enhet</string>
-    <string name="sync_kserver_link_client_option_nfc">Använd två enheter med NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Starta kamera</string>
     <string name="sync_kserver_link_client_link_action">Länka enhet</string>
-    <string name="sync_kserver_link_client_nfc_action">Söker efter NFC-värd. Håll den nära enheten som erbjuder att dela kontoåtkomst.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-tr/strings.xml
+++ b/syncs-kserver/src/main/res/values-tr/strings.xml
@@ -15,13 +15,9 @@
     <string name="sync_kserver_link_code_label">Bağlantı kodu</string>
     <string name="sync_kserver_link_host_option_direct">Diğer uygulamalar aracılığıyla gönderebileceğiniz bir metin kodu oluşturun</string>
     <string name="sync_kserver_link_host_option_qrcode">QR kodu göster</string>
-    <string name="sync_kserver_link_host_option_nfc">Cihazı NFC ile bağlayın</string>
     <string name="sync_kserver_link_host_device_linked_message">Hesabınıza yeni bir cihaz bağlandı.</string>
-    <string name="sync_kserver_link_host_nfc_action">NFC istemcisi aranıyor. Bu cihazı hesabınıza bağlamak istediğiniz cihaza yakın tutun.</string>
     <string name="sync_kserver_link_client_option_direct">Bağlantı kodunu manuel olarak kopyalayıp yapıştırın</string>
     <string name="sync_kserver_link_client_option_qrcode">Başka bir cihazdan QR kodu tarama</string>
-    <string name="sync_kserver_link_client_option_nfc">Iki cihaz ile NFC kullanın</string>
     <string name="sync_kserver_link_client_startcamera_action">Kamerayı Aç</string>
     <string name="sync_kserver_link_client_link_action">Cihazı bağla</string>
-    <string name="sync_kserver_link_client_nfc_action">NFC ana bilgisayarı aranıyor. Hesap erişimini paylaşmayı teklif eden cihaza yakın tutun.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-uk/strings.xml
+++ b/syncs-kserver/src/main/res/values-uk/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Код зв\'язку</string>
     <string name="sync_kserver_link_host_option_direct">Створити текстовий код, який можна надіслати через інші додатки</string>
     <string name="sync_kserver_link_host_option_qrcode">Показати QR-код</string>
-    <string name="sync_kserver_link_host_option_nfc">Зв\'язати пристрій через NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Новий пристрій було зв\'язано з вашим обліковим записом.</string>
-    <string name="sync_kserver_link_host_nfc_action">Пошук NFC-клієнта. Тримайте цей пристрій поруч із пристроєм, який ви хочете зв\'язати з вашим обліковим записом.</string>
     <string name="sync_kserver_link_client_option_qrcode">Сканувати QR-код з іншого пристрою</string>
-    <string name="sync_kserver_link_client_option_nfc">Використовувати два пристрої з NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Запустити камеру</string>
     <string name="sync_kserver_link_client_link_action">Зв\'язати пристрій</string>
-    <string name="sync_kserver_link_client_nfc_action">Пошук NFC-хоста. Тримайте його поруч із пристроєм, що пропонує поділитися доступом до облікового запису.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-vi/strings.xml
+++ b/syncs-kserver/src/main/res/values-vi/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">Mã liên kết</string>
     <string name="sync_kserver_link_host_option_direct">Tạo mã văn bản mà bạn có thể gửi qua các ứng dụng khác</string>
     <string name="sync_kserver_link_host_option_qrcode">Hiển thị mã QR</string>
-    <string name="sync_kserver_link_host_option_nfc">Liên kết thiết bị qua NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">Một thiết bị mới đã được liên kết với tài khoản của bạn.</string>
-    <string name="sync_kserver_link_host_nfc_action">Đang tìm kiếm máy khách NFC. Giữ thiết bị này gần thiết bị bạn muốn liên kết với tài khoản của mình.</string>
     <string name="sync_kserver_link_client_option_qrcode">Quét mã QR từ thiết bị khác</string>
-    <string name="sync_kserver_link_client_option_nfc">Sử dụng hai thiết bị có NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Khởi động máy ảnh</string>
     <string name="sync_kserver_link_client_link_action">Liên kết thiết bị</string>
-    <string name="sync_kserver_link_client_nfc_action">Đang tìm kiếm máy chủ NFC. Giữ nó gần thiết bị đang cung cấp quyền truy cập tài khoản chia sẻ.</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-zh-rCN/strings.xml
+++ b/syncs-kserver/src/main/res/values-zh-rCN/strings.xml
@@ -15,12 +15,8 @@
     <string name="sync_kserver_link_code_label">链接代码</string>
     <string name="sync_kserver_link_host_option_direct">创建可通过其他应用发送的文本代码</string>
     <string name="sync_kserver_link_host_option_qrcode">显示二维码</string>
-    <string name="sync_kserver_link_host_option_nfc">通过NFC链接设备</string>
     <string name="sync_kserver_link_host_device_linked_message">一个新设备被链接到你的账户。</string>
-    <string name="sync_kserver_link_host_nfc_action">正在查找NFC客户端。将此设备靠近您要链接到帐户的设备。</string>
     <string name="sync_kserver_link_client_option_qrcode">从另一台设备扫描QR码</string>
-    <string name="sync_kserver_link_client_option_nfc">使用两台设备进行NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">启动摄像机</string>
     <string name="sync_kserver_link_client_link_action">链接设备</string>
-    <string name="sync_kserver_link_client_nfc_action">正在查找NFC主机。将其靠近设备以共享帐户访问权限。</string>
 </resources>

--- a/syncs-kserver/src/main/res/values-zh-rTW/strings.xml
+++ b/syncs-kserver/src/main/res/values-zh-rTW/strings.xml
@@ -14,12 +14,8 @@
     <string name="sync_kserver_link_code_label">連結代碼</string>
     <string name="sync_kserver_link_host_option_direct">建立可透過其他應用程式傳送的文字代碼</string>
     <string name="sync_kserver_link_host_option_qrcode">顯示 QR Code</string>
-    <string name="sync_kserver_link_host_option_nfc">透過 NFC 連結裝置</string>
     <string name="sync_kserver_link_host_device_linked_message">新裝置已連結至您的帳戶。</string>
-    <string name="sync_kserver_link_host_nfc_action">正在尋找 NFC 用戶端。請將此裝置靠近您要連結至帳戶的裝置。</string>
     <string name="sync_kserver_link_client_option_qrcode">從其他裝置掃描 QR Code</string>
-    <string name="sync_kserver_link_client_option_nfc">使用兩部具有 NFC 功能的裝置</string>
     <string name="sync_kserver_link_client_startcamera_action">啟動相機</string>
     <string name="sync_kserver_link_client_link_action">連結裝置</string>
-    <string name="sync_kserver_link_client_nfc_action">正在尋找 NFC 主機。請將其靠近提供分享帳戶存取權限的裝置。</string>
 </resources>

--- a/syncs-kserver/src/main/res/values/strings.xml
+++ b/syncs-kserver/src/main/res/values/strings.xml
@@ -14,13 +14,9 @@
     <string name="sync_kserver_link_code_label">Link code</string>
     <string name="sync_kserver_link_host_option_direct">Create a text code that you can send through other apps</string>
     <string name="sync_kserver_link_host_option_qrcode">Show a QRCode</string>
-    <string name="sync_kserver_link_host_option_nfc">Link device via NFC</string>
     <string name="sync_kserver_link_host_device_linked_message">A new device was linked to your account.</string>
-    <string name="sync_kserver_link_host_nfc_action">Looking for NFC client. Hold this device close to the device you want link to your account.</string>
     <string name="sync_kserver_link_client_option_direct">Manually copy and paste a link code</string>
     <string name="sync_kserver_link_client_option_qrcode">Scan a QR code from another device</string>
-    <string name="sync_kserver_link_client_option_nfc">Use two devices with NFC</string>
     <string name="sync_kserver_link_client_startcamera_action">Start camera</string>
     <string name="sync_kserver_link_client_link_action">Link device</string>
-    <string name="sync_kserver_link_client_nfc_action">Looking for NFC host. Hold it close to the device offering to share account access.</string>
 </resources>


### PR DESCRIPTION
## Summary
NFC linking was never implemented (marked `TODO NOOP?`) and the UI elements were hidden with `visibility="gone"`. This removes the dead code:

- Remove `NFC` from `KServerLinkOption` enum
- Remove NFC cases from client/host fragments
- Remove NFC radio buttons and containers from layouts
- Remove unused NFC strings from all 30 locales

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] Open KServer linking flow, confirm only QR code and Direct options visible