### PR TITLE
Use plurals for minutes quantity display

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/preferences/SliderInputPreference.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/preferences/SliderInputPreference.kt
@@ -101,6 +101,6 @@ class SliderInputPreference @JvmOverloads constructor(
     }
 
     private fun updateSummary(value: Int) {
-        summary = context.getString(R.string.preference_slider_input_summary, value)
+        summary = context.resources.getQuantityString(R.plurals.general_minutes_quantity_label, value, value)
     }
 }

--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Gaan voort</string>
     <string name="general_show_details_action">Wys besonderhede</string>
     <string name="general_minutes_label">Minute</string>
-    <string name="preference_slider_input_summary">%1$d minute</string>
 </resources>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">استمرار</string>
     <string name="general_show_details_action">إظهار التفاصيل</string>
     <string name="general_minutes_label">دقائق</string>
-    <string name="preference_slider_input_summary">%1$d دقائق</string>
 </resources>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Continua</string>
     <string name="general_show_details_action">Mostra els detalls</string>
     <string name="general_minutes_label">Minuts</string>
-    <string name="preference_slider_input_summary">%1$d minuts</string>
 </resources>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Pokračovat</string>
     <string name="general_show_details_action">Zobrazit podrobnosti</string>
     <string name="general_minutes_label">Minuty</string>
-    <string name="preference_slider_input_summary">%1$d minut</string>
 </resources>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Fortsæt</string>
     <string name="general_show_details_action">Vis detaljer</string>
     <string name="general_minutes_label">Minutter</string>
-    <string name="preference_slider_input_summary">%1$d minutter</string>
 </resources>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Weiter</string>
     <string name="general_show_details_action">Details anzeigen</string>
     <string name="general_minutes_label">Minuten</string>
-    <string name="preference_slider_input_summary">%1$d Minuten</string>
 </resources>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Συνέχεια</string>
     <string name="general_show_details_action">Εμφάνιση λεπτομερειών</string>
     <string name="general_minutes_label">Λεπτά</string>
-    <string name="preference_slider_input_summary">%1$d λεπτά</string>
 </resources>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Continuar</string>
     <string name="general_show_details_action">Mostrar detalles</string>
     <string name="general_minutes_label">Minutos</string>
-    <string name="preference_slider_input_summary">%1$d minutos</string>
 </resources>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Jatka</string>
     <string name="general_show_details_action">Näytä tiedot</string>
     <string name="general_minutes_label">Minuutit</string>
-    <string name="preference_slider_input_summary">%1$d minuuttia</string>
 </resources>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Poursuivre</string>
     <string name="general_show_details_action">Afficher les détails</string>
     <string name="general_minutes_label">Minutes</string>
-    <string name="preference_slider_input_summary">%1$d minutes</string>
 </resources>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_show_details_action">Részletek megjelenítése</string>
     <string name="general_na_label">N/A</string>
     <string name="general_minutes_label">Percek</string>
-    <string name="preference_slider_input_summary">%1$d perc</string>
 </resources>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Continua</string>
     <string name="general_show_details_action">Mostra i dettagli</string>
     <string name="general_minutes_label">Minuti</string>
-    <string name="preference_slider_input_summary">%1$d minuti</string>
 </resources>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">המשך</string>
     <string name="general_show_details_action">הצג פרטים</string>
     <string name="general_minutes_label">דקות</string>
-    <string name="preference_slider_input_summary">%1$d דקות</string>
 </resources>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">続行</string>
     <string name="general_show_details_action">詳細を表示</string>
     <string name="general_minutes_label">分</string>
-    <string name="preference_slider_input_summary">%1$d 分</string>
 </resources>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">계속</string>
     <string name="general_show_details_action">자세히 보기</string>
     <string name="general_minutes_label">분</string>
-    <string name="preference_slider_input_summary">%1$d분</string>
 </resources>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Fortsett</string>
     <string name="general_show_details_action">Vis detaljer</string>
     <string name="general_minutes_label">Minutter</string>
-    <string name="preference_slider_input_summary">%1$d minutter</string>
 </resources>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_show_details_action">Details tonen</string>
     <string name="general_quota_label">Quotum</string>
     <string name="general_minutes_label">Minuten</string>
-    <string name="preference_slider_input_summary">%1$d minuten</string>
 </resources>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Kontynuuj</string>
     <string name="general_show_details_action">Pokaż szczegóły</string>
     <string name="general_minutes_label">Minuty</string>
-    <string name="preference_slider_input_summary">%1$d minut</string>
 </resources>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Continuar</string>
     <string name="general_show_details_action">Mostrar detalhes</string>
     <string name="general_minutes_label">Minutos</string>
-    <string name="preference_slider_input_summary">%1$d minutos</string>
 </resources>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Continuar</string>
     <string name="general_show_details_action">Mostrar detalhes</string>
     <string name="general_minutes_label">Minutos</string>
-    <string name="preference_slider_input_summary">%1$d minutos</string>
 </resources>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_show_details_action">Afișează detalii</string>
     <string name="general_na_label">N/A</string>
     <string name="general_minutes_label">Minute</string>
-    <string name="preference_slider_input_summary">%1$d minute</string>
 </resources>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Продолжить</string>
     <string name="general_show_details_action">Показать детали</string>
     <string name="general_minutes_label">Минуты</string>
-    <string name="preference_slider_input_summary">%1$d минут</string>
 </resources>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Настави</string>
     <string name="general_show_details_action">Прикажи детаље</string>
     <string name="general_minutes_label">Минути</string>
-    <string name="preference_slider_input_summary">%1$d минута</string>
 </resources>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Fortsätt</string>
     <string name="general_show_details_action">Visa detaljer</string>
     <string name="general_minutes_label">Minuter</string>
-    <string name="preference_slider_input_summary">%1$d minuter</string>
 </resources>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Devam</string>
     <string name="general_show_details_action">Detayları göster</string>
     <string name="general_minutes_label">Dakika</string>
-    <string name="preference_slider_input_summary">%1$d dakika</string>
 </resources>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Продовжити</string>
     <string name="general_show_details_action">Показати деталі</string>
     <string name="general_minutes_label">Хвилини</string>
-    <string name="preference_slider_input_summary">%1$d хвилин</string>
 </resources>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">Tiếp tục</string>
     <string name="general_show_details_action">Hiển thị chi tiết</string>
     <string name="general_minutes_label">Phút</string>
-    <string name="preference_slider_input_summary">%1$d phút</string>
 </resources>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">继续</string>
     <string name="general_show_details_action">详细信息</string>
     <string name="general_minutes_label">分钟</string>
-    <string name="preference_slider_input_summary">%1$d 分钟</string>
 </resources>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -25,5 +25,4 @@
     <string name="general_continue">繼續</string>
     <string name="general_show_details_action">顯示詳細資訊</string>
     <string name="general_minutes_label">分鐘</string>
-    <string name="preference_slider_input_summary">%1$d 分鐘</string>
 </resources>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -24,5 +24,8 @@
     <string name="general_continue">Continue</string>
     <string name="general_show_details_action">Show details</string>
     <string name="general_minutes_label">Minutes</string>
-    <string name="preference_slider_input_summary">%1$d minutes</string>
+    <plurals name="general_minutes_quantity_label">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
## Summary
- Replace hardcoded `preference_slider_input_summary` string ("X minutes") with a generic Android `plurals` resource (`general_minutes_quantity_label`) so "1 minute" renders correctly instead of "1 minutes"
- Remove old translated `<string>` entries from all locales — Crowdin will regenerate them as proper `<plurals>` with language-specific quantity rules

## Test plan
- [ ] Verify slider preference shows "1 minute" for value 1
- [ ] Verify slider preference shows "15 minutes" for value 15
