### PR TITLE
Add Droidify and F-Droid Basic as recognized installers

### DIFF
--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfoExtensions.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfoExtensions.kt
@@ -8,7 +8,10 @@ import eu.darken.octi.modules.apps.R
 @get:DrawableRes
 val AppsInfo.Pkg?.installerIconRes: Int
     get() = when (this?.installerPkg) {
-        "org.fdroid.fdroid" -> R.drawable.ic_f_droid_24
+        "org.fdroid.fdroid",
+        "org.fdroid.basic",
+        "com.looker.droidify",
+        -> R.drawable.ic_f_droid_24
         "com.amazon.venezia" -> R.drawable.ic_amazon_24
         "com.sec.android.app.samsungapps" -> R.drawable.ic_galaxy_store_24
         null -> R.drawable.ic_human_dolly_24
@@ -16,10 +19,13 @@ val AppsInfo.Pkg?.installerIconRes: Int
     }
 
 fun AppsInfo.Pkg.getInstallerIntent(): Pair<Intent, Intent> = when (installerPkg) {
-    "org.fdroid.fdroid" -> {
+    "org.fdroid.fdroid",
+    "org.fdroid.basic",
+    "com.looker.droidify",
+    -> {
         val main = Intent(Intent.ACTION_VIEW).apply {
             data = Uri.parse("fdroid://details?id=${packageName}")
-            setPackage("org.fdroid.fdroid")
+            setPackage(installerPkg)
         }
         val fallback = Intent(Intent.ACTION_VIEW).apply {
             data = Uri.parse("https://f-droid.org/packages/${packageName}/")


### PR DESCRIPTION
## Summary

- Recognize `com.looker.droidify` (Droidify) and `org.fdroid.basic` (F-Droid Basic) as F-Droid clients
- Show the F-Droid icon instead of Google Play for apps installed by these clients
- Use `installerPkg` dynamically for the deep link intent so the correct client opens

Closes #83