### PR TITLE
Fix stale share code when linking additional devices via KServer

### DIFF
--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostScreen.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostScreen.kt
@@ -67,7 +67,8 @@ fun KServerLinkHostScreenHost(
     val context = LocalContext.current
     val activity = context as? Activity
 
-    LaunchedEffect(vm.deviceLinkedEvents) {
+    LaunchedEffect(Unit) {
+        vm.onScreenVisible()
         vm.deviceLinkedEvents.collect {
             Toast.makeText(
                 context,

--- a/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostVM.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/kserver/ui/link/host/KServerLinkHostVM.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.syncs.kserver.core.KServerConnector
 import eu.darken.octi.syncs.kserver.ui.link.KServerLinkOption
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,6 +22,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
@@ -52,13 +54,46 @@ class KServerLinkHostVM @Inject constructor(
             }
         }
 
-    val deviceLinkedEvents = SingleEventFlow<Unit>()
+    var deviceLinkedEvents = SingleEventFlow<Unit>()
+        private set
+
+    private var deviceMonitorJob: Job? = null
 
     fun initialize(connectorId: String) {
         if (connectorIdFlow.value != null) return
         connectorIdFlow.value = connectorId
 
         launch {
+            val connector = connectorFlow.first()
+            while (currentCoroutineContext().isActive) {
+                connector.sync(SyncOptions())
+                delay(3000)
+            }
+        }
+    }
+
+    fun onScreenVisible() {
+        log(TAG) { "onScreenVisible()" }
+
+        // Cancel previous monitor and discard stale events
+        deviceMonitorJob?.cancel()
+        deviceLinkedEvents = SingleEventFlow()
+
+        // Reset to loading state, then generate fresh code
+        launch {
+            stateLock.withLock {
+                _state.value = _state.value.copy(encodedLinkCode = null)
+            }
+            val connector = connectorFlow.first()
+            val container = connector.createLinkCode()
+            log(TAG) { "New magic link code generated." }
+            stateLock.withLock {
+                _state.value = _state.value.copy(encodedLinkCode = container.toEncodedString(json))
+            }
+        }
+
+        // Monitor for new device linking
+        deviceMonitorJob = vmScope.launch {
             connectorFlow
                 .flatMapLatest { it.state }
                 .map { it.devices }
@@ -73,23 +108,6 @@ class KServerLinkHostVM @Inject constructor(
                 .first()
             deviceLinkedEvents.tryEmit(Unit)
         }
-
-        launch {
-            val connector = connectorFlow.first()
-            val container = connector.createLinkCode()
-            log(TAG) { "New magic link code generated." }
-
-            stateLock.withLock {
-                _state.value = _state.value.copy(encodedLinkCode = container.toEncodedString(json))
-            }
-        }
-        launch {
-            val connector = connectorFlow.first()
-            while (currentCoroutineContext().isActive) {
-                connector.sync(SyncOptions())
-                delay(3000)
-            }
-        }
     }
 
     fun onLinkOptionSelected(option: KServerLinkOption) = launch {
@@ -101,7 +119,7 @@ class KServerLinkHostVM @Inject constructor(
 
     fun shareLinkCode(activity: Activity) = launch {
         log(TAG) { "shareLinkCode()" }
-        val encodedCode = _state.value.encodedLinkCode!!
+        val encodedCode = _state.value.encodedLinkCode ?: return@launch
         val sendIntent = Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(Intent.EXTRA_TEXT, encodedCode)


### PR DESCRIPTION
## Summary

- Generate a fresh share code every time the "Link device" screen is opened, instead of only once during ViewModel initialization
- Cancel stale device monitors and reinitialize the event channel on each screen visit to prevent auto-close from buffered events
- Guard a potential crash in `shareLinkCode()` when the code is null during regeneration

## Problem

When linking a third device after already linking a second one, the share code displayed was the old consumed code. The server rejected it with "could not resolve share code" because the code had already been used by the second device.

The root cause was that share code generation was tied to one-time ViewModel initialization. If Navigation3 reused the ViewModel (same data class NavKey with same `connectorId`), the `initialize()` guard prevented re-initialization, leaving the stale code visible.

## Changes

Split per-visit work (share code generation, device monitoring) out of `initialize()` into a new `onScreenVisible()` method, called from `LaunchedEffect(Unit)` in the composable. This fires once per composition instance, ensuring fresh state on every screen visit regardless of ViewModel lifecycle.
