### PR TITLE
Extract missing translations from acknowledgements screen

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,9 @@
     <string name="settings_privacy_policy_desc">Handling data responsibly.</string>
     <string name="settings_licenses_label">Licenses</string>
     <string name="general_thank_you_label">Thank you</string>
+    <string name="acks_thanks_jakob_desc">Thanks for Octi\'s open-source sync server.</string>
+    <string name="acks_thanks_maxpatchs_desc">Thanks for the lovely icons.</string>
+    <string name="acks_thanks_crowdin_desc">For supporting translation of open-source projects</string>
     <string name="settings_category_other_label">Other</string>
 
     <string name="general_settings_label">General</string>

--- a/app/src/main/res/xml/preferences_acknowledgements.xml
+++ b/app/src/main/res/xml/preferences_acknowledgements.xml
@@ -6,7 +6,7 @@
         app:iconSpaceReserved="false">
         <eu.darken.octi.common.preferences.IntentPreference
             android:key="thanks.jakob"
-            android:summary="Thanks for Octi\'s open-source sync server."
+            android:summary="@string/acks_thanks_jakob_desc"
             android:title="Jakob Möller"
             app:iconSpaceReserved="false">
             <intent
@@ -15,7 +15,7 @@
         </eu.darken.octi.common.preferences.IntentPreference>
         <eu.darken.octi.common.preferences.IntentPreference
             android:key="thanks.maxpatchs"
-            android:summary="Thanks for the lovely icons."
+            android:summary="@string/acks_thanks_maxpatchs_desc"
             android:title="Max Patchs"
             app:iconSpaceReserved="false">
             <intent
@@ -24,7 +24,7 @@
         </eu.darken.octi.common.preferences.IntentPreference>
         <eu.darken.octi.common.preferences.IntentPreference
             android:key="thanks.crowdin"
-            android:summary="For supporting translation of open-source projects"
+            android:summary="@string/acks_thanks_crowdin_desc"
             android:title="crowdin.com"
             app:iconSpaceReserved="false">
             <intent


### PR DESCRIPTION
## Summary
- Extract 3 hardcoded summary strings from the acknowledgements "Thank you" section to `strings.xml`
- Enables Crowdin to pick up these strings for translation

## Changes
- `app/src/main/res/values/strings.xml`: Add `acks_thanks_jakob_desc`, `acks_thanks_maxpatchs_desc`, `acks_thanks_crowdin_desc`
- `app/src/main/res/xml/preferences_acknowledgements.xml`: Replace hardcoded `android:summary` values with `@string/` references
