### PR TITLE
Restrict GITHUB_TOKEN permissions to minimum required

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   lint-vital:
     name: Lint vitals
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -37,6 +42,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -54,6 +61,8 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
 
@@ -66,5 +75,7 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - name: Validate metadata lengths
         run: bash fastlane/check_metadata_length.sh

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,10 +8,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
       - uses: gradle/actions/wrapper-validation@0723195856401067f7a2779048b490ace7a47d7c #v5.0.2

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,6 +11,8 @@ on:
         type: boolean
         default: true
 
+permissions: {}
+
 jobs:
   release-github:
     name: Create GitHub release
@@ -33,6 +35,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup
@@ -108,6 +111,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup project and build environment
         uses: ./.github/actions/common-setup


### PR DESCRIPTION
Adds explicit permissions and persist-credentials: false to all three GitHub Actions workflows.

Two changes per workflow:

1. **Top-level permissions: contents: read** (or `{}` for release) — Without an explicit permissions block, GITHUB_TOKEN inherits the repo default, which is typically read+write on all scopes. These workflows only need to check out code and run builds/tests/lint. The release workflow's release-github job already declares permissions: contents: write at job level, which overrides the top-level default for that job only.

2. **persist-credentials: false on all actions/checkout steps** — By default, actions/checkout writes the GITHUB_TOKEN into .git/config as an authorization header, where it remains accessible to all subsequent steps in the job. No workflow in this repo needs git push after checkout, so there is no reason to leave credentials in the git config.

**Not affected:** All actions remain pinned to commit SHAs (already done). The release job retains its job-level contents: write permission. No functional behavior changes.