### PR TITLE
Redesign battery widget with rounded bars and Material You colors

### DIFF
--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widgetContainerBackground" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/widget_bar_progress.xml
+++ b/app/src/main/res/drawable/widget_bar_progress.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle">
+            <solid android:color="@color/widgetBarTrack" />
+            <corners android:radius="12dp" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape android:shape="rectangle">
+                <solid android:color="@color/widgetBarFill" />
+                <corners android:radius="12dp" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/widget_battery_charging_full_24.xml
+++ b/app/src/main/res/drawable/widget_battery_charging_full_24.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/widgetOnBackground"
+        android:fillColor="@color/widgetBarIcon"
         android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4zM11,20v-5.5H9L13,7v5.5h2L11,20z" />
 </vector>

--- a/app/src/main/res/drawable/widget_battery_full_24.xml
+++ b/app/src/main/res/drawable/widget_battery_full_24.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/widgetOnBackground"
+        android:fillColor="@color/widgetBarIcon"
         android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4z" />
 </vector>

--- a/app/src/main/res/layout/module_power_widget_row.xml
+++ b/app/src/main/res/layout/module_power_widget_row.xml
@@ -1,52 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingTop="1dp"
+    android:paddingBottom="1dp">
 
-    <ImageView
-        android:id="@+id/battery_icon"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_alignTop="@id/device_label"
-        android:layout_alignBottom="@id/battery_progressbar"
-        android:layout_alignParentStart="true"
-        android:src="@drawable/widget_battery_full_24" />
-
-    <TextView
-        android:id="@+id/device_label"
-        style="@style/BatteryWidget.TextPrimary"
+    <FrameLayout
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:singleLine="true"
-        android:ellipsize="end"
-        android:layout_alignStart="@id/battery_progressbar"
-        android:layout_alignParentTop="true"
-        android:layout_marginEnd="8dp"
-        android:layout_toStartOf="@id/charge_percent"
-        android:text="Pixel 6"
-        android:textStyle="bold" />
+        android:layout_height="30dp"
+        android:layout_weight="1">
+
+        <ProgressBar
+            android:id="@+id/battery_progressbar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:indeterminate="false"
+            android:max="100"
+            android:progress="60"
+            android:progressDrawable="@drawable/widget_bar_progress" />
+
+        <ImageView
+            android:id="@+id/battery_icon"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:layout_gravity="center_vertical|start"
+            android:layout_marginStart="10dp"
+            android:src="@drawable/widget_battery_full_24" />
+
+        <TextView
+            android:id="@+id/device_label"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginStart="34dp"
+            android:layout_marginEnd="4dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            android:text="Pixel 6"
+            android:textColor="@color/widgetBarIcon"
+            android:textSize="11sp" />
+
+    </FrameLayout>
 
     <TextView
         android:id="@+id/charge_percent"
-        style="@style/BatteryWidget.TextSecondary"
-        android:layout_width="wrap_content"
+        style="@style/BatteryWidget.TextPercent"
+        android:layout_width="44dp"
         android:layout_height="wrap_content"
-        android:layout_above="@id/battery_progressbar"
-        android:layout_alignParentTop="true"
-        android:layout_alignParentEnd="true"
-        android:gravity="center"
-        android:text="60%"
-        android:textSize="12sp" />
+        android:gravity="end"
+        android:text="60%" />
 
-    <ProgressBar
-        android:id="@+id/battery_progressbar"
-        style="?android:attr/progressBarStyleHorizontal"
-        android:layout_width="match_parent"
-        android:layout_height="8dp"
-        android:layout_below="@id/device_label"
-        android:layout_alignParentEnd="true"
-        android:layout_toEndOf="@id/battery_icon"
-        android:indeterminate="false"
-        android:max="100"
-        android:progress="60" />
-</RelativeLayout>
+</LinearLayout>

--- a/app/src/main/res/values-night-v31/colors.xml
+++ b/app/src/main/res/values-night-v31/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material You dynamic colors for battery widget (Android 12+, dark mode) -->
+    <color name="widgetContainerBackground">@android:color/system_accent1_700</color>
+    <color name="widgetBarFill">@android:color/system_accent1_100</color>
+    <color name="widgetBarTrack">#33FFFFFF</color>
+    <color name="widgetBarIcon">@android:color/system_accent1_700</color>
+    <color name="widgetOnContainer">@android:color/system_accent1_100</color>
+</resources>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -147,4 +147,9 @@
     <color name="widgetOnBackground">@color/md_theme_onBackground</color>
     <color name="widgetPrimary">@color/md_theme_primary</color>
     <color name="widgetOnPrimary">@color/md_theme_onPrimary</color>
+    <color name="widgetContainerBackground">@color/md_theme_primaryContainer</color>
+    <color name="widgetBarFill">@color/md_theme_onPrimaryContainer</color>
+    <color name="widgetBarTrack">#33FFFFFF</color>
+    <color name="widgetBarIcon">@color/md_theme_primaryContainer</color>
+    <color name="widgetOnContainer">@color/md_theme_onPrimaryContainer</color>
 </resources>

--- a/app/src/main/res/values-v31/colors.xml
+++ b/app/src/main/res/values-v31/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Material You dynamic colors for battery widget (Android 12+, light mode) -->
+    <color name="widgetContainerBackground">@android:color/system_accent1_600</color>
+    <color name="widgetBarFill">@android:color/system_accent1_100</color>
+    <color name="widgetBarTrack">#33FFFFFF</color>
+    <color name="widgetBarIcon">@android:color/system_accent1_900</color>
+    <color name="widgetOnContainer">@android:color/system_accent1_0</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -151,4 +151,9 @@
     <color name="widgetOnBackground">@color/md_theme_onBackground</color>
     <color name="widgetPrimary">@color/md_theme_primary</color>
     <color name="widgetOnPrimary">@color/md_theme_onPrimary</color>
+    <color name="widgetContainerBackground">@color/md_theme_primary</color>
+    <color name="widgetBarFill">@color/md_theme_primaryContainer</color>
+    <color name="widgetBarTrack">#33FFFFFF</color>
+    <color name="widgetBarIcon">@color/md_theme_onPrimaryContainer</color>
+    <color name="widgetOnContainer">@color/md_theme_onPrimary</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,20 +17,14 @@
     </style>
 
     <style name="BatteryWidget.Container">
-        <item name="android:background">?android:attr/colorBackground</item>
-        <item name="android:theme">@style/Theme.Material3.DynamicColors.DayNight</item>
-        <item name="android:paddingStart">4dp</item>
-        <item name="android:paddingEnd">8dp</item>
-        <item name="android:paddingTop">4dp</item>
-        <item name="android:paddingBottom">4dp</item>
-        <!--        <item name="android:background">@color/widgetBackground</item>-->
+        <item name="android:background">@drawable/widget_background</item>
+        <item name="android:clipToOutline">true</item>
+        <item name="android:padding">8dp</item>
     </style>
 
-    <style name="BatteryWidget.TextPrimary">
-        <item name="android:textColor">?android:attr/textColorPrimary</item>
-    </style>
-
-    <style name="BatteryWidget.TextSecondary">
-        <item name="android:textColor">?android:attr/textColorSecondary</item>
+    <style name="BatteryWidget.TextPercent">
+        <item name="android:textColor">@color/widgetOnContainer</item>
+        <item name="android:textSize">13sp</item>
+        <item name="android:textStyle">bold</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/battery_widget_info.xml
+++ b/app/src/main/res/xml/battery_widget_info.xml
@@ -12,4 +12,5 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:widgetFeatures="reconfigurable|configuration_optional"
+    android:radius="16dp"
     tools:targetApi="s" />


### PR DESCRIPTION
## Summary
- Redesign widget rows as tall rounded pill-shaped progress bars with device icon, name, and last-seen time inline
- Add rounded 16dp corners to widget container with `android:radius` for Android 12+ system cooperation
- Add Material You dynamic color support on Android 12+ via `system_accent1_*`, falling back to static theme colors on older versions
- Limit visible rows based on widget height to prevent clipped/broken rows at the bottom
- Add dedicated widget color palette (container, bar fill, bar track, icon, text) for both light and dark themes

Closes #18

## Test plan
- [ ] Deploy to device and add battery widget to home screen
- [ ] Verify rounded corners on container and progress bars
- [ ] Verify device name (bold) and last-seen time display inline on bars
- [ ] Resize widget vertically — rows that don't fit should be hidden, not clipped
- [ ] Test in both light and dark mode
- [ ] Test on Android 12+ to verify Material You dynamic colors adapt to wallpaper
- [ ] Test on pre-Android 12 device to verify static green theme fallback
- [ ] Verify widget preview in widget picker looks correct