### PR TITLE
Add detail bottom sheets for all dashboard module rows

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -323,6 +323,9 @@ class DashboardVM @Inject constructor(
         onSettingsAction = {
             DashboardFragmentDirections.actionDashFragmentToPowerAlertsFragment(deviceId).navigate()
         }.takeIf { deviceId != syncSettings.deviceId },
+        onDetailClicked = {
+            DashboardFragmentDirections.actionDashFragmentToPowerDetailFragment(deviceId).navigate()
+        },
     )
 
     private fun ModuleData<WifiInfo>.createVHItem(
@@ -346,7 +349,10 @@ class DashboardVM @Inject constructor(
                         }
                     ).run { dashboardEvents.postValue(this) }
                 }
-            }
+            },
+        onDetailClicked = {
+            DashboardFragmentDirections.actionDashFragmentToWifiDetailFragment(deviceId).navigate()
+        },
     )
 
     private fun ModuleData<AppsInfo>.createVHItem() = DeviceAppsVH.Item(
@@ -375,7 +381,10 @@ class DashboardVM @Inject constructor(
         onClearClicked = { launch { clipboardHandler.setSharedClipboard(ClipboardInfo()) } },
         onPasteClicked = { launch { clipboardHandler.shareCurrentOSClipboard() } }
             .takeIf { deviceId == syncSettings.deviceId },
-        onCopyClicked = { launch { clipboardHandler.setOSClipboard(data) } }
+        onCopyClicked = { launch { clipboardHandler.setOSClipboard(data) } },
+        onDetailClicked = {
+            DashboardFragmentDirections.actionDashFragmentToClipboardDetailFragment(deviceId).navigate()
+        },
     )
 
 

--- a/app/src/main/java/eu/darken/octi/modules/clipboard/ClipboardVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/clipboard/ClipboardVH.kt
@@ -48,6 +48,8 @@ class ClipboardVH(parent: ViewGroup) :
             item.onCopyClicked(clip)
             Toast.makeText(context, ClipboardR.string.module_clipboard_copied_octi_to_os, Toast.LENGTH_SHORT).show()
         }
+
+        itemView.setOnClickListener { item.onDetailClicked() }
     }
 
     data class Item(
@@ -56,6 +58,7 @@ class ClipboardVH(parent: ViewGroup) :
         val onClearClicked: (() -> Unit),
         val onPasteClicked: (() -> Unit)?,
         val onCopyClicked: ((ClipboardInfo) -> Unit),
+        val onDetailClicked: () -> Unit,
     ) : PerDeviceModuleAdapter.Item {
         override val stableId: Long = data.moduleId.hashCode().toLong()
     }

--- a/app/src/main/java/eu/darken/octi/modules/clipboard/ui/detail/ClipboardDetailFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/clipboard/ui/detail/ClipboardDetailFragment.kt
@@ -1,0 +1,52 @@
+package eu.darken.octi.modules.clipboard.ui.detail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.octi.common.uix.BottomSheetDialogFragment2
+import eu.darken.octi.databinding.ClipboardDetailSheetBinding
+import eu.darken.octi.modules.clipboard.ClipboardInfo
+import eu.darken.octi.modules.clipboard.R as ClipboardR
+
+@AndroidEntryPoint
+class ClipboardDetailFragment : BottomSheetDialogFragment2() {
+
+    override val vm: ClipboardDetailVM by viewModels()
+    override lateinit var ui: ClipboardDetailSheetBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        ui = ClipboardDetailSheetBinding.inflate(inflater, container, false)
+        return ui.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        ui.copyAction.setOnClickListener {
+            vm.copyToClipboard()
+            Toast.makeText(
+                requireContext(),
+                ClipboardR.string.module_clipboard_copied_octi_to_os,
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
+
+        vm.state.observe2(ui) { state ->
+            val clip = state.clipboardData?.data ?: return@observe2
+
+            typeValue.text = when (clip.type) {
+                ClipboardInfo.Type.EMPTY -> getString(ClipboardR.string.module_clipboard_detail_type_empty)
+                ClipboardInfo.Type.SIMPLE_TEXT -> getString(ClipboardR.string.module_clipboard_detail_type_text)
+            }
+
+            contentValue.text = when (clip.type) {
+                ClipboardInfo.Type.EMPTY -> ""
+                ClipboardInfo.Type.SIMPLE_TEXT -> clip.data.utf8()
+            }
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/eu/darken/octi/modules/clipboard/ui/detail/ClipboardDetailVM.kt
+++ b/app/src/main/java/eu/darken/octi/modules/clipboard/ui/detail/ClipboardDetailVM.kt
@@ -1,0 +1,45 @@
+package eu.darken.octi.modules.clipboard.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.navigation.navArgs
+import eu.darken.octi.common.uix.ViewModel3
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.modules.clipboard.ClipboardHandler
+import eu.darken.octi.modules.clipboard.ClipboardInfo
+import eu.darken.octi.modules.clipboard.ClipboardRepo
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class ClipboardDetailVM @Inject constructor(
+    handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    clipboardRepo: ClipboardRepo,
+    private val clipboardHandler: ClipboardHandler,
+) : ViewModel3(dispatcherProvider = dispatcherProvider) {
+
+    private val navArgs: ClipboardDetailFragmentArgs by handle.navArgs()
+
+    data class State(
+        val clipboardData: ModuleData<ClipboardInfo>? = null,
+    )
+
+    val state = clipboardRepo.state
+        .map { repoState ->
+            val data = repoState.all.firstOrNull { it.deviceId == navArgs.deviceId }
+            State(clipboardData = data)
+        }
+        .asLiveData2()
+
+    fun copyToClipboard() = launch {
+        val info = state.value?.clipboardData?.data ?: return@launch
+        clipboardHandler.setOSClipboard(info)
+    }
+
+    companion object {
+        private val TAG = logTag("Module", "Clipboard", "Detail", "VM")
+    }
+}

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/detail/PowerDetailFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/detail/PowerDetailFragment.kt
@@ -1,0 +1,80 @@
+package eu.darken.octi.modules.power.ui.detail
+
+import android.os.BatteryManager
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.octi.common.TemperatureFormatter
+import eu.darken.octi.common.uix.BottomSheetDialogFragment2
+import eu.darken.octi.databinding.PowerDetailSheetBinding
+import eu.darken.octi.modules.power.R as PowerR
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.modules.power.core.PowerInfo.ChargeIO
+import eu.darken.octi.modules.power.core.PowerInfo.Status
+import eu.darken.octi.modules.power.ui.PowerEstimationFormatter
+
+@AndroidEntryPoint
+class PowerDetailFragment : BottomSheetDialogFragment2() {
+
+    override val vm: PowerDetailVM by viewModels()
+    override lateinit var ui: PowerDetailSheetBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        ui = PowerDetailSheetBinding.inflate(inflater, container, false)
+        return ui.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val temperatureFormatter = TemperatureFormatter(requireContext())
+        val estimationFormatter = PowerEstimationFormatter(requireContext())
+
+        vm.state.observe2(ui) { state ->
+            val power = state.powerData?.data ?: return@observe2
+
+            levelValue.text = "${(power.battery.percent * 100).toInt()}%"
+
+            statusValue.text = when (power.status) {
+                Status.FULL -> getString(PowerR.string.module_power_battery_status_full)
+                Status.CHARGING -> getString(PowerR.string.module_power_battery_status_charging)
+                Status.DISCHARGING -> getString(PowerR.string.module_power_battery_status_discharging)
+                Status.UNKNOWN -> getString(PowerR.string.module_power_battery_status_unknown)
+            }
+
+            speedValue.text = when (power.status) {
+                Status.CHARGING -> when (power.chargeIO.speed) {
+                    ChargeIO.Speed.SLOW -> getString(PowerR.string.module_power_battery_status_charging_slow)
+                    ChargeIO.Speed.FAST -> getString(PowerR.string.module_power_battery_status_charging_fast)
+                    ChargeIO.Speed.NORMAL -> getString(PowerR.string.module_power_battery_status_charging)
+                }
+
+                Status.DISCHARGING -> when (power.chargeIO.speed) {
+                    ChargeIO.Speed.SLOW -> getString(PowerR.string.module_power_battery_status_discharging_slow)
+                    ChargeIO.Speed.FAST -> getString(PowerR.string.module_power_battery_status_discharging_fast)
+                    ChargeIO.Speed.NORMAL -> getString(PowerR.string.module_power_battery_status_discharging)
+                }
+
+                else -> getString(eu.darken.octi.common.R.string.general_na_label)
+            }
+
+            temperatureValue.text = power.battery.temp?.let {
+                temperatureFormatter.formatTemperature(it)
+            } ?: getString(eu.darken.octi.common.R.string.general_na_label)
+
+            estimationValue.text = estimationFormatter.format(power)
+
+            healthValue.text = when (power.battery.health) {
+                BatteryManager.BATTERY_HEALTH_GOOD -> getString(PowerR.string.module_power_detail_health_good)
+                BatteryManager.BATTERY_HEALTH_OVERHEAT -> getString(PowerR.string.module_power_detail_health_overheat)
+                BatteryManager.BATTERY_HEALTH_DEAD -> getString(PowerR.string.module_power_detail_health_dead)
+                BatteryManager.BATTERY_HEALTH_OVER_VOLTAGE -> getString(PowerR.string.module_power_detail_health_over_voltage)
+                BatteryManager.BATTERY_HEALTH_COLD -> getString(PowerR.string.module_power_detail_health_cold)
+                else -> getString(PowerR.string.module_power_detail_health_unknown)
+            }
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/eu/darken/octi/modules/power/ui/detail/PowerDetailVM.kt
+++ b/app/src/main/java/eu/darken/octi/modules/power/ui/detail/PowerDetailVM.kt
@@ -1,0 +1,38 @@
+package eu.darken.octi.modules.power.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.navigation.navArgs
+import eu.darken.octi.common.uix.ViewModel3
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.modules.power.core.PowerRepo
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class PowerDetailVM @Inject constructor(
+    handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    powerRepo: PowerRepo,
+) : ViewModel3(dispatcherProvider = dispatcherProvider) {
+
+    private val navArgs: PowerDetailFragmentArgs by handle.navArgs()
+
+    data class State(
+        val powerData: ModuleData<PowerInfo>? = null,
+    )
+
+    val state = powerRepo.state
+        .map { repoState ->
+            val data = repoState.all.firstOrNull { it.deviceId == navArgs.deviceId }
+            State(powerData = data)
+        }
+        .asLiveData2()
+
+    companion object {
+        private val TAG = logTag("Module", "Power", "Detail", "VM")
+    }
+}

--- a/app/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/DeviceWifiVH.kt
+++ b/app/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/DeviceWifiVH.kt
@@ -53,11 +53,14 @@ class DeviceWifiVH(parent: ViewGroup) :
             isGone = item.onGrantPermission == null
             setOnClickListener { item.onGrantPermission?.invoke() }
         }
+
+        itemView.setOnClickListener { item.onDetailClicked() }
     }
 
     data class Item(
         val data: ModuleData<WifiInfo>,
         val onGrantPermission: (() -> Unit)?,
+        val onDetailClicked: () -> Unit,
     ) : PerDeviceModuleAdapter.Item {
         override val stableId: Long = data.moduleId.hashCode().toLong()
     }

--- a/app/src/main/java/eu/darken/octi/modules/wifi/ui/detail/WifiDetailFragment.kt
+++ b/app/src/main/java/eu/darken/octi/modules/wifi/ui/detail/WifiDetailFragment.kt
@@ -1,0 +1,50 @@
+package eu.darken.octi.modules.wifi.ui.detail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import eu.darken.octi.common.uix.BottomSheetDialogFragment2
+import eu.darken.octi.databinding.WifiDetailSheetBinding
+import eu.darken.octi.modules.wifi.R as WifiR
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.modules.wifi.core.WifiInfo
+
+@AndroidEntryPoint
+class WifiDetailFragment : BottomSheetDialogFragment2() {
+
+    override val vm: WifiDetailVM by viewModels()
+    override lateinit var ui: WifiDetailSheetBinding
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        ui = WifiDetailSheetBinding.inflate(inflater, container, false)
+        return ui.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        vm.state.observe2(ui) { state ->
+            val wifi = state.wifiData?.data ?: return@observe2
+
+            ssidValue.text = wifi.currentWifi?.ssid
+                ?: getString(WifiR.string.module_wifi_unknown_ssid_label)
+
+            frequencyValue.text = when (wifi.currentWifi?.freqType) {
+                WifiInfo.Wifi.Type.FIVE_GHZ -> getString(WifiR.string.module_wifi_freq_5ghz)
+                WifiInfo.Wifi.Type.TWO_POINT_FOUR_GHZ -> getString(WifiR.string.module_wifi_freq_2_4ghz)
+                else -> getString(CommonR.string.general_na_label)
+            }
+
+            val sig = wifi.currentWifi?.reception ?: 0f
+            signalValue.text = when {
+                sig > 0.65f -> getString(WifiR.string.module_wifi_reception_good_label)
+                sig > 0.3f -> getString(WifiR.string.module_wifi_reception_okay_label)
+                sig > 0.0f -> getString(WifiR.string.module_wifi_reception_bad_label)
+                else -> getString(CommonR.string.general_na_label)
+            }
+        }
+
+        super.onViewCreated(view, savedInstanceState)
+    }
+}

--- a/app/src/main/java/eu/darken/octi/modules/wifi/ui/detail/WifiDetailVM.kt
+++ b/app/src/main/java/eu/darken/octi/modules/wifi/ui/detail/WifiDetailVM.kt
@@ -1,0 +1,38 @@
+package eu.darken.octi.modules.wifi.ui.detail
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.navigation.navArgs
+import eu.darken.octi.common.uix.ViewModel3
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.modules.wifi.core.WifiInfo
+import eu.darken.octi.modules.wifi.core.WifiRepo
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class WifiDetailVM @Inject constructor(
+    handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+    wifiRepo: WifiRepo,
+) : ViewModel3(dispatcherProvider = dispatcherProvider) {
+
+    private val navArgs: WifiDetailFragmentArgs by handle.navArgs()
+
+    data class State(
+        val wifiData: ModuleData<WifiInfo>? = null,
+    )
+
+    val state = wifiRepo.state
+        .map { repoState ->
+            val data = repoState.all.firstOrNull { it.deviceId == navArgs.deviceId }
+            State(wifiData = data)
+        }
+        .asLiveData2()
+
+    companion object {
+        private val TAG = logTag("Module", "Wifi", "Detail", "VM")
+    }
+}

--- a/app/src/main/res/layout/clipboard_detail_sheet.xml
+++ b/app/src/main/res/layout/clipboard_detail_sheet.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Material3.TitleLarge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/module_clipboard_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/type_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_clipboard_detail_type_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/type_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="Text" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/content_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_clipboard_detail_content_label" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:maxHeight="200dp">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/content_value"
+            style="@style/TextAppearance.Material3.BodyMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textIsSelectable="true"
+            tools:text="Clipboard content goes here..." />
+    </ScrollView>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/copy_action"
+        style="@style/Widget.Material3.Button.TonalButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_clipboard_copy_action"
+        app:icon="@drawable/ic_baseline_content_copy_24"
+        app:iconGravity="textStart"
+        xmlns:app="http://schemas.android.com/apk/res-auto" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/dashboard_device_apps_item.xml
+++ b/app/src/main/res/layout/dashboard_device_apps_item.xml
@@ -5,18 +5,7 @@
     style="@style/DashboardDeviceInfoRow"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?selectableItemBackground"
-    android:paddingStart="0dp"
-    android:paddingEnd="16dp">
-
-    <ImageView
-        android:id="@+id/tap_indicator"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
-        android:src="@drawable/ic_gesture_tap_24"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:background="?selectableItemBackground">
 
     <ImageView
         android:id="@+id/apps_icon"

--- a/app/src/main/res/layout/dashboard_device_connectivity_item.xml
+++ b/app/src/main/res/layout/dashboard_device_connectivity_item.xml
@@ -5,18 +5,7 @@
     style="@style/DashboardDeviceInfoRow"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?selectableItemBackground"
-    android:paddingStart="0dp"
-    android:paddingEnd="16dp">
-
-    <ImageView
-        android:id="@+id/tap_indicator"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
-        android:src="@drawable/ic_gesture_tap_24"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    android:background="?selectableItemBackground">
 
     <ImageView
         android:id="@+id/connectivity_icon"

--- a/app/src/main/res/layout/dashboard_device_power_item.xml
+++ b/app/src/main/res/layout/dashboard_device_power_item.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/DashboardDeviceInfoRow"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground">
 
     <ImageView
         android:id="@+id/power_icon"

--- a/app/src/main/res/layout/dashboard_device_wifi_item.xml
+++ b/app/src/main/res/layout/dashboard_device_wifi_item.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/DashboardDeviceInfoRow"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground">
 
     <ImageView
         android:id="@+id/wifi_icon"

--- a/app/src/main/res/layout/power_detail_sheet.xml
+++ b/app/src/main/res/layout/power_detail_sheet.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Material3.TitleLarge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/module_power_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/level_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_level_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/level_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="68%" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/status_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_status_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/status_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="Discharging" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/speed_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_speed_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/speed_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="Normal" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/temperature_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_temperature_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/temperature_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="32°C" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/estimation_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_estimation_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/estimation_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="2 hr, 1 min remaining" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/health_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_power_detail_health_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/health_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="Good" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/wifi_detail_sheet.xml
+++ b/app/src/main/res/layout/wifi_detail_sheet.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Material3.TitleLarge"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/module_wifi_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/ssid_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_wifi_detail_ssid_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/ssid_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="MyWifiSSID" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/frequency_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_wifi_detail_frequency_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/frequency_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        tools:text="5 GHz" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/signal_label"
+        style="@style/TextAppearance.Material3.LabelMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/module_wifi_detail_signal_label" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/signal_value"
+        style="@style/TextAppearance.Material3.BodyMedium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        tools:text="Good signal" />
+
+</LinearLayout>

--- a/app/src/main/res/navigation/main.xml
+++ b/app/src/main/res/navigation/main.xml
@@ -31,6 +31,15 @@
         <action
             android:id="@+id/action_dashFragment_to_connectivityDetailFragment"
             app:destination="@id/connectivityDetailFragment" />
+        <action
+            android:id="@+id/action_dashFragment_to_powerDetailFragment"
+            app:destination="@id/powerDetailFragment" />
+        <action
+            android:id="@+id/action_dashFragment_to_wifiDetailFragment"
+            app:destination="@id/wifiDetailFragment" />
+        <action
+            android:id="@+id/action_dashFragment_to_clipboardDetailFragment"
+            app:destination="@id/clipboardDetailFragment" />
     </fragment>
 
     <fragment
@@ -193,6 +202,30 @@
         android:id="@+id/connectivityDetailFragment"
         android:name="eu.darken.octi.modules.connectivity.ui.detail.ConnectivityDetailFragment"
         tools:layout="@layout/connectivity_detail_sheet">
+        <argument
+            android:name="deviceId"
+            app:argType="eu.darken.octi.sync.core.DeviceId" />
+    </dialog>
+    <dialog
+        android:id="@+id/powerDetailFragment"
+        android:name="eu.darken.octi.modules.power.ui.detail.PowerDetailFragment"
+        tools:layout="@layout/power_detail_sheet">
+        <argument
+            android:name="deviceId"
+            app:argType="eu.darken.octi.sync.core.DeviceId" />
+    </dialog>
+    <dialog
+        android:id="@+id/wifiDetailFragment"
+        android:name="eu.darken.octi.modules.wifi.ui.detail.WifiDetailFragment"
+        tools:layout="@layout/wifi_detail_sheet">
+        <argument
+            android:name="deviceId"
+            app:argType="eu.darken.octi.sync.core.DeviceId" />
+    </dialog>
+    <dialog
+        android:id="@+id/clipboardDetailFragment"
+        android:name="eu.darken.octi.modules.clipboard.ui.detail.ClipboardDetailFragment"
+        tools:layout="@layout/clipboard_detail_sheet">
         <argument
             android:name="deviceId"
             app:argType="eu.darken.octi.sync.core.DeviceId" />

--- a/modules-clipboard/src/main/res/values/strings.xml
+++ b/modules-clipboard/src/main/res/values/strings.xml
@@ -4,4 +4,10 @@
     <string name="module_clipboard_desc">Copy and paste text between devices.</string>
     <string name="module_clipboard_copied_octi_to_os">Copied Octi to system clipboard</string>
     <string name="module_clipboard_copied_os_to_octi">Copied system to Octi clipboard</string>
+
+    <string name="module_clipboard_detail_type_label">Type</string>
+    <string name="module_clipboard_detail_content_label">Content</string>
+    <string name="module_clipboard_detail_type_empty">Empty</string>
+    <string name="module_clipboard_detail_type_text">Text</string>
+    <string name="module_clipboard_copy_action">Copy to clipboard</string>
 </resources>

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/PowerEstimationFormatter.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/PowerEstimationFormatter.kt
@@ -1,0 +1,54 @@
+package eu.darken.octi.modules.power.ui
+
+import android.content.Context
+import android.text.format.DateUtils
+import eu.darken.octi.modules.power.R
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.modules.power.core.PowerInfo.Status
+import java.time.Duration
+import java.time.Instant
+
+class PowerEstimationFormatter(private val context: Context) {
+
+    fun format(power: PowerInfo): String = when {
+        power.status == Status.FULL && power.chargeIO.fullSince != null -> {
+            context.getString(
+                R.string.module_power_battery_full_since_x,
+                DateUtils.getRelativeTimeSpanString(power.chargeIO.fullSince!!.toEpochMilli())
+            )
+        }
+
+        power.status == Status.CHARGING
+                && power.chargeIO.fullAt != null
+                && Duration.between(Instant.now(), power.chargeIO.fullAt).isNegative -> {
+            context.getString(
+                R.string.module_power_battery_full_since_x,
+                DateUtils.getRelativeTimeSpanString(power.chargeIO.fullAt!!.toEpochMilli())
+            )
+        }
+
+        power.status == Status.CHARGING && power.chargeIO.fullAt != null -> {
+            context.getString(
+                R.string.module_power_battery_full_in_x,
+                DateUtils.getRelativeTimeSpanString(
+                    power.chargeIO.fullAt!!.toEpochMilli(),
+                    Instant.now().toEpochMilli(),
+                    DateUtils.MINUTE_IN_MILLIS,
+                )
+            )
+        }
+
+        power.status == Status.DISCHARGING && power.chargeIO.emptyAt != null -> {
+            context.getString(
+                R.string.module_power_battery_empty_in_x,
+                DateUtils.getRelativeTimeSpanString(
+                    power.chargeIO.emptyAt!!.toEpochMilli(),
+                    Instant.now().toEpochMilli(),
+                    DateUtils.MINUTE_IN_MILLIS,
+                )
+            )
+        }
+
+        else -> context.getString(R.string.module_power_battery_estimation_na)
+    }
+}

--- a/modules-power/src/main/res/values/strings.xml
+++ b/modules-power/src/main/res/values/strings.xml
@@ -32,4 +32,17 @@
     <string name="module_power_alerts_highbattery_disabled_caption">Don\'t notify when battery is high</string>
     <string name="module_power_alerts_notification_battery_high_title">High battery: %s</string>
     <string name="module_power_alerts_notification_battery_high_body">%1$s is at %3$d%% battery (>%2$d%%) and still charging.</string>
+
+    <string name="module_power_detail_level_label">Battery level</string>
+    <string name="module_power_detail_status_label">Status</string>
+    <string name="module_power_detail_speed_label">Charge speed</string>
+    <string name="module_power_detail_temperature_label">Temperature</string>
+    <string name="module_power_detail_estimation_label">Estimation</string>
+    <string name="module_power_detail_health_label">Health</string>
+    <string name="module_power_detail_health_good">Good</string>
+    <string name="module_power_detail_health_overheat">Overheat</string>
+    <string name="module_power_detail_health_dead">Dead</string>
+    <string name="module_power_detail_health_over_voltage">Over voltage</string>
+    <string name="module_power_detail_health_cold">Cold</string>
+    <string name="module_power_detail_health_unknown">Unknown</string>
 </resources>

--- a/modules-wifi/src/main/res/values/strings.xml
+++ b/modules-wifi/src/main/res/values/strings.xml
@@ -7,4 +7,10 @@
     <string name="module_wifi_reception_good_label">Good signal</string>
     <string name="module_wifi_reception_okay_label">OK signal</string>
     <string name="module_wifi_reception_bad_label">Bad signal</string>
+
+    <string name="module_wifi_detail_ssid_label">SSID</string>
+    <string name="module_wifi_detail_frequency_label">Frequency</string>
+    <string name="module_wifi_detail_signal_label">Signal</string>
+    <string name="module_wifi_freq_5ghz">5 GHz</string>
+    <string name="module_wifi_freq_2_4ghz">2.4 GHz</string>
 </resources>


### PR DESCRIPTION
## Summary
- Add clickable detail bottom sheets for battery, WiFi, and clipboard module rows on the dashboard
- Remove tap indicator icons from apps and connectivity rows for consistent UX
- Add selectable ripple background to battery and WiFi rows (apps/clipboard/connectivity already had it)
- All module rows now navigate to a detail bottom sheet on tap while keeping existing inline action buttons

## Test plan
- [ ] Verify each module row shows ripple feedback on touch
- [ ] Verify tapping battery row opens power detail sheet with level, status, speed, temperature, estimation, health
- [ ] Verify tapping WiFi row opens WiFi detail sheet with SSID, frequency, signal
- [ ] Verify tapping clipboard row opens clipboard detail sheet with type, content, and copy button
- [ ] Verify existing action buttons (alert settings, permission grant, paste/copy, install) still work
- [ ] Verify apps and connectivity rows no longer show tap indicator icon