### PR TITLE
Auto-pause KServer connector on device auth failure

### DIFF
--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/KServerStateVH.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isGone
 import com.google.android.material.R as MaterialR
 import eu.darken.octi.R
 import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.error.localized
 import eu.darken.octi.common.getColorForAttr
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.syncs.kserver.R as KServerR
@@ -49,7 +50,7 @@ class KServerStateVH(parent: ViewGroup) :
         }
         lastSyncError.apply {
             isGone = item.ourState.lastError == null
-            text = item.ourState.lastError?.toString()
+            text = item.ourState.lastError?.localized(context)?.asText()?.get(context)
         }
 
         syncProgressIndicator.isGone = !item.ourState.isBusy

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerEndpoint.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerEndpoint.kt
@@ -160,7 +160,7 @@ class KServerEndpoint @AssistedInject constructor(
             throw KServerHttpException(e)
         }
 
-        if (!response.isSuccessful) throw HttpException(response)
+        if (!response.isSuccessful) throw KServerHttpException(HttpException(response))
 
         val lastModifiedAt = response.headers()["X-Modified-At"]
             ?.let { ZonedDateTime.parse(it, DateTimeFormatter.RFC_1123_DATE_TIME) }?.toInstant()

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerHttpException.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerHttpException.kt
@@ -3,17 +3,25 @@ package eu.darken.octi.syncs.kserver.core
 import eu.darken.octi.common.ca.caString
 import eu.darken.octi.common.error.HasLocalizedError
 import eu.darken.octi.common.error.LocalizedError
+import eu.darken.octi.syncs.kserver.R
 import retrofit2.HttpException
 
 class KServerHttpException(
     override val cause: HttpException,
 ) : Exception(), HasLocalizedError {
 
+    val httpCode: Int get() = cause.code()
+
+    val isDeviceUnknown: Boolean get() = httpCode == 401 || httpCode == 404 || httpCode == 410
+
     private var errorMessage: String = cause.response()?.errorBody()?.string() ?: cause.toString()
 
     override fun getLocalizedError(): LocalizedError = LocalizedError(
         throwable = this,
         label = caString { cause.message() },
-        description = caString { errorMessage },
+        description = when {
+            isDeviceUnknown -> caString { it.getString(R.string.sync_kserver_error_device_not_registered) }
+            else -> caString { errorMessage }
+        },
     )
 }

--- a/syncs-kserver/src/main/res/values/strings.xml
+++ b/syncs-kserver/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="sync_kserver_link_client_option_qrcode">Scan a QR code from another device</string>
     <string name="sync_kserver_link_client_startcamera_action">Start camera</string>
     <string name="sync_kserver_link_client_link_action">Link device</string>
+    <string name="sync_kserver_error_device_not_registered">This device is no longer registered on the server. Disconnect and re-link from another device, or create a new account.</string>
 </resources>

--- a/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerHttpExceptionTest.kt
+++ b/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerHttpExceptionTest.kt
@@ -1,0 +1,43 @@
+package eu.darken.octi.syncs.kserver.core
+
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import retrofit2.HttpException
+import retrofit2.Response
+
+class KServerHttpExceptionTest {
+
+    private fun createException(code: Int): KServerHttpException {
+        val response = Response.error<Any>(code, "error".toResponseBody())
+        return KServerHttpException(HttpException(response))
+    }
+
+    @Test
+    fun `httpCode returns the HTTP status code`() {
+        createException(404).httpCode shouldBe 404
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [401, 404, 410])
+    fun `isDeviceUnknown is true for auth and not-found codes`(code: Int) {
+        createException(code).isDeviceUnknown shouldBe true
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [400, 403, 500, 502, 503])
+    fun `isDeviceUnknown is false for other error codes`(code: Int) {
+        createException(code).isDeviceUnknown shouldBe false
+    }
+
+    @Test
+    fun `cause is preserved`() {
+        val httpException = HttpException(Response.error<Any>(404, "body".toResponseBody()))
+        val exception = KServerHttpException(httpException)
+        exception.cause shouldBe httpException
+    }
+}


### PR DESCRIPTION
## Summary
- Auto-pause KServer connector when the server returns 401, 404, or 410 (device no longer registered)
- Show user-friendly localized error message instead of raw exception text
- Wrap all non-successful HTTP responses in `KServerHttpException` for consistent error handling
- Remove dead commented-out stats code from `KServerConnector`

## Test plan
- [x] Unit tests for `KServerHttpException` (httpCode, isDeviceUnknown, cause)
- [x] Manual: delete device from KServer, verify connector auto-pauses and shows localized error