### PR TITLE
Fix status bar color split in landscape mode on API 35+

### DIFF
--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
@@ -21,9 +21,8 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.scrollView, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.scrollView, left = true, right = true, bottom = true)
         }
         ui.toolbar.setupWithNavController(findNavController())
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
@@ -26,8 +26,8 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true, bottom = true)
-            insetsPadding(ui.toolbar, top = true)
+            insetsPadding(ui.root, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
         }
         ui.toolbar.setupWithNavController(findNavController())
 

--- a/app/src/main/java/eu/darken/octi/common/theming/Theming.kt
+++ b/app/src/main/java/eu/darken/octi/common/theming/Theming.kt
@@ -13,7 +13,6 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
-import eu.darken.octi.common.getColorForAttr
 import eu.darken.octi.main.core.GeneralSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
@@ -122,7 +121,6 @@ class Theming @Inject constructor(
                 log(TAG) { "Applying MATERIAL_YOU to $activity" }
 
                 DynamicColors.applyToActivityIfAvailable(activity)
-                activity.window.statusBarColor = activity.getColorForAttr(android.R.attr.colorPrimaryDark)
             }
         }
     }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardFragment.kt
@@ -66,10 +66,9 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.refreshSwipe, bottom = true)
-            insetsPadding(ui.refreshActionContainer, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.refreshSwipe, left = true, right = true, bottom = true)
+            insetsPadding(ui.refreshActionContainer, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsFragment.kt
@@ -35,9 +35,8 @@ class SettingsFragment : Fragment2(R.layout.settings_fragment),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.contentFrame, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.contentFrame, left = true, right = true, bottom = true)
         }
         childFragmentManager.addOnBackStackChangedListener {
             val backStackCnt = childFragmentManager.backStackEntryCount

--- a/app/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListFragment.kt
@@ -28,9 +28,8 @@ class AppsListFragment : Fragment3(R.layout.module_apps_list_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.list, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.list, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
@@ -24,9 +24,8 @@ class PowerAlertsFragment : Fragment3(R.layout.module_power_alerts_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.list, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.list, left = true, right = true, bottom = true)
         }
         ui.toolbar.apply {
             setupWithNavController(findNavController())

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddFragment.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddFragment.kt
@@ -27,9 +27,8 @@ class SyncAddFragment : Fragment3(R.layout.sync_add_new_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.list, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.list, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesFragment.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesFragment.kt
@@ -26,9 +26,8 @@ class SyncDevicesFragment : Fragment3(R.layout.sync_devices_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.list, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.list, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.setupWithNavController(findNavController())

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListFragment.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListFragment.kt
@@ -26,10 +26,9 @@ class SyncListFragment : Fragment3(R.layout.sync_list_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true)
-            insetsPadding(ui.toolbar, top = true)
-            insetsPadding(ui.list, bottom = true)
-            insetsPadding(ui.fabContainer, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.list, left = true, right = true, bottom = true)
+            insetsPadding(ui.fabContainer, right = true, bottom = true)
         }
         ui.toolbar.setupWithNavController(findNavController())
         ui.fab.setOnClickListener { vm.addConnector() }

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
@@ -30,8 +30,8 @@ class AddGDriveFragment : Fragment3(R.layout.sync_add_new_gdrive_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true, bottom = true)
-            insetsPadding(ui.toolbar, top = true)
+            insetsPadding(ui.root, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
         }
 
         ui.toolbar.setupWithNavController(findNavController())

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
@@ -28,8 +28,8 @@ class AddKServerFragment : Fragment3(R.layout.sync_add_new_kserver_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true, bottom = true)
-            insetsPadding(ui.toolbar, top = true)
+            insetsPadding(ui.root, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
@@ -39,8 +39,8 @@ class KServerLinkClientFragment : Fragment3(R.layout.sync_kserver_link_client_fr
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true, bottom = true)
-            insetsPadding(ui.toolbar, top = true)
+            insetsPadding(ui.root, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
@@ -28,8 +28,8 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, left = true, right = true, bottom = true)
-            insetsPadding(ui.toolbar, top = true)
+            insetsPadding(ui.root, bottom = true)
+            insetsPadding(ui.toolbar, top = true, left = true, right = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -69,8 +69,6 @@
     <style name="AppTheme" parent="BaseAppTheme">
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeCloseDrawable">@drawable/ic_baseline_close_24</item>
-        <item name="android:statusBarColor">?colorSurface</item>
-        <item name="android:navigationBarColor">?colorSurface</item>
     </style>
 
     <style name="AppThemeFloating" parent="BaseAppTheme">

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -70,8 +70,6 @@
     <style name="AppTheme" parent="BaseAppTheme">
         <item name="windowActionModeOverlay">true</item>
         <item name="actionModeCloseDrawable">@drawable/ic_baseline_close_24</item>
-        <item name="android:statusBarColor">?colorSurface</item>
-        <item name="android:navigationBarColor">?colorSurface</item>
         <item name="android:windowLightStatusBar">true</item>
         <item name="android:windowLightNavigationBar" tools:targetApi="27">true</item>
     </style>


### PR DESCRIPTION
## Summary

- Move left/right window insets from root views to toolbar and content views across 13 fragments, so their backgrounds extend behind side system bars
- Remove deprecated `statusBarColor`/`navigationBarColor` theme attributes that are ignored on API 35+ with enforced edge-to-edge
- Eliminates the visible color split at the toolbar-to-status-bar boundary in landscape mode

Closes #146

## Test plan

- [x] Build succeeds (`assembleDebug`)
- [x] Unit tests pass (`testDebugUnitTest`)
- [x] Verified on Pixel 8 emulator (API 36) in landscape — toolbar color extends seamlessly behind side system bars
- [ ] Verify portrait mode has no visual regression
- [ ] Verify with both DEFAULT and MATERIAL_YOU theme styles
- [ ] Verify in both light and dark modes