### PR TITLE
Upgrade AGP from 8.13.2 to 9.0.0

### DIFF
--- a/app-common-test/build.gradle.kts
+++ b/app-common-test/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("kotlin-android")
     id("kotlin-kapt")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -19,10 +20,6 @@ android {
         viewBinding = true
     }
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -32,6 +29,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -22,10 +23,6 @@ android {
         viewBinding = true
     }
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -35,6 +32,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "androidx.navigation.safeargs.kotlin")
@@ -88,26 +89,10 @@ android {
         }
     }
 
-    buildOutputs.all {
-        val variantOutputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
-        val variantName: String = variantOutputImpl.name
-
-        if (listOf("release", "beta").any { variantName.lowercase().contains(it) }) {
-            val outputFileName = packageName +
-                    "-v${defaultConfig.versionName}-${defaultConfig.versionCode}" +
-                    "-${variantName.uppercase()}.apk"
-
-            variantOutputImpl.outputFileName = outputFileName
-        }
-    }
-
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
-
-    setupCompileOptions()
-
-    setupKotlinOptions()
 
     testOptions {
         unitTests {
@@ -123,6 +108,44 @@ android {
         }
     }
 }
+
+androidComponents {
+    onVariants { variant ->
+        val buildType = variant.buildType ?: return@onVariants
+        if (buildType != "release" && buildType != "beta") return@onVariants
+
+        val formattedVariantName = variant.name
+            .replace(Regex("([a-z])([A-Z])"), "$1-$2")
+            .uppercase()
+
+        val apkFolder = variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK)
+        val loader = variant.artifacts.getBuiltArtifactsLoader()
+        val packageName = ProjectConfig.packageName
+
+        val renameTask = tasks.register("rename${variant.name.replaceFirstChar { it.uppercase() }}Apk") {
+            inputs.files(apkFolder)
+            outputs.upToDateWhen { false }
+
+            doLast {
+                val builtArtifacts = loader.load(apkFolder.get()) ?: return@doLast
+
+                builtArtifacts.elements.forEach { element ->
+                    val apkFile = File(element.outputFile)
+                    val outputFileName = "$packageName-v${element.versionName}-${element.versionCode}-$formattedVariantName.apk"
+                    if (apkFile.exists() && apkFile.name != outputFileName) {
+                        apkFile.copyTo(File(apkFile.parentFile, outputFileName), overwrite = true)
+                    }
+                }
+            }
+        }
+
+        tasks.matching { it.name == "assemble${variant.name.replaceFirstChar { it.uppercase() }}" }.configureEach {
+            finalizedBy(renameTask)
+        }
+    }
+}
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeFragment.kt
@@ -10,6 +10,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.EdgeToEdgeHelper
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
@@ -99,7 +100,7 @@ class UpgradeFragment : Fragment3(R.layout.upgrade_fragment) {
                         ${getString(R.string.upgrade_screen_restore_multiaccount_hint)}
                         """.trimIndent()
                     )
-                    setPositiveButton(R.string.general_dismiss_action) { _, _ ->
+                    setPositiveButton(CommonR.string.general_dismiss_action) { _, _ ->
 
                     }
                 }.show()

--- a/app/src/main/java/eu/darken/octi/common/ClipboardHelper.kt
+++ b/app/src/main/java/eu/darken/octi/common/ClipboardHelper.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import java.util.concurrent.locks.ReentrantLock
@@ -41,7 +41,7 @@ class ClipboardHelper @Inject constructor(
     }
 
     fun copyToClipboard(text: String) {
-        val clip = ClipData.newPlainText(context.getString(R.string.app_name), text)
+        val clip = ClipData.newPlainText(context.getString(CommonR.string.app_name), text)
         clipboard.setPrimaryClip(clip)
     }
 

--- a/app/src/main/java/eu/darken/octi/common/error/ErrorDialog.kt
+++ b/app/src/main/java/eu/darken/octi/common/error/ErrorDialog.kt
@@ -2,7 +2,7 @@ package eu.darken.octi.common.error
 
 import android.app.Activity
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 
 fun Throwable.asErrorDialogBuilder(
     activity: Activity
@@ -21,7 +21,7 @@ fun Throwable.asErrorDialogBuilder(
             ) { _, _ ->
                 localizedError.fixAction!!.invoke(activity)
             }
-            setNegativeButton(R.string.general_cancel_action) { _, _ ->
+            setNegativeButton(CommonR.string.general_cancel_action) { _, _ ->
             }
         } else {
             setPositiveButton(android.R.string.ok) { _, _ ->
@@ -30,7 +30,7 @@ fun Throwable.asErrorDialogBuilder(
 
         when {
             localizedError.infoAction != null -> {
-                setNeutralButton(R.string.general_show_details_action) { _, _ ->
+                setNeutralButton(CommonR.string.general_show_details_action) { _, _ ->
                     localizedError.infoAction!!.invoke(activity)
                 }
             }

--- a/app/src/main/java/eu/darken/octi/common/views/ThemedSwipeRefreshLayout.kt
+++ b/app/src/main/java/eu/darken/octi/common/views/ThemedSwipeRefreshLayout.kt
@@ -3,7 +3,7 @@ package eu.darken.octi.common.views
 import android.content.Context
 import android.util.AttributeSet
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import eu.darken.octi.R
+import com.google.android.material.R as MaterialR
 import eu.darken.octi.common.getColorForAttr
 
 class ThemedSwipeRefreshLayout @JvmOverloads constructor(
@@ -12,10 +12,10 @@ class ThemedSwipeRefreshLayout @JvmOverloads constructor(
 ) : SwipeRefreshLayout(context, attrs) {
 
     override fun onFinishInflate() {
-        setProgressBackgroundColorSchemeColor(context.getColorForAttr(R.attr.colorSurface))
+        setProgressBackgroundColorSchemeColor(context.getColorForAttr(MaterialR.attr.colorSurface))
         setColorSchemeColors(
-            context.getColorForAttr(R.attr.colorPrimary),
-            context.getColorForAttr(R.attr.colorPrimaryDark)
+            context.getColorForAttr(MaterialR.attr.colorPrimary),
+            context.getColorForAttr(MaterialR.attr.colorPrimaryDark)
         )
         super.onFinishInflate()
     }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardFragment.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardFragment.kt
@@ -18,6 +18,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.EdgeToEdgeHelper
 import eu.darken.octi.common.colorString
@@ -104,14 +105,14 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
 
             val baseTitle = when {
                 state.isPro -> getString(R.string.app_name_upgraded)
-                else -> getString(R.string.app_name)
+                else -> getString(CommonR.string.app_name)
             }.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
 
             toolbar.title = if (baseTitle.size == 2) {
                 val builder = SpannableStringBuilder(baseTitle[0] + " ")
                 builder.append(colorString(requireContext().getColor(R.color.colorUpgraded), baseTitle[1]))
             } else {
-                getString(R.string.app_name)
+                getString(CommonR.string.app_name)
             }
         }
 
@@ -193,7 +194,7 @@ class DashboardFragment : Fragment3(R.layout.dashboard_fragment) {
             } else if (offlineSnackbar == null && state.isOffline) {
                 offlineSnackbar = Snackbar.make(
                     ui.coordinator,
-                    getString(R.string.general_internal_not_available_msg),
+                    getString(CommonR.string.general_internal_not_available_msg),
                     Snackbar.LENGTH_INDEFINITE
                 )
                 offlineSnackbar?.show()

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/DeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/DeviceVH.kt
@@ -9,6 +9,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.RecyclerView
 import eu.darken.octi.R
+import eu.darken.octi.modules.meta.R as MetaR
 import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.DividerItemDecoration2
 import eu.darken.octi.common.lists.binding
@@ -57,7 +58,7 @@ class DeviceVH(parent: ViewGroup) :
         if (BuildConfigWrap.DEBUG) deviceLabel.append(" (#${adapterPosition + 1})")
 
         deviceSubtitle.apply {
-            val osName = getString(R.string.module_meta_android_name_x_label, meta.androidVersionName)
+            val osName = getString(MetaR.string.module_meta_android_name_x_label, meta.androidVersionName)
             text = "$osName (API ${meta.androidApiLevel})"
         }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/StaleDeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/items/perdevice/StaleDeviceVH.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.main.ui.dashboard.items.perdevice
 
 import android.view.ViewGroup
 import eu.darken.octi.R
+import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.databinding.DashboardDeviceStaleItemBinding
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.StalenessUtil
@@ -21,7 +22,7 @@ class StaleDeviceVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = { item, _ ->
         val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSyncTime)
-        staleWarningText.text = getString(R.string.sync_device_stale_warning_text, stalePeriod)
+        staleWarningText.text = getString(SyncR.string.sync_device_stale_warning_text, stalePeriod)
         manageDeviceAction.setOnClickListener { item.onManageDevice() }
     }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/support/SupportFragment.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/support/SupportFragment.kt
@@ -8,6 +8,7 @@ import androidx.preference.Preference
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.ClipboardHelper
 import eu.darken.octi.common.PrivacyPolicy
 import eu.darken.octi.common.WebpageTool
@@ -60,8 +61,8 @@ class SupportFragment : PreferenceFragment2() {
                 SupportEvent.DebugLogInfo -> MaterialAlertDialogBuilder(requireContext()).apply {
                     setTitle(R.string.support_debuglog_label)
                     setMessage(R.string.settings_debuglog_explanation)
-                    setPositiveButton(R.string.general_continue) { _, _ -> vm.toggleDebugLog(consent = true) }
-                    setNegativeButton(R.string.general_cancel_action) { _, _ -> }
+                    setPositiveButton(CommonR.string.general_continue) { _, _ -> vm.toggleDebugLog(consent = true) }
+                    setNegativeButton(CommonR.string.general_cancel_action) { _, _ -> }
                     setNeutralButton(R.string.settings_privacy_policy_label) { _, _ -> webpageTool.open(PrivacyPolicy.URL) }
                 }.show()
             }

--- a/app/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/DeviceAppsVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/DeviceAppsVH.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.modules.apps.ui.dashboard
 import android.view.ViewGroup
 import eu.darken.octi.R
 import eu.darken.octi.databinding.DashboardDeviceAppsItemBinding
+import eu.darken.octi.modules.apps.R as AppsR
 import eu.darken.octi.main.ui.dashboard.items.perdevice.PerDeviceModuleAdapter
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.modules.apps.core.AppsInfo
@@ -25,14 +26,14 @@ class DeviceAppsVH(parent: ViewGroup) :
 
         appsPrimary.apply {
             text = resources.getQuantityString(
-                R.plurals.module_apps_x_installed,
+                AppsR.plurals.module_apps_x_installed,
                 apps.installedPackages.size,
                 apps.installedPackages.size
             )
         }
         val last = apps.installedPackages.maxByOrNull { it.installedAt }
         appsSecondary.text =
-            last?.let { getString(R.string.module_apps_last_installed_x, "${it.label} (${it.versionName})") }
+            last?.let { getString(AppsR.string.module_apps_last_installed_x, "${it.label} (${it.versionName})") }
 
         itemView.setOnClickListener { item.onAppsInfoClicked() }
 

--- a/app/src/main/java/eu/darken/octi/modules/clipboard/ClipboardVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/clipboard/ClipboardVH.kt
@@ -4,7 +4,9 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.view.isGone
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.databinding.DashboardDeviceClipboardItemBinding
+import eu.darken.octi.modules.clipboard.R as ClipboardR
 import eu.darken.octi.main.ui.dashboard.items.perdevice.PerDeviceModuleAdapter
 import eu.darken.octi.module.core.ModuleData
 
@@ -24,7 +26,7 @@ class ClipboardVH(parent: ViewGroup) :
         val clip = item.data.data
 
         secondary.text = when (clip.type) {
-            ClipboardInfo.Type.EMPTY -> getString(R.string.general_empty_label)
+            ClipboardInfo.Type.EMPTY -> getString(CommonR.string.general_empty_label)
             ClipboardInfo.Type.SIMPLE_TEXT -> clip.data.utf8()
             else -> clip.data.toString()
         }.let { "\"$it\"" }
@@ -32,7 +34,7 @@ class ClipboardVH(parent: ViewGroup) :
         pasteAction.apply {
             setOnClickListener {
                 item.onPasteClicked?.invoke()
-                Toast.makeText(context, R.string.module_clipboard_copied_os_to_octi, Toast.LENGTH_SHORT).show()
+                Toast.makeText(context, ClipboardR.string.module_clipboard_copied_os_to_octi, Toast.LENGTH_SHORT).show()
             }
             setOnLongClickListener {
                 item.onClearClicked()
@@ -44,7 +46,7 @@ class ClipboardVH(parent: ViewGroup) :
         copyAction.setOnClickListener {
             it.requestFocus()
             item.onCopyClicked(clip)
-            Toast.makeText(context, R.string.module_clipboard_copied_octi_to_os, Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, ClipboardR.string.module_clipboard_copied_octi_to_os, Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsFragment.kt
@@ -9,6 +9,7 @@ import com.google.android.material.slider.Slider
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
 import eu.darken.octi.common.EdgeToEdgeHelper
+import eu.darken.octi.modules.power.R as PowerR
 import eu.darken.octi.common.isBold
 import eu.darken.octi.common.observe2
 import eu.darken.octi.common.uix.Fragment3
@@ -39,9 +40,9 @@ class PowerAlertsFragment : Fragment3(R.layout.module_power_alerts_fragment) {
         ui.lowbatteryThresholdSlider.apply {
             addOnChangeListener { _, value, _ ->
                 ui.lowbatteryThresholdSliderCaption.text = when (value) {
-                    0f -> getString(R.string.module_power_alerts_lowbattery_disabled_caption)
+                    0f -> getString(PowerR.string.module_power_alerts_lowbattery_disabled_caption)
                     else -> getString(
-                        R.string.module_power_alerts_lowbattery_slider_value_caption,
+                        PowerR.string.module_power_alerts_lowbattery_slider_value_caption,
                         "${(value * 100).toInt()}%"
                     )
                 }
@@ -61,9 +62,9 @@ class PowerAlertsFragment : Fragment3(R.layout.module_power_alerts_fragment) {
         ui.highbatteryThresholdSlider.apply {
             addOnChangeListener { _, value, _ ->
                 ui.highbatteryThresholdSliderCaption.text = when (value) {
-                    0f -> getString(R.string.module_power_alerts_highbattery_disabled_caption)
+                    0f -> getString(PowerR.string.module_power_alerts_highbattery_disabled_caption)
                     else -> getString(
-                        R.string.module_power_alerts_highbattery_slider_value_caption,
+                        PowerR.string.module_power_alerts_highbattery_slider_value_caption,
                         "${(value * 100).toInt()}%"
                     )
                 }

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/dashboard/DevicePowerVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/dashboard/DevicePowerVH.kt
@@ -5,8 +5,10 @@ import android.text.format.DateUtils
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import androidx.core.widget.ImageViewCompat
+import com.google.android.material.R as MaterialR
 import eu.darken.octi.R
 import eu.darken.octi.common.TemperatureFormatter
+import eu.darken.octi.modules.power.R as PowerR
 import eu.darken.octi.common.getColorForAttr
 import eu.darken.octi.common.isBold
 import eu.darken.octi.databinding.DashboardDevicePowerItemBinding
@@ -48,7 +50,7 @@ class DevicePowerVH(parent: ViewGroup) :
             } else {
                 ImageViewCompat.setImageTintList(
                     this,
-                    ColorStateList.valueOf(context.getColorForAttr(R.attr.colorControlNormal))
+                    ColorStateList.valueOf(context.getColorForAttr(MaterialR.attr.colorControlNormal))
                 )
             }
         }
@@ -57,22 +59,22 @@ class DevicePowerVH(parent: ViewGroup) :
             val percentTxt = (powerInfo.battery.percent * 100).toInt()
             val stateTxt = when (powerInfo.status) {
                 Status.FULL -> {
-                    getString(R.string.module_power_battery_status_full)
+                    getString(PowerR.string.module_power_battery_status_full)
                 }
 
                 Status.CHARGING -> when (powerInfo.chargeIO.speed) {
-                    ChargeIO.Speed.SLOW -> getString(R.string.module_power_battery_status_charging_slow)
-                    ChargeIO.Speed.FAST -> getString(R.string.module_power_battery_status_charging_fast)
-                    else -> getString(R.string.module_power_battery_status_charging)
+                    ChargeIO.Speed.SLOW -> getString(PowerR.string.module_power_battery_status_charging_slow)
+                    ChargeIO.Speed.FAST -> getString(PowerR.string.module_power_battery_status_charging_fast)
+                    else -> getString(PowerR.string.module_power_battery_status_charging)
                 }
 
                 Status.DISCHARGING -> when (powerInfo.chargeIO.speed) {
-                    ChargeIO.Speed.SLOW -> getString(R.string.module_power_battery_status_discharging_slow)
-                    ChargeIO.Speed.FAST -> getString(R.string.module_power_battery_status_discharging_fast)
-                    else -> getString(R.string.module_power_battery_status_discharging)
+                    ChargeIO.Speed.SLOW -> getString(PowerR.string.module_power_battery_status_discharging_slow)
+                    ChargeIO.Speed.FAST -> getString(PowerR.string.module_power_battery_status_discharging_fast)
+                    else -> getString(PowerR.string.module_power_battery_status_discharging)
                 }
 
-                else -> getString(R.string.module_power_battery_status_unknown)
+                else -> getString(PowerR.string.module_power_battery_status_unknown)
             }
             text = "$percentTxt% • $stateTxt"
 
@@ -81,7 +83,7 @@ class DevicePowerVH(parent: ViewGroup) :
                 setTextColor(context.getColor(R.color.error))
                 isBold = true
             } else {
-                setTextColor(context.getColorForAttr(R.attr.colorOnSurface))
+                setTextColor(context.getColorForAttr(MaterialR.attr.colorOnSurface))
                 isBold = false
             }
         }
@@ -90,7 +92,7 @@ class DevicePowerVH(parent: ViewGroup) :
             val estimationText = when {
                 powerInfo.status == Status.FULL && powerInfo.chargeIO.fullSince != null -> {
                     getString(
-                        R.string.module_power_battery_full_since_x,
+                        PowerR.string.module_power_battery_full_since_x,
                         DateUtils.getRelativeTimeSpanString(powerInfo.chargeIO.fullSince!!.toEpochMilli())
                     )
                 }
@@ -99,14 +101,14 @@ class DevicePowerVH(parent: ViewGroup) :
                         && powerInfo.chargeIO.fullAt != null
                         && Duration.between(Instant.now(), powerInfo.chargeIO.fullAt).isNegative -> {
                     getString(
-                        R.string.module_power_battery_full_since_x,
+                        PowerR.string.module_power_battery_full_since_x,
                         DateUtils.getRelativeTimeSpanString(powerInfo.chargeIO.fullAt!!.toEpochMilli())
                     )
                 }
 
                 powerInfo.status == Status.CHARGING && powerInfo.chargeIO.fullAt != null -> {
                     getString(
-                        R.string.module_power_battery_full_in_x,
+                        PowerR.string.module_power_battery_full_in_x,
                         DateUtils.getRelativeTimeSpanString(
                             powerInfo.chargeIO.fullAt!!.toEpochMilli(),
                             Instant.now().toEpochMilli(),
@@ -117,7 +119,7 @@ class DevicePowerVH(parent: ViewGroup) :
 
                 powerInfo.status == Status.DISCHARGING && powerInfo.chargeIO.emptyAt != null -> {
                     getString(
-                        R.string.module_power_battery_empty_in_x,
+                        PowerR.string.module_power_battery_empty_in_x,
                         DateUtils.getRelativeTimeSpanString(
                             powerInfo.chargeIO.emptyAt!!.toEpochMilli(),
                             Instant.now().toEpochMilli(),
@@ -126,7 +128,7 @@ class DevicePowerVH(parent: ViewGroup) :
                     )
                 }
 
-                else -> getString(R.string.module_power_battery_estimation_na)
+                else -> getString(PowerR.string.module_power_battery_estimation_na)
             }
 
             val temperatureText = powerInfo.battery.temp?.let {

--- a/app/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/DeviceWifiVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/DeviceWifiVH.kt
@@ -3,10 +3,12 @@ package eu.darken.octi.modules.wifi.ui.dashboard
 import android.view.ViewGroup
 import androidx.core.view.isGone
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.databinding.DashboardDeviceWifiItemBinding
 import eu.darken.octi.main.ui.dashboard.items.perdevice.PerDeviceModuleAdapter
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.modules.wifi.core.WifiInfo
+import eu.darken.octi.modules.wifi.R as WifiR
 import eu.darken.octi.modules.wifi.ui.receptIconRes
 
 
@@ -30,22 +32,22 @@ class DeviceWifiVH(parent: ViewGroup) :
             val freqText = when (wifi.currentWifi?.freqType) {
                 WifiInfo.Wifi.Type.FIVE_GHZ -> "5 Ghz"
                 WifiInfo.Wifi.Type.TWO_POINT_FOUR_GHZ -> "2.4 Ghz"
-                else -> getString(R.string.general_na_label)
+                else -> getString(CommonR.string.general_na_label)
             }
             val sig = wifi.currentWifi?.reception ?: 0f
             val reception = when {
-                sig > 0.65f -> getString(R.string.module_wifi_reception_good_label)
-                sig > 0.3f -> getString(R.string.module_wifi_reception_okay_label)
-                sig > 0.0f -> getString(R.string.module_wifi_reception_bad_label)
-                else -> getString(R.string.general_na_label)
+                sig > 0.65f -> getString(WifiR.string.module_wifi_reception_good_label)
+                sig > 0.3f -> getString(WifiR.string.module_wifi_reception_okay_label)
+                sig > 0.0f -> getString(WifiR.string.module_wifi_reception_bad_label)
+                else -> getString(CommonR.string.general_na_label)
             }
 
             text = "$freqText • $reception"
         }
 
         wifiSecondary.apply {
-            val ipText = wifi.currentWifi?.addressIpv4 ?: getString(R.string.module_wifi_unknown_ip_label)
-            val ssidText = wifi.currentWifi?.ssid ?: getString(R.string.module_wifi_unknown_ssid_label)
+            val ipText = wifi.currentWifi?.addressIpv4 ?: getString(WifiR.string.module_wifi_unknown_ip_label)
+            val ssidText = wifi.currentWifi?.ssid ?: getString(WifiR.string.module_wifi_unknown_ssid_label)
             text = "$ssidText - $ipText"
         }
 

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddFragment.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddFragment.kt
@@ -8,6 +8,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.EdgeToEdgeHelper
 import eu.darken.octi.common.WebpageTool
 import eu.darken.octi.common.lists.differ.update
@@ -55,7 +56,7 @@ class SyncAddFragment : Fragment3(R.layout.sync_add_new_fragment) {
 
     private fun showHelpDialog() = MaterialAlertDialogBuilder(requireContext()).apply {
         setMessage(R.string.sync_add_help_desc)
-        setPositiveButton(R.string.general_gotit_action) { _, _ ->
+        setPositiveButton(CommonR.string.general_gotit_action) { _, _ ->
 
         }
         setNeutralButton(R.string.documentation_label) { _, _ ->

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DefaultSyncDeviceVH.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DefaultSyncDeviceVH.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.core.view.isGone
 import eu.darken.octi.R
 import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.databinding.SyncDevicesItemDefaultBinding
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.DeviceId
@@ -39,7 +40,7 @@ class DefaultSyncDeviceVH(parent: ViewGroup) :
             val isStale = StalenessUtil.isStale(item.lastSeen)
             text = if (isStale && item.lastSeen != null) {
                 val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSeen)
-                getString(R.string.sync_device_stale_warning_text, stalePeriod)
+                getString(SyncR.string.sync_device_stale_warning_text, stalePeriod)
             } else ""
             isGone = text.isEmpty()
         }

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveStateVH.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveStateVH.kt
@@ -4,8 +4,12 @@ import android.text.format.DateUtils
 import android.text.format.Formatter
 import android.view.ViewGroup
 import androidx.core.view.isGone
+import com.google.android.material.R as MaterialR
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.getColorForAttr
+import eu.darken.octi.sync.R as SyncR
+import eu.darken.octi.syncs.gdrive.R as GDriveR
 import eu.darken.octi.databinding.SyncListItemGdriveBinding
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.ui.list.SyncListAdapter
@@ -22,8 +26,8 @@ class GDriveStateVH(parent: ViewGroup) :
         payloads: List<Any>
     ) -> Unit = { item, _ ->
         title.apply {
-            text = getString(R.string.sync_gdrive_type_label)
-            if (item.account.isAppDataScope) append(" (${getString(R.string.sync_gdrive_appdata_label)})")
+            text = getString(GDriveR.string.sync_gdrive_type_label)
+            if (item.account.isAppDataScope) append(" (${getString(GDriveR.string.sync_gdrive_appdata_label)})")
         }
 
         accountText.text = item.account.email
@@ -34,7 +38,7 @@ class GDriveStateVH(parent: ViewGroup) :
                 ?: getString(R.string.sync_last_never_label)
 
             if (item.ourState.lastError != null) {
-                setTextColor(context.getColorForAttr(R.attr.colorError))
+                setTextColor(context.getColorForAttr(MaterialR.attr.colorError))
             } else {
                 setTextColor(context.getColorForAttr(android.R.attr.textColorPrimary))
             }
@@ -54,7 +58,7 @@ class GDriveStateVH(parent: ViewGroup) :
                 val free = Formatter.formatShortFileSize(context, stats.storageFree)
                 getString(R.string.sync_quota_storage_msg, free, used, total)
             }
-            ?: getString(R.string.general_na_label)
+            ?: getString(CommonR.string.general_na_label)
 
         devicesText.text = item.ourState.devices?.let { ourDevices ->
             var deviceString = getQuantityString(R.plurals.general_devices_count_label, ourDevices.size)
@@ -67,12 +71,12 @@ class GDriveStateVH(parent: ViewGroup) :
             }
 
             deviceString
-        } ?: getString(R.string.general_na_label)
+        } ?: getString(CommonR.string.general_na_label)
 
         staleDevicesWarning.apply {
             isGone = item.staleDevicesCount == 0
             text = getQuantityString(
-                R.plurals.sync_stale_devices_info_message,
+                SyncR.plurals.sync_stale_devices_info_message,
                 item.staleDevicesCount,
                 item.staleDevicesCount
             )

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/actions/GDriveActionsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/actions/GDriveActionsFragment.kt
@@ -8,7 +8,9 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.setChecked2
+import eu.darken.octi.syncs.gdrive.R as GDriveR
 import eu.darken.octi.common.uix.BottomSheetDialogFragment2
 import eu.darken.octi.databinding.SyncActionsGdriveFragmentBinding
 
@@ -32,26 +34,26 @@ class GDriveActionsFragment : BottomSheetDialogFragment2() {
         }
         ui.disconnectAction.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext()).apply {
-                setMessage(R.string.sync_gdrive_disconnect_confirmation_desc)
+                setMessage(GDriveR.string.sync_gdrive_disconnect_confirmation_desc)
                 setPositiveButton(R.string.general_disconnect_action) { _, _ ->
                     vm.disconnct()
                 }
-                setNegativeButton(R.string.general_cancel_action) { _, _ -> }
+                setNegativeButton(CommonR.string.general_cancel_action) { _, _ -> }
             }.show()
         }
         ui.resetAction.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext()).apply {
-                setMessage(R.string.sync_gdrive_reset_confirmation_desc)
+                setMessage(GDriveR.string.sync_gdrive_reset_confirmation_desc)
                 setPositiveButton(R.string.general_reset_action) { _, _ ->
                     vm.reset()
                 }
-                setNegativeButton(R.string.general_cancel_action) { _, _ -> }
+                setNegativeButton(CommonR.string.general_cancel_action) { _, _ -> }
             }.show()
         }
         vm.state.observe2(ui) {
             title.apply {
-                text = getString(R.string.sync_gdrive_type_label)
-                if (it.account.isAppDataScope) append(" (${getString(R.string.sync_gdrive_appdata_label)})")
+                text = getString(GDriveR.string.sync_gdrive_type_label)
+                if (it.account.isAppDataScope) append(" (${getString(GDriveR.string.sync_gdrive_appdata_label)})")
             }
             subtitle.text = it.account.email
             pausedToggle.setChecked2(it.isPaused, false)

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
@@ -12,6 +12,7 @@ import androidx.navigation.ui.setupWithNavController
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
 import eu.darken.octi.common.EdgeToEdgeHelper
+import eu.darken.octi.syncs.gdrive.R as GDriveR
 import eu.darken.octi.common.uix.Fragment3
 import eu.darken.octi.common.viewbinding.viewBinding
 import eu.darken.octi.databinding.SyncAddNewGdriveFragmentBinding
@@ -45,7 +46,7 @@ class AddGDriveFragment : Fragment3(R.layout.sync_add_new_gdrive_fragment) {
                 is AddGDriveEvents.NoGoogleAccount -> {
                     Toast.makeText(
                         requireContext(),
-                        R.string.sync_gdrive_error_no_account_on_device,
+                        GDriveR.string.sync_gdrive_error_no_account_on_device,
                         Toast.LENGTH_LONG
                     ).show()
                 }

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
@@ -4,8 +4,12 @@ import android.text.format.DateUtils
 import android.text.format.Formatter
 import android.view.ViewGroup
 import androidx.core.view.isGone
+import com.google.android.material.R as MaterialR
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.getColorForAttr
+import eu.darken.octi.sync.R as SyncR
+import eu.darken.octi.syncs.kserver.R as KServerR
 import eu.darken.octi.databinding.SyncListItemKserverBinding
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.ui.list.SyncListAdapter
@@ -23,11 +27,11 @@ class KServerStateVH(parent: ViewGroup) :
     ) -> Unit = { item, _ ->
         title.text = when {
             item.credentials.serverAdress.domain.endsWith(".darken.eu") -> {
-                "${getString(R.string.sync_kserver_type_label)} (${item.credentials.serverAdress.domain})"
+                "${getString(KServerR.string.sync_kserver_type_label)} (${item.credentials.serverAdress.domain})"
             }
 
             else -> {
-                "${getString(R.string.sync_kserver_type_label)} (${item.credentials.serverAdress.address})"
+                "${getString(KServerR.string.sync_kserver_type_label)} (${item.credentials.serverAdress.address})"
             }
         }
         accountText.text = item.credentials.accountId.id
@@ -38,7 +42,7 @@ class KServerStateVH(parent: ViewGroup) :
                 ?: getString(R.string.sync_last_never_label)
 
             if (item.ourState.lastError != null) {
-                setTextColor(context.getColorForAttr(R.attr.colorError))
+                setTextColor(context.getColorForAttr(MaterialR.attr.colorError))
             } else {
                 setTextColor(context.getColorForAttr(android.R.attr.textColorPrimary))
             }
@@ -58,7 +62,7 @@ class KServerStateVH(parent: ViewGroup) :
                 val free = Formatter.formatShortFileSize(context, stats.storageFree)
                 getString(R.string.sync_quota_storage_msg, free, used, total)
             }
-            ?: getString(R.string.general_na_label)
+            ?: getString(CommonR.string.general_na_label)
 
         devicesText.text = item.ourState.devices?.let { ourDevices ->
             var deviceString = getQuantityString(R.plurals.general_devices_count_label, ourDevices.size)
@@ -71,12 +75,12 @@ class KServerStateVH(parent: ViewGroup) :
             }
 
             deviceString
-        } ?: getString(R.string.general_na_label)
+        } ?: getString(CommonR.string.general_na_label)
 
         staleDevicesWarning.apply {
             isGone = item.staleDevicesCount == 0
             text = getQuantityString(
-                R.plurals.sync_stale_devices_info_message,
+                SyncR.plurals.sync_stale_devices_info_message,
                 item.staleDevicesCount,
                 item.staleDevicesCount
             )

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/actions/KServerActionsFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/actions/KServerActionsFragment.kt
@@ -8,7 +8,9 @@ import androidx.fragment.app.viewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.setChecked2
+import eu.darken.octi.syncs.kserver.R as KServerR
 import eu.darken.octi.common.uix.BottomSheetDialogFragment2
 import eu.darken.octi.databinding.SyncActionsKserverFragmentBinding
 
@@ -33,29 +35,29 @@ class KServerActionsFragment : BottomSheetDialogFragment2() {
         ui.linkAction.setOnClickListener { vm.linkNewDevice() }
         ui.disconnectAction.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext()).apply {
-                setMessage(R.string.sync_kserver_disconnect_confirmation_desc)
+                setMessage(KServerR.string.sync_kserver_disconnect_confirmation_desc)
                 setPositiveButton(R.string.general_disconnect_action) { _, _ ->
                     vm.disconnct()
                 }
-                setNegativeButton(R.string.general_cancel_action) { _, _ ->
+                setNegativeButton(CommonR.string.general_cancel_action) { _, _ ->
 
                 }
             }.show()
         }
         ui.resetAction.setOnClickListener {
             MaterialAlertDialogBuilder(requireContext()).apply {
-                setMessage(R.string.sync_kserver_reset_confirmation_desc)
+                setMessage(KServerR.string.sync_kserver_reset_confirmation_desc)
                 setPositiveButton(R.string.general_reset_action) { _, _ ->
                     vm.reset()
                 }
-                setNegativeButton(R.string.general_cancel_action) { _, _ ->
+                setNegativeButton(CommonR.string.general_cancel_action) { _, _ ->
 
                 }
             }.show()
         }
 
         vm.state.observe2(ui) {
-            title.text = "${getString(R.string.sync_kserver_type_label)} (${it.credentials.serverAdress.domain})"
+            title.text = "${getString(KServerR.string.sync_kserver_type_label)} (${it.credentials.serverAdress.domain})"
             subtitle.text = it.credentials.accountId.id
             pausedToggle.setChecked2(it.isPaused, false)
             devicesAction.isEnabled = !it.isPaused

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
@@ -9,7 +9,9 @@ import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.BuildConfigWrap
+import eu.darken.octi.syncs.kserver.R as KServerR
 import eu.darken.octi.common.EdgeToEdgeHelper
 import eu.darken.octi.common.WebpageTool
 import eu.darken.octi.common.uix.Fragment3
@@ -97,12 +99,12 @@ class AddKServerFragment : Fragment3(R.layout.sync_add_new_kserver_fragment) {
     }
 
     private fun showAbout() = MaterialAlertDialogBuilder(requireContext()).apply {
-        setTitle(R.string.sync_kserver_about_title)
-        setMessage(R.string.sync_kserver_about_desc)
-        setPositiveButton(R.string.general_gotit_action) { _, _ ->
+        setTitle(KServerR.string.sync_kserver_about_title)
+        setMessage(KServerR.string.sync_kserver_about_desc)
+        setPositiveButton(CommonR.string.general_gotit_action) { _, _ ->
 
         }
-        setNeutralButton(R.string.sync_kserver_about_source_action) { _, _ ->
+        setNeutralButton(KServerR.string.sync_kserver_about_source_action) { _, _ ->
             webpageTool.open("https://github.com/d4rken/octi-sync-server-kotlin")
         }
     }.show()

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
@@ -12,6 +12,7 @@ import com.journeyapps.barcodescanner.BarcodeEncoder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
 import eu.darken.octi.common.EdgeToEdgeHelper
+import eu.darken.octi.syncs.kserver.R as KServerR
 import eu.darken.octi.common.error.asErrorDialogBuilder
 import eu.darken.octi.common.navigation.popBackStack
 import eu.darken.octi.common.uix.Fragment3
@@ -73,7 +74,7 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
         vm.autoNavOnNewDevice.observe2(ui) {
             Toast.makeText(
                 requireActivity(),
-                R.string.sync_kserver_link_host_device_linked_message,
+                KServerR.string.sync_kserver_link_host_device_linked_message,
                 Toast.LENGTH_LONG
             ).show()
             popBackStack()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,8 +8,9 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("com.android.tools.build:gradle:8.13.2")
+    implementation("com.android.tools.build:gradle:9.0.0")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
+    implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.1.0-1.0.29")
     implementation("com.squareup:javapoet:1.13.0")
     implementation("com.android.tools:common:31.13.2")
 }

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -1,10 +1,12 @@
 import com.android.build.gradle.BaseExtension
-import org.gradle.api.Action
 import org.gradle.api.JavaVersion
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.kotlin.dsl.DependencyHandlerScope
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 private fun DependencyHandler.implementation(dependencyNotation: Any): Dependency? =
     add("implementation", dependencyNotation)
@@ -30,27 +32,28 @@ private fun DependencyHandler.`testRuntimeOnly`(dependencyNotation: Any): Depend
 private fun DependencyHandler.`debugImplementation`(dependencyNotation: Any): Dependency? =
     add("debugImplementation", dependencyNotation)
 
-private fun BaseExtension.kotlinOptions(configure: Action<KotlinJvmOptions>): Unit =
-    (this as org.gradle.api.plugins.ExtensionAware).extensions.configure("kotlinOptions", configure)
+private fun DependencyHandler.ksp(dependencyNotation: Any): Dependency? =
+    add("ksp", dependencyNotation)
 
-fun BaseExtension.setupKotlinOptions() {
-    kotlinOptions {
-        jvmTarget = "1.8"
-        freeCompilerArgs = freeCompilerArgs + listOf(
-            "-opt-in=kotlin.ExperimentalStdlibApi",
-            "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
-            "-opt-in=kotlinx.coroutines.FlowPreview",
-            "-opt-in=kotlin.time.ExperimentalTime",
-            "-opt-in=kotlin.RequiresOptIn"
-        )
+fun Project.setupModule() {
+    extensions.configure<BaseExtension> {
+        compileOptions {
+            isCoreLibraryDesugaringEnabled = true
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
     }
-}
-
-fun BaseExtension.setupCompileOptions() {
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+    extensions.configure<KotlinAndroidProjectExtension> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_1_8)
+            freeCompilerArgs.addAll(
+                "-opt-in=kotlin.ExperimentalStdlibApi",
+                "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+                "-opt-in=kotlinx.coroutines.FlowPreview",
+                "-opt-in=kotlin.time.ExperimentalTime",
+                "-opt-in=kotlin.RequiresOptIn",
+            )
+        }
     }
 }
 
@@ -88,7 +91,7 @@ fun DependencyHandlerScope.addCoroutines() {
 fun DependencyHandlerScope.addSerialization() {
     implementation("com.squareup.moshi:moshi:${Versions.Moshi.core}")
     implementation("com.squareup.moshi:moshi-adapters:${Versions.Moshi.core}")
-    kapt("com.squareup.moshi:moshi-kotlin-codegen:${Versions.Moshi.core}")
+    ksp("com.squareup.moshi:moshi-kotlin-codegen:${Versions.Moshi.core}")
 }
 
 fun DependencyHandlerScope.addIO() {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,10 +1,10 @@
 object Versions {
     object Gradle {
-        const val buildTools = "8.4.0"
+        const val buildTools = "9.0.0"
     }
 
     object Kotlin {
-        const val core = "2.0.0"
+        const val core = "2.1.0"
         const val coroutines = "1.8.1"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-android.defaults.buildfeatures.buildconfig=true
-android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.r8.optimizedResourceShrinking=false
+android.uniquePackageNames=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri May 03 17:27:23 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/module-core/build.gradle.kts
+++ b/module-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/modules-apps/build.gradle.kts
+++ b/modules-apps/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/modules-clipboard/build.gradle.kts
+++ b/modules-clipboard/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/modules-meta/build.gradle.kts
+++ b/modules-meta/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfoSource.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfoSource.kt
@@ -11,7 +11,7 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.replayingShare
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.module.core.ModuleInfoSource
-import eu.darken.octi.modules.meta.R
+import eu.darken.octi.common.R
 import eu.darken.octi.sync.core.SyncSettings
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow

--- a/modules-power/build.gradle.kts
+++ b/modules-power/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/modules-wifi/build.gradle.kts
+++ b/modules-wifi/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/sync-core/build.gradle.kts
+++ b/sync-core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -19,10 +20,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -32,6 +29,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/syncs-gdrive/build.gradle.kts
+++ b/syncs-gdrive/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")

--- a/syncs-kserver/build.gradle.kts
+++ b/syncs-kserver/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-android")
     id("kotlin-kapt")
     id("kotlin-parcelize")
+    id("com.google.devtools.ksp")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -18,10 +19,6 @@ android {
 
     setupModuleBuildTypes()
 
-    setupCompileOptions()
-
-    setupKotlinOptions()
-
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -31,6 +28,8 @@ android {
         }
     }
 }
+
+setupModule()
 
 dependencies {
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:${Versions.Desugar.core}")


### PR DESCRIPTION
## Summary
- Upgrade Android Gradle Plugin from 8.13.2 to 9.0.0 and Gradle from 8.13 to 9.3.1
- Enable non-transitive R classes (AGP 9 default) with aliased imports across 22+ files
- Migrate Moshi codegen from kapt to KSP
- Consolidate `setupCompileOptions()` + `setupKotlinOptions()` into `setupModule()`
- Replace deprecated `buildOutputs.all` APK renaming with `androidComponents.onVariants` API
- Remove unnecessary AGP 9 opt-out flags from gradle.properties
- Fix Kotlin version mismatch (2.0.0 → 2.1.0)
- Clean up dead code in ProjectConfig.kt and fix FileInputStream leak

## Test plan
- [ ] `./gradlew assembleDebug` passes
- [ ] `./gradlew testDebugUnitTest` passes
- [ ] `./gradlew assembleFossBeta` passes (R8 verification)