### PR TITLE
Remove non-debug unit test variants from CI

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [ Debug,Beta,Release ]
+        variant: [ Debug ]
         flavor: [ test,testFoss,testGplay ]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Summary
- Remove Beta and Release variants from CI unit test matrix
- Reduces unit test jobs from 9 to 3 (67% reduction)

## Rationale
AGP 9.0 (January 2026) will default to only creating unit test tasks for the debug build type. This change preemptively aligns CI with the upcoming AGP behavior while saving CI resources.

## Test plan
- [x] CI runs successfully with only Debug unit tests
- [x] All 3 flavors (test, testFoss, testGplay) pass