### PR TITLE
Replace sync interval SeekBar with slider and text input dialog

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/preferences/SliderInputPreference.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/preferences/SliderInputPreference.kt
@@ -1,0 +1,106 @@
+package eu.darken.octi.common.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import androidx.preference.Preference
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.slider.Slider
+import com.google.android.material.textfield.TextInputEditText
+import eu.darken.octi.common.R
+
+class SliderInputPreference @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
+) : Preference(context, attrs, defStyleAttr) {
+
+    private var minValue: Int = 15
+    private var maxValue: Int = 1440
+    private var stepSize: Int = 15
+
+    init {
+        context.obtainStyledAttributes(attrs, R.styleable.SliderInputPreference).apply {
+            minValue = getInteger(R.styleable.SliderInputPreference_minValue, 15)
+            maxValue = getInteger(R.styleable.SliderInputPreference_maxValue, 1440)
+            stepSize = getInteger(R.styleable.SliderInputPreference_stepSize, 15)
+            recycle()
+        }
+    }
+
+    override fun onSetInitialValue(defaultValue: Any?) {
+        val defVal = (defaultValue as? Int) ?: minValue
+        val currentValue = getPersistedInt(defVal)
+        updateSummary(currentValue)
+    }
+
+    override fun onGetDefaultValue(a: android.content.res.TypedArray, index: Int): Any {
+        return a.getInt(index, minValue)
+    }
+
+    override fun onClick() {
+        val currentValue = getPersistedInt(minValue)
+        val dialogView = LayoutInflater.from(context).inflate(R.layout.preference_slider_input_dialog, null)
+
+        val slider = dialogView.findViewById<Slider>(R.id.slider)
+        val textInput = dialogView.findViewById<TextInputEditText>(R.id.text_input)
+
+        slider.valueFrom = minValue.toFloat()
+        slider.valueTo = maxValue.toFloat()
+        slider.stepSize = stepSize.toFloat()
+        slider.value = currentValue.toFloat().coerceIn(slider.valueFrom, slider.valueTo).let { value ->
+            // Snap to nearest step for the slider
+            val steps = ((value - slider.valueFrom) / slider.stepSize).toInt()
+            (slider.valueFrom + steps * slider.stepSize).coerceIn(slider.valueFrom, slider.valueTo)
+        }
+
+        textInput.setText(currentValue.toString())
+
+        var updatingFromSlider = false
+        var updatingFromText = false
+
+        slider.addOnChangeListener { _, value, fromUser ->
+            if (fromUser && !updatingFromText) {
+                updatingFromSlider = true
+                textInput.setText(value.toInt().toString())
+                updatingFromSlider = false
+            }
+        }
+
+        textInput.addTextChangedListener(object : android.text.TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) = Unit
+            override fun afterTextChanged(s: android.text.Editable?) {
+                if (updatingFromSlider) return
+                val typed = s?.toString()?.toIntOrNull() ?: return
+                if (typed < minValue || typed > maxValue) return
+                updatingFromText = true
+                val snapped = typed.toFloat().let { value ->
+                    val steps = ((value - slider.valueFrom) / slider.stepSize).toInt()
+                    (slider.valueFrom + steps * slider.stepSize).coerceIn(slider.valueFrom, slider.valueTo)
+                }
+                slider.value = snapped
+                updatingFromText = false
+            }
+        })
+
+        MaterialAlertDialogBuilder(context)
+            .setTitle(title)
+            .setView(dialogView)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                val newValue = textInput.text?.toString()?.toIntOrNull()
+                    ?.coerceIn(minValue, maxValue)
+                    ?: currentValue
+                if (callChangeListener(newValue)) {
+                    persistInt(newValue)
+                    updateSummary(newValue)
+                }
+            }
+            .setNegativeButton(R.string.general_cancel_action, null)
+            .show()
+    }
+
+    private fun updateSummary(value: Int) {
+        summary = context.getString(R.string.preference_slider_input_summary, value)
+    }
+}

--- a/app-common/src/main/res/layout/preference_slider_input_dialog.xml
+++ b/app-common/src/main/res/layout/preference_slider_input_dialog.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="16dp">
+
+    <com.google.android.material.slider.Slider
+        android:id="@+id/slider"
+        style="@style/Widget.Material3.Slider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/text_input_layout"
+        style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/general_minutes_label">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+</LinearLayout>

--- a/app-common/src/main/res/values/attrs.xml
+++ b/app-common/src/main/res/values/attrs.xml
@@ -1,3 +1,9 @@
 <resources>
     <bool name="isTablet">false</bool>
+
+    <declare-styleable name="SliderInputPreference">
+        <attr name="minValue" format="integer" />
+        <attr name="maxValue" format="integer" />
+        <attr name="stepSize" format="integer" />
+    </declare-styleable>
 </resources>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -23,4 +23,6 @@
     <string name="general_refresh_action">Refresh</string>
     <string name="general_continue">Continue</string>
     <string name="general_show_details_action">Show details</string>
+    <string name="general_minutes_label">Minutes</string>
+    <string name="preference_slider_input_summary">%1$d minutes</string>
 </resources>

--- a/app/src/main/res/xml/preferences_sync.xml
+++ b/app/src/main/res/xml/preferences_sync.xml
@@ -16,15 +16,14 @@
             android:summary="@string/sync_setting_background_enable_desc"
             android:title="@string/sync_setting_background_enable_title" />
 
-        <SeekBarPreference
+        <eu.darken.octi.common.preferences.SliderInputPreference
             android:defaultValue="60"
             android:icon="@drawable/ic_baseline_av_timer_24"
             android:key="sync.background.interval.minutes"
-            android:max="1440"
-            android:summary="@string/sync_setting_interval_desc"
             android:title="@string/sync_setting_interval_label"
-            app:min="15"
-            app:showSeekBarValue="true" />
+            app:minValue="15"
+            app:maxValue="1440"
+            app:stepSize="15" />
 
         <CheckBoxPreference
             android:defaultValue="true"


### PR DESCRIPTION
## Summary
- Replace the `SeekBarPreference` for sync interval with a new `SliderInputPreference` that opens a Material dialog
- Dialog contains both a slider (15-minute steps) for rough selection and a text input for precise minute entry
- Slider and text input sync bidirectionally; text input value is persisted on confirm

Closes #101, closes #13, closes #23

## Test plan
- [ ] Open Settings → Sync → tap "Sync interval"
- [ ] Verify dialog shows slider (snapped to 15-min steps) and text input with current value
- [ ] Verify slider ↔ text input sync bidirectionally
- [ ] Verify typing a precise value (e.g., 37) persists correctly
- [ ] Verify values outside 15–1440 are clamped
- [ ] Verify disabling "Background synchronization" still grays out the interval preference