### PR TITLE
Show per-module sync progress in dashboard status bar

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardConfig.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardConfig.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 data class DashboardConfig(
     @SerialName("collapsedDevices") val collapsedDevices: Set<String> = emptySet(),
     @SerialName("deviceOrder") val deviceOrder: List<String> = emptyList(),
+    @SerialName("isSyncExpanded") val isSyncExpanded: Boolean = false,
 ) {
 
     fun isCollapsed(deviceId: String): Boolean = collapsedDevices.contains(deviceId)

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -87,22 +87,33 @@ import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.descriptionRes
 import eu.darken.octi.common.permissions.labelRes
 import eu.darken.octi.common.upgrade.UpgradeRepo
-import eu.darken.octi.modules.meta.R as MetaR
-import eu.darken.octi.modules.meta.core.MetaInfo
-import eu.darken.octi.modules.power.core.PowerInfo
-import eu.darken.octi.modules.power.core.PowerInfo.ChargeIO
-import eu.darken.octi.modules.power.core.PowerInfo.Status
+import eu.darken.octi.modules.apps.AppsModule
+import eu.darken.octi.modules.apps.R as AppsR
 import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.apps.ui.dashboard.AppsModuleItem
+import eu.darken.octi.modules.clipboard.ClipboardModule
 import eu.darken.octi.modules.clipboard.ClipboardInfo
+import eu.darken.octi.modules.clipboard.R as ClipboardR
 import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardDashState
 import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardDetailSheet
 import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardModuleItem
+import eu.darken.octi.modules.connectivity.ConnectivityModule
+import eu.darken.octi.modules.connectivity.R as ConnectivityR
 import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityDetailSheet
 import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityModuleItem
+import eu.darken.octi.modules.meta.MetaModule
+import eu.darken.octi.modules.meta.R as MetaR
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.power.PowerModule
+import eu.darken.octi.modules.power.R as PowerR
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.modules.power.core.PowerInfo.ChargeIO
+import eu.darken.octi.modules.power.core.PowerInfo.Status
 import eu.darken.octi.modules.power.ui.dashboard.PowerDashState
 import eu.darken.octi.modules.power.ui.dashboard.PowerDetailSheet
 import eu.darken.octi.modules.power.ui.dashboard.PowerModuleItem
+import eu.darken.octi.modules.wifi.WifiModule
+import eu.darken.octi.modules.wifi.R as WifiR
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiDashState
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiDetailSheet
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiModuleItem
@@ -552,10 +563,23 @@ private fun SyncStatusBar(
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             when (syncStatus) {
-                is DashboardVM.SyncStatus.Syncing -> Text(
-                    text = stringResource(R.string.dashboard_sync_status_syncing),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
+                is DashboardVM.SyncStatus.Syncing -> {
+                    val moduleNames = syncStatus.syncingModules
+                        .sortedBy { MODULE_DISPLAY_ORDER.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE }
+                        .mapNotNull { moduleIdToStringRes(it) }
+                        .map { stringResource(it) }
+                    val text = if (moduleNames.isNotEmpty()) {
+                        stringResource(R.string.dashboard_sync_status_syncing_modules, moduleNames.joinToString(", "))
+                    } else {
+                        stringResource(R.string.dashboard_sync_status_syncing)
+                    }
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
 
                 is DashboardVM.SyncStatus.Idle -> {
                     val primaryText = syncStatus.lastSyncAt?.let {
@@ -612,6 +636,25 @@ private fun SyncStatusBar(
             }
         }
     }
+}
+
+private val MODULE_DISPLAY_ORDER = listOf(
+    PowerModule.MODULE_ID,
+    ConnectivityModule.MODULE_ID,
+    WifiModule.MODULE_ID,
+    ClipboardModule.MODULE_ID,
+    AppsModule.MODULE_ID,
+    MetaModule.MODULE_ID,
+)
+
+private fun moduleIdToStringRes(moduleId: ModuleId): Int? = when (moduleId) {
+    PowerModule.MODULE_ID -> PowerR.string.module_power_label
+    WifiModule.MODULE_ID -> WifiR.string.module_wifi_label
+    AppsModule.MODULE_ID -> AppsR.string.module_apps_label
+    ClipboardModule.MODULE_ID -> ClipboardR.string.module_clipboard_label
+    ConnectivityModule.MODULE_ID -> ConnectivityR.string.module_connectivity_label
+    MetaModule.MODULE_ID -> MetaR.string.module_meta_label
+    else -> null
 }
 
 @Composable

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -33,7 +33,17 @@ import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Tablet
+import androidx.compose.material.icons.twotone.Apps
+import androidx.compose.material.icons.twotone.BatteryFull
+import androidx.compose.material.icons.twotone.CellTower
+import androidx.compose.material.icons.twotone.Coffee
+import androidx.compose.material.icons.twotone.ContentPaste
+import androidx.compose.material.icons.twotone.ExpandLess
+import androidx.compose.material.icons.twotone.ExpandMore
+import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.Warning
+import androidx.compose.material.icons.twotone.Wifi
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -78,10 +88,13 @@ import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
+import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.module.core.ModuleManager
+import eu.darken.octi.module.core.ModuleSync
 import java.time.Instant
 import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.descriptionRes
@@ -231,6 +244,7 @@ fun DashboardScreenHost(vm: DashboardVM = hiltViewModel()) {
             onDismissUpdate = { vm.dismissUpdate() },
             onViewUpdate = { vm.viewUpdate() },
             onStartUpdate = { vm.startUpdate() },
+            onToggleSyncExpanded = { vm.toggleSyncExpanded() },
             onToggleDeviceCollapsed = { vm.toggleDeviceCollapsed(it) },
             onPowerAlerts = { vm.goToPowerAlerts(it) },
             onAppsList = { vm.goToAppsList(it) },
@@ -258,6 +272,7 @@ fun DashboardScreen(
     onDismissUpdate: () -> Unit,
     onViewUpdate: () -> Unit,
     onStartUpdate: () -> Unit,
+    onToggleSyncExpanded: () -> Unit,
     onToggleDeviceCollapsed: (String) -> Unit,
     onPowerAlerts: (DeviceId) -> Unit,
     onAppsList: (DeviceId) -> Unit,
@@ -335,6 +350,8 @@ fun DashboardScreen(
                 item(key = "sync_status") {
                     SyncStatusBar(
                         syncStatus = syncStatus,
+                        isExpanded = state.isSyncExpanded,
+                        onToggleExpanded = onToggleSyncExpanded,
                         onRefresh = onRefresh,
                     )
                 }
@@ -547,93 +564,237 @@ private fun connectorTypesLabel(connectorTypes: List<String>): String? {
 @Composable
 private fun SyncStatusBar(
     syncStatus: DashboardVM.SyncStatus,
+    isExpanded: Boolean,
+    onToggleExpanded: () -> Unit,
     onRefresh: () -> Unit,
 ) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+            .animateContentSize(),
+    ) {
+        Box {
+            Column {
+                // Header row
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onToggleExpanded)
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    OctiMascot(modifier = Modifier.size(24.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        when (syncStatus) {
+                            is DashboardVM.SyncStatus.Syncing -> {
+                                val moduleNames = syncStatus.syncingModules
+                                    .sortedBy { MODULE_DISPLAY_ORDER.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE }
+                                    .mapNotNull { moduleIdToStringRes(it) }
+                                    .map { stringResource(it) }
+                                val text = if (moduleNames.isNotEmpty()) {
+                                    stringResource(R.string.dashboard_sync_status_syncing_modules, moduleNames.joinToString(", "))
+                                } else {
+                                    stringResource(R.string.dashboard_sync_status_syncing)
+                                }
+                                Text(
+                                    text = text,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+
+                            is DashboardVM.SyncStatus.Idle -> {
+                                val primaryText = syncStatus.lastSyncAt?.let {
+                                    stringResource(
+                                        R.string.dashboard_sync_status_last_synced,
+                                        DateUtils.getRelativeTimeSpanString(it.toEpochMilli()).toString(),
+                                    )
+                                } ?: stringResource(R.string.dashboard_sync_status_never)
+                                Text(
+                                    text = primaryText,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+
+                            is DashboardVM.SyncStatus.Error -> Text(
+                                text = stringResource(R.string.dashboard_sync_status_failed),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                        val secondaryText = when (syncStatus) {
+                            is DashboardVM.SyncStatus.Error -> syncStatus.message ?: connectorTypesLabel(syncStatus.connectorTypes)
+                            else -> connectorTypesLabel(syncStatus.connectorTypes)
+                        }
+                        if (secondaryText != null) {
+                            Text(
+                                text = secondaryText,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                    Box(
+                        modifier = Modifier.size(48.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        when (syncStatus) {
+                            is DashboardVM.SyncStatus.Syncing -> {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                            }
+
+                            else -> {
+                                IconButton(onClick = onRefresh) {
+                                    Icon(
+                                        imageVector = Icons.TwoTone.Refresh,
+                                        contentDescription = stringResource(R.string.general_sync_action),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Expanded detail
+                if (isExpanded) {
+                    val detail = syncStatus.syncDetail
+                    HorizontalDivider()
+
+                    // Module rows
+                    Spacer(modifier = Modifier.height(4.dp))
+                    val sortedModules = detail.modules.sortedBy {
+                        MODULE_DISPLAY_ORDER.indexOf(it.moduleId).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE
+                    }
+                    sortedModules.forEach { moduleState ->
+                        SyncDetailModuleRow(moduleState)
+                    }
+
+                    // Backend rows
+                    if (detail.connectors.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        HorizontalDivider()
+                        Spacer(modifier = Modifier.height(4.dp))
+                        detail.connectors.forEach { connector ->
+                            SyncDetailConnectorRow(connector)
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+            }
+
+            // Overlapping bottom-center chevron
+            Icon(
+                imageVector = if (isExpanded) Icons.TwoTone.ExpandLess else Icons.TwoTone.ExpandMore,
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .size(20.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SyncDetailModuleRow(moduleState: ModuleManager.ModuleSyncState) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 8.dp),
+            .padding(start = 16.dp, end = 20.dp, top = 4.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        val icon = moduleIdToIcon(moduleState.moduleId)
         Icon(
-            imageVector = Icons.TwoTone.CloudSync,
+            imageVector = icon,
             contentDescription = null,
-            modifier = Modifier.size(24.dp),
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Spacer(modifier = Modifier.width(12.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            when (syncStatus) {
-                is DashboardVM.SyncStatus.Syncing -> {
-                    val moduleNames = syncStatus.syncingModules
-                        .sortedBy { MODULE_DISPLAY_ORDER.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE }
-                        .mapNotNull { moduleIdToStringRes(it) }
-                        .map { stringResource(it) }
-                    val text = if (moduleNames.isNotEmpty()) {
-                        stringResource(R.string.dashboard_sync_status_syncing_modules, moduleNames.joinToString(", "))
-                    } else {
-                        stringResource(R.string.dashboard_sync_status_syncing)
-                    }
-                    Text(
-                        text = text,
-                        style = MaterialTheme.typography.bodyMedium,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                }
-
-                is DashboardVM.SyncStatus.Idle -> {
-                    val primaryText = syncStatus.lastSyncAt?.let {
-                        stringResource(
-                            R.string.dashboard_sync_status_last_synced,
-                            DateUtils.getRelativeTimeSpanString(it.toEpochMilli()).toString(),
-                        )
-                    } ?: stringResource(R.string.dashboard_sync_status_never)
-                    Text(
-                        text = primaryText,
-                        style = MaterialTheme.typography.bodyMedium,
-                    )
-                }
-
-                is DashboardVM.SyncStatus.Error -> Text(
-                    text = stringResource(R.string.dashboard_sync_status_failed),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-            val secondaryText = when (syncStatus) {
-                is DashboardVM.SyncStatus.Error -> syncStatus.message ?: connectorTypesLabel(syncStatus.connectorTypes)
-                else -> connectorTypesLabel(syncStatus.connectorTypes)
-            }
-            if (secondaryText != null) {
-                Text(
-                    text = secondaryText,
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
+        Spacer(modifier = Modifier.width(10.dp))
+        val nameRes = moduleIdToStringRes(moduleState.moduleId)
+        Text(
+            text = nameRes?.let { stringResource(it) } ?: moduleState.moduleId.id,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(1f),
+        )
+        val isActive = moduleState.activity != ModuleSync.SyncActivity.IDLE
+        val statusText = when (moduleState.activity) {
+            ModuleSync.SyncActivity.IDLE -> stringResource(R.string.dashboard_sync_detail_idle)
+            ModuleSync.SyncActivity.READING -> stringResource(R.string.dashboard_sync_detail_reading)
+            ModuleSync.SyncActivity.WRITING -> stringResource(R.string.dashboard_sync_detail_writing)
         }
-        Box(
-            modifier = Modifier.size(48.dp),
-            contentAlignment = Alignment.Center,
-        ) {
-            when (syncStatus) {
-                is DashboardVM.SyncStatus.Syncing -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                    )
-                }
+        Text(
+            text = statusText,
+            style = MaterialTheme.typography.bodySmall,
+            color = if (isActive) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        if (isActive) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(12.dp),
+                strokeWidth = 1.5.dp,
+            )
+        } else {
+            Icon(
+                imageVector = Icons.TwoTone.Coffee,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
 
-                else -> {
-                    IconButton(onClick = onRefresh) {
-                        Icon(
-                            imageVector = Icons.TwoTone.Refresh,
-                            contentDescription = stringResource(R.string.general_sync_action),
-                        )
-                    }
-                }
-            }
+@Composable
+private fun SyncDetailConnectorRow(connector: DashboardVM.ConnectorDetail) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 44.dp, end = 20.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val name = when (connector.type) {
+            "gdrive" -> stringResource(GDriveR.string.sync_gdrive_type_label)
+            "kserver" -> stringResource(KServerR.string.sync_kserver_type_label)
+            else -> connector.type
+        }
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.weight(1f),
+        )
+        if (connector.isBusy) {
+            Text(
+                text = stringResource(R.string.dashboard_sync_status_syncing),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            CircularProgressIndicator(
+                modifier = Modifier.size(12.dp),
+                strokeWidth = 1.5.dp,
+            )
+        } else {
+            Text(
+                text = stringResource(R.string.dashboard_sync_detail_idle),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.TwoTone.Coffee,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }
@@ -646,6 +807,16 @@ private val MODULE_DISPLAY_ORDER = listOf(
     AppsModule.MODULE_ID,
     MetaModule.MODULE_ID,
 )
+
+private fun moduleIdToIcon(moduleId: ModuleId): ImageVector = when (moduleId) {
+    PowerModule.MODULE_ID -> Icons.TwoTone.BatteryFull
+    WifiModule.MODULE_ID -> Icons.TwoTone.Wifi
+    AppsModule.MODULE_ID -> Icons.TwoTone.Apps
+    ClipboardModule.MODULE_ID -> Icons.TwoTone.ContentPaste
+    ConnectivityModule.MODULE_ID -> Icons.TwoTone.CellTower
+    MetaModule.MODULE_ID -> Icons.TwoTone.Info
+    else -> Icons.TwoTone.QuestionMark
+}
 
 private fun moduleIdToStringRes(moduleId: ModuleId): Int? = when (moduleId) {
     PowerModule.MODULE_ID -> PowerR.string.module_power_label
@@ -1147,6 +1318,7 @@ private fun DashboardScreenEmptyPreview() = PreviewWrapper {
         onDismissUpdate = {},
         onViewUpdate = {},
         onStartUpdate = {},
+        onToggleSyncExpanded = {},
         onToggleDeviceCollapsed = {},
         onPowerAlerts = {},
         onAppsList = {},
@@ -1223,6 +1395,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
             syncStatus = DashboardVM.SyncStatus.Idle(
                 lastSyncAt = now.minusSeconds(300),
                 connectorTypes = listOf("gdrive"),
+                syncDetail = DashboardVM.SyncDetail(modules = emptyList(), connectors = emptyList()),
             ),
             isOffline = false,
             showSyncSetup = false,
@@ -1242,6 +1415,7 @@ private fun DashboardScreenPreview() = PreviewWrapper {
         onDismissUpdate = {},
         onViewUpdate = {},
         onStartUpdate = {},
+        onToggleSyncExpanded = {},
         onToggleDeviceCollapsed = {},
         onPowerAlerts = {},
         onAppsList = {},
@@ -1317,6 +1491,7 @@ private fun DashboardScreenMultiDevicePreview() = PreviewWrapper {
             syncStatus = DashboardVM.SyncStatus.Idle(
                 lastSyncAt = now.minusSeconds(300),
                 connectorTypes = listOf("gdrive", "kserver"),
+                syncDetail = DashboardVM.SyncDetail(modules = emptyList(), connectors = emptyList()),
             ),
             isOffline = false,
             showSyncSetup = false,
@@ -1336,6 +1511,7 @@ private fun DashboardScreenMultiDevicePreview() = PreviewWrapper {
         onDismissUpdate = {},
         onViewUpdate = {},
         onStartUpdate = {},
+        onToggleSyncExpanded = {},
         onToggleDeviceCollapsed = {},
         onPowerAlerts = {},
         onAppsList = {},

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -25,6 +25,7 @@ import eu.darken.octi.main.core.updater.UpdateService
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.module.core.ModuleManager
+import eu.darken.octi.module.core.ModuleSync
 import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.apps.core.getInstallerIntent
 import eu.darken.octi.modules.clipboard.ClipboardHandler
@@ -92,13 +93,16 @@ class DashboardVM @Inject constructor(
     }
 
     private val syncStatusFlow: Flow<SyncStatus?> = combine(
+        syncSettings.showDashboardCard.flow,
         isManuallyRefreshing,
         syncManager.connectors,
         syncManager.states,
         syncSettings.pausedConnectors.flow,
         tickerUiRefresh,
         moduleManager.syncingModules,
-    ) { isRefreshing, connectors, allStates, pausedIds, _, syncingModules ->
+        moduleManager.moduleSyncStates,
+    ) { showCard, isRefreshing, connectors, allStates, pausedIds, _, syncingModules, moduleSyncStates ->
+        if (!showCard) return@combine null
         val activeConnectors = connectors.filter { !pausedIds.contains(it.identifier) }
         if (activeConnectors.isEmpty()) return@combine null
 
@@ -108,19 +112,32 @@ class DashboardVM @Inject constructor(
             .filter { !pausedIds.contains(connectors[it].identifier) }
             .mapNotNull { statesList.getOrNull(it) }
 
+        val connectorDetails = activeConnectors.zip(activeStates).map { (connector, state) ->
+            ConnectorDetail(
+                type = connector.identifier.type,
+                isBusy = state.isBusy,
+                lastSyncAt = state.lastSyncAt,
+            )
+        }
+
+        val syncDetail = SyncDetail(
+            modules = moduleSyncStates,
+            connectors = connectorDetails,
+        )
+
         when {
             isRefreshing || activeStates.any { it.isBusy } || syncingModules.isNotEmpty() -> {
-                SyncStatus.Syncing(connectorTypes, syncingModules)
+                SyncStatus.Syncing(connectorTypes, syncingModules, syncDetail)
             }
 
             activeStates.any { it.lastError != null } -> {
                 val error = activeStates.first { it.lastError != null }.lastError
-                SyncStatus.Error(error?.message, connectorTypes)
+                SyncStatus.Error(error?.message, connectorTypes, syncDetail)
             }
 
             else -> {
                 val lastSync = activeStates.mapNotNull { it.lastSyncAt }.maxByOrNull { it }
-                SyncStatus.Idle(lastSync, connectorTypes)
+                SyncStatus.Idle(lastSync, connectorTypes, syncDetail)
             }
         }
     }.setupCommonEventHandlers(TAG) { "syncStatus" }
@@ -129,6 +146,7 @@ class DashboardVM @Inject constructor(
         val devices: List<DeviceItem>,
         val deviceCount: Int,
         val syncStatus: SyncStatus?,
+        val isSyncExpanded: Boolean = false,
         val isOffline: Boolean,
         val showSyncSetup: Boolean,
         val missingPermissions: List<Permission>,
@@ -167,15 +185,36 @@ class DashboardVM @Inject constructor(
         ) : ModuleItem
     }
 
+    data class SyncDetail(
+        val modules: List<ModuleManager.ModuleSyncState>,
+        val connectors: List<ConnectorDetail>,
+    )
+
+    data class ConnectorDetail(
+        val type: String,
+        val isBusy: Boolean,
+        val lastSyncAt: Instant?,
+    )
+
     sealed interface SyncStatus {
         val connectorTypes: List<String>
+        val syncDetail: SyncDetail
 
         data class Syncing(
             override val connectorTypes: List<String>,
             val syncingModules: Set<ModuleId> = emptySet(),
+            override val syncDetail: SyncDetail,
         ) : SyncStatus
-        data class Idle(val lastSyncAt: Instant?, override val connectorTypes: List<String>) : SyncStatus
-        data class Error(val message: String?, override val connectorTypes: List<String>) : SyncStatus
+        data class Idle(
+            val lastSyncAt: Instant?,
+            override val connectorTypes: List<String>,
+            override val syncDetail: SyncDetail,
+        ) : SyncStatus
+        data class Error(
+            val message: String?,
+            override val connectorTypes: List<String>,
+            override val syncDetail: SyncDetail,
+        ) : SyncStatus
     }
 
     val state: Flow<State> = combine(
@@ -227,6 +266,7 @@ class DashboardVM @Inject constructor(
             devices = orderedDeviceItems,
             deviceCount = orderedDeviceItems.size,
             syncStatus = syncStatus,
+            isSyncExpanded = uiConfig.isSyncExpanded,
             isOffline = !networkState.isInternetAvailable,
             showSyncSetup = showSyncSetup,
             missingPermissions = filteredPermissions,
@@ -304,6 +344,10 @@ class DashboardVM @Inject constructor(
 
     fun toggleDeviceCollapsed(deviceId: String) = launch {
         generalSettings.toggleDeviceCollapsed(deviceId)
+    }
+
+    fun toggleSyncExpanded() = launch {
+        generalSettings.dashboardConfig.update { it.copy(isSyncExpanded = !it.isSyncExpanded) }
     }
 
     fun goToPowerAlerts(deviceId: DeviceId) {

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -23,6 +23,7 @@ import eu.darken.octi.main.core.GeneralSettings
 import eu.darken.octi.main.core.updater.UpdateChecker
 import eu.darken.octi.main.core.updater.UpdateService
 import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.module.core.ModuleManager
 import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.apps.core.getInstallerIntent
@@ -96,7 +97,8 @@ class DashboardVM @Inject constructor(
         syncManager.states,
         syncSettings.pausedConnectors.flow,
         tickerUiRefresh,
-    ) { isRefreshing, connectors, allStates, pausedIds, _ ->
+        moduleManager.syncingModules,
+    ) { isRefreshing, connectors, allStates, pausedIds, _, syncingModules ->
         val activeConnectors = connectors.filter { !pausedIds.contains(it.identifier) }
         if (activeConnectors.isEmpty()) return@combine null
 
@@ -107,7 +109,10 @@ class DashboardVM @Inject constructor(
             .mapNotNull { statesList.getOrNull(it) }
 
         when {
-            isRefreshing || activeStates.any { it.isBusy } -> SyncStatus.Syncing(connectorTypes)
+            isRefreshing || activeStates.any { it.isBusy } || syncingModules.isNotEmpty() -> {
+                SyncStatus.Syncing(connectorTypes, syncingModules)
+            }
+
             activeStates.any { it.lastError != null } -> {
                 val error = activeStates.first { it.lastError != null }.lastError
                 SyncStatus.Error(error?.message, connectorTypes)
@@ -165,7 +170,10 @@ class DashboardVM @Inject constructor(
     sealed interface SyncStatus {
         val connectorTypes: List<String>
 
-        data class Syncing(override val connectorTypes: List<String>) : SyncStatus
+        data class Syncing(
+            override val connectorTypes: List<String>,
+            val syncingModules: Set<ModuleId> = emptySet(),
+        ) : SyncStatus
         data class Idle(val lastSyncAt: Instant?, override val connectorTypes: List<String>) : SyncStatus
         data class Error(val message: String?, override val connectorTypes: List<String>) : SyncStatus
     }

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.Label
 import androidx.compose.material.icons.twotone.BatteryChargingFull
+import androidx.compose.material.icons.twotone.Dashboard
 import androidx.compose.material.icons.twotone.SignalWifi4Bar
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Sync
@@ -69,6 +70,7 @@ fun SyncSettingsScreenHost(vm: SyncSettingsVM = hiltViewModel()) {
         SyncSettingsScreen(
             state = it,
             onNavigateUp = { vm.navUp() },
+            onShowDashboardCardChanged = { enabled -> vm.setShowDashboardCard(enabled) },
             onDeviceLabelChanged = { label -> vm.setDeviceLabel(label) },
             onBackgroundSyncEnabledChanged = { enabled -> vm.setBackgroundSyncEnabled(enabled) },
             onBackgroundSyncIntervalChanged = { minutes -> vm.setBackgroundSyncInterval(minutes) },
@@ -85,6 +87,7 @@ fun SyncSettingsScreenHost(vm: SyncSettingsVM = hiltViewModel()) {
 fun SyncSettingsScreen(
     state: SyncSettingsVM.State,
     onNavigateUp: () -> Unit,
+    onShowDashboardCardChanged: (Boolean) -> Unit,
     onDeviceLabelChanged: (String?) -> Unit,
     onBackgroundSyncEnabledChanged: (Boolean) -> Unit,
     onBackgroundSyncIntervalChanged: (Int) -> Unit,
@@ -115,6 +118,17 @@ fun SyncSettingsScreen(
         },
     ) { innerPadding ->
         LazyColumn(modifier = Modifier.padding(innerPadding)) {
+            // Dashboard card visibility
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Dashboard,
+                    title = stringResource(R.string.sync_setting_dashboard_card_title),
+                    subtitle = stringResource(R.string.sync_setting_dashboard_card_desc),
+                    checked = state.showDashboardCard,
+                    onCheckedChange = onShowDashboardCardChanged,
+                )
+            }
+
             // Device label
             item {
                 SettingsBaseItem(
@@ -401,6 +415,7 @@ private fun DeviceLabelDialog(
 private fun SyncSettingsScreenPreview() = PreviewWrapper {
     SyncSettingsScreen(
         state = SyncSettingsVM.State(
+            showDashboardCard = true,
             deviceLabel = null,
             backgroundSyncEnabled = true,
             backgroundSyncInterval = 60,
@@ -412,6 +427,7 @@ private fun SyncSettingsScreenPreview() = PreviewWrapper {
             foregroundSyncInterval = 5,
         ),
         onNavigateUp = {},
+        onShowDashboardCardChanged = {},
         onDeviceLabelChanged = {},
         onBackgroundSyncEnabledChanged = {},
         onBackgroundSyncIntervalChanged = {},

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
@@ -20,6 +20,7 @@ class SyncSettingsVM @Inject constructor(
 ) : ViewModel4(dispatcherProvider) {
 
     data class State(
+        val showDashboardCard: Boolean,
         val deviceLabel: String?,
         val backgroundSyncEnabled: Boolean,
         val backgroundSyncInterval: Int,
@@ -32,6 +33,7 @@ class SyncSettingsVM @Inject constructor(
     )
 
     val state = combine(
+        syncSettings.showDashboardCard.flow,
         syncSettings.deviceLabel.flow,
         syncSettings.backgroundSyncEnabled.flow,
         syncSettings.backgroundSyncInterval.flow,
@@ -41,8 +43,9 @@ class SyncSettingsVM @Inject constructor(
         syncSettings.backgroundSyncChargingInterval.flow,
         syncSettings.foregroundSyncEnabled.flow,
         syncSettings.foregroundSyncInterval.flow,
-    ) { deviceLabel, bgEnabled, bgInterval, bgMobile, upgradeInfo, chargingEnabled, chargingInterval, fgEnabled, fgInterval ->
+    ) { showCard, deviceLabel, bgEnabled, bgInterval, bgMobile, upgradeInfo, chargingEnabled, chargingInterval, fgEnabled, fgInterval ->
         State(
+            showDashboardCard = showCard,
             deviceLabel = deviceLabel,
             backgroundSyncEnabled = bgEnabled,
             backgroundSyncInterval = bgInterval,
@@ -54,6 +57,10 @@ class SyncSettingsVM @Inject constructor(
             foregroundSyncInterval = fgInterval,
         )
     }.asStateFlow()
+
+    fun setShowDashboardCard(enabled: Boolean) = launch {
+        syncSettings.showDashboardCard.value(enabled)
+    }
 
     fun setDeviceLabel(label: String?) = launch {
         syncSettings.deviceLabel.value(label?.ifBlank { null })

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -218,6 +218,7 @@
     <string name="support_debuglog_session_failed_label">Corrupted</string>
 
     <string name="dashboard_sync_status_syncing">Syncing\u2026</string>
+    <string name="dashboard_sync_status_syncing_modules">Syncing %1$s\u2026</string>
     <string name="dashboard_sync_status_last_synced">Last synced %1$s</string>
     <string name="dashboard_sync_status_failed">Sync failed</string>
     <string name="dashboard_sync_status_via">via %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,11 +217,17 @@
     <string name="support_debuglog_session_compressing_label">Compressing…</string>
     <string name="support_debuglog_session_failed_label">Corrupted</string>
 
+    <string name="sync_setting_dashboard_card_title">Show dashboard card</string>
+    <string name="sync_setting_dashboard_card_desc">Show sync status and module activity on the dashboard</string>
+
     <string name="dashboard_sync_status_syncing">Syncing\u2026</string>
     <string name="dashboard_sync_status_syncing_modules">Syncing %1$s\u2026</string>
     <string name="dashboard_sync_status_last_synced">Last synced %1$s</string>
     <string name="dashboard_sync_status_failed">Sync failed</string>
     <string name="dashboard_sync_status_via">via %1$s</string>
     <string name="dashboard_sync_status_never">Not yet synced</string>
+    <string name="dashboard_sync_detail_idle">Idle</string>
+    <string name="dashboard_sync_detail_reading">Reading\u2026</string>
+    <string name="dashboard_sync_detail_writing">Writing\u2026</string>
 
 </resources>

--- a/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleRepo.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleRepo.kt
@@ -28,13 +28,15 @@ import java.util.UUID
 abstract class BaseModuleRepo<T : Any>(
     private val tag: String,
     @AppScope private val scope: CoroutineScope,
-    private val moduleId: ModuleId,
+    override val moduleId: ModuleId,
     dispatcherProvider: DispatcherProvider,
-    moduleSettings: ModuleSettings,
+    private val moduleSettings: ModuleSettings,
     private val moduleSync: ModuleSync<T>,
     private val infoSource: ModuleInfoSource<T>,
     private val moduleCache: ModuleCache<T>,
 ) : ModuleRepo<T> {
+
+    override val isEnabled: Flow<Boolean> = moduleSettings.isEnabled.flow
 
     data class State<T>(
         val moduleId: ModuleId,

--- a/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleSync.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleSync.kt
@@ -9,7 +9,9 @@ import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.sync.core.*
 import eu.darken.octi.sync.core.errors.PayloadDecodingException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 import java.io.IOException
@@ -26,6 +28,10 @@ abstract class BaseModuleSync<T : Any> constructor(
 
     override val ourDeviceId: DeviceId
         get() = syncSettings.deviceId
+
+    private val syncingCount = MutableStateFlow(0)
+
+    override val isSyncing: Flow<Boolean> = syncingCount.map { it > 0 }
 
     override val others: Flow<List<ModuleData<T>>> = syncManager.data
         .map { reads ->
@@ -63,7 +69,12 @@ abstract class BaseModuleSync<T : Any> constructor(
             throw IllegalArgumentException("You can only sync your own device data.")
         }
 
-        syncManager.write(serialize(self.data))
+        syncingCount.update { it + 1 }
+        try {
+            syncManager.write(serialize(self.data))
+        } finally {
+            syncingCount.update { it - 1 }
+        }
     }
 
     private fun serialize(item: T): SyncWrite.Device.Module {

--- a/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleSync.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleSync.kt
@@ -10,6 +10,7 @@ import eu.darken.octi.sync.core.*
 import eu.darken.octi.sync.core.errors.PayloadDecodingException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import okio.ByteString
@@ -29,36 +30,50 @@ abstract class BaseModuleSync<T : Any> constructor(
     override val ourDeviceId: DeviceId
         get() = syncSettings.deviceId
 
-    private val syncingCount = MutableStateFlow(0)
+    private val readCount = MutableStateFlow(0)
+    private val writeCount = MutableStateFlow(0)
 
-    override val isSyncing: Flow<Boolean> = syncingCount.map { it > 0 }
+    override val syncActivity: Flow<ModuleSync.SyncActivity> = combine(readCount, writeCount) { r, w ->
+        when {
+            w > 0 -> ModuleSync.SyncActivity.WRITING
+            r > 0 -> ModuleSync.SyncActivity.READING
+            else -> ModuleSync.SyncActivity.IDLE
+        }
+    }
+
+    override val isSyncing: Flow<Boolean> = syncActivity.map { it != ModuleSync.SyncActivity.IDLE }
 
     override val others: Flow<List<ModuleData<T>>> = syncManager.data
         .map { reads ->
-            reads
-                .filter { it.deviceId != syncSettings.deviceId }
-                .mapNotNull { device ->
-                    val rawModule = device.modules.singleOrNull {
-                        it.moduleId == moduleId
-                    }
-                    if (rawModule == null) {
-                        log(tag, WARN) { "syncRead(): Missing module $moduleId on ${device.deviceId}" }
-                        return@mapNotNull null
-                    }
+            readCount.update { it + 1 }
+            try {
+                reads
+                    .filter { it.deviceId != syncSettings.deviceId }
+                    .mapNotNull { device ->
+                        val rawModule = device.modules.singleOrNull {
+                            it.moduleId == moduleId
+                        }
+                        if (rawModule == null) {
+                            log(tag, WARN) { "syncRead(): Missing module $moduleId on ${device.deviceId}" }
+                            return@mapNotNull null
+                        }
 
-                    try {
-                        ModuleData(
-                            modifiedAt = rawModule.modifiedAt,
-                            deviceId = device.deviceId,
-                            moduleId = moduleId,
-                            data = deserialize(rawModule),
-                        )
-                    } catch (e: Exception) {
-                        log(tag, ERROR) { "syncRead(): Failed to decode $rawModule:\n${e.asLog()}" }
-                        Bugs.report(PayloadDecodingException(rawModule))
-                        null
+                        try {
+                            ModuleData(
+                                modifiedAt = rawModule.modifiedAt,
+                                deviceId = device.deviceId,
+                                moduleId = moduleId,
+                                data = deserialize(rawModule),
+                            )
+                        } catch (e: Exception) {
+                            log(tag, ERROR) { "syncRead(): Failed to decode $rawModule:\n${e.asLog()}" }
+                            Bugs.report(PayloadDecodingException(rawModule))
+                            null
+                        }
                     }
-                }
+            } finally {
+                readCount.update { it - 1 }
+            }
         }
         .setupCommonEventHandlers(tag) { "others" }
 
@@ -69,11 +84,11 @@ abstract class BaseModuleSync<T : Any> constructor(
             throw IllegalArgumentException("You can only sync your own device data.")
         }
 
-        syncingCount.update { it + 1 }
+        writeCount.update { it + 1 }
         try {
             syncManager.write(serialize(self.data))
         } finally {
-            syncingCount.update { it - 1 }
+            writeCount.update { it - 1 }
         }
     }
 

--- a/module-core/src/main/java/eu/darken/octi/module/core/ModuleManager.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/ModuleManager.kt
@@ -18,6 +18,7 @@ class ModuleManager @Inject constructor(
     @AppScope private val scope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val moduleRepos: Set<@JvmSuppressWildcards ModuleRepo<out Any>>,
+    private val moduleSyncs: Set<@JvmSuppressWildcards ModuleSync<out Any>>,
 ) {
 
     private val data = combine(moduleRepos.map { it.state }) {
@@ -48,6 +49,17 @@ class ModuleManager @Inject constructor(
         .onEach {
             log(TAG, VERBOSE) { "BYDEVICE: $it" }
         }
+
+    val syncingModules: Flow<Set<ModuleId>> = if (moduleSyncs.isEmpty()) {
+        flowOf(emptySet())
+    } else {
+        kotlinx.coroutines.flow.combine(moduleSyncs.map { sync ->
+            sync.isSyncing.map { busy -> if (busy) sync.moduleId else null }
+        }) { results ->
+            results.filterNotNull().toSet()
+        }
+    }
+        .setupCommonEventHandlers(TAG) { "syncingModules" }
 
     suspend fun refresh() {
         log(TAG) { "refresh()" }

--- a/module-core/src/main/java/eu/darken/octi/module/core/ModuleManager.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/ModuleManager.kt
@@ -50,15 +50,30 @@ class ModuleManager @Inject constructor(
             log(TAG, VERBOSE) { "BYDEVICE: $it" }
         }
 
-    val syncingModules: Flow<Set<ModuleId>> = if (moduleSyncs.isEmpty()) {
-        flowOf(emptySet())
+    data class ModuleSyncState(
+        val moduleId: ModuleId,
+        val activity: ModuleSync.SyncActivity,
+    )
+
+    val moduleSyncStates: Flow<List<ModuleSyncState>> = if (moduleSyncs.isEmpty()) {
+        flowOf(emptyList())
     } else {
-        kotlinx.coroutines.flow.combine(moduleSyncs.map { sync ->
-            sync.isSyncing.map { busy -> if (busy) sync.moduleId else null }
-        }) { results ->
-            results.filterNotNull().toSet()
+        val enabledFlows = moduleRepos.associateBy { it.moduleId }
+        combine(
+            moduleSyncs.map { sync ->
+                val enabledFlow = enabledFlows[sync.moduleId]?.isEnabled ?: flowOf(true)
+                combine(sync.syncActivity, enabledFlow) { activity, enabled ->
+                    if (enabled) ModuleSyncState(sync.moduleId, activity) else null
+                }
+            }
+        ) { results ->
+            results.filterNotNull().toList()
         }
     }
+        .setupCommonEventHandlers(TAG) { "moduleSyncStates" }
+
+    val syncingModules: Flow<Set<ModuleId>> = moduleSyncStates
+        .map { states -> states.filter { it.activity != ModuleSync.SyncActivity.IDLE }.map { it.moduleId }.toSet() }
         .setupCommonEventHandlers(TAG) { "syncingModules" }
 
     suspend fun refresh() {

--- a/module-core/src/main/java/eu/darken/octi/module/core/ModuleRepo.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/ModuleRepo.kt
@@ -8,6 +8,10 @@ interface ModuleRepo<T> {
         val all: Collection<ModuleData<T>>
     }
 
+    val moduleId: ModuleId
+
+    val isEnabled: Flow<Boolean>
+
     val state: Flow<State<T>>
 
     val keepAlive: Flow<Unit>

--- a/module-core/src/main/java/eu/darken/octi/module/core/ModuleSync.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/ModuleSync.kt
@@ -6,9 +6,13 @@ import kotlinx.coroutines.flow.Flow
 
 interface ModuleSync<T : Any> {
 
+    enum class SyncActivity { IDLE, READING, WRITING }
+
     val ourDeviceId: DeviceId
 
     val moduleId: ModuleId
+
+    val syncActivity: Flow<SyncActivity>
 
     val isSyncing: Flow<Boolean>
 

--- a/module-core/src/main/java/eu/darken/octi/module/core/ModuleSync.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/ModuleSync.kt
@@ -10,6 +10,8 @@ interface ModuleSync<T : Any> {
 
     val moduleId: ModuleId
 
+    val isSyncing: Flow<Boolean>
+
     val others: Flow<List<ModuleData<T>>>
 
     suspend fun sync(self: ModuleData<T>)

--- a/module-core/src/test/java/eu/darken/octi/module/core/BaseModuleSyncTest.kt
+++ b/module-core/src/test/java/eu/darken/octi/module/core/BaseModuleSyncTest.kt
@@ -1,8 +1,10 @@
 package eu.darken.octi.module.core
 
 import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import io.kotest.matchers.shouldBe
@@ -10,11 +12,15 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import okio.ByteString
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -27,7 +33,9 @@ class BaseModuleSyncTest : BaseTest() {
     @MockK lateinit var dispatcherProvider: DispatcherProvider
 
     private val testDeviceId = DeviceId("test-device")
+    private val otherDeviceId = DeviceId("other-device")
     private val testModuleId = ModuleId("test.module")
+    private val testConnectorId = ConnectorId(type = "test", subtype = "test", account = "test")
 
     private lateinit var sync: TestModuleSync
 
@@ -45,68 +53,179 @@ class BaseModuleSyncTest : BaseTest() {
         )
     }
 
-    @Test
-    fun `isSyncing is false initially`() = runTest2 {
-        sync.isSyncing.first() shouldBe false
+    private fun createSyncReadDevice(
+        deviceId: DeviceId,
+        moduleId: ModuleId,
+        payload: String,
+    ): SyncRead.Device = object : SyncRead.Device {
+        override val deviceId = deviceId
+        override val modules = listOf(
+            object : SyncRead.Device.Module {
+                override val connectorId = testConnectorId
+                override val deviceId = deviceId
+                override val moduleId = moduleId
+                override val modifiedAt = Instant.now()
+                override val payload: ByteString = ByteString.of(*payload.toByteArray())
+            }
+        )
     }
 
-    @Test
-    fun `isSyncing is true during active sync`() = runTest2 {
-        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
-            sync.isSyncing.first() shouldBe true
+    private fun createSync(
+        dataFlow: MutableSharedFlow<Collection<SyncRead.Device>>,
+        serializer: ModuleSerializer<String> = defaultSerializer,
+    ): TestModuleSync {
+        every { syncManager.data } returns dataFlow
+        return TestModuleSync(
+            moduleId = testModuleId,
+            dispatcherProvider = dispatcherProvider,
+            syncSettings = syncSettings,
+            syncManager = syncManager,
+            moduleSerializer = serializer,
+        )
+    }
+
+    @Nested
+    inner class `write tracking` {
+        @Test
+        fun `syncActivity is IDLE initially`() = runTest2 {
+            sync.syncActivity.first() shouldBe ModuleSync.SyncActivity.IDLE
+            sync.isSyncing.first() shouldBe false
         }
 
-        val data = ModuleData(
-            modifiedAt = Instant.now(),
-            deviceId = testDeviceId,
-            moduleId = testModuleId,
-            data = "test-data",
-        )
-        sync.sync(data)
+        @Test
+        fun `syncActivity is WRITING during active sync`() = runTest2 {
+            coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
+                sync.syncActivity.first() shouldBe ModuleSync.SyncActivity.WRITING
+                sync.isSyncing.first() shouldBe true
+            }
 
-        sync.isSyncing.first() shouldBe false
-    }
-
-    @Test
-    fun `isSyncing is false after sync throws`() = runTest2 {
-        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } throws RuntimeException("Sync failed")
-
-        val data = ModuleData(
-            modifiedAt = Instant.now(),
-            deviceId = testDeviceId,
-            moduleId = testModuleId,
-            data = "test-data",
-        )
-
-        try {
+            val data = ModuleData(
+                modifiedAt = Instant.now(),
+                deviceId = testDeviceId,
+                moduleId = testModuleId,
+                data = "test-data",
+            )
             sync.sync(data)
-        } catch (_: RuntimeException) {
-            // Expected
+
+            sync.isSyncing.first() shouldBe false
         }
 
-        sync.isSyncing.first() shouldBe false
+        @Test
+        fun `syncActivity is IDLE after sync throws`() = runTest2 {
+            coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } throws RuntimeException("Sync failed")
+
+            val data = ModuleData(
+                modifiedAt = Instant.now(),
+                deviceId = testDeviceId,
+                moduleId = testModuleId,
+                data = "test-data",
+            )
+
+            try {
+                sync.sync(data)
+            } catch (_: RuntimeException) {
+                // Expected
+            }
+
+            sync.isSyncing.first() shouldBe false
+        }
+
+        @Test
+        fun `syncActivity is IDLE after cancellation`() = runTest2 {
+            coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
+                kotlinx.coroutines.awaitCancellation()
+            }
+
+            val data = ModuleData(
+                modifiedAt = Instant.now(),
+                deviceId = testDeviceId,
+                moduleId = testModuleId,
+                data = "test-data",
+            )
+
+            val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+                sync.sync(data)
+            }
+            job.cancel()
+            job.join()
+
+            sync.isSyncing.first() shouldBe false
+        }
     }
 
-    @Test
-    fun `isSyncing is false after cancellation`() = runTest2 {
-        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
-            kotlinx.coroutines.awaitCancellation()
+    @Nested
+    inner class `read tracking` {
+        @Test
+        fun `isSyncing is false after others read completes`() = runTest2 {
+            val dataFlow = MutableSharedFlow<Collection<SyncRead.Device>>()
+            val testSync = createSync(dataFlow)
+
+            val othersJob = testSync.others.launchIn(this)
+
+            dataFlow.emit(listOf(createSyncReadDevice(otherDeviceId, testModuleId, "hello")))
+
+            testSync.isSyncing.first() shouldBe false
+
+            othersJob.cancel()
         }
 
-        val data = ModuleData(
-            modifiedAt = Instant.now(),
-            deviceId = testDeviceId,
-            moduleId = testModuleId,
-            data = "test-data",
-        )
+        @Test
+        fun `isSyncing is false after others deserialization error`() = runTest2 {
+            val dataFlow = MutableSharedFlow<Collection<SyncRead.Device>>()
+            val failingSerializer = object : ModuleSerializer<String> {
+                override fun serialize(item: String): ByteString = ByteString.of(*item.toByteArray())
+                override fun deserialize(raw: ByteString): String = throw RuntimeException("Deserialization failed")
+            }
+            val testSync = createSync(dataFlow, failingSerializer)
 
-        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
-            sync.sync(data)
+            val othersJob = testSync.others.launchIn(this)
+
+            dataFlow.emit(listOf(createSyncReadDevice(otherDeviceId, testModuleId, "bad-data")))
+
+            testSync.isSyncing.first() shouldBe false
+
+            othersJob.cancel()
         }
-        job.cancel()
-        job.join()
 
-        sync.isSyncing.first() shouldBe false
+        @Test
+        fun `isSyncing stays true when read overlaps with ongoing write`() = runTest2 {
+            val dataFlow = MutableSharedFlow<Collection<SyncRead.Device>>()
+            val testSync = createSync(dataFlow)
+            coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
+                kotlinx.coroutines.awaitCancellation()
+            }
+
+            val othersJob = testSync.others.launchIn(this)
+
+            // Start a write that suspends indefinitely
+            val writeJob = launch(UnconfinedTestDispatcher(testScheduler)) {
+                testSync.sync(
+                    ModuleData(
+                        modifiedAt = Instant.now(),
+                        deviceId = testDeviceId,
+                        moduleId = testModuleId,
+                        data = "write-data",
+                    )
+                )
+            }
+
+            // isSyncing should be true from the write
+            testSync.isSyncing.first() shouldBe true
+
+            // Emit read data while write is still in progress - counter goes 1->2->1
+            dataFlow.emit(listOf(createSyncReadDevice(otherDeviceId, testModuleId, "read-data")))
+
+            // Still syncing because write is ongoing
+            testSync.isSyncing.first() shouldBe true
+
+            // Cancel write
+            writeJob.cancel()
+            writeJob.join()
+
+            testSync.isSyncing.first() shouldBe false
+
+            othersJob.cancel()
+        }
     }
 
     private class TestModuleSync(
@@ -114,15 +233,20 @@ class BaseModuleSyncTest : BaseTest() {
         dispatcherProvider: DispatcherProvider,
         syncSettings: SyncSettings,
         syncManager: SyncManager,
+        moduleSerializer: ModuleSerializer<String> = defaultSerializer,
     ) : BaseModuleSync<String>(
         moduleId = moduleId,
         tag = "Test:Sync",
         dispatcherProvider = dispatcherProvider,
         syncSettings = syncSettings,
         syncManager = syncManager,
-        moduleSerializer = object : ModuleSerializer<String> {
-            override fun serialize(item: String): okio.ByteString = okio.ByteString.of(*item.toByteArray())
-            override fun deserialize(raw: okio.ByteString): String = raw.utf8()
-        },
+        moduleSerializer = moduleSerializer,
     )
+
+    companion object {
+        private val defaultSerializer = object : ModuleSerializer<String> {
+            override fun serialize(item: String): ByteString = ByteString.of(*item.toByteArray())
+            override fun deserialize(raw: ByteString): String = raw.utf8()
+        }
+    }
 }

--- a/module-core/src/test/java/eu/darken/octi/module/core/BaseModuleSyncTest.kt
+++ b/module-core/src/test/java/eu/darken/octi/module/core/BaseModuleSyncTest.kt
@@ -1,0 +1,128 @@
+package eu.darken.octi.module.core
+
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.SyncWrite
+import io.kotest.matchers.shouldBe
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class BaseModuleSyncTest : BaseTest() {
+
+    @MockK lateinit var syncManager: SyncManager
+    @MockK lateinit var syncSettings: SyncSettings
+    @MockK lateinit var dispatcherProvider: DispatcherProvider
+
+    private val testDeviceId = DeviceId("test-device")
+    private val testModuleId = ModuleId("test.module")
+
+    private lateinit var sync: TestModuleSync
+
+    @BeforeEach
+    fun setup() {
+        MockKAnnotations.init(this)
+        every { syncSettings.deviceId } returns testDeviceId
+        every { syncManager.data } returns flowOf(emptyList())
+
+        sync = TestModuleSync(
+            moduleId = testModuleId,
+            dispatcherProvider = dispatcherProvider,
+            syncSettings = syncSettings,
+            syncManager = syncManager,
+        )
+    }
+
+    @Test
+    fun `isSyncing is false initially`() = runTest2 {
+        sync.isSyncing.first() shouldBe false
+    }
+
+    @Test
+    fun `isSyncing is true during active sync`() = runTest2 {
+        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
+            sync.isSyncing.first() shouldBe true
+        }
+
+        val data = ModuleData(
+            modifiedAt = Instant.now(),
+            deviceId = testDeviceId,
+            moduleId = testModuleId,
+            data = "test-data",
+        )
+        sync.sync(data)
+
+        sync.isSyncing.first() shouldBe false
+    }
+
+    @Test
+    fun `isSyncing is false after sync throws`() = runTest2 {
+        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } throws RuntimeException("Sync failed")
+
+        val data = ModuleData(
+            modifiedAt = Instant.now(),
+            deviceId = testDeviceId,
+            moduleId = testModuleId,
+            data = "test-data",
+        )
+
+        try {
+            sync.sync(data)
+        } catch (_: RuntimeException) {
+            // Expected
+        }
+
+        sync.isSyncing.first() shouldBe false
+    }
+
+    @Test
+    fun `isSyncing is false after cancellation`() = runTest2 {
+        coEvery { syncManager.write(any<SyncWrite.Device.Module>()) } coAnswers {
+            kotlinx.coroutines.awaitCancellation()
+        }
+
+        val data = ModuleData(
+            modifiedAt = Instant.now(),
+            deviceId = testDeviceId,
+            moduleId = testModuleId,
+            data = "test-data",
+        )
+
+        val job = launch(UnconfinedTestDispatcher(testScheduler)) {
+            sync.sync(data)
+        }
+        job.cancel()
+        job.join()
+
+        sync.isSyncing.first() shouldBe false
+    }
+
+    private class TestModuleSync(
+        moduleId: ModuleId,
+        dispatcherProvider: DispatcherProvider,
+        syncSettings: SyncSettings,
+        syncManager: SyncManager,
+    ) : BaseModuleSync<String>(
+        moduleId = moduleId,
+        tag = "Test:Sync",
+        dispatcherProvider = dispatcherProvider,
+        syncSettings = syncSettings,
+        syncManager = syncManager,
+        moduleSerializer = object : ModuleSerializer<String> {
+            override fun serialize(item: String): okio.ByteString = okio.ByteString.of(*item.toByteArray())
+            override fun deserialize(raw: okio.ByteString): String = raw.utf8()
+        },
+    )
+}

--- a/modules-meta/src/main/res/values/strings.xml
+++ b/modules-meta/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="module_meta_label">Meta module</string>
     <string name="module_meta_android_name_x_label">Android %s</string>
 </resources>

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
@@ -45,6 +45,8 @@ class SyncSettings @Inject constructor(
 
     val foregroundSyncInterval = dataStore.createValue("sync.foreground.interval.minutes", 5)
 
+    val showDashboardCard = dataStore.createValue("sync.dashboard.card.show", true)
+
     val pausedConnectors = dataStore.createSetValue<ConnectorId>("sync.connectors.paused", emptySet(), json)
 
     val deviceId by lazy {


### PR DESCRIPTION
## Summary
- Dashboard sync status bar now shows which modules are actively syncing (e.g. "Syncing Power module, Wi-Fi module...") instead of generic "Syncing..."
- Adds isSyncing tracking to BaseModuleSync with overlap-safe counter
- Exposes syncingModules flow from ModuleManager for aggregated per-module sync state
- Reuses existing translated module label strings for display names
- Falls back to generic "Syncing..." when no specific module is active

## Test plan
- [x] Build passes: ./gradlew assembleDebug
- [x] Unit tests pass: ./gradlew :module-core:testDebugUnitTest
- [ ] Manual: trigger sync, verify module names appear in status bar
- [ ] Manual: verify fallback to generic text when connector is busy but no module is active
- [ ] Manual: verify text overflow with ellipsis when many modules sync simultaneously