### PR TITLE
Fix system bar overlap and missing scroll on sync setup screens

### DIFF
--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveFragment.kt
@@ -31,8 +31,8 @@ class AddGDriveFragment : Fragment3(R.layout.sync_add_new_gdrive_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, bottom = true)
             insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.scrollView, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.setupWithNavController(findNavController())

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/add/AddKServerFragment.kt
@@ -30,8 +30,8 @@ class AddKServerFragment : Fragment3(R.layout.sync_add_new_kserver_fragment) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, bottom = true)
             insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.scrollView, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/client/KServerLinkClientFragment.kt
@@ -39,8 +39,8 @@ class KServerLinkClientFragment : Fragment3(R.layout.sync_kserver_link_client_fr
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, bottom = true)
             insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.scrollView, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostFragment.kt
@@ -29,8 +29,8 @@ class KServerLinkHostFragment : Fragment3(R.layout.sync_kserver_link_host_fragme
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         EdgeToEdgeHelper(requireActivity()).apply {
-            insetsPadding(ui.root, bottom = true)
             insetsPadding(ui.toolbar, top = true, left = true, right = true)
+            insetsPadding(ui.scrollView, left = true, right = true, bottom = true)
         }
 
         ui.toolbar.apply {

--- a/app/src/main/res/layout/sync_add_new_gdrive_fragment.xml
+++ b/app/src/main/res/layout/sync_add_new_gdrive_fragment.xml
@@ -16,12 +16,13 @@
         app:title="@string/sync_gdrive_type_label" />
 
     <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:id="@+id/scrollView"
         app:layout_constraintTop_toBottomOf="@id/toolbar">
 
         <LinearLayout

--- a/app/src/main/res/layout/sync_add_new_kserver_fragment.xml
+++ b/app/src/main/res/layout/sync_add_new_kserver_fragment.xml
@@ -16,131 +16,127 @@
         app:menu="@menu/menu_kserver_add"
         app:title="@string/sync_kserver_type_label" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/server_group_label"
-        style="@style/TextAppearance.Material3.BodyMedium"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="32dp"
-        android:layout_marginTop="32dp"
-        android:text="@string/general_select_server_label"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+        app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-    <RadioGroup
-        android:id="@+id/server_group"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="32dp"
-        android:checkedButton="@id/server_kserver_prod_item"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/server_group_label">
-
-        <com.google.android.material.radiobutton.MaterialRadioButton
-            android:id="@+id/server_kserver_prod_item"
-            style="@style/Widget.Material3.CompoundButton.RadioButton"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="prod.kserver.octi.darken.eu (Production)"
-            android:textStyle="bold"
-            tools:ignore="HardcodedText" />
+            android:orientation="vertical"
+            android:paddingBottom="16dp">
 
-        <com.google.android.material.radiobutton.MaterialRadioButton
-            android:id="@+id/server_kserver_beta_item"
-            style="@style/Widget.Material3.CompoundButton.RadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="beta.kserver.octi.darken.eu (Beta)"
-            tools:ignore="HardcodedText" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/server_group_label"
+                style="@style/TextAppearance.Material3.BodyMedium"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="32dp"
+                android:layout_marginTop="32dp"
+                android:text="@string/general_select_server_label" />
 
-        <com.google.android.material.radiobutton.MaterialRadioButton
-            android:id="@+id/server_kserver_local_item"
-            style="@style/Widget.Material3.CompoundButton.RadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="localhost (Local)"
-            tools:ignore="HardcodedText" />
+            <RadioGroup
+                android:id="@+id/server_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="32dp"
+                android:checkedButton="@id/server_kserver_prod_item">
 
-        <com.google.android.material.radiobutton.MaterialRadioButton
-            android:id="@+id/server_kserver_custom_item"
-            style="@style/Widget.Material3.CompoundButton.RadioButton"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/sync_custom_server_label"
-            tools:ignore="HardcodedText" />
-    </RadioGroup>
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/server_kserver_prod_item"
+                    style="@style/Widget.Material3.CompoundButton.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="prod.kserver.octi.darken.eu (Production)"
+                    android:textStyle="bold"
+                    tools:ignore="HardcodedText" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/custom_server_input_layout"
-        style="@style/Widget.Material3.TextInputEditText.FilledBox"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:layout_constraintBottom_toTopOf="@id/create_new_account"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/server_group"
-        tools:visibility="visible">
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/server_kserver_beta_item"
+                    style="@style/Widget.Material3.CompoundButton.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="beta.kserver.octi.darken.eu (Beta)"
+                    tools:ignore="HardcodedText" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/custom_server_input"
-            style="@style/Widget.Material3.TextInputEditText.FilledBox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="protocol://server:port"
-            android:imeOptions="actionGo"
-            android:inputType="text"
-            tools:ignore="HardcodedText" />
-    </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/server_kserver_local_item"
+                    style="@style/Widget.Material3.CompoundButton.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="localhost (Local)"
+                    tools:ignore="HardcodedText" />
 
+                <com.google.android.material.radiobutton.MaterialRadioButton
+                    android:id="@+id/server_kserver_custom_item"
+                    style="@style/Widget.Material3.CompoundButton.RadioButton"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sync_custom_server_label"
+                    tools:ignore="HardcodedText" />
+            </RadioGroup>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/create_new_account"
-        style="@style/Widget.Material3.Button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="32dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/general_create_account_action"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/custom_server_input_layout" />
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/custom_server_input_layout"
+                style="@style/Widget.Material3.TextInputEditText.FilledBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/create_new_account_hint"
-        style="@style/TextAppearance.Material3.LabelSmall"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:gravity="center"
-        android:text="@string/sync_kserver_add_create_action_hint"
-        app:layout_constraintEnd_toEndOf="@id/create_new_account"
-        app:layout_constraintStart_toStartOf="@id/create_new_account"
-        app:layout_constraintTop_toBottomOf="@id/create_new_account" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/custom_server_input"
+                    style="@style/Widget.Material3.TextInputEditText.FilledBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="protocol://server:port"
+                    android:imeOptions="actionGo"
+                    android:inputType="text"
+                    tools:ignore="HardcodedText" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/link_existing_account"
-        style="@style/Widget.Material3.Button.TonalButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="32dp"
-        android:layout_marginTop="16dp"
-        android:text="@string/general_link_existing_action"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/create_new_account_hint" />
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/create_new_account"
+                style="@style/Widget.Material3.Button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="32dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/general_create_account_action" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/link_existing_account_hint"
-        style="@style/TextAppearance.Material3.LabelSmall"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
-        android:gravity="center"
-        android:text="@string/sync_kserver_add_link_action_hint"
-        app:layout_constraintEnd_toEndOf="@id/link_existing_account"
-        app:layout_constraintStart_toStartOf="@id/link_existing_account"
-        app:layout_constraintTop_toBottomOf="@id/link_existing_account" />
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/create_new_account_hint"
+                style="@style/TextAppearance.Material3.LabelSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:gravity="center"
+                android:text="@string/sync_kserver_add_create_action_hint" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/link_existing_account"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="32dp"
+                android:layout_marginTop="16dp"
+                android:text="@string/general_link_existing_action" />
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/link_existing_account_hint"
+                style="@style/TextAppearance.Material3.LabelSmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:gravity="center"
+                android:text="@string/sync_kserver_add_link_action_hint" />
+
+        </LinearLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/sync_kserver_link_client_fragment.xml
+++ b/app/src/main/res/layout/sync_kserver_link_client_fragment.xml
@@ -16,103 +16,110 @@
         app:subtitle="@string/sync_kserver_link_device_action"
         app:title="@string/sync_kserver_type_label" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/link_options_card"
-        style="@style/Widget.Material3.CardView.Elevated"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-        <RadioGroup
-            android:id="@+id/link_options"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="16dp">
+            android:orientation="vertical"
+            android:paddingBottom="16dp">
 
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_qrcode"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/link_options_card"
+                style="@style/Widget.Material3.CardView.Elevated"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_client_option_qrcode" />
+                android:layout_margin="16dp">
 
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_direct"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
+                <RadioGroup
+                    android:id="@+id/link_options"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp">
+
+                    <com.google.android.material.radiobutton.MaterialRadioButton
+                        android:id="@+id/link_option_qrcode"
+                        style="@style/Widget.Material3.CompoundButton.RadioButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/sync_kserver_link_client_option_qrcode" />
+
+                    <com.google.android.material.radiobutton.MaterialRadioButton
+                        android:id="@+id/link_option_direct"
+                        style="@style/Widget.Material3.CompoundButton.RadioButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/sync_kserver_link_client_option_direct" />
+
+                </RadioGroup>
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <LinearLayout
+                android:id="@+id/link_container_qrcode"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_client_option_direct" />
+                android:layout_margin="32dp"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-        </RadioGroup>
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/link_qrcode_camera_action"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/sync_kserver_link_client_startcamera_action" />
 
-    </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
 
-
-    <LinearLayout
-        android:id="@+id/link_container_qrcode"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_margin="32dp"
-        android:orientation="vertical"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card"
-        tools:visibility="visible">
-
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/link_qrcode_camera_action"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/sync_kserver_link_client_startcamera_action" />
-
-    </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/link_container_direct"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_margin="32dp"
-        android:gravity="center"
-        android:orientation="vertical"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card"
-        tools:visibility="visible">
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/link_code_actual_container"
-            style="@style/Widget.Material3.TextInputLayout.FilledBox"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/link_code_actual"
-                style="@style/Widget.Material3.TextInputEditText.FilledBox"
+            <LinearLayout
+                android:id="@+id/link_container_direct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:imeOptions="actionGo"
-                android:inputType="text"
-                android:hint="@string/sync_kserver_link_code_label" />
+                android:layout_margin="32dp"
+                android:gravity="center"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/link_code_actual_container"
+                    style="@style/Widget.Material3.TextInputLayout.FilledBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/link_code_input_action"
-            style="@style/Widget.Material3.Button"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="32dp"
-            android:layout_marginTop="16dp"
-            android:text="@string/sync_kserver_link_client_link_action" />
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/link_code_actual"
+                        style="@style/Widget.Material3.TextInputEditText.FilledBox"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/sync_kserver_link_code_label"
+                        android:imeOptions="actionGo"
+                        android:inputType="text" />
 
-    </LinearLayout>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/link_code_input_action"
+                    style="@style/Widget.Material3.Button"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="32dp"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/sync_kserver_link_client_link_action" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+    </ScrollView>
 
     <FrameLayout
         android:id="@+id/busy_container"

--- a/app/src/main/res/layout/sync_kserver_link_host_fragment.xml
+++ b/app/src/main/res/layout/sync_kserver_link_host_fragment.xml
@@ -16,118 +16,110 @@
         app:subtitle="@string/sync_kserver_link_device_action"
         app:title="@string/sync_kserver_type_label" />
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/link_options_card"
-        style="@style/Widget.Material3.CardView.Elevated"
+    <ScrollView
+        android:id="@+id/scrollView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-        <RadioGroup
-            android:id="@+id/link_options"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="16dp">
-
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_qrcode"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_host_option_qrcode" />
-
-            <com.google.android.material.radiobutton.MaterialRadioButton
-                android:id="@+id/link_option_direct"
-                style="@style/Widget.Material3.CompoundButton.RadioButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/sync_kserver_link_host_option_direct" />
-
-        </RadioGroup>
-    </com.google.android.material.card.MaterialCardView>
-
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/link_container_qrcode"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="vertical"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card"
-        tools:visibility="visible">
-
-        <androidx.constraintlayout.utils.widget.ImageFilterView
-            android:id="@+id/qrcode_image"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_margin="8dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintDimensionRatio="1:1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:background="@color/seed" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <ScrollView
-        android:id="@+id/link_container_direct"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/link_options_card"
-        tools:visibility="visible">
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingBottom="16dp">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/sharecode_label"
-                style="@style/TextAppearance.Material3.LabelLarge"
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/link_options_card"
+                style="@style/Widget.Material3.CardView.Elevated"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="32dp"
-                android:layout_marginTop="32dp"
-                android:text="@string/sync_kserver_link_code_label"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/toolbar" />
+                android:layout_margin="16dp">
 
-            <com.google.android.material.textview.MaterialTextView
-                android:id="@+id/link_code_actual"
-                style="@style/TextAppearance.Material3.BodyLarge"
+                <RadioGroup
+                    android:id="@+id/link_options"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp">
+
+                    <com.google.android.material.radiobutton.MaterialRadioButton
+                        android:id="@+id/link_option_qrcode"
+                        style="@style/Widget.Material3.CompoundButton.RadioButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/sync_kserver_link_host_option_qrcode" />
+
+                    <com.google.android.material.radiobutton.MaterialRadioButton
+                        android:id="@+id/link_option_direct"
+                        style="@style/Widget.Material3.CompoundButton.RadioButton"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/sync_kserver_link_host_option_direct" />
+
+                </RadioGroup>
+            </com.google.android.material.card.MaterialCardView>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/link_container_qrcode"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="32dp"
-                android:layout_marginTop="8dp"
-                android:textIsSelectable="true"
-                android:textStyle="italic"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/sharecode_label"
-                tools:text="@tools:sample/lorem/random" />
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/link_code_input_action"
+                <androidx.constraintlayout.utils.widget.ImageFilterView
+                    android:id="@+id/qrcode_image"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:layout_margin="8dp"
+                    app:layout_constraintDimensionRatio="1:1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:background="@color/seed" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <LinearLayout
+                android:id="@+id/link_container_direct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="32dp"
-                android:layout_marginBottom="32dp"
-                android:layout_marginTop="16dp"
-                android:text="@string/general_share_action"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/link_code_actual" />
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/sharecode_label"
+                    style="@style/TextAppearance.Material3.LabelLarge"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="32dp"
+                    android:layout_marginTop="32dp"
+                    android:text="@string/sync_kserver_link_code_label" />
+
+                <com.google.android.material.textview.MaterialTextView
+                    android:id="@+id/link_code_actual"
+                    style="@style/TextAppearance.Material3.BodyLarge"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="32dp"
+                    android:layout_marginTop="8dp"
+                    android:textIsSelectable="true"
+                    android:textStyle="italic"
+                    tools:text="@tools:sample/lorem/random" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/link_code_input_action"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="32dp"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginBottom="32dp"
+                    android:text="@string/general_share_action" />
+
+            </LinearLayout>
 
         </LinearLayout>
     </ScrollView>


### PR DESCRIPTION
## Summary
- K-Server Add, Link Client, Link Host, and GDrive Add screens had content overlapping the navigation bar in landscape mode
- K-Server screens also lacked scrolling, cutting off bottom content (e.g. "Link existing account" button)
- Wrapped content in `ScrollView` with `clipToPadding="false"` and applied left/right/bottom insets to scroll area instead of root

## Test plan
- [ ] Verify K-Server Add screen scrolls and respects nav bar in landscape
- [ ] Verify K-Server Link Client/Host screens respect nav bar in landscape
- [ ] Verify GDrive Add screen respects nav bar in landscape
- [ ] Verify all screens look correct in portrait mode