### PR TITLE
Add sort options to the apps list

### DIFF
--- a/app/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListFragment.kt
@@ -5,6 +5,7 @@ import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.ui.setupWithNavController
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.R
 import eu.darken.octi.common.EdgeToEdgeHelper
@@ -15,6 +16,8 @@ import eu.darken.octi.common.observe2
 import eu.darken.octi.common.uix.Fragment3
 import eu.darken.octi.common.viewbinding.viewBinding
 import eu.darken.octi.databinding.ModuleAppsListFragmentBinding
+import eu.darken.octi.modules.apps.R as AppsR
+import eu.darken.octi.modules.apps.core.AppsSortMode
 import javax.inject.Inject
 
 
@@ -36,6 +39,11 @@ class AppsListFragment : Fragment3(R.layout.module_apps_list_fragment) {
             setupWithNavController(findNavController())
             setOnMenuItemClickListener {
                 when (it.itemId) {
+                    R.id.action_sort -> {
+                        showSortDialog()
+                        true
+                    }
+
                     else -> super.onOptionsItemSelected(it)
                 }
             }
@@ -65,5 +73,19 @@ class AppsListFragment : Fragment3(R.layout.module_apps_list_fragment) {
         }
 
         super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun showSortDialog() {
+        val modes = AppsSortMode.entries
+        val labels = modes.map { it.label.get(requireContext()) as CharSequence }.toTypedArray()
+        val currentIndex = modes.indexOf(vm.listItems.value?.sortMode ?: AppsSortMode.NAME)
+
+        MaterialAlertDialogBuilder(requireContext())
+            .setTitle(AppsR.string.module_apps_sort_label)
+            .setSingleChoiceItems(labels, currentIndex) { dialog, which ->
+                vm.updateSortMode(modes[which])
+                dialog.dismiss()
+            }
+            .show()
     }
 }

--- a/app/src/main/res/drawable/ic_sort_24.xml
+++ b/app/src/main/res/drawable/ic_sort_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M3,18h6v-2L3,16v2zM3,6v2h18L21,6L3,6zM3,13h12v-2L3,11v2z" />
+</vector>

--- a/app/src/main/res/layout/module_apps_list_fragment.xml
+++ b/app/src/main/res/layout/module_apps_list_fragment.xml
@@ -12,6 +12,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:menu="@menu/menu_apps_list"
         app:title="@string/module_apps_list_title" />
 
     <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/menu/menu_apps_list.xml
+++ b/app/src/main/res/menu/menu_apps_list.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_sort"
+        android:icon="@drawable/ic_sort_24"
+        android:orderInCategory="100"
+        android:title="@string/module_apps_sort_label"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfo.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfo.kt
@@ -17,6 +17,7 @@ data class AppsInfo(
         @Json(name = "versionName") val versionName: String?,
         @Json(name = "installedAt") val installedAt: Instant,
         @Json(name = "installerPkg") val installerPkg: String?,
+        @Json(name = "updatedAt") val updatedAt: Instant? = null,
     )
 
     override fun toString(): String = "AppsInfo(size=${installedPackages.size})"

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfoSource.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfoSource.kt
@@ -44,6 +44,7 @@ class AppsInfoSource @Inject constructor(
                 AppsInfo.Pkg(
                     packageName = pkgInfo.packageName,
                     installedAt = Instant.ofEpochMilli(pkgInfo.firstInstallTime),
+                    updatedAt = Instant.ofEpochMilli(pkgInfo.lastUpdateTime),
                     versionCode = PackageInfoCompat.getLongVersionCode(pkgInfo),
                     versionName = pkgInfo.versionName,
                     label = pkgInfo.applicationInfo?.loadLabel(pm)?.toString(),

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsSettings.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsSettings.kt
@@ -29,9 +29,12 @@ class AppsSettings @Inject constructor(
 
     val includeInstaller = dataStore.createValue("module.apps.include.installer", false)
 
+    val sortMode = dataStore.createValue("module.apps.sort.mode", AppsSortMode.NAME, moshi)
+
     override val mapper: PreferenceStoreMapper = PreferenceStoreMapper(
         isEnabled,
         includeInstaller,
+        sortMode,
     )
 
     companion object {

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsSortMode.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsSortMode.kt
@@ -1,0 +1,16 @@
+package eu.darken.octi.modules.apps.core
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import eu.darken.octi.common.ca.CaString
+import eu.darken.octi.common.ca.toCaString
+import eu.darken.octi.common.preferences.EnumPreference
+import eu.darken.octi.modules.apps.R
+
+@JsonClass(generateAdapter = false)
+enum class AppsSortMode(override val label: CaString) : EnumPreference<AppsSortMode> {
+    @Json(name = "NAME") NAME(R.string.module_apps_sort_name_label.toCaString()),
+    @Json(name = "INSTALLED_AT") INSTALLED_AT(R.string.module_apps_sort_install_date_label.toCaString()),
+    @Json(name = "UPDATED_AT") UPDATED_AT(R.string.module_apps_sort_update_date_label.toCaString()),
+    ;
+}

--- a/modules-apps/src/main/res/values/strings.xml
+++ b/modules-apps/src/main/res/values/strings.xml
@@ -10,6 +10,11 @@
     <string name="module_apps_last_installed_x">Last installed app: %s</string>
     <string name="module_apps_list_title">Installed apps</string>
 
+    <string name="module_apps_sort_label">Sort</string>
+    <string name="module_apps_sort_name_label">Name</string>
+    <string name="module_apps_sort_install_date_label">Install date</string>
+    <string name="module_apps_sort_update_date_label">Update date</string>
+
     <string name="module_apps_installer_label">App installation source</string>
     <string name="module_apps_installer_desc">Sync and include information about each app’s installation source.</string>
 </resources>

--- a/modules-apps/src/test/java/eu/darken/octi/modules/apps/core/AppsInfoSerializationTest.kt
+++ b/modules-apps/src/test/java/eu/darken/octi/modules/apps/core/AppsInfoSerializationTest.kt
@@ -1,0 +1,132 @@
+package eu.darken.octi.modules.apps.core
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.adapter
+import eu.darken.octi.common.serialization.adapter.InstantAdapter
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+import java.time.Instant
+
+class AppsInfoSerializationTest : BaseTest() {
+
+    private val moshi = Moshi.Builder()
+        .add(InstantAdapter())
+        .build()
+
+    private val adapter by lazy { moshi.adapter<AppsInfo>() }
+
+    private val testPkg = AppsInfo.Pkg(
+        packageName = "com.example.app",
+        label = "Example App",
+        versionCode = 42L,
+        versionName = "1.2.3",
+        installedAt = Instant.parse("2024-01-15T10:30:00Z"),
+        installerPkg = "com.android.vending",
+        updatedAt = Instant.parse("2024-06-20T14:00:00Z"),
+    )
+
+    @Test
+    fun `serialize AppsInfo with updatedAt`() {
+        val appsInfo = AppsInfo(installedPackages = listOf(testPkg))
+
+        val json = adapter.toJson(appsInfo)
+
+        json.toComparableJson() shouldBe """
+            {
+                "installedPackages": [
+                    {
+                        "packageName": "com.example.app",
+                        "label": "Example App",
+                        "versionCode": 42,
+                        "versionName": "1.2.3",
+                        "installedAt": "2024-01-15T10:30:00Z",
+                        "installerPkg": "com.android.vending",
+                        "updatedAt": "2024-06-20T14:00:00Z"
+                    }
+                ]
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `deserialize old JSON without updatedAt field`() {
+        val oldJson = """
+            {
+                "installedPackages": [
+                    {
+                        "packageName": "com.example.app",
+                        "label": "Example App",
+                        "versionCode": 42,
+                        "versionName": "1.2.3",
+                        "installedAt": "2024-01-15T10:30:00Z",
+                        "installerPkg": "com.android.vending"
+                    }
+                ]
+            }
+        """
+
+        val result = adapter.fromJson(oldJson)
+
+        result shouldNotBe null
+        result!!.installedPackages.size shouldBe 1
+        val pkg = result.installedPackages.first()
+        pkg.packageName shouldBe "com.example.app"
+        pkg.label shouldBe "Example App"
+        pkg.versionCode shouldBe 42L
+        pkg.versionName shouldBe "1.2.3"
+        pkg.installedAt shouldBe Instant.parse("2024-01-15T10:30:00Z")
+        pkg.installerPkg shouldBe "com.android.vending"
+        pkg.updatedAt shouldBe null
+    }
+
+    @Test
+    fun `deserialize JSON with updatedAt field`() {
+        val json = """
+            {
+                "installedPackages": [
+                    {
+                        "packageName": "com.example.app",
+                        "label": "Example App",
+                        "versionCode": 42,
+                        "versionName": "1.2.3",
+                        "installedAt": "2024-01-15T10:30:00Z",
+                        "installerPkg": "com.android.vending",
+                        "updatedAt": "2024-06-20T14:00:00Z"
+                    }
+                ]
+            }
+        """
+
+        val result = adapter.fromJson(json)
+
+        result shouldNotBe null
+        val pkg = result!!.installedPackages.first()
+        pkg.updatedAt shouldBe Instant.parse("2024-06-20T14:00:00Z")
+    }
+
+    @Test
+    fun `round-trip serialization preserves all fields`() {
+        val original = AppsInfo(installedPackages = listOf(testPkg))
+
+        val json = adapter.toJson(original)
+        val deserialized = adapter.fromJson(json)
+
+        deserialized shouldNotBe null
+        deserialized!!.installedPackages.size shouldBe 1
+        val pkg = deserialized.installedPackages.first()
+        pkg shouldBe testPkg
+    }
+
+    @Test
+    fun `updatedAt null is omitted from JSON`() {
+        val pkgWithoutUpdate = testPkg.copy(updatedAt = null)
+        val appsInfo = AppsInfo(installedPackages = listOf(pkgWithoutUpdate))
+
+        val json = adapter.toJson(appsInfo)
+
+        json.contains("updatedAt") shouldBe false
+    }
+}


### PR DESCRIPTION
## Summary
- Add three sort options (Name, Install date, Update date) to the apps list screen
- Add toolbar sort icon with a single-choice dialog for selecting sort mode
- Track app update date via new `updatedAt` field in `AppsInfo.Pkg` (nullable for backward compatibility)
- Persist selected sort mode via DataStore preference
- Include serialization tests to verify backward compatibility with old JSON data

Closes #17

## Test plan
- [ ] Open apps list for a device, verify sort icon appears in toolbar
- [ ] Tap sort icon, verify dialog shows Name / Install date / Update date options
- [ ] Select each sort option and verify the list reorders correctly
- [ ] Verify sort selection persists across screen rotations and app restarts
- [ ] Verify old synced data (without `updatedAt` field) still deserializes correctly
- [ ] Run `./gradlew testDebugUnitTest` — all tests pass