### PR TITLE
Remove dead commented code from SyncWorker

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/core/worker/SyncWorker.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/worker/SyncWorker.kt
@@ -22,20 +22,12 @@ import kotlinx.coroutines.delay
 class SyncWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted private val params: WorkerParameters,
-//    syncWorkerComponentBuilder: SyncWorkerComponent.Builder,
     private val syncManager: SyncManager,
     private val moduleManager: ModuleManager,
     private val batteryWidgetManager: BatteryWidgetManager,
 ) : CoroutineWorker(context, params) {
 
     private val workerScope = SyncWorkerCoroutineScope()
-//    private val monitorComponent = syncWorkerComponentBuilder
-//        .coroutineScope(workerScope)
-//        .build()
-//
-//    private val entryPoint by lazy {
-//        EntryPoints.get(monitorComponent, SyncWorkerEntryPoint::class.java)
-//    }
 
     private var finishedWithError = false
 


### PR DESCRIPTION
## Summary
- Remove legacy Dagger component code that was commented out after migrating to Hilt's `@HiltWorker`

## Changes
- Removed commented `syncWorkerComponentBuilder` parameter
- Removed commented `monitorComponent` and `entryPoint` declarations

## Test plan
- [x] Build passes (`./gradlew assembleDebug`)
- [x] Unit tests pass (`./gradlew testDebugUnitTest`)