### PR TITLE
Fix KT-73255 annotation default target warning

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -47,6 +47,7 @@ fun Project.setupModule() {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_1_8)
             freeCompilerArgs.addAll(
+                "-Xannotation-default-target=param-property",
                 "-opt-in=kotlin.ExperimentalStdlibApi",
                 "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
                 "-opt-in=kotlinx.coroutines.FlowPreview",


### PR DESCRIPTION
## Summary
- Add `-Xannotation-default-target=param-property` compiler flag to `setupModule()` in `Dependencies.kt`
- Opts into the new Kotlin annotation target behavior globally, suppressing KT-73255 warnings across all modules

## Test plan
- [x] `./gradlew assembleDebug` builds successfully with no KT-73255 warnings