### PR TITLE
Narrow release APK glob to avoid duplicate uploads

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -65,7 +65,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/beta/*.apk
+          files: app/build/outputs/apk/foss/beta/eu.darken.octi-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +77,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/release/*.apk
+          files: app/build/outputs/apk/foss/release/eu.darken.octi-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- AGP 9.0's `copyTo()`-based APK renaming leaves both the original `app-foss-*.apk` and the renamed `eu.darken.octi-*.apk` in the output directory
- The `*.apk` glob in the release workflow matched both, uploading duplicate APKs to GitHub releases
- Narrowed the glob to `eu.darken.octi-*.apk` so only the properly named APK is uploaded

## Test plan
- [ ] Verify `./gradlew assembleFossRelease` produces both files but only one matches the new glob