### PR TITLE
Add build type and git hash to user agent for dev builds

### DIFF
--- a/app/src/main/java/eu/darken/octi/common/http/UserAgentInterceptor.kt
+++ b/app/src/main/java/eu/darken/octi/common/http/UserAgentInterceptor.kt
@@ -9,7 +9,13 @@ import javax.inject.Inject
 @Reusable
 class UserAgentInterceptor @Inject constructor() : Interceptor {
 
-    private val userAgent = "octi/${BuildConfigWrap.VERSION_NAME}/${BuildConfigWrap.FLAVOR}"
+    private val userAgent = buildString {
+        append("octi/${BuildConfigWrap.VERSION_NAME}/${BuildConfigWrap.FLAVOR}")
+        if (BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.DEV) {
+            val sha = BuildConfigWrap.GIT_SHA.takeIf { it.isNotBlank() }
+            append(if (sha != null) "/dev-$sha" else "/dev")
+        }
+    }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val originalRequest = chain.request()

--- a/app/src/test/java/eu/darken/octi/common/http/UserAgentInterceptorTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/http/UserAgentInterceptorTest.kt
@@ -1,0 +1,77 @@
+package eu.darken.octi.common.http
+
+import eu.darken.octi.common.BuildConfigWrap
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import okhttp3.Interceptor
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class UserAgentInterceptorTest : BaseTest() {
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(BuildConfigWrap)
+        every { BuildConfigWrap.VERSION_NAME } returns "1.2.3-rc0"
+        every { BuildConfigWrap.FLAVOR } returns BuildConfigWrap.Flavor.FOSS
+    }
+
+    private fun intercept(): String {
+        val instance = UserAgentInterceptor()
+
+        val requestSlot = slot<Request>()
+        val chain = mockk<Interceptor.Chain> {
+            every { request() } returns Request.Builder().url("https://example.com").build()
+            every { proceed(capture(requestSlot)) } returns mockk<Response>()
+        }
+
+        instance.intercept(chain)
+        return requestSlot.captured.header("User-Agent")!!
+    }
+
+    @Test
+    fun `release build uses base format`() {
+        every { BuildConfigWrap.BUILD_TYPE } returns BuildConfigWrap.BuildType.RELEASE
+        every { BuildConfigWrap.GIT_SHA } returns "a1b2c3d"
+
+        intercept() shouldBe "octi/1.2.3-rc0/FOSS"
+    }
+
+    @Test
+    fun `beta build uses base format`() {
+        every { BuildConfigWrap.BUILD_TYPE } returns BuildConfigWrap.BuildType.BETA
+        every { BuildConfigWrap.GIT_SHA } returns "a1b2c3d"
+
+        intercept() shouldBe "octi/1.2.3-rc0/FOSS"
+    }
+
+    @Test
+    fun `dev build includes git sha`() {
+        every { BuildConfigWrap.BUILD_TYPE } returns BuildConfigWrap.BuildType.DEV
+        every { BuildConfigWrap.GIT_SHA } returns "a1b2c3d"
+
+        intercept() shouldBe "octi/1.2.3-rc0/FOSS/dev-a1b2c3d"
+    }
+
+    @Test
+    fun `dev build with empty git sha falls back to dev`() {
+        every { BuildConfigWrap.BUILD_TYPE } returns BuildConfigWrap.BuildType.DEV
+        every { BuildConfigWrap.GIT_SHA } returns ""
+
+        intercept() shouldBe "octi/1.2.3-rc0/FOSS/dev"
+    }
+
+    @Test
+    fun `dev build with blank git sha falls back to dev`() {
+        every { BuildConfigWrap.BUILD_TYPE } returns BuildConfigWrap.BuildType.DEV
+        every { BuildConfigWrap.GIT_SHA } returns "   "
+
+        intercept() shouldBe "octi/1.2.3-rc0/FOSS/dev"
+    }
+}


### PR DESCRIPTION
## Summary
- Dev builds now include `/dev-{gitsha}` suffix in the HTTP user agent (e.g. `octi/0.14.0-rc0/FOSS/dev-a1b2c3d`), helping trace requests back to specific builds during debugging
- Falls back to `/dev` when git SHA is unavailable
- Non-dev builds (BETA/RELEASE) keep the existing `octi/{version}/{flavor}` format unchanged

## Test plan
- [x] Unit tests added covering all branches (release, beta, dev with SHA, dev with empty SHA, dev with blank SHA)
- [ ] Verify user agent in HTTP traffic from a debug build