### PR TITLE
Add instant sync with real-time notifications

### DIFF
--- a/app/src/main/java/eu/darken/octi/App.kt
+++ b/app/src/main/java/eu/darken/octi/App.kt
@@ -21,9 +21,7 @@ import eu.darken.octi.main.core.CurriculumVitae
 import eu.darken.octi.main.core.GeneralSettings
 import eu.darken.octi.main.core.release.ReleaseManager
 import eu.darken.octi.module.core.ModuleManager
-import eu.darken.octi.sync.core.ForegroundSyncControl
-import eu.darken.octi.sync.core.SyncManager
-import eu.darken.octi.sync.core.worker.SyncWorkerControl
+import eu.darken.octi.sync.core.SyncOrchestrator
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -37,10 +35,8 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var dispatcherProvider: DispatcherProvider
     @Inject lateinit var workerFactory: HiltWorkerFactory
     @Inject lateinit var bugReporter: AutomaticBugReporter
-    @Inject lateinit var syncManager: SyncManager
+    @Inject lateinit var syncOrchestrator: SyncOrchestrator
     @Inject lateinit var moduleManager: ModuleManager
-    @Inject lateinit var syncWorkerControl: SyncWorkerControl
-    @Inject lateinit var foregroundSyncControl: ForegroundSyncControl
     @Inject lateinit var generalSettings: GeneralSettings
     @Inject lateinit var debugSessionManager: DebugSessionManager
     @Inject lateinit var imageLoaderFactory: SingletonImageLoader.Factory
@@ -64,11 +60,8 @@ open class App : Application(), Configuration.Provider {
 
         bugReporter.setup(this)
 
-        syncManager.start()
         moduleManager.start()
-
-        syncWorkerControl.start()
-        foregroundSyncControl.start()
+        syncOrchestrator.start()
 
         curriculumVitae.updateAppLaunch()
 
@@ -81,18 +74,19 @@ open class App : Application(), Configuration.Provider {
         log(TAG) { "onCreate() done! ${Exception().asLog()}" }
     }
 
-    override val workManagerConfiguration: Configuration get() = Configuration.Builder()
-        .setMinimumLoggingLevel(
-            when {
-                BuildConfigWrap.DEBUG -> android.util.Log.VERBOSE
-                BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.DEV -> android.util.Log.DEBUG
-                BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.BETA -> android.util.Log.INFO
-                BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.RELEASE -> android.util.Log.WARN
-                else -> android.util.Log.VERBOSE
-            }
-        )
-        .setWorkerFactory(workerFactory)
-        .build()
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setMinimumLoggingLevel(
+                when {
+                    BuildConfigWrap.DEBUG -> android.util.Log.VERBOSE
+                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.DEV -> android.util.Log.DEBUG
+                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.BETA -> android.util.Log.INFO
+                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.RELEASE -> android.util.Log.WARN
+                    else -> android.util.Log.VERBOSE
+                }
+            )
+            .setWorkerFactory(workerFactory)
+            .build()
 
     companion object {
         internal val TAG = logTag("App")

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -118,6 +118,8 @@ import eu.darken.octi.modules.wifi.WifiModule
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiDetailSheet
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.StalenessUtil
+import eu.darken.octi.sync.core.SyncConnector.EventMode
+import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncOrchestrator
 import kotlinx.coroutines.launch
 import java.time.Instant
@@ -603,20 +605,18 @@ private fun connectorTypesLabel(
     val base = stringResource(R.string.dashboard_sync_status_via, names.joinToString(", "))
 
     val orchestratorState = syncStatus.orchestratorState
-    val quickSync = orchestratorState.quickSync
-    if (quickSync.isActive && quickSync.connectorModes.isNotEmpty()) {
-        val modes = connectorTypes.mapNotNull { quickSync.connectorModes[it] }.distinct()
+    val activeModes = orchestratorState.quickSync.connectorModes.values.distinct()
+    if (activeModes.isNotEmpty()) {
         val modeLabel = when {
-            modes.size == 1 && modes.first() == SyncOrchestrator.QuickSyncState.Mode.LIVE ->
+            activeModes.size == 1 && activeModes.first() == SyncConnector.EventMode.LIVE ->
                 stringResource(R.string.dashboard_sync_status_mode_live)
 
-            modes.size == 1 && modes.first() == SyncOrchestrator.QuickSyncState.Mode.POLLING ->
-                stringResource(R.string.dashboard_sync_status_mode_polling)
+            activeModes.size == 1 && activeModes.first() == SyncConnector.EventMode.POLLING ->
+                stringResource(R.string.dashboard_sync_status_mode_fast)
 
-            modes.isNotEmpty() -> stringResource(R.string.dashboard_sync_status_mode_quicksync)
-            else -> null
+            else -> stringResource(R.string.dashboard_sync_status_mode_quicksync)
         }
-        if (modeLabel != null) return "$base \u00B7 $modeLabel"
+        return "$base \u00B7 $modeLabel"
     }
 
     val nextRun = orchestratorState.backgroundSync.defaultWorker.nextRunAt
@@ -763,7 +763,7 @@ private fun SyncStatusBar(
                         detail.connectors.forEach { connector ->
                             SyncDetailConnectorRow(
                                 connector = connector,
-                                quickSyncMode = syncStatus.orchestratorState.quickSync.connectorModes[connector.type],
+                                quickSyncMode = syncStatus.orchestratorState.quickSync.connectorModes[connector.connectorId],
                             )
                         }
                     }
@@ -837,7 +837,7 @@ private fun SyncDetailModuleRow(moduleState: ModuleManager.ModuleSyncState) {
 @Composable
 private fun SyncDetailConnectorRow(
     connector: DashboardVM.ConnectorDetail,
-    quickSyncMode: SyncOrchestrator.QuickSyncState.Mode? = null,
+    quickSyncMode: SyncConnector.EventMode? = null,
 ) {
     Row(
         modifier = Modifier
@@ -866,10 +866,11 @@ private fun SyncDetailConnectorRow(
                 modifier = Modifier.size(12.dp),
                 strokeWidth = 1.5.dp,
             )
-        } else if (quickSyncMode != null) {
+        } else if (quickSyncMode != null && quickSyncMode != SyncConnector.EventMode.NONE) {
             val modeLabel = when (quickSyncMode) {
-                SyncOrchestrator.QuickSyncState.Mode.LIVE -> stringResource(R.string.dashboard_sync_status_mode_live)
-                SyncOrchestrator.QuickSyncState.Mode.POLLING -> stringResource(R.string.dashboard_sync_status_mode_polling)
+                SyncConnector.EventMode.LIVE -> stringResource(R.string.dashboard_sync_status_mode_live)
+                SyncConnector.EventMode.POLLING -> stringResource(R.string.dashboard_sync_status_mode_fast)
+                SyncConnector.EventMode.NONE -> error("Filtered above")
             }
             Text(
                 text = modeLabel,

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -26,26 +26,25 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Apps
+import androidx.compose.material.icons.twotone.BatteryFull
+import androidx.compose.material.icons.twotone.CellTower
 import androidx.compose.material.icons.twotone.ChevronRight
 import androidx.compose.material.icons.twotone.CloudSync
+import androidx.compose.material.icons.twotone.Coffee
+import androidx.compose.material.icons.twotone.ContentPaste
+import androidx.compose.material.icons.twotone.ExpandLess
+import androidx.compose.material.icons.twotone.ExpandMore
 import androidx.compose.material.icons.twotone.Home
+import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material.icons.twotone.QuestionMark
 import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Tablet
-import androidx.compose.material.icons.twotone.Apps
-import androidx.compose.material.icons.twotone.BatteryFull
-import androidx.compose.material.icons.twotone.CellTower
-import androidx.compose.material.icons.twotone.Coffee
-import androidx.compose.material.icons.twotone.ContentPaste
-import androidx.compose.material.icons.twotone.ExpandLess
-import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material.icons.twotone.Wifi
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -61,6 +60,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,74 +70,67 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import kotlinx.coroutines.launch
 import eu.darken.octi.R
 import eu.darken.octi.common.BuildConfigWrap
-import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import androidx.compose.runtime.collectAsState
-import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
-import eu.darken.octi.module.core.ModuleData
-import eu.darken.octi.module.core.ModuleId
-import eu.darken.octi.module.core.ModuleManager
-import eu.darken.octi.module.core.ModuleSync
-import java.time.Instant
 import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.descriptionRes
 import eu.darken.octi.common.permissions.labelRes
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.main.ui.dashboard.editor.TileEditorCard
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.module.core.ModuleManager
+import eu.darken.octi.module.core.ModuleSync
 import eu.darken.octi.modules.apps.AppsModule
-import eu.darken.octi.modules.apps.R as AppsR
 import eu.darken.octi.modules.apps.core.AppsInfo
-import eu.darken.octi.modules.apps.ui.dashboard.AppsModuleItem
-import eu.darken.octi.modules.clipboard.ClipboardModule
 import eu.darken.octi.modules.clipboard.ClipboardInfo
-import eu.darken.octi.modules.clipboard.R as ClipboardR
-import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardDashState
+import eu.darken.octi.modules.clipboard.ClipboardModule
 import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardDetailSheet
-import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardModuleItem
 import eu.darken.octi.modules.connectivity.ConnectivityModule
-import eu.darken.octi.modules.connectivity.R as ConnectivityR
 import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityDetailSheet
-import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityModuleItem
 import eu.darken.octi.modules.meta.MetaModule
-import eu.darken.octi.modules.meta.R as MetaR
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.power.PowerModule
-import eu.darken.octi.modules.power.R as PowerR
 import eu.darken.octi.modules.power.core.PowerInfo
 import eu.darken.octi.modules.power.core.PowerInfo.ChargeIO
 import eu.darken.octi.modules.power.core.PowerInfo.Status
-import eu.darken.octi.modules.power.ui.dashboard.PowerDashState
 import eu.darken.octi.modules.power.ui.dashboard.PowerDetailSheet
-import eu.darken.octi.modules.power.ui.dashboard.PowerModuleItem
 import eu.darken.octi.modules.wifi.WifiModule
-import eu.darken.octi.modules.wifi.R as WifiR
-import eu.darken.octi.modules.wifi.ui.dashboard.WifiDashState
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiDetailSheet
-import eu.darken.octi.modules.wifi.ui.dashboard.WifiModuleItem
-import eu.darken.octi.main.ui.dashboard.editor.TileEditorCard
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.StalenessUtil
+import eu.darken.octi.sync.core.SyncOrchestrator
+import kotlinx.coroutines.launch
+import java.time.Instant
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.modules.apps.R as AppsR
+import eu.darken.octi.modules.clipboard.R as ClipboardR
+import eu.darken.octi.modules.connectivity.R as ConnectivityR
+import eu.darken.octi.modules.meta.R as MetaR
+import eu.darken.octi.modules.power.R as PowerR
+import eu.darken.octi.modules.wifi.R as WifiR
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.syncs.gdrive.R as GDriveR
 import eu.darken.octi.syncs.kserver.R as KServerR
-import eu.darken.octi.sync.core.DeviceId
-import eu.darken.octi.sync.core.StalenessUtil
 
 @Composable
 fun DashboardScreenHost(vm: DashboardVM = hiltViewModel()) {
@@ -377,167 +370,167 @@ fun DashboardScreen(
             }
 
             // Sync setup card
-                if (state.showSyncSetup) {
-                    item(key = "sync_setup") {
-                        SyncSetupCard(
-                            onDismiss = onDismissSyncSetup,
-                            onSetup = onSetupSync,
-                        )
-                    }
+            if (state.showSyncSetup) {
+                item(key = "sync_setup") {
+                    SyncSetupCard(
+                        onDismiss = onDismissSyncSetup,
+                        onSetup = onSetupSync,
+                    )
                 }
+            }
 
-                // Permission cards
+            // Permission cards
+            items(
+                items = state.missingPermissions,
+                key = { "perm_${it.permissionId}" },
+            ) { permission ->
+                PermissionCard(
+                    permission = permission,
+                    onGrant = onGrantPermission,
+                    onDismiss = onDismissPermission,
+                )
+            }
+
+            // Update card
+            if (state.update != null) {
+                item(key = "update") {
+                    UpdateCard(
+                        update = state.update,
+                        onDismiss = onDismissUpdate,
+                        onViewUpdate = onViewUpdate,
+                        onUpdate = onStartUpdate,
+                    )
+                }
+            }
+
+            // Device cards with limit card interleaved
+            val devices = state.devices
+            val deviceLimit = 3
+            val showLimitCard = state.deviceLimitReached
+
+            if (showLimitCard) {
+                // Show devices before limit
                 items(
-                    items = state.missingPermissions,
-                    key = { "perm_${it.permissionId}" },
-                ) { permission ->
-                    PermissionCard(
-                        permission = permission,
-                        onGrant = onGrantPermission,
-                        onDismiss = onDismissPermission,
+                    items = devices.take(deviceLimit),
+                    key = { it.meta.deviceId.hashCode() },
+                ) { device ->
+                    DeviceCardOrEditor(
+                        device = device,
+                        editingDeviceId = editingDeviceId,
+                        onToggleCollapse = onToggleDeviceCollapsed,
+                        onLongPress = { editingDeviceId = it },
+                        onUpgrade = onUpgrade,
+                        onManageStaleDevice = onSyncServices,
+                        onPowerClicked = { showPowerDetail = it },
+                        onPowerAlerts = onPowerAlerts,
+                        onWifiClicked = { showWifiDetail = it },
+                        onWifiPermissionGrant = onWifiPermissionGrant,
+                        onConnectivityClicked = { showConnectivityDetail = it },
+                        onAppsClicked = onAppsList,
+                        onInstallLatestApp = onInstallLatestApp,
+                        onClipboardClicked = { showClipboardDetail = it },
+                        onClearClipboard = onClearClipboard,
+                        onShareClipboard = onShareClipboard,
+                        onCopyClipboard = onCopyClipboard,
+                        showMessage = showMessage,
+                        onDoneEditing = { deviceId, config ->
+                            onSaveTileLayout(deviceId, config)
+                            editingDeviceId = null
+                        },
+                        onCancelEditing = { editingDeviceId = null },
+                        onResetTileLayout = onResetTileLayout,
+                        onSaveAsDefault = onSaveAsDefaultTileLayout,
                     )
                 }
 
-                // Update card
-                if (state.update != null) {
-                    item(key = "update") {
-                        UpdateCard(
-                            update = state.update,
-                            onDismiss = onDismissUpdate,
-                            onViewUpdate = onViewUpdate,
-                            onUpdate = onStartUpdate,
-                        )
-                    }
+                // Device limit card
+                item(key = "device_limit") {
+                    DeviceLimitCard(
+                        current = devices.size,
+                        maximum = deviceLimit,
+                        onManageDevices = onSyncServices,
+                        onUpgrade = onUpgrade,
+                    )
                 }
 
-                // Device cards with limit card interleaved
-                val devices = state.devices
-                val deviceLimit = 3
-                val showLimitCard = state.deviceLimitReached
-
-                if (showLimitCard) {
-                    // Show devices before limit
-                    items(
-                        items = devices.take(deviceLimit),
-                        key = { it.meta.deviceId.hashCode() },
-                    ) { device ->
-                        DeviceCardOrEditor(
-                            device = device,
-                            editingDeviceId = editingDeviceId,
-                            onToggleCollapse = onToggleDeviceCollapsed,
-                            onLongPress = { editingDeviceId = it },
-                            onUpgrade = onUpgrade,
-                            onManageStaleDevice = onSyncServices,
-                            onPowerClicked = { showPowerDetail = it },
-                            onPowerAlerts = onPowerAlerts,
-                            onWifiClicked = { showWifiDetail = it },
-                            onWifiPermissionGrant = onWifiPermissionGrant,
-                            onConnectivityClicked = { showConnectivityDetail = it },
-                            onAppsClicked = onAppsList,
-                            onInstallLatestApp = onInstallLatestApp,
-                            onClipboardClicked = { showClipboardDetail = it },
-                            onClearClipboard = onClearClipboard,
-                            onShareClipboard = onShareClipboard,
-                            onCopyClipboard = onCopyClipboard,
-                            showMessage = showMessage,
-                            onDoneEditing = { deviceId, config ->
-                                onSaveTileLayout(deviceId, config)
-                                editingDeviceId = null
-                            },
-                            onCancelEditing = { editingDeviceId = null },
-                            onResetTileLayout = onResetTileLayout,
-                            onSaveAsDefault = onSaveAsDefaultTileLayout,
-                        )
-                    }
-
-                    // Device limit card
-                    item(key = "device_limit") {
-                        DeviceLimitCard(
-                            current = devices.size,
-                            maximum = deviceLimit,
-                            onManageDevices = onSyncServices,
-                            onUpgrade = onUpgrade,
-                        )
-                    }
-
-                    // Show devices after limit
-                    items(
-                        items = devices.drop(deviceLimit),
-                        key = { "after_${it.meta.deviceId.id}" },
-                    ) { device ->
-                        DeviceCardOrEditor(
-                            device = device,
-                            editingDeviceId = editingDeviceId,
-                            onToggleCollapse = onToggleDeviceCollapsed,
-                            onLongPress = { editingDeviceId = it },
-                            onUpgrade = onUpgrade,
-                            onManageStaleDevice = onSyncServices,
-                            onPowerClicked = { showPowerDetail = it },
-                            onPowerAlerts = onPowerAlerts,
-                            onWifiClicked = { showWifiDetail = it },
-                            onWifiPermissionGrant = onWifiPermissionGrant,
-                            onConnectivityClicked = { showConnectivityDetail = it },
-                            onAppsClicked = onAppsList,
-                            onInstallLatestApp = onInstallLatestApp,
-                            onClipboardClicked = { showClipboardDetail = it },
-                            onClearClipboard = onClearClipboard,
-                            onShareClipboard = onShareClipboard,
-                            onCopyClipboard = onCopyClipboard,
-                            showMessage = showMessage,
-                            onDoneEditing = { deviceId, config ->
-                                onSaveTileLayout(deviceId, config)
-                                editingDeviceId = null
-                            },
-                            onCancelEditing = { editingDeviceId = null },
-                            onResetTileLayout = onResetTileLayout,
-                            onSaveAsDefault = onSaveAsDefaultTileLayout,
-                        )
-                    }
-                } else {
-                    items(
-                        items = devices,
-                        key = { it.meta.deviceId.hashCode() },
-                    ) { device ->
-                        DeviceCardOrEditor(
-                            device = device,
-                            editingDeviceId = editingDeviceId,
-                            onToggleCollapse = onToggleDeviceCollapsed,
-                            onLongPress = { editingDeviceId = it },
-                            onUpgrade = onUpgrade,
-                            onManageStaleDevice = onSyncServices,
-                            onPowerClicked = { showPowerDetail = it },
-                            onPowerAlerts = onPowerAlerts,
-                            onWifiClicked = { showWifiDetail = it },
-                            onWifiPermissionGrant = onWifiPermissionGrant,
-                            onConnectivityClicked = { showConnectivityDetail = it },
-                            onAppsClicked = onAppsList,
-                            onInstallLatestApp = onInstallLatestApp,
-                            onClipboardClicked = { showClipboardDetail = it },
-                            onClearClipboard = onClearClipboard,
-                            onShareClipboard = onShareClipboard,
-                            onCopyClipboard = onCopyClipboard,
-                            showMessage = showMessage,
-                            onDoneEditing = { deviceId, config ->
-                                onSaveTileLayout(deviceId, config)
-                                editingDeviceId = null
-                            },
-                            onCancelEditing = { editingDeviceId = null },
-                            onResetTileLayout = onResetTileLayout,
-                            onSaveAsDefault = onSaveAsDefaultTileLayout,
-                        )
-                    }
+                // Show devices after limit
+                items(
+                    items = devices.drop(deviceLimit),
+                    key = { "after_${it.meta.deviceId.id}" },
+                ) { device ->
+                    DeviceCardOrEditor(
+                        device = device,
+                        editingDeviceId = editingDeviceId,
+                        onToggleCollapse = onToggleDeviceCollapsed,
+                        onLongPress = { editingDeviceId = it },
+                        onUpgrade = onUpgrade,
+                        onManageStaleDevice = onSyncServices,
+                        onPowerClicked = { showPowerDetail = it },
+                        onPowerAlerts = onPowerAlerts,
+                        onWifiClicked = { showWifiDetail = it },
+                        onWifiPermissionGrant = onWifiPermissionGrant,
+                        onConnectivityClicked = { showConnectivityDetail = it },
+                        onAppsClicked = onAppsList,
+                        onInstallLatestApp = onInstallLatestApp,
+                        onClipboardClicked = { showClipboardDetail = it },
+                        onClearClipboard = onClearClipboard,
+                        onShareClipboard = onShareClipboard,
+                        onCopyClipboard = onCopyClipboard,
+                        showMessage = showMessage,
+                        onDoneEditing = { deviceId, config ->
+                            onSaveTileLayout(deviceId, config)
+                            editingDeviceId = null
+                        },
+                        onCancelEditing = { editingDeviceId = null },
+                        onResetTileLayout = onResetTileLayout,
+                        onSaveAsDefault = onSaveAsDefaultTileLayout,
+                    )
                 }
-
-                // Upgrade card at bottom
-                if (!state.upgradeInfo.isPro) {
-                    item(key = "upgrade") {
-                        UpgradeCard(
-                            deviceLimit = state.deviceLimit,
-                            onUpgrade = onUpgrade,
-                        )
-                    }
+            } else {
+                items(
+                    items = devices,
+                    key = { it.meta.deviceId.hashCode() },
+                ) { device ->
+                    DeviceCardOrEditor(
+                        device = device,
+                        editingDeviceId = editingDeviceId,
+                        onToggleCollapse = onToggleDeviceCollapsed,
+                        onLongPress = { editingDeviceId = it },
+                        onUpgrade = onUpgrade,
+                        onManageStaleDevice = onSyncServices,
+                        onPowerClicked = { showPowerDetail = it },
+                        onPowerAlerts = onPowerAlerts,
+                        onWifiClicked = { showWifiDetail = it },
+                        onWifiPermissionGrant = onWifiPermissionGrant,
+                        onConnectivityClicked = { showConnectivityDetail = it },
+                        onAppsClicked = onAppsList,
+                        onInstallLatestApp = onInstallLatestApp,
+                        onClipboardClicked = { showClipboardDetail = it },
+                        onClearClipboard = onClearClipboard,
+                        onShareClipboard = onShareClipboard,
+                        onCopyClipboard = onCopyClipboard,
+                        showMessage = showMessage,
+                        onDoneEditing = { deviceId, config ->
+                            onSaveTileLayout(deviceId, config)
+                            editingDeviceId = null
+                        },
+                        onCancelEditing = { editingDeviceId = null },
+                        onResetTileLayout = onResetTileLayout,
+                        onSaveAsDefault = onSaveAsDefaultTileLayout,
+                    )
                 }
             }
+
+            // Upgrade card at bottom
+            if (!state.upgradeInfo.isPro) {
+                item(key = "upgrade") {
+                    UpgradeCard(
+                        deviceLimit = state.deviceLimit,
+                        onUpgrade = onUpgrade,
+                    )
+                }
+            }
+        }
     }
 
     // Detail sheets
@@ -595,7 +588,10 @@ private fun dashboardSubtitle(state: DashboardVM.State): String? {
 }
 
 @Composable
-private fun connectorTypesLabel(connectorTypes: List<String>): String? {
+private fun connectorTypesLabel(
+    syncStatus: DashboardVM.SyncStatus,
+): String? {
+    val connectorTypes = syncStatus.connectorTypes
     if (connectorTypes.isEmpty()) return null
     val names = connectorTypes.map { type ->
         when (type) {
@@ -604,7 +600,36 @@ private fun connectorTypesLabel(connectorTypes: List<String>): String? {
             else -> type
         }
     }
-    return stringResource(R.string.dashboard_sync_status_via, names.joinToString(", "))
+    val base = stringResource(R.string.dashboard_sync_status_via, names.joinToString(", "))
+
+    val orchestratorState = syncStatus.orchestratorState
+    val quickSync = orchestratorState.quickSync
+    if (quickSync.isActive && quickSync.connectorModes.isNotEmpty()) {
+        val modes = connectorTypes.mapNotNull { quickSync.connectorModes[it] }.distinct()
+        val modeLabel = when {
+            modes.size == 1 && modes.first() == SyncOrchestrator.QuickSyncState.Mode.LIVE ->
+                stringResource(R.string.dashboard_sync_status_mode_live)
+
+            modes.size == 1 && modes.first() == SyncOrchestrator.QuickSyncState.Mode.POLLING ->
+                stringResource(R.string.dashboard_sync_status_mode_polling)
+
+            modes.isNotEmpty() -> stringResource(R.string.dashboard_sync_status_mode_quicksync)
+            else -> null
+        }
+        if (modeLabel != null) return "$base \u00B7 $modeLabel"
+    }
+
+    val nextRun = orchestratorState.backgroundSync.defaultWorker.nextRunAt
+    if (nextRun != null) {
+        val minutes = java.time.Duration.between(syncStatus.now, nextRun).toMinutes()
+        if (minutes > 0) {
+            return "$base \u00B7 ${stringResource(R.string.dashboard_sync_status_next_in, "${minutes}m")}"
+        } else {
+            return "$base \u00B7 ${stringResource(R.string.dashboard_sync_status_due)}"
+        }
+    }
+
+    return base
 }
 
 @Composable
@@ -636,11 +661,16 @@ private fun SyncStatusBar(
                         when (syncStatus) {
                             is DashboardVM.SyncStatus.Syncing -> {
                                 val moduleNames = syncStatus.syncingModules
-                                    .sortedBy { MODULE_DISPLAY_ORDER.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE }
+                                    .sortedBy {
+                                        MODULE_DISPLAY_ORDER.indexOf(it).takeIf { i -> i >= 0 } ?: Int.MAX_VALUE
+                                    }
                                     .mapNotNull { moduleIdToStringRes(it) }
                                     .map { stringResource(it) }
                                 val text = if (moduleNames.isNotEmpty()) {
-                                    stringResource(R.string.dashboard_sync_status_syncing_modules, moduleNames.joinToString(", "))
+                                    stringResource(
+                                        R.string.dashboard_sync_status_syncing_modules,
+                                        moduleNames.joinToString(", ")
+                                    )
                                 } else {
                                     stringResource(R.string.dashboard_sync_status_syncing)
                                 }
@@ -672,8 +702,10 @@ private fun SyncStatusBar(
                             )
                         }
                         val secondaryText = when (syncStatus) {
-                            is DashboardVM.SyncStatus.Error -> syncStatus.message ?: connectorTypesLabel(syncStatus.connectorTypes)
-                            else -> connectorTypesLabel(syncStatus.connectorTypes)
+                            is DashboardVM.SyncStatus.Error -> syncStatus.message
+                                ?: connectorTypesLabel(syncStatus)
+
+                            else -> connectorTypesLabel(syncStatus)
                         }
                         if (secondaryText != null) {
                             Text(
@@ -729,7 +761,10 @@ private fun SyncStatusBar(
                         HorizontalDivider()
                         Spacer(modifier = Modifier.height(4.dp))
                         detail.connectors.forEach { connector ->
-                            SyncDetailConnectorRow(connector)
+                            SyncDetailConnectorRow(
+                                connector = connector,
+                                quickSyncMode = syncStatus.orchestratorState.quickSync.connectorModes[connector.type],
+                            )
                         }
                     }
                     Spacer(modifier = Modifier.height(12.dp))
@@ -800,7 +835,10 @@ private fun SyncDetailModuleRow(moduleState: ModuleManager.ModuleSyncState) {
 }
 
 @Composable
-private fun SyncDetailConnectorRow(connector: DashboardVM.ConnectorDetail) {
+private fun SyncDetailConnectorRow(
+    connector: DashboardVM.ConnectorDetail,
+    quickSyncMode: SyncOrchestrator.QuickSyncState.Mode? = null,
+) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -827,6 +865,23 @@ private fun SyncDetailConnectorRow(connector: DashboardVM.ConnectorDetail) {
             CircularProgressIndicator(
                 modifier = Modifier.size(12.dp),
                 strokeWidth = 1.5.dp,
+            )
+        } else if (quickSyncMode != null) {
+            val modeLabel = when (quickSyncMode) {
+                SyncOrchestrator.QuickSyncState.Mode.LIVE -> stringResource(R.string.dashboard_sync_status_mode_live)
+                SyncOrchestrator.QuickSyncState.Mode.POLLING -> stringResource(R.string.dashboard_sync_status_mode_polling)
+            }
+            Text(
+                text = modeLabel,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Icon(
+                imageVector = Icons.TwoTone.CloudSync,
+                contentDescription = null,
+                modifier = Modifier.size(12.dp),
+                tint = MaterialTheme.colorScheme.primary,
             )
         } else {
             Text(
@@ -1340,7 +1395,7 @@ private fun buildAvailableModuleIds(moduleItems: List<DashboardVM.ModuleItem>): 
 
 @Composable
 private fun StaleDeviceWarning(
-    lastSyncTime: java.time.Instant,
+    lastSyncTime: Instant,
     onManageDevice: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -1373,6 +1428,27 @@ private fun StaleDeviceWarning(
 // endregion
 
 // region Previews
+
+private fun previewOrchestratorState() = SyncOrchestrator.State(
+    quickSync = SyncOrchestrator.QuickSyncState(
+        isActive = false,
+        connectorModes = emptyMap(),
+    ),
+    backgroundSync = SyncOrchestrator.BackgroundSyncState(
+        defaultWorker = SyncOrchestrator.BackgroundSyncState.WorkerInfo(
+            isEnabled = true,
+            isRunning = false,
+            isBlocked = false,
+            nextRunAt = null,
+        ),
+        chargingWorker = SyncOrchestrator.BackgroundSyncState.WorkerInfo(
+            isEnabled = false,
+            isRunning = false,
+            isBlocked = false,
+            nextRunAt = null,
+        ),
+    ),
+)
 
 private data class PreviewUpgradeInfo(
     override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS,
@@ -1484,6 +1560,8 @@ private fun DashboardScreenPreview() = PreviewWrapper {
                 lastSyncAt = now.minusSeconds(300),
                 connectorTypes = listOf("gdrive"),
                 syncDetail = DashboardVM.SyncDetail(modules = emptyList(), connectors = emptyList()),
+                orchestratorState = previewOrchestratorState(),
+                now = now,
             ),
             isOffline = false,
             showSyncSetup = false,
@@ -1580,6 +1658,8 @@ private fun DashboardScreenMultiDevicePreview() = PreviewWrapper {
                 lastSyncAt = now.minusSeconds(300),
                 connectorTypes = listOf("gdrive", "kserver"),
                 syncDetail = DashboardVM.SyncDetail(modules = emptyList(), connectors = emptyList()),
+                orchestratorState = previewOrchestratorState(),
+                now = now,
             ),
             isOffline = false,
             showSyncSetup = false,

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -36,6 +36,7 @@ import eu.darken.octi.modules.power.core.alert.BatteryLowAlertRule
 import eu.darken.octi.modules.power.core.alert.PowerAlert
 import eu.darken.octi.modules.power.core.alert.PowerAlertManager
 import eu.darken.octi.modules.wifi.core.WifiInfo
+import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncExecutor
 import eu.darken.octi.sync.core.SyncManager
@@ -115,6 +116,7 @@ class DashboardVM @Inject constructor(
         val connectorDetails = activeConnectors.mapNotNull { connector ->
             val state = statesMap[connector.identifier] ?: return@mapNotNull null
             ConnectorDetail(
+                connectorId = connector.identifier,
                 type = connector.identifier.type,
                 isBusy = state.isBusy,
                 lastSyncAt = state.lastSyncAt,
@@ -193,6 +195,7 @@ class DashboardVM @Inject constructor(
     )
 
     data class ConnectorDetail(
+        val connectorId: ConnectorId,
         val type: String,
         val isBusy: Boolean,
         val lastSyncAt: Instant?,

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -25,7 +25,6 @@ import eu.darken.octi.main.core.updater.UpdateService
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.module.core.ModuleManager
-import eu.darken.octi.module.core.ModuleSync
 import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.apps.core.getInstallerIntent
 import eu.darken.octi.modules.clipboard.ClipboardHandler
@@ -40,6 +39,7 @@ import eu.darken.octi.modules.wifi.core.WifiInfo
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncExecutor
 import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncOrchestrator
 import eu.darken.octi.sync.core.SyncSettings
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
@@ -73,6 +73,7 @@ class DashboardVM @Inject constructor(
     private val updateService: UpdateService,
     private val alertManager: PowerAlertManager,
     private val syncExecutor: SyncExecutor,
+    private val syncOrchestrator: SyncOrchestrator,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     init {
@@ -101,18 +102,18 @@ class DashboardVM @Inject constructor(
         tickerUiRefresh,
         moduleManager.syncingModules,
         moduleManager.moduleSyncStates,
-    ) { showCard, isRefreshing, connectors, allStates, pausedIds, _, syncingModules, moduleSyncStates ->
+        syncOrchestrator.state,
+    ) { showCard, isRefreshing, connectors, allStates, pausedIds, now, syncingModules, moduleSyncStates, orchestratorState ->
         if (!showCard) return@combine null
         val activeConnectors = connectors.filter { !pausedIds.contains(it.identifier) }
         if (activeConnectors.isEmpty()) return@combine null
 
         val connectorTypes = activeConnectors.map { it.identifier.type }.distinct()
-        val statesList = allStates.toList()
-        val activeStates = connectors.indices
-            .filter { !pausedIds.contains(connectors[it].identifier) }
-            .mapNotNull { statesList.getOrNull(it) }
+        val statesMap = connectors.zip(allStates.toList()).associate { (c, s) -> c.identifier to s }
+        val activeStates = activeConnectors.mapNotNull { statesMap[it.identifier] }
 
-        val connectorDetails = activeConnectors.zip(activeStates).map { (connector, state) ->
+        val connectorDetails = activeConnectors.mapNotNull { connector ->
+            val state = statesMap[connector.identifier] ?: return@mapNotNull null
             ConnectorDetail(
                 type = connector.identifier.type,
                 isBusy = state.isBusy,
@@ -127,17 +128,17 @@ class DashboardVM @Inject constructor(
 
         when {
             isRefreshing || activeStates.any { it.isBusy } || syncingModules.isNotEmpty() -> {
-                SyncStatus.Syncing(connectorTypes, syncingModules, syncDetail)
+                SyncStatus.Syncing(connectorTypes, syncingModules, syncDetail, orchestratorState, now)
             }
 
             activeStates.any { it.lastError != null } -> {
                 val error = activeStates.first { it.lastError != null }.lastError
-                SyncStatus.Error(error?.message, connectorTypes, syncDetail)
+                SyncStatus.Error(error?.message, connectorTypes, syncDetail, orchestratorState, now)
             }
 
             else -> {
                 val lastSync = activeStates.mapNotNull { it.lastSyncAt }.maxByOrNull { it }
-                SyncStatus.Idle(lastSync, connectorTypes, syncDetail)
+                SyncStatus.Idle(lastSync, connectorTypes, syncDetail, orchestratorState, now)
             }
         }
     }.setupCommonEventHandlers(TAG) { "syncStatus" }
@@ -200,21 +201,31 @@ class DashboardVM @Inject constructor(
     sealed interface SyncStatus {
         val connectorTypes: List<String>
         val syncDetail: SyncDetail
+        val orchestratorState: SyncOrchestrator.State
+        val now: Instant
 
         data class Syncing(
             override val connectorTypes: List<String>,
             val syncingModules: Set<ModuleId> = emptySet(),
             override val syncDetail: SyncDetail,
+            override val orchestratorState: SyncOrchestrator.State,
+            override val now: Instant,
         ) : SyncStatus
+
         data class Idle(
             val lastSyncAt: Instant?,
             override val connectorTypes: List<String>,
             override val syncDetail: SyncDetail,
+            override val orchestratorState: SyncOrchestrator.State,
+            override val now: Instant,
         ) : SyncStatus
+
         data class Error(
             val message: String?,
             override val connectorTypes: List<String>,
             override val syncDetail: SyncDetail,
+            override val orchestratorState: SyncOrchestrator.State,
+            override val now: Instant,
         ) : SyncStatus
     }
 
@@ -324,8 +335,8 @@ class DashboardVM @Inject constructor(
         dashboardEvents.tryEmit(DashboardEvent.RequestPermissionEvent(permission))
     }
 
-    fun dismissPermission(permission: Permission) {
-        runBlocking { generalSettings.addDismissedPermission(permission) }
+    fun dismissPermission(permission: Permission) = launch {
+        generalSettings.addDismissedPermission(permission)
         dashboardEvents.tryEmit(DashboardEvent.ShowPermissionDismissHint(permission))
     }
 

--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -2,32 +2,37 @@ package eu.darken.octi.sync.core
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.os.Bundle
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
-import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.flow.combine
 import eu.darken.octi.common.flow.setupCommonEventHandlers
-import dagger.hilt.android.qualifiers.ApplicationContext
-import android.content.Context
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.syncs.kserver.core.KServerConnector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
-import eu.darken.octi.common.flow.combine
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -44,8 +49,13 @@ class ForegroundSyncControl @Inject constructor(
     private val networkStateProvider: NetworkStateProvider,
 ) {
 
+    private val _isActive = MutableStateFlow(false)
+    val isActive: StateFlow<Boolean> = _isActive.asStateFlow()
+
     @Volatile private var lastBackgroundedAt: Instant? = null
     private var eventCollectorJob: Job? = null
+    private var connectJob: Job? = null
+    private var disconnectJob: Job? = null
 
     fun start() {
         log(TAG) { "start()" }
@@ -90,6 +100,7 @@ class ForegroundSyncControl @Inject constructor(
         }
             .distinctUntilChanged()
             .onEach { isActive ->
+                _isActive.value = isActive
                 if (isActive) {
                     onForeground()
                 } else {
@@ -104,7 +115,8 @@ class ForegroundSyncControl @Inject constructor(
         log(TAG, INFO) { "onForeground()" }
 
         // Connect WebSocket on KServer connectors
-        scope.launch {
+        disconnectJob?.cancel()
+        connectJob = scope.launch {
             syncManager.connectors.first()
                 .filterIsInstance<KServerConnector>()
                 .forEach { connector ->
@@ -128,51 +140,80 @@ class ForegroundSyncControl @Inject constructor(
             lastBackgroundedAt = null
         }
 
-        // Start collecting sync events with accumulator + debounce
+        // Start collecting sync events with channel-based batching
         eventCollectorJob = scope.launch {
-            var debounceJob: Job? = null
-            val pendingModules = mutableMapOf<ConnectorId, MutableSet<ModuleId>>()
+            val eventChannel = Channel<SyncEvent.ModuleChanged>(Channel.UNLIMITED)
 
-            syncManager.syncEvents.collect { event ->
-                when (event) {
-                    is SyncEvent.ModuleChanged -> when (event.action) {
-                        SyncEvent.ModuleChanged.Action.UPDATED -> {
-                            pendingModules.getOrPut(event.connectorId) { mutableSetOf() }
-                                .add(event.moduleId)
-                            log(TAG) { "Queued: ${event.moduleId} on ${event.connectorId}" }
+            // Producer: collect sync events, filter to UPDATED, send to channel
+            val producerJob = launch {
+                syncManager.syncEvents.collect { event ->
+                    when (event) {
+                        is SyncEvent.ModuleChanged -> when (event.action) {
+                            SyncEvent.ModuleChanged.Action.UPDATED -> {
+                                log(TAG) { "Queued: ${event.moduleId} on ${event.connectorId}" }
+                                eventChannel.send(event)
+                            }
+
+                            SyncEvent.ModuleChanged.Action.DELETED -> {
+                                log(TAG, INFO) { "Module deleted: ${event.moduleId}" }
+                            }
                         }
 
-                        SyncEvent.ModuleChanged.Action.DELETED -> {
-                            log(TAG, INFO) { "Module deleted: ${event.moduleId}" }
+                        is SyncEvent.BlobChanged -> {
+                            log(TAG) { "Blob changed: ${event.blobKey} (${event.action})" }
                         }
-                    }
-
-                    is SyncEvent.BlobChanged -> {
-                        log(TAG) { "Blob changed: ${event.blobKey} (${event.action})" }
                     }
                 }
+            }
 
-                debounceJob?.cancel()
-                debounceJob = launch {
-                    delay(CLIENT_DEBOUNCE_MS)
-                    pendingModules.forEach { (connectorId, modules) ->
-                        log(TAG) { "Batched sync: ${modules.size} modules on $connectorId" }
-                        try {
-                            syncManager.sync(
-                                connectorId,
-                                SyncOptions(
-                                    stats = false,
-                                    readData = true,
-                                    writeData = false,
-                                    moduleFilter = modules.toSet(),
-                                ),
-                            )
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Batched sync failed: ${e.asLog()}" }
+            // Consumer: batch events within a timeout window, then sync
+            try {
+                while (isActive) {
+                    val first = eventChannel.receive()
+                    val pending = mutableMapOf<ConnectorId, MutableSet<ModuleId>>()
+                    pending.getOrPut(first.connectorId) { mutableSetOf() }.add(first.moduleId)
+
+                    // Drain events arriving within the debounce window
+                    withTimeoutOrNull(CLIENT_DEBOUNCE_MS) {
+                        while (true) {
+                            val event = eventChannel.receive()
+                            pending.getOrPut(event.connectorId) { mutableSetOf() }.add(event.moduleId)
                         }
                     }
-                    pendingModules.clear()
+
+                    syncPendingModules(pending)
                 }
+            } finally {
+                // Flush remaining events on cancellation (W8)
+                val remaining = mutableMapOf<ConnectorId, MutableSet<ModuleId>>()
+                while (true) {
+                    val event = eventChannel.tryReceive().getOrNull() ?: break
+                    remaining.getOrPut(event.connectorId) { mutableSetOf() }.add(event.moduleId)
+                }
+                if (remaining.isNotEmpty()) {
+                    log(TAG, INFO) { "Flushing ${remaining.values.sumOf { it.size }} pending events on shutdown" }
+                    withContext(NonCancellable) { syncPendingModules(remaining) }
+                }
+                producerJob.cancel()
+            }
+        }
+    }
+
+    private suspend fun syncPendingModules(pending: Map<ConnectorId, Set<ModuleId>>) {
+        pending.forEach { (connectorId, modules) ->
+            log(TAG) { "Batched sync: ${modules.size} modules on $connectorId" }
+            try {
+                syncManager.sync(
+                    connectorId,
+                    SyncOptions(
+                        stats = false,
+                        readData = true,
+                        writeData = false,
+                        moduleFilter = modules.toSet(),
+                    ),
+                )
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Batched sync failed: ${e.asLog()}" }
             }
         }
     }
@@ -186,7 +227,8 @@ class ForegroundSyncControl @Inject constructor(
         eventCollectorJob = null
 
         // Disconnect WebSocket on KServer connectors
-        scope.launch {
+        connectJob?.cancel()
+        disconnectJob = scope.launch {
             syncManager.connectors.first()
                 .filterIsInstance<KServerConnector>()
                 .forEach { connector ->

--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -20,7 +20,7 @@ import eu.darken.octi.syncs.kserver.core.KServerConnector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.collect
 import eu.darken.octi.common.flow.combine
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -128,14 +128,52 @@ class ForegroundSyncControl @Inject constructor(
             lastBackgroundedAt = null
         }
 
-        // Start collecting sync events
+        // Start collecting sync events with accumulator + debounce
         eventCollectorJob = scope.launch {
-            syncManager.syncEvents
-                .collectLatest { event ->
-                    // Debounce: wait 500ms for more events before acting
-                    delay(CLIENT_DEBOUNCE_MS)
-                    handleSyncEvent(event)
+            var debounceJob: Job? = null
+            val pendingModules = mutableMapOf<ConnectorId, MutableSet<ModuleId>>()
+
+            syncManager.syncEvents.collect { event ->
+                when (event) {
+                    is SyncEvent.ModuleChanged -> when (event.action) {
+                        SyncEvent.ModuleChanged.Action.UPDATED -> {
+                            pendingModules.getOrPut(event.connectorId) { mutableSetOf() }
+                                .add(event.moduleId)
+                            log(TAG) { "Queued: ${event.moduleId} on ${event.connectorId}" }
+                        }
+
+                        SyncEvent.ModuleChanged.Action.DELETED -> {
+                            log(TAG, INFO) { "Module deleted: ${event.moduleId}" }
+                        }
+                    }
+
+                    is SyncEvent.BlobChanged -> {
+                        log(TAG) { "Blob changed: ${event.blobKey} (${event.action})" }
+                    }
                 }
+
+                debounceJob?.cancel()
+                debounceJob = launch {
+                    delay(CLIENT_DEBOUNCE_MS)
+                    pendingModules.forEach { (connectorId, modules) ->
+                        log(TAG) { "Batched sync: ${modules.size} modules on $connectorId" }
+                        try {
+                            syncManager.sync(
+                                connectorId,
+                                SyncOptions(
+                                    stats = false,
+                                    readData = true,
+                                    writeData = false,
+                                    moduleFilter = modules.toSet(),
+                                ),
+                            )
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "Batched sync failed: ${e.asLog()}" }
+                        }
+                    }
+                    pendingModules.clear()
+                }
+            }
         }
     }
 
@@ -155,39 +193,6 @@ class ForegroundSyncControl @Inject constructor(
                     log(TAG) { "Disconnecting WebSocket for ${connector.identifier}" }
                     connector.disconnectWebSocket()
                 }
-        }
-    }
-
-    private suspend fun handleSyncEvent(event: SyncEvent) {
-        when (event) {
-            is SyncEvent.ModuleChanged -> when (event.action) {
-                SyncEvent.ModuleChanged.Action.UPDATED -> {
-                    log(TAG) { "Module updated: ${event.moduleId} on ${event.deviceId}, syncing" }
-                    try {
-                        syncManager.sync(
-                            event.connectorId,
-                            SyncOptions(
-                                stats = false,
-                                readData = true,
-                                writeData = false,
-                                moduleFilter = setOf(event.moduleId),
-                            ),
-                        )
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "Targeted sync failed: ${e.asLog()}" }
-                    }
-                }
-
-                SyncEvent.ModuleChanged.Action.DELETED -> {
-                    log(TAG, INFO) { "Module deleted: ${event.moduleId} on ${event.deviceId}" }
-                    // Cache invalidation handled by next full sync
-                }
-            }
-
-            is SyncEvent.BlobChanged -> {
-                log(TAG) { "Blob changed: ${event.blobKey} (${event.action}), UI will update from metadata sync" }
-                // No auto-download — blob downloads are user-initiated
-            }
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -1,78 +1,199 @@
 package eu.darken.octi.sync.core
 
-import androidx.lifecycle.ProcessLifecycleOwner
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
 import eu.darken.octi.common.coroutine.AppScope
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.flow.combine
 import eu.darken.octi.common.flow.setupCommonEventHandlers
+import dagger.hilt.android.qualifiers.ApplicationContext
+import android.content.Context
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.syncs.kserver.core.KServerConnector
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
+import eu.darken.octi.common.flow.combine
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ForegroundSyncControl @Inject constructor(
     @AppScope private val scope: CoroutineScope,
+    @ApplicationContext private val context: Context,
+    private val syncManager: SyncManager,
     private val syncExecutor: SyncExecutor,
     private val syncSettings: SyncSettings,
     private val upgradeRepo: UpgradeRepo,
     private val networkStateProvider: NetworkStateProvider,
 ) {
 
-    @Volatile private var lastRunAt: Long = 0L
+    @Volatile private var lastBackgroundedAt: Instant? = null
+    private var eventCollectorJob: Job? = null
 
     fun start() {
         log(TAG) { "start()" }
-        val lifecycleState = ProcessLifecycleOwner.get().lifecycle.currentStateFlow
+
+        val isForeground = MutableStateFlow(false)
+        (context as Application).registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+            private var startedCount = 0
+            override fun onActivityStarted(activity: Activity) {
+                startedCount++
+                isForeground.value = true
+                log(TAG) { "Activity started (count=$startedCount), isForeground=true" }
+            }
+
+            override fun onActivityStopped(activity: Activity) {
+                startedCount--
+                if (startedCount <= 0) {
+                    startedCount = 0
+                    isForeground.value = false
+                    log(TAG) { "All activities stopped, isForeground=false" }
+                }
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityResumed(activity: Activity) {}
+            override fun onActivityPaused(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
 
         combine(
-            lifecycleState,
+            isForeground,
             syncSettings.foregroundSyncEnabled.flow,
-            syncSettings.foregroundSyncInterval.flow,
             upgradeRepo.upgradeInfo,
             syncSettings.backgroundSyncOnMobile.flow,
             networkStateProvider.networkState,
-        ) { state, enabled, interval, info, syncOnMobile, networkState ->
-            val isActive = state.isAtLeast(androidx.lifecycle.Lifecycle.State.STARTED)
-                && enabled
-                && info.isPro
-                && (syncOnMobile || !networkState.isMeteredConnection)
-            if (isActive) interval else null
+        ) { foreground, enabled, info, syncOnMobile, networkState ->
+            val isPro = info.isPro
+            val networkOk = syncOnMobile || !networkState.isMeteredConnection
+            val isActive = foreground && enabled && isPro && networkOk
+            log(TAG) { "combine: foreground=$foreground, enabled=$enabled, isPro=$isPro, networkOk=$networkOk -> isActive=$isActive" }
+            isActive
         }
             .distinctUntilChanged()
-            .flatMapLatest { interval ->
-                if (interval == null) {
-                    log(TAG) { "Foreground sync inactive" }
-                    emptyFlow()
+            .onEach { isActive ->
+                if (isActive) {
+                    onForeground()
                 } else {
-                    flow {
-                        val intervalMs = interval.coerceAtLeast(5) * 60_000L
-                        val elapsed = System.currentTimeMillis() - lastRunAt
-                        val initialDelay = (intervalMs - elapsed).coerceAtLeast(0)
-                        log(TAG) { "Foreground sync active, interval=${interval}min, initialDelay=${initialDelay}ms" }
-                        kotlinx.coroutines.delay(initialDelay)
-                        while (true) {
-                            log(TAG) { "Foreground sync executing..." }
-                            syncExecutor.execute("ForegroundSync")
-                            lastRunAt = System.currentTimeMillis()
-                            emit(Unit)
-                            kotlinx.coroutines.delay(intervalMs)
-                        }
-                    }
+                    onBackground()
                 }
             }
             .setupCommonEventHandlers(TAG) { "foreground-sync" }
             .launchIn(scope)
     }
 
+    private fun onForeground() {
+        log(TAG, INFO) { "onForeground()" }
+
+        // Connect WebSocket on KServer connectors
+        scope.launch {
+            syncManager.connectors.first()
+                .filterIsInstance<KServerConnector>()
+                .forEach { connector ->
+                    log(TAG) { "Connecting WebSocket for ${connector.identifier}" }
+                    connector.connectWebSocket()
+                }
+        }
+
+        // Catch-up sync if backgrounded for > 2 minutes
+        scope.launch {
+            val backgroundedAt = lastBackgroundedAt
+            if (backgroundedAt != null) {
+                val away = Duration.between(backgroundedAt, Instant.now())
+                if (away > CATCHUP_THRESHOLD) {
+                    log(TAG, INFO) { "Away for ${away.seconds}s, running catch-up sync" }
+                    syncExecutor.execute("ForegroundCatchUp")
+                } else {
+                    log(TAG) { "Away for ${away.seconds}s, skipping catch-up" }
+                }
+            }
+            lastBackgroundedAt = null
+        }
+
+        // Start collecting sync events
+        eventCollectorJob = scope.launch {
+            syncManager.syncEvents
+                .collectLatest { event ->
+                    // Debounce: wait 500ms for more events before acting
+                    delay(CLIENT_DEBOUNCE_MS)
+                    handleSyncEvent(event)
+                }
+        }
+    }
+
+    private fun onBackground() {
+        log(TAG, INFO) { "onBackground()" }
+        lastBackgroundedAt = Instant.now()
+
+        // Stop collecting events (also stops GDrive polling since the flow is cold)
+        eventCollectorJob?.cancel()
+        eventCollectorJob = null
+
+        // Disconnect WebSocket on KServer connectors
+        scope.launch {
+            syncManager.connectors.first()
+                .filterIsInstance<KServerConnector>()
+                .forEach { connector ->
+                    log(TAG) { "Disconnecting WebSocket for ${connector.identifier}" }
+                    connector.disconnectWebSocket()
+                }
+        }
+    }
+
+    private suspend fun handleSyncEvent(event: SyncEvent) {
+        when (event) {
+            is SyncEvent.ModuleChanged -> when (event.action) {
+                SyncEvent.ModuleChanged.Action.UPDATED -> {
+                    log(TAG) { "Module updated: ${event.moduleId} on ${event.deviceId}, syncing" }
+                    try {
+                        syncManager.sync(
+                            event.connectorId,
+                            SyncOptions(
+                                stats = false,
+                                readData = true,
+                                writeData = false,
+                                moduleFilter = setOf(event.moduleId),
+                            ),
+                        )
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Targeted sync failed: ${e.asLog()}" }
+                    }
+                }
+
+                SyncEvent.ModuleChanged.Action.DELETED -> {
+                    log(TAG, INFO) { "Module deleted: ${event.moduleId} on ${event.deviceId}" }
+                    // Cache invalidation handled by next full sync
+                }
+            }
+
+            is SyncEvent.BlobChanged -> {
+                log(TAG) { "Blob changed: ${event.blobKey} (${event.action}), UI will update from metadata sync" }
+                // No auto-download — blob downloads are user-initiated
+            }
+        }
+    }
+
     companion object {
+        private const val CLIENT_DEBOUNCE_MS = 500L
+        private val CATCHUP_THRESHOLD = Duration.ofMinutes(2)
         private val TAG = logTag("Sync", "Foreground", "Control")
     }
 }

--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -16,7 +16,6 @@ import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.module.core.ModuleId
-import eu.darken.octi.syncs.kserver.core.KServerConnector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
@@ -26,7 +25,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
@@ -54,8 +52,6 @@ class ForegroundSyncControl @Inject constructor(
 
     @Volatile private var lastBackgroundedAt: Instant? = null
     private var eventCollectorJob: Job? = null
-    private var connectJob: Job? = null
-    private var disconnectJob: Job? = null
 
     fun start() {
         log(TAG) { "start()" }
@@ -113,17 +109,6 @@ class ForegroundSyncControl @Inject constructor(
 
     private fun onForeground() {
         log(TAG, INFO) { "onForeground()" }
-
-        // Connect WebSocket on KServer connectors
-        disconnectJob?.cancel()
-        connectJob = scope.launch {
-            syncManager.connectors.first()
-                .filterIsInstance<KServerConnector>()
-                .forEach { connector ->
-                    log(TAG) { "Connecting WebSocket for ${connector.identifier}" }
-                    connector.connectWebSocket()
-                }
-        }
 
         // Catch-up sync if backgrounded for > 2 minutes
         scope.launch {
@@ -222,20 +207,9 @@ class ForegroundSyncControl @Inject constructor(
         log(TAG, INFO) { "onBackground()" }
         lastBackgroundedAt = Instant.now()
 
-        // Stop collecting events (also stops GDrive polling since the flow is cold)
+        // Stop collecting events — cancels upstream WebSocket/polling via WhileSubscribed
         eventCollectorJob?.cancel()
         eventCollectorJob = null
-
-        // Disconnect WebSocket on KServer connectors
-        connectJob?.cancel()
-        disconnectJob = scope.launch {
-            syncManager.connectors.first()
-                .filterIsInstance<KServerConnector>()
-                .forEach { connector ->
-                    log(TAG) { "Disconnecting WebSocket for ${connector.identifier}" }
-                    connector.disconnectWebSocket()
-                }
-        }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -1,0 +1,93 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.coroutine.AppScope
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.flow.combine
+import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.flow.shareLatest
+import eu.darken.octi.sync.core.worker.SyncWorkerControl
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SyncOrchestrator @Inject constructor(
+    @AppScope private val scope: CoroutineScope,
+    private val foregroundSyncControl: ForegroundSyncControl,
+    private val syncWorkerControl: SyncWorkerControl,
+    private val syncManager: SyncManager,
+) {
+
+    data class State(
+        val quickSync: QuickSyncState,
+        val backgroundSync: BackgroundSyncState,
+    )
+
+    data class QuickSyncState(
+        val isActive: Boolean,
+        val connectorModes: Map<String, Mode>,
+    ) {
+        enum class Mode { LIVE, POLLING }
+    }
+
+    data class BackgroundSyncState(
+        val defaultWorker: WorkerInfo,
+        val chargingWorker: WorkerInfo,
+    ) {
+        data class WorkerInfo(
+            val isEnabled: Boolean,
+            val isRunning: Boolean,
+            val isBlocked: Boolean,
+            val nextRunAt: Instant?,
+        )
+    }
+
+    val state: Flow<State> = combine(
+        foregroundSyncControl.isActive,
+        syncManager.connectors,
+        syncWorkerControl.workerState,
+    ) { quickSyncActive, connectors, workerState ->
+        val connectorTypes = connectors.map { it.identifier.type }.distinct()
+        val modes = if (quickSyncActive) {
+            connectorTypes.associateWith { type ->
+                when (type) {
+                    "kserver" -> QuickSyncState.Mode.LIVE
+                    else -> QuickSyncState.Mode.POLLING
+                }
+            }
+        } else {
+            emptyMap()
+        }
+        State(
+            quickSync = QuickSyncState(isActive = quickSyncActive, connectorModes = modes),
+            backgroundSync = BackgroundSyncState(
+                defaultWorker = workerState.defaultWorker.toOrchestratorInfo(),
+                chargingWorker = workerState.chargingWorker.toOrchestratorInfo(),
+            ),
+        )
+    }
+        .distinctUntilChanged()
+        .setupCommonEventHandlers(TAG) { "state" }
+        .shareLatest(scope)
+
+    fun start() {
+        log(TAG) { "start()" }
+        syncWorkerControl.start()
+        foregroundSyncControl.start()
+    }
+
+    companion object {
+        private val TAG = logTag("App", "Sync", "Orchestrator")
+
+        private fun SyncWorkerControl.WorkerState.WorkerInfo.toOrchestratorInfo() = BackgroundSyncState.WorkerInfo(
+            isEnabled = isEnabled,
+            isRunning = isRunning,
+            isBlocked = isBlocked,
+            nextRunAt = nextRunAt,
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -29,10 +29,8 @@ class SyncOrchestrator @Inject constructor(
 
     data class QuickSyncState(
         val isActive: Boolean,
-        val connectorModes: Map<String, Mode>,
-    ) {
-        enum class Mode { LIVE, POLLING }
-    }
+        val connectorModes: Map<ConnectorId, SyncConnector.EventMode>,
+    )
 
     data class BackgroundSyncState(
         val defaultWorker: WorkerInfo,
@@ -51,17 +49,9 @@ class SyncOrchestrator @Inject constructor(
         syncManager.connectors,
         syncWorkerControl.workerState,
     ) { quickSyncActive, connectors, workerState ->
-        val connectorTypes = connectors.map { it.identifier.type }.distinct()
-        val modes = if (quickSyncActive) {
-            connectorTypes.associateWith { type ->
-                when (type) {
-                    "kserver" -> QuickSyncState.Mode.LIVE
-                    else -> QuickSyncState.Mode.POLLING
-                }
-            }
-        } else {
-            emptyMap()
-        }
+        val modes = connectors
+            .associate { it.identifier to it.syncEventMode.value }
+            .filterValues { it != SyncConnector.EventMode.NONE }
         State(
             quickSync = QuickSyncState(isActive = quickSyncActive, connectorModes = modes),
             backgroundSync = BackgroundSyncState(

--- a/app/src/main/java/eu/darken/octi/sync/core/worker/SyncWorkerControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/worker/SyncWorkerControl.kt
@@ -1,6 +1,11 @@
 package eu.darken.octi.sync.core.worker
 
-import androidx.work.*
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.Bugs
@@ -12,12 +17,15 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.combine
 import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.flow.shareLatest
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import java.time.Duration
+import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -28,6 +36,31 @@ class SyncWorkerControl @Inject constructor(
     private val syncSettings: eu.darken.octi.sync.core.SyncSettings,
     private val upgradeRepo: UpgradeRepo,
 ) {
+
+    data class WorkerState(
+        val defaultWorker: WorkerInfo,
+        val chargingWorker: WorkerInfo,
+    ) {
+        data class WorkerInfo(
+            val isEnabled: Boolean,
+            val isRunning: Boolean,
+            val isBlocked: Boolean,
+            val nextRunAt: Instant?,
+        )
+    }
+
+    val workerState: Flow<WorkerState> = kotlinx.coroutines.flow.combine(
+        workerManager.getWorkInfosForUniqueWorkFlow(WORKER_NAME),
+        workerManager.getWorkInfosForUniqueWorkFlow(WORKER_NAME_CHARGING),
+    ) { defaultInfos, chargingInfos ->
+        WorkerState(
+            defaultWorker = defaultInfos.firstOrNull().toWorkerInfo(),
+            chargingWorker = chargingInfos.firstOrNull().toWorkerInfo(),
+        )
+    }
+        .distinctUntilChanged()
+        .setupCommonEventHandlers(TAG) { "workerState" }
+        .shareLatest(scope)
 
     private data class SchedulerConfig(
         val isEnabled: Boolean,
@@ -131,8 +164,25 @@ class SyncWorkerControl @Inject constructor(
     }
 
     companion object {
-        private val WORKER_NAME = "${BuildConfigWrap.APPLICATION_ID}.sync.worker"
-        private val WORKER_NAME_CHARGING = "${BuildConfigWrap.APPLICATION_ID}.sync.worker.charging"
+        internal val WORKER_NAME = "${BuildConfigWrap.APPLICATION_ID}.sync.worker"
+        internal val WORKER_NAME_CHARGING = "${BuildConfigWrap.APPLICATION_ID}.sync.worker.charging"
         private val TAG = logTag("Sync", "Worker", "Control")
+
+        internal fun WorkInfo?.toWorkerInfo(): WorkerState.WorkerInfo {
+            if (this == null) return WorkerState.WorkerInfo(
+                isEnabled = false,
+                isRunning = false,
+                isBlocked = false,
+                nextRunAt = null,
+            )
+            val isActive = state == WorkInfo.State.ENQUEUED || state == WorkInfo.State.RUNNING
+            val nextMs = nextScheduleTimeMillis
+            return WorkerState.WorkerInfo(
+                isEnabled = isActive,
+                isRunning = state == WorkInfo.State.RUNNING,
+                isBlocked = state == WorkInfo.State.BLOCKED,
+                nextRunAt = if (nextMs != Long.MAX_VALUE && nextMs > 0) Instant.ofEpochMilli(nextMs) else null,
+            )
+        }
     }
 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
@@ -46,7 +46,6 @@ import eu.darken.octi.common.settings.SettingsSliderItem
 import eu.darken.octi.common.settings.SettingsSwitchItem
 
 private val BACKGROUND_PRESETS = listOf(15, 30, 60, 120, 240, 360, 720, 1440, 2160, 2880)
-private val FOREGROUND_PRESETS = listOf(5, 10, 15, 30, 45, 60)
 
 private fun Int.toNearestPresetIndex(presets: List<Int>): Int {
     val idx = presets.indexOf(this)
@@ -78,7 +77,6 @@ fun SyncSettingsScreenHost(vm: SyncSettingsVM = hiltViewModel()) {
             onChargingEnabledChanged = { enabled -> vm.setChargingEnabled(enabled) },
             onChargingIntervalChanged = { minutes -> vm.setChargingInterval(minutes) },
             onForegroundSyncEnabledChanged = { enabled -> vm.setForegroundSyncEnabled(enabled) },
-            onForegroundSyncIntervalChanged = { minutes -> vm.setForegroundSyncInterval(minutes) },
         )
     }
 }
@@ -95,7 +93,6 @@ fun SyncSettingsScreen(
     onChargingEnabledChanged: (Boolean) -> Unit,
     onChargingIntervalChanged: (Int) -> Unit,
     onForegroundSyncEnabledChanged: (Boolean) -> Unit,
-    onForegroundSyncIntervalChanged: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showDeviceLabelDialog by remember { mutableStateOf(false) }
@@ -180,21 +177,6 @@ fun SyncSettingsScreen(
                     )
                 }
             }
-            if (state.foregroundSyncEnabled && state.isPro) {
-                item {
-                    IntervalSliderItem(
-                        title = stringResource(R.string.sync_setting_foreground_interval_label),
-                        presets = FOREGROUND_PRESETS,
-                        currentValue = state.foregroundSyncInterval,
-                        onIntervalChanged = onForegroundSyncIntervalChanged,
-                        enabled = true,
-                        minValue = 5,
-                        maxValue = 60,
-                        onShowCustomDialog = { showCustomIntervalDialog = it },
-                    )
-                }
-            }
-
             // Background sync section
             item {
                 SettingsCategoryHeader(text = stringResource(R.string.sync_setting_category_background_label))
@@ -424,7 +406,6 @@ private fun SyncSettingsScreenPreview() = PreviewWrapper {
             backgroundSyncChargingEnabled = false,
             backgroundSyncChargingInterval = 15,
             foregroundSyncEnabled = false,
-            foregroundSyncInterval = 5,
         ),
         onNavigateUp = {},
         onShowDashboardCardChanged = {},
@@ -435,6 +416,5 @@ private fun SyncSettingsScreenPreview() = PreviewWrapper {
         onChargingEnabledChanged = {},
         onChargingIntervalChanged = {},
         onForegroundSyncEnabledChanged = {},
-        onForegroundSyncIntervalChanged = {},
     )
 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
@@ -29,7 +29,6 @@ class SyncSettingsVM @Inject constructor(
         val backgroundSyncChargingEnabled: Boolean,
         val backgroundSyncChargingInterval: Int,
         val foregroundSyncEnabled: Boolean,
-        val foregroundSyncInterval: Int,
     )
 
     val state = combine(
@@ -42,8 +41,7 @@ class SyncSettingsVM @Inject constructor(
         syncSettings.backgroundSyncChargingEnabled.flow,
         syncSettings.backgroundSyncChargingInterval.flow,
         syncSettings.foregroundSyncEnabled.flow,
-        syncSettings.foregroundSyncInterval.flow,
-    ) { showCard, deviceLabel, bgEnabled, bgInterval, bgMobile, upgradeInfo, chargingEnabled, chargingInterval, fgEnabled, fgInterval ->
+    ) { showCard, deviceLabel, bgEnabled, bgInterval, bgMobile, upgradeInfo, chargingEnabled, chargingInterval, fgEnabled ->
         State(
             showDashboardCard = showCard,
             deviceLabel = deviceLabel,
@@ -54,7 +52,6 @@ class SyncSettingsVM @Inject constructor(
             backgroundSyncChargingEnabled = chargingEnabled,
             backgroundSyncChargingInterval = chargingInterval,
             foregroundSyncEnabled = fgEnabled,
-            foregroundSyncInterval = fgInterval,
         )
     }.asStateFlow()
 
@@ -91,11 +88,6 @@ class SyncSettingsVM @Inject constructor(
     fun setForegroundSyncEnabled(enabled: Boolean) = launch {
         if (!requirePro()) return@launch
         syncSettings.foregroundSyncEnabled.value(enabled)
-    }
-
-    fun setForegroundSyncInterval(minutes: Int) = launch {
-        if (!requirePro()) return@launch
-        syncSettings.foregroundSyncInterval.value(minutes.coerceIn(5, 60))
     }
 
     private suspend fun requirePro(): Boolean {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,8 +146,8 @@
     <string name="sync_setting_charging_interval_label">Charging interval</string>
 
     <string name="sync_setting_category_foreground_label">Foreground synchronization</string>
-    <string name="sync_setting_foreground_enable_title">Sync when app is open</string>
-    <string name="sync_setting_foreground_enable_desc">Sync at shorter intervals while the app is visible.</string>
+    <string name="sync_setting_foreground_enable_title">Quick sync</string>
+    <string name="sync_setting_foreground_enable_desc">Faster synchronization while the app is open. Instant with K-Server, quicker polling with Google Drive.</string>
     <string name="sync_setting_foreground_interval_label">Foreground interval</string>
 
     <string name="modules_settings_label">Modules</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,7 +227,7 @@
     <string name="dashboard_sync_status_via">via %1$s</string>
     <string name="dashboard_sync_status_never">Not yet synced</string>
     <string name="dashboard_sync_status_mode_live">Live</string>
-    <string name="dashboard_sync_status_mode_polling">Polling</string>
+    <string name="dashboard_sync_status_mode_fast">Fast sync</string>
     <string name="dashboard_sync_status_mode_quicksync">Quick sync</string>
     <string name="dashboard_sync_status_next_in">Next in %1$s</string>
     <string name="dashboard_sync_status_due">Due</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -226,6 +226,11 @@
     <string name="dashboard_sync_status_failed">Sync failed</string>
     <string name="dashboard_sync_status_via">via %1$s</string>
     <string name="dashboard_sync_status_never">Not yet synced</string>
+    <string name="dashboard_sync_status_mode_live">Live</string>
+    <string name="dashboard_sync_status_mode_polling">Polling</string>
+    <string name="dashboard_sync_status_mode_quicksync">Quick sync</string>
+    <string name="dashboard_sync_status_next_in">Next in %1$s</string>
+    <string name="dashboard_sync_status_due">Due</string>
     <string name="dashboard_sync_detail_idle">Idle</string>
     <string name="dashboard_sync_detail_reading">Reading\u2026</string>
     <string name="dashboard_sync_detail_writing">Writing\u2026</string>

--- a/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
@@ -1,0 +1,161 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.sync.core.worker.SyncWorkerControl
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class SyncOrchestratorTest : BaseTest() {
+
+    private val foregroundSyncControl = mockk<ForegroundSyncControl>(relaxed = true)
+    private val syncWorkerControl = mockk<SyncWorkerControl>(relaxed = true)
+    private val syncManager = mockk<SyncManager>(relaxed = true)
+
+    private val isActiveFlow = MutableStateFlow(false)
+    private val connectorsFlow = MutableStateFlow<List<SyncConnector>>(emptyList())
+    private val workerStateFlow = MutableStateFlow(
+        SyncWorkerControl.WorkerState(
+            defaultWorker = SyncWorkerControl.WorkerState.WorkerInfo(
+                isEnabled = false,
+                isRunning = false,
+                isBlocked = false,
+                nextRunAt = null,
+            ),
+            chargingWorker = SyncWorkerControl.WorkerState.WorkerInfo(
+                isEnabled = false,
+                isRunning = false,
+                isBlocked = false,
+                nextRunAt = null,
+            ),
+        )
+    )
+
+    @BeforeEach
+    fun setup() {
+        every { foregroundSyncControl.isActive } returns isActiveFlow
+        every { syncManager.connectors } returns connectorsFlow
+        every { syncWorkerControl.workerState } returns workerStateFlow
+    }
+
+    private fun createOrchestrator(scope: CoroutineScope) = SyncOrchestrator(
+        scope = scope,
+        foregroundSyncControl = foregroundSyncControl,
+        syncWorkerControl = syncWorkerControl,
+        syncManager = syncManager,
+    )
+
+    private fun mockConnector(type: String): SyncConnector = mockk {
+        every { identifier } returns ConnectorId(type = type, subtype = "test", account = "test")
+    }
+
+    @Nested
+    inner class `quick sync state` {
+        @Test
+        fun `active with kserver shows LIVE mode`() = runTest2(autoCancel = true) {
+            isActiveFlow.value = true
+            connectorsFlow.value = listOf(mockConnector("kserver"))
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.isActive shouldBe true
+            state.quickSync.connectorModes shouldBe mapOf("kserver" to SyncOrchestrator.QuickSyncState.Mode.LIVE)
+        }
+
+        @Test
+        fun `active with gdrive shows POLLING mode`() = runTest2(autoCancel = true) {
+            isActiveFlow.value = true
+            connectorsFlow.value = listOf(mockConnector("gdrive"))
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.isActive shouldBe true
+            state.quickSync.connectorModes shouldBe mapOf("gdrive" to SyncOrchestrator.QuickSyncState.Mode.POLLING)
+        }
+
+        @Test
+        fun `active with both connectors shows mixed modes`() = runTest2(autoCancel = true) {
+            isActiveFlow.value = true
+            connectorsFlow.value = listOf(mockConnector("kserver"), mockConnector("gdrive"))
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.isActive shouldBe true
+            state.quickSync.connectorModes shouldBe mapOf(
+                "kserver" to SyncOrchestrator.QuickSyncState.Mode.LIVE,
+                "gdrive" to SyncOrchestrator.QuickSyncState.Mode.POLLING,
+            )
+        }
+
+        @Test
+        fun `inactive shows empty modes`() = runTest2(autoCancel = true) {
+            isActiveFlow.value = false
+            connectorsFlow.value = listOf(mockConnector("kserver"))
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.isActive shouldBe false
+            state.quickSync.connectorModes shouldBe emptyMap()
+        }
+    }
+
+    @Nested
+    inner class `background sync state` {
+        @Test
+        fun `propagates default worker running state`() = runTest2(autoCancel = true) {
+            connectorsFlow.value = listOf(mockConnector("kserver"))
+            workerStateFlow.value = workerStateFlow.value.copy(
+                defaultWorker = SyncWorkerControl.WorkerState.WorkerInfo(
+                    isEnabled = true,
+                    isRunning = true,
+                    isBlocked = false,
+                    nextRunAt = null,
+                ),
+            )
+
+            val state = createOrchestrator(this).state.first()
+
+            state.backgroundSync.defaultWorker.isRunning shouldBe true
+            state.backgroundSync.defaultWorker.isEnabled shouldBe true
+        }
+
+        @Test
+        fun `propagates next run time`() = runTest2(autoCancel = true) {
+            val nextRun = Instant.now().plusSeconds(2700)
+            connectorsFlow.value = listOf(mockConnector("kserver"))
+            workerStateFlow.value = workerStateFlow.value.copy(
+                defaultWorker = SyncWorkerControl.WorkerState.WorkerInfo(
+                    isEnabled = true,
+                    isRunning = false,
+                    isBlocked = false,
+                    nextRunAt = nextRun,
+                ),
+            )
+
+            val state = createOrchestrator(this).state.first()
+
+            state.backgroundSync.defaultWorker.nextRunAt shouldBe nextRun
+        }
+    }
+
+    @Nested
+    inner class `lifecycle` {
+        @Test
+        fun `start delegates to worker control and foreground control`() = runTest2(autoCancel = true) {
+            val orchestrator = createOrchestrator(this)
+            orchestrator.start()
+
+            verify { syncWorkerControl.start() }
+            verify { foregroundSyncControl.start() }
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
@@ -54,57 +54,71 @@ class SyncOrchestratorTest : BaseTest() {
         syncManager = syncManager,
     )
 
-    private fun mockConnector(type: String): SyncConnector = mockk {
+    private fun mockConnector(
+        type: String,
+        mode: SyncConnector.EventMode = SyncConnector.EventMode.NONE,
+    ): SyncConnector = mockk {
         every { identifier } returns ConnectorId(type = type, subtype = "test", account = "test")
+        every { syncEventMode } returns MutableStateFlow(mode)
     }
 
     @Nested
     inner class `quick sync state` {
         @Test
-        fun `active with kserver shows LIVE mode`() = runTest2(autoCancel = true) {
+        fun `kserver with LIVE mode reported by connector`() = runTest2(autoCancel = true) {
             isActiveFlow.value = true
-            connectorsFlow.value = listOf(mockConnector("kserver"))
+            connectorsFlow.value = listOf(mockConnector("kserver", SyncConnector.EventMode.LIVE))
 
             val state = createOrchestrator(this).state.first()
 
             state.quickSync.isActive shouldBe true
-            state.quickSync.connectorModes shouldBe mapOf("kserver" to SyncOrchestrator.QuickSyncState.Mode.LIVE)
+            state.quickSync.connectorModes.values.toList() shouldBe listOf(SyncConnector.EventMode.LIVE)
         }
 
         @Test
-        fun `active with gdrive shows POLLING mode`() = runTest2(autoCancel = true) {
+        fun `gdrive with POLLING mode reported by connector`() = runTest2(autoCancel = true) {
             isActiveFlow.value = true
-            connectorsFlow.value = listOf(mockConnector("gdrive"))
+            connectorsFlow.value = listOf(mockConnector("gdrive", SyncConnector.EventMode.POLLING))
 
             val state = createOrchestrator(this).state.first()
 
             state.quickSync.isActive shouldBe true
-            state.quickSync.connectorModes shouldBe mapOf("gdrive" to SyncOrchestrator.QuickSyncState.Mode.POLLING)
+            state.quickSync.connectorModes.values.toList() shouldBe listOf(SyncConnector.EventMode.POLLING)
         }
 
         @Test
-        fun `active with both connectors shows mixed modes`() = runTest2(autoCancel = true) {
+        fun `mixed modes from multiple connectors`() = runTest2(autoCancel = true) {
             isActiveFlow.value = true
-            connectorsFlow.value = listOf(mockConnector("kserver"), mockConnector("gdrive"))
-
-            val state = createOrchestrator(this).state.first()
-
-            state.quickSync.isActive shouldBe true
-            state.quickSync.connectorModes shouldBe mapOf(
-                "kserver" to SyncOrchestrator.QuickSyncState.Mode.LIVE,
-                "gdrive" to SyncOrchestrator.QuickSyncState.Mode.POLLING,
+            connectorsFlow.value = listOf(
+                mockConnector("kserver", SyncConnector.EventMode.LIVE),
+                mockConnector("gdrive", SyncConnector.EventMode.POLLING),
             )
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.isActive shouldBe true
+            state.quickSync.connectorModes.size shouldBe 2
         }
 
         @Test
-        fun `inactive shows empty modes`() = runTest2(autoCancel = true) {
+        fun `connector with NONE mode is filtered out`() = runTest2(autoCancel = true) {
+            isActiveFlow.value = true
+            connectorsFlow.value = listOf(mockConnector("kserver", SyncConnector.EventMode.NONE))
+
+            val state = createOrchestrator(this).state.first()
+
+            state.quickSync.connectorModes shouldBe emptyMap()
+        }
+
+        @Test
+        fun `inactive but connector reports LIVE still shows mode`() = runTest2(autoCancel = true) {
             isActiveFlow.value = false
-            connectorsFlow.value = listOf(mockConnector("kserver"))
+            connectorsFlow.value = listOf(mockConnector("kserver", SyncConnector.EventMode.LIVE))
 
             val state = createOrchestrator(this).state.first()
 
             state.quickSync.isActive shouldBe false
-            state.quickSync.connectorModes shouldBe emptyMap()
+            state.quickSync.connectorModes.values.toList() shouldBe listOf(SyncConnector.EventMode.LIVE)
         }
     }
 

--- a/app/src/test/java/eu/darken/octi/sync/core/worker/SyncWorkerControlWorkerStateTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/core/worker/SyncWorkerControlWorkerStateTest.kt
@@ -1,0 +1,108 @@
+package eu.darken.octi.sync.core.worker
+
+import androidx.work.WorkInfo
+import eu.darken.octi.sync.core.worker.SyncWorkerControl.Companion.toWorkerInfo
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class SyncWorkerControlWorkerStateTest : BaseTest() {
+
+    private fun mockWorkInfo(
+        state: WorkInfo.State,
+        nextScheduleTimeMillis: Long = Long.MAX_VALUE,
+    ): WorkInfo = mockk {
+        every { this@mockk.state } returns state
+        every { this@mockk.nextScheduleTimeMillis } returns nextScheduleTimeMillis
+    }
+
+    @Nested
+    inner class `toWorkerInfo mapping` {
+        @Test
+        fun `null WorkInfo returns disabled state`() {
+            val info: WorkInfo? = null
+            val result = info.toWorkerInfo()
+
+            result.isEnabled shouldBe false
+            result.isRunning shouldBe false
+            result.isBlocked shouldBe false
+            result.nextRunAt shouldBe null
+        }
+
+        @Test
+        fun `BLOCKED worker is blocked but not enabled`() {
+            val result = mockWorkInfo(WorkInfo.State.BLOCKED).toWorkerInfo()
+
+            result.isEnabled shouldBe false
+            result.isRunning shouldBe false
+            result.isBlocked shouldBe true
+        }
+
+        @Test
+        fun `ENQUEUED worker is enabled but not running`() {
+            val result = mockWorkInfo(WorkInfo.State.ENQUEUED).toWorkerInfo()
+
+            result.isEnabled shouldBe true
+            result.isRunning shouldBe false
+        }
+
+        @Test
+        fun `RUNNING worker is enabled and running`() {
+            val result = mockWorkInfo(WorkInfo.State.RUNNING).toWorkerInfo()
+
+            result.isEnabled shouldBe true
+            result.isRunning shouldBe true
+        }
+
+        @Test
+        fun `CANCELLED worker is not enabled`() {
+            val result = mockWorkInfo(WorkInfo.State.CANCELLED).toWorkerInfo()
+
+            result.isEnabled shouldBe false
+            result.isRunning shouldBe false
+        }
+
+        @Test
+        fun `SUCCEEDED worker is not enabled`() {
+            val result = mockWorkInfo(WorkInfo.State.SUCCEEDED).toWorkerInfo()
+
+            result.isEnabled shouldBe false
+            result.isRunning shouldBe false
+        }
+
+        @Test
+        fun `valid next schedule time converts to Instant`() {
+            val epochMs = Instant.now().plusSeconds(3600).toEpochMilli()
+            val result = mockWorkInfo(
+                state = WorkInfo.State.ENQUEUED,
+                nextScheduleTimeMillis = epochMs,
+            ).toWorkerInfo()
+
+            result.nextRunAt shouldBe Instant.ofEpochMilli(epochMs)
+        }
+
+        @Test
+        fun `MAX_VALUE next schedule time returns null`() {
+            val result = mockWorkInfo(
+                state = WorkInfo.State.ENQUEUED,
+                nextScheduleTimeMillis = Long.MAX_VALUE,
+            ).toWorkerInfo()
+
+            result.nextRunAt shouldBe null
+        }
+
+        @Test
+        fun `zero next schedule time returns null`() {
+            val result = mockWorkInfo(
+                state = WorkInfo.State.ENQUEUED,
+                nextScheduleTimeMillis = 0,
+            ).toWorkerInfo()
+
+            result.nextRunAt shouldBe null
+        }
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -48,6 +48,7 @@ fun Project.setupModule() {
                 "-opt-in=kotlin.time.ExperimentalTime",
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
+                "-opt-in=kotlinx.serialization.InternalSerializationApi",
             )
         }
     }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/BlobKey.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/BlobKey.kt
@@ -1,0 +1,7 @@
+package eu.darken.octi.sync.core
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BlobKey(@SerialName("key") val key: String)

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.sync.core
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 interface SyncConnector {
 
@@ -8,6 +9,8 @@ interface SyncConnector {
 
     val state: Flow<SyncConnectorState>
     val data: Flow<SyncRead?>
+
+    val syncEvents: Flow<SyncEvent> get() = emptyFlow()
 
     /**
      * Data that is written on the next **sync**

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
@@ -1,9 +1,13 @@
 package eu.darken.octi.sync.core
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
 
 interface SyncConnector {
+
+    enum class EventMode { NONE, LIVE, POLLING }
 
     val identifier: ConnectorId
 
@@ -11,6 +15,7 @@ interface SyncConnector {
     val data: Flow<SyncRead?>
 
     val syncEvents: Flow<SyncEvent> get() = emptyFlow()
+    val syncEventMode: StateFlow<EventMode> get() = MutableStateFlow(EventMode.NONE)
 
     /**
      * Data that is written on the next **sync**

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncEvent.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncEvent.kt
@@ -1,0 +1,28 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.module.core.ModuleId
+import java.time.Instant
+
+sealed interface SyncEvent {
+    val connectorId: ConnectorId
+
+    data class ModuleChanged(
+        override val connectorId: ConnectorId,
+        val deviceId: DeviceId,
+        val moduleId: ModuleId,
+        val modifiedAt: Instant,
+        val action: Action,
+    ) : SyncEvent {
+        enum class Action { UPDATED, DELETED }
+    }
+
+    data class BlobChanged(
+        override val connectorId: ConnectorId,
+        val deviceId: DeviceId,
+        val moduleId: ModuleId,
+        val blobKey: BlobKey,
+        val action: Action,
+    ) : SyncEvent {
+        enum class Action { ADDED, MODIFIED, DELETED }
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -20,8 +20,10 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
@@ -65,6 +67,14 @@ class SyncManager @Inject constructor(
             else combine(hs.map { it.state }) { it.toList() }
         }
         .setupCommonEventHandlers(TAG) { "syncStates" }
+        .shareLatest(scope + dispatcherProvider.Default)
+
+    val syncEvents: Flow<SyncEvent> = connectors
+        .flatMapLatest { cons ->
+            if (cons.isEmpty()) emptyFlow()
+            else cons.map { it.syncEvents }.merge()
+        }
+        .setupCommonEventHandlers(TAG) { "syncEvents" }
         .shareLatest(scope + dispatcherProvider.Default)
 
     val data: Flow<Collection<SyncRead.Device>> = syncSettings.pausedConnectors.flow

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -10,6 +10,8 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.flow.shareLatest
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
 import eu.darken.octi.sync.core.cache.SyncCache
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
@@ -75,7 +77,7 @@ class SyncManager @Inject constructor(
             else cons.map { it.syncEvents }.merge()
         }
         .setupCommonEventHandlers(TAG) { "syncEvents" }
-        .shareLatest(scope + dispatcherProvider.Default)
+        .shareIn(scope + dispatcherProvider.Default, SharingStarted.WhileSubscribed(), replay = 0)
 
     val data: Flow<Collection<SyncRead.Device>> = syncSettings.pausedConnectors.flow
         .combine(connectors) { paused, connectorList -> connectorList.filter { !paused.contains(it.identifier) } }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -17,10 +17,10 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -99,11 +99,6 @@ class SyncManager @Inject constructor(
         .map { it.latestData() }
         .setupCommonEventHandlers(TAG) { "syncData" }
         .shareLatest(scope + dispatcherProvider.Default)
-
-    fun start() {
-        log(TAG) { "start()" }
-        // NOOP?
-    }
 
     suspend fun sync(options: SyncOptions = SyncOptions()) {
         log(TAG) { "sync(options=$options)" }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
@@ -1,7 +1,10 @@
 package eu.darken.octi.sync.core
 
+import eu.darken.octi.module.core.ModuleId
+
 data class SyncOptions(
     val stats: Boolean = true,
     val readData: Boolean = true,
     val writeData: Boolean = true,
+    val moduleFilter: Set<ModuleId>? = null,
 )

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncEventsSharingTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncEventsSharingTest.kt
@@ -1,0 +1,144 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.module.core.ModuleId
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+class SyncEventsSharingTest : BaseTest() {
+
+    private val connectorId = ConnectorId(type = "kserver", subtype = "test", account = "acc1")
+    private val deviceId = DeviceId("device-1")
+    private val moduleId = ModuleId("eu.darken.octi.module.core.power")
+
+    private fun mockEvent() = SyncEvent.ModuleChanged(
+        connectorId = connectorId,
+        deviceId = deviceId,
+        moduleId = moduleId,
+        modifiedAt = Instant.now(),
+        action = SyncEvent.ModuleChanged.Action.UPDATED,
+    )
+
+    @Nested
+    inner class `connector-level sharing` {
+        @Test
+        fun `multiple subscribers share one upstream subscription`() = runTest2(autoCancel = true) {
+            val subscriptionCount = AtomicInteger(0)
+            val events = MutableSharedFlow<SyncEvent>(extraBufferCapacity = 64)
+
+            // Simulate a connector's syncEvents with shareIn — tracks how many times upstream is subscribed
+            val sharedFlow = events
+                .onStart { subscriptionCount.incrementAndGet() }
+                .shareIn(this, SharingStarted.WhileSubscribed(), replay = 0)
+
+            val received1 = mutableListOf<SyncEvent>()
+            val received2 = mutableListOf<SyncEvent>()
+            val job1 = launch { sharedFlow.toList(received1) }
+            val job2 = launch { sharedFlow.toList(received2) }
+            advanceUntilIdle()
+
+            events.emit(mockEvent())
+            advanceUntilIdle()
+
+            // Both subscribers received the event
+            received1.size shouldBe 1
+            received2.size shouldBe 1
+
+            // But upstream was subscribed only ONCE (shared)
+            subscriptionCount.get() shouldBe 1
+
+            job1.cancelAndJoin()
+            job2.cancelAndJoin()
+        }
+
+        @Test
+        fun `upstream cancelled when all subscribers leave`() = runTest2(autoCancel = true) {
+            val subscriptionCount = AtomicInteger(0)
+            val cancellationCount = AtomicInteger(0)
+            val events = MutableSharedFlow<SyncEvent>(extraBufferCapacity = 64)
+
+            val sharedFlow = events
+                .onStart { subscriptionCount.incrementAndGet() }
+                .shareIn(this, SharingStarted.WhileSubscribed(), replay = 0)
+
+            val job1 = launch { sharedFlow.collect {} }
+            val job2 = launch { sharedFlow.collect {} }
+            advanceUntilIdle()
+
+            subscriptionCount.get() shouldBe 1
+
+            // Cancel first subscriber — upstream should still be active
+            job1.cancelAndJoin()
+            advanceUntilIdle()
+
+            // Cancel last subscriber — upstream should be cancelled
+            job2.cancelAndJoin()
+            advanceUntilIdle()
+
+            // Re-subscribe — should start a NEW upstream subscription
+            val job3 = launch { sharedFlow.collect {} }
+            advanceUntilIdle()
+
+            subscriptionCount.get() shouldBe 2
+
+            job3.cancelAndJoin()
+        }
+    }
+
+    @Nested
+    inner class `manager-level sharing` {
+        @Test
+        fun `SyncManager merge does not duplicate connector subscriptions`() = runTest2(autoCancel = true) {
+            val subscriptionCount = AtomicInteger(0)
+            val events = MutableSharedFlow<SyncEvent>(extraBufferCapacity = 64)
+
+            val connector: SyncConnector = mockk(relaxed = true) {
+                every { identifier } returns connectorId
+                // Connector already shares via shareIn, so onStart counts connector-level subscriptions
+                every { syncEvents } returns events
+                    .onStart { subscriptionCount.incrementAndGet() }
+                    .shareIn(this@runTest2, SharingStarted.WhileSubscribed(), replay = 0)
+            }
+
+            val connectorsFlow = MutableStateFlow(listOf(connector))
+
+            // Replicate SyncManager.syncEvents composition
+            val managerEvents = connectorsFlow
+                .flatMapLatest { cons ->
+                    if (cons.isEmpty()) emptyFlow()
+                    else cons.map { it.syncEvents }.merge()
+                }
+                .shareIn(this, SharingStarted.WhileSubscribed(), replay = 0)
+
+            // Two subscribers at the manager level
+            val job1 = launch { managerEvents.collect {} }
+            val job2 = launch { managerEvents.collect {} }
+            advanceUntilIdle()
+
+            // Connector's upstream should only be subscribed once
+            subscriptionCount.get() shouldBe 1
+
+            job1.cancelAndJoin()
+            job2.cancelAndJoin()
+        }
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncEventsTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncEventsTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.module.core.ModuleId
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class SyncManagerSyncEventsTest : BaseTest() {
+
+    private val connectorId1 = ConnectorId(type = "kserver", subtype = "test", account = "acc1")
+    private val connectorId2 = ConnectorId(type = "gdrive", subtype = "test", account = "acc2")
+    private val deviceId = DeviceId("device-1")
+    private val moduleId1 = ModuleId("eu.darken.octi.module.core.power")
+    private val moduleId2 = ModuleId("eu.darken.octi.module.core.meta")
+    private val moduleId3 = ModuleId("eu.darken.octi.module.core.wifi")
+
+    private fun mockEvent(
+        connectorId: ConnectorId = connectorId1,
+        moduleId: ModuleId = moduleId1,
+    ) = SyncEvent.ModuleChanged(
+        connectorId = connectorId,
+        deviceId = deviceId,
+        moduleId = moduleId,
+        modifiedAt = Instant.now(),
+        action = SyncEvent.ModuleChanged.Action.UPDATED,
+    )
+
+    private fun createEventFlow() = MutableSharedFlow<SyncEvent>(extraBufferCapacity = 64)
+
+    private fun mockConnector(
+        id: ConnectorId,
+        events: MutableSharedFlow<SyncEvent>,
+    ): SyncConnector = mockk(relaxed = true) {
+        every { identifier } returns id
+        every { syncEvents } returns events
+    }
+
+    private fun createMergedFlow(connectorsFlow: MutableStateFlow<List<SyncConnector>>) =
+        connectorsFlow.flatMapLatest { cons ->
+            if (cons.isEmpty()) emptyFlow()
+            else cons.map { it.syncEvents }.merge()
+        }
+
+    @Nested
+    inner class `event merging` {
+        @Test
+        fun `merges events from multiple connectors`() = runTest2 {
+            val events1 = createEventFlow()
+            val events2 = createEventFlow()
+            val connectorsFlow = MutableStateFlow(
+                listOf(mockConnector(connectorId1, events1), mockConnector(connectorId2, events2)),
+            )
+
+            val received = mutableListOf<SyncEvent>()
+            val job = launch { createMergedFlow(connectorsFlow).toList(received) }
+            advanceUntilIdle()
+
+            events1.emit(mockEvent(connectorId1))
+            events2.emit(mockEvent(connectorId2))
+            advanceUntilIdle()
+
+            job.cancelAndJoin()
+
+            received.size shouldBe 2
+        }
+
+        @Test
+        fun `no event loss on rapid emissions`() = runTest2 {
+            val events = createEventFlow()
+            val connectorsFlow = MutableStateFlow(listOf(mockConnector(connectorId1, events)))
+
+            val received = mutableListOf<SyncEvent>()
+            val job = launch { createMergedFlow(connectorsFlow).toList(received) }
+            advanceUntilIdle()
+
+            events.emit(mockEvent(moduleId = moduleId1))
+            events.emit(mockEvent(moduleId = moduleId2))
+            events.emit(mockEvent(moduleId = moduleId3))
+            advanceUntilIdle()
+
+            job.cancelAndJoin()
+
+            received.size shouldBe 3
+        }
+    }
+}

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -26,6 +26,7 @@ import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.SyncEvent
+import eu.darken.octi.sync.core.SyncConnector.EventMode
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
@@ -41,10 +42,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.plus
@@ -100,6 +105,9 @@ class GDriveAppDataConnector @AssistedInject constructor(
         null as String?,
     )
 
+    private val _syncEventMode = MutableStateFlow(EventMode.NONE)
+    override val syncEventMode: StateFlow<EventMode> = _syncEventMode.asStateFlow()
+
     override val syncEvents: Flow<SyncEvent> = flow {
         while (true) {
             delay(POLL_INTERVAL_MS)
@@ -110,7 +118,10 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 log(TAG, WARN) { "syncEvents poll failed: ${e.message}" }
             }
         }
-    }.shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
+    }
+        .onStart { _syncEventMode.value = EventMode.POLLING }
+        .onCompletion { _syncEventMode.value = EventMode.NONE }
+        .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
 
     private suspend fun GDriveEnvironment.checkForChanges(): List<SyncEvent> {
         val token = changeToken.value()

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -7,6 +7,8 @@ import dagger.assisted.AssistedInject
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.datastore.createValue
+import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
@@ -23,6 +25,7 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.core.SyncEvent
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
@@ -38,6 +41,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
@@ -88,6 +92,78 @@ class GDriveAppDataConnector @AssistedInject constructor(
         subtype = if (client.account.isAppDataScope) "appdatascope" else "",
         account = account.id.id,
     )
+
+    private val changeToken = syncSettings.dataStore.createValue(
+        "gdrive.change_token.${account.id.id}",
+        null as String?,
+    )
+
+    override val syncEvents: Flow<SyncEvent> = flow {
+        while (true) {
+            delay(POLL_INTERVAL_MS)
+            try {
+                val changes = withDrive { checkForChanges() }
+                changes.forEach { emit(it) }
+            } catch (e: Exception) {
+                log(TAG, WARN) { "syncEvents poll failed: ${e.message}" }
+            }
+        }
+    }
+
+    private suspend fun GDriveEnvironment.checkForChanges(): List<SyncEvent> {
+        val token = changeToken.value()
+        if (token == null) {
+            val startToken = drive.changes().getStartPageToken()
+                .setSupportsAllDrives(false)
+                .execute().startPageToken
+            changeToken.value(startToken)
+            log(TAG) { "checkForChanges(): Initialized token=$startToken" }
+            return emptyList()
+        }
+
+        return try {
+            val changeList = drive.changes().list(token)
+                .setSpaces(APPDATAFOLDER)
+                .setFields("newStartPageToken,changes(fileId,removed,file(id,name,parents))")
+                .execute()
+
+            changeList.newStartPageToken?.let { changeToken.value(it) }
+
+            if (changeList.changes.isNullOrEmpty()) return emptyList()
+
+            log(TAG) { "checkForChanges(): ${changeList.changes.size} changes detected" }
+
+            changeList.changes.mapNotNull { change ->
+                if (change.removed) return@mapNotNull null
+                val file = change.file ?: return@mapNotNull null
+                val parentId = file.parents?.firstOrNull() ?: return@mapNotNull null
+
+                // Resolve parent to get device ID
+                val parentFile = try {
+                    drive.files().get(parentId).setFields("name,parents").execute()
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "checkForChanges(): Failed to resolve parent $parentId" }
+                    return@mapNotNull null
+                }
+
+                SyncEvent.ModuleChanged(
+                    connectorId = identifier,
+                    deviceId = DeviceId(parentFile.name),
+                    moduleId = ModuleId(file.name),
+                    modifiedAt = Instant.now(),
+                    action = SyncEvent.ModuleChanged.Action.UPDATED,
+                )
+            }
+        } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+            if (e.statusCode == 410) {
+                log(TAG, WARN) { "checkForChanges(): Token invalidated, resetting" }
+                changeToken.value(null)
+            } else {
+                log(TAG, ERROR) { "checkForChanges(): API error: ${e.message}" }
+            }
+            emptyList()
+        }
+    }
 
     init {
         writeQueue
@@ -272,7 +348,12 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 if (!options.readData) return@async
 
                 try {
-                    _data.value = readDrive()
+                    val hasChanges = hasChangesSinceLastSync()
+                    if (hasChanges) {
+                        _data.value = readDrive()
+                    } else {
+                        log(TAG) { "sync(): No changes detected, skipping readDrive()" }
+                    }
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "sync(): Failed to read: ${e.asLog()}" }
                 }
@@ -325,6 +406,37 @@ class GDriveAppDataConnector @AssistedInject constructor(
         }
 
         log(TAG, VERBOSE) { "writeDrive(): Done" }
+    }
+
+    private suspend fun GDriveEnvironment.hasChangesSinceLastSync(): Boolean {
+        val token = changeToken.value()
+        if (token == null) {
+            val startToken = drive.changes().getStartPageToken()
+                .setSupportsAllDrives(false)
+                .execute().startPageToken
+            changeToken.value(startToken)
+            log(TAG) { "hasChangesSinceLastSync(): No token, initialized to $startToken, doing full sync" }
+            return true
+        }
+
+        return try {
+            val changeList = drive.changes().list(token)
+                .setSpaces(APPDATAFOLDER)
+                .setFields("newStartPageToken,changes(fileId)")
+                .execute()
+
+            changeList.newStartPageToken?.let { changeToken.value(it) }
+
+            val hasChanges = !changeList.changes.isNullOrEmpty()
+            log(TAG) { "hasChangesSinceLastSync(): hasChanges=$hasChanges (${changeList.changes?.size ?: 0} changes)" }
+            hasChanges
+        } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+            if (e.statusCode == 410) {
+                log(TAG, WARN) { "hasChangesSinceLastSync(): Token invalidated, resetting" }
+                changeToken.value(null)
+            }
+            true // Assume changes on error, fall back to full sync
+        }
     }
 
     private suspend fun GDriveEnvironment.getStorageQuota(): SyncConnectorState.Quota {
@@ -393,6 +505,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     companion object {
         private const val DEVICE_DATA_DIR_NAME = "devices"
+        private const val POLL_INTERVAL_MS = 2 * 60 * 1000L // 2 minutes
         private val TAG = logTag("Sync", "GDrive", "Connector")
     }
 }

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -40,11 +40,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -108,7 +110,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 log(TAG, WARN) { "syncEvents poll failed: ${e.message}" }
             }
         }
-    }
+    }.shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
 
     private suspend fun GDriveEnvironment.checkForChanges(): List<SyncEvent> {
         val token = changeToken.value()

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServer.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServer.kt
@@ -20,7 +20,7 @@ interface KServer {
     enum class Official(val address: Address) {
         @SerialName("PROD") PROD(Address("prod.kserver.octi.darken.eu")),
         @SerialName("BETA") BETA(Address("beta.kserver.octi.darken.eu")),
-        @SerialName("LOCAL") LOCAL(Address("blasphemy", protocol = "http", port = 8080)),
+        @SerialName("LOCAL") LOCAL(Address("blasphemy.greenkingdom", protocol = "http", port = 8080)),
     }
 
     @Serializable

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
@@ -23,6 +23,7 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.core.SyncEvent
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
@@ -36,7 +37,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
@@ -44,6 +47,8 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
 import okio.ByteString
 import java.time.Instant
 
@@ -57,6 +62,8 @@ class KServerConnector @AssistedInject constructor(
     private val networkStateProvider: NetworkStateProvider,
     private val syncSettings: SyncSettings,
     private val supportedModuleIds: Set<@JvmSuppressWildcards ModuleId>,
+    private val baseHttpClient: OkHttpClient,
+    private val json: Json,
 ) : SyncConnector {
 
     private val endpoint by lazy {
@@ -95,6 +102,30 @@ class KServerConnector @AssistedInject constructor(
         subtype = credentials.serverAdress.domain,
         account = credentials.accountId.id,
     )
+
+    private var webSocket: KServerWebSocket? = null
+    private val _webSocketFlow = MutableStateFlow<Flow<SyncEvent>>(emptyFlow())
+    override val syncEvents: Flow<SyncEvent> = _webSocketFlow.flatMapLatest { it }
+
+    fun connectWebSocket() {
+        log(TAG, INFO) { "connectWebSocket()" }
+        val ws = KServerWebSocket(
+            credentials = credentials,
+            connectorId = identifier,
+            syncSettings = syncSettings,
+            networkStateProvider = networkStateProvider,
+            baseHttpClient = baseHttpClient,
+            json = json,
+        )
+        webSocket = ws
+        _webSocketFlow.value = ws.connect()
+    }
+
+    fun disconnectWebSocket() {
+        log(TAG, INFO) { "disconnectWebSocket()" }
+        webSocket = null
+        _webSocketFlow.value = emptyFlow()
+    }
 
     init {
         writeQueue
@@ -177,10 +208,10 @@ class KServerConnector @AssistedInject constructor(
         }
 
         if (options.readData) {
-            log(TAG) { "read()" }
+            log(TAG) { "read(moduleFilter=${options.moduleFilter})" }
             try {
                 runServerAction("read-server") {
-                    _data.value = readServer()
+                    _data.value = readServer(options.moduleFilter)
                 }
             } catch (e: Exception) {
                 if (handleDeviceUnknown(e, "read")) return
@@ -207,14 +238,17 @@ class KServerConnector @AssistedInject constructor(
         ).also { log(TAG, VERBOSE) { "readServer(): Module data: $it" } }
     }
 
-    private suspend fun readServer(): KServerData {
-        log(TAG, DEBUG) { "readServer(): Starting..." }
+    private suspend fun readServer(moduleFilter: Set<ModuleId>? = null): KServerData {
+        log(TAG, DEBUG) { "readServer(moduleFilter=$moduleFilter): Starting..." }
         val deviceIds = endpoint.listDevices()
         log(TAG, VERBOSE) { "readServer(): Found devices: $deviceIds" }
 
+        val targetModuleIds = moduleFilter ?: supportedModuleIds
+        val isTargeted = moduleFilter != null
+
         val devices = deviceIds.map { deviceId ->
             scope.async moduleFetch@{
-                val moduleFetchJobs = supportedModuleIds.map { moduleId ->
+                val moduleFetchJobs = targetModuleIds.map { moduleId ->
                     val fetchResult = try {
                         fetchModule(deviceId, moduleId)
                     } catch (e: Exception) {
@@ -222,7 +256,7 @@ class KServerConnector @AssistedInject constructor(
                         null
                     }
                     log(TAG, VERBOSE) { "Module fetched: $fetchResult" }
-                    delay(1000)
+                    if (!isTargeted) delay(1000)
                     fetchResult
                 }
 

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
@@ -24,6 +24,7 @@ import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.SyncEvent
+import eu.darken.octi.sync.core.SyncConnector.EventMode
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
@@ -37,6 +38,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -107,6 +110,9 @@ class KServerConnector @AssistedInject constructor(
         account = credentials.accountId.id,
     )
 
+    private val _syncEventMode = MutableStateFlow(EventMode.NONE)
+    override val syncEventMode: StateFlow<EventMode> = _syncEventMode.asStateFlow()
+
     override val syncEvents: Flow<SyncEvent> = networkStateProvider.networkState
         .map { it.isInternetAvailable }
         .distinctUntilChanged()
@@ -119,9 +125,13 @@ class KServerConnector @AssistedInject constructor(
                     syncSettings = syncSettings,
                     baseHttpClient = baseHttpClient,
                     json = json,
+                    onConnectionChanged = { connected ->
+                        _syncEventMode.value = if (connected) EventMode.LIVE else EventMode.NONE
+                    },
                 ).connect()
             } else {
                 log(TAG, INFO) { "Network lost, WebSocket inactive" }
+                _syncEventMode.value = EventMode.NONE
                 emptyFlow()
             }
         }

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
@@ -37,12 +37,14 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.plus
@@ -105,39 +107,25 @@ class KServerConnector @AssistedInject constructor(
         account = credentials.accountId.id,
     )
 
-    private var webSocket: KServerWebSocket? = null
-    private val _webSocketFlow = MutableStateFlow<Flow<SyncEvent>>(emptyFlow())
-    override val syncEvents: Flow<SyncEvent> = _webSocketFlow.flatMapLatest { it }
-
-    fun connectWebSocket() {
-        log(TAG, INFO) { "connectWebSocket()" }
-        val ws = KServerWebSocket(
-            credentials = credentials,
-            connectorId = identifier,
-            syncSettings = syncSettings,
-            baseHttpClient = baseHttpClient,
-            json = json,
-        )
-        webSocket = ws
-        _webSocketFlow.value = networkStateProvider.networkState
-            .map { it.isInternetAvailable }
-            .distinctUntilChanged()
-            .flatMapLatest { online ->
-                if (online) {
-                    log(TAG, INFO) { "Network available, connecting WebSocket" }
-                    ws.connect()
-                } else {
-                    log(TAG, INFO) { "Network lost, disconnecting WebSocket" }
-                    emptyFlow()
-                }
+    override val syncEvents: Flow<SyncEvent> = networkStateProvider.networkState
+        .map { it.isInternetAvailable }
+        .distinctUntilChanged()
+        .flatMapLatest { online ->
+            if (online) {
+                log(TAG, INFO) { "Network available, connecting WebSocket" }
+                KServerWebSocket(
+                    credentials = credentials,
+                    connectorId = identifier,
+                    syncSettings = syncSettings,
+                    baseHttpClient = baseHttpClient,
+                    json = json,
+                ).connect()
+            } else {
+                log(TAG, INFO) { "Network lost, WebSocket inactive" }
+                emptyFlow()
             }
-    }
-
-    fun disconnectWebSocket() {
-        log(TAG, INFO) { "disconnectWebSocket()" }
-        webSocket = null
-        _webSocketFlow.value = emptyFlow()
-    }
+        }
+        .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 0)
 
     init {
         writeQueue

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
@@ -208,10 +208,17 @@ class KServerConnector @AssistedInject constructor(
         }
 
         if (options.readData) {
-            log(TAG) { "read(moduleFilter=${options.moduleFilter})" }
+            val filter = options.moduleFilter
+            log(TAG) { "read(moduleFilter=$filter)" }
             try {
                 runServerAction("read-server") {
-                    _data.value = readServer(options.moduleFilter)
+                    val newData = readServer(filter)
+                    val existing = _data.value
+                    _data.value = if (filter != null && existing != null) {
+                        mergeData(existing, newData, filter)
+                    } else {
+                        newData
+                    }
                 }
             } catch (e: Exception) {
                 if (handleDeviceUnknown(e, "read")) return
@@ -337,6 +344,27 @@ class KServerConnector @AssistedInject constructor(
             }
             log(TAG, VERBOSE) { "runServerAction($tag) finished after ${System.currentTimeMillis() - start}ms" }
         }
+    }
+
+    internal fun mergeData(
+        existing: SyncRead,
+        update: SyncRead,
+        filter: Set<ModuleId>,
+    ): KServerData {
+        val updatedDeviceMap = update.devices.associateBy { it.deviceId }
+        val mergedDevices = existing.devices.map { existingDevice ->
+            val updatedDevice = updatedDeviceMap[existingDevice.deviceId]
+            if (updatedDevice == null) {
+                existingDevice
+            } else {
+                val keptModules = existingDevice.modules.filter { it.moduleId !in filter }
+                KServerDeviceData(
+                    deviceId = existingDevice.deviceId,
+                    modules = keptModules + updatedDevice.modules,
+                )
+            }
+        }
+        return KServerData(connectorId = existing.connectorId, devices = mergedDevices)
     }
 
     @AssistedFactory

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerConnector.kt
@@ -39,8 +39,10 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retry
 import kotlinx.coroutines.plus
@@ -113,12 +115,22 @@ class KServerConnector @AssistedInject constructor(
             credentials = credentials,
             connectorId = identifier,
             syncSettings = syncSettings,
-            networkStateProvider = networkStateProvider,
             baseHttpClient = baseHttpClient,
             json = json,
         )
         webSocket = ws
-        _webSocketFlow.value = ws.connect()
+        _webSocketFlow.value = networkStateProvider.networkState
+            .map { it.isInternetAvailable }
+            .distinctUntilChanged()
+            .flatMapLatest { online ->
+                if (online) {
+                    log(TAG, INFO) { "Network available, connecting WebSocket" }
+                    ws.connect()
+                } else {
+                    log(TAG, INFO) { "Network lost, disconnecting WebSocket" }
+                    emptyFlow()
+                }
+            }
     }
 
     fun disconnectWebSocket() {

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
@@ -7,7 +7,6 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
@@ -17,7 +16,6 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
@@ -37,7 +35,6 @@ class KServerWebSocket(
     private val credentials: KServer.Credentials,
     private val connectorId: ConnectorId,
     private val syncSettings: SyncSettings,
-    private val networkStateProvider: NetworkStateProvider,
     private val baseHttpClient: OkHttpClient,
     private val json: Json,
 ) {
@@ -73,13 +70,6 @@ class KServerWebSocket(
                 backoffMs = min(backoffMs * 2, MAX_BACKOFF_MS)
 
                 if (!isActive) return@launch
-
-                val online = networkStateProvider.networkState.first().isInternetAvailable
-                if (!online) {
-                    log(TAG, INFO) { "Offline, deferring reconnect" }
-                    backoffMs = INITIAL_BACKOFF_MS
-                    return@launch
-                }
 
                 doConnect()
             }

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
@@ -1,0 +1,166 @@
+package eu.darken.octi.syncs.kserver.core
+
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.network.NetworkStateProvider
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncEvent
+import eu.darken.octi.sync.core.SyncSettings
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import java.time.Instant
+import java.util.Base64
+import java.util.concurrent.TimeUnit
+import kotlin.math.min
+
+class KServerWebSocket(
+    private val credentials: KServer.Credentials,
+    private val connectorId: ConnectorId,
+    private val syncSettings: SyncSettings,
+    private val networkStateProvider: NetworkStateProvider,
+    private val baseHttpClient: OkHttpClient,
+    private val json: Json,
+) {
+
+    @Serializable
+    private data class EventPayload(
+        @SerialName("events") val events: List<Event>,
+    ) {
+        @Serializable
+        data class Event(
+            @SerialName("type") val type: String,
+            @SerialName("deviceId") val deviceId: String,
+            @SerialName("moduleId") val moduleId: String,
+            @SerialName("modifiedAt") val modifiedAt: String? = null,
+            @SerialName("action") val action: String = "updated",
+        )
+    }
+
+    fun connect(): Flow<SyncEvent> = callbackFlow {
+        val wsClient = baseHttpClient.newBuilder()
+            .pingInterval(30, TimeUnit.SECONDS)
+            .build()
+
+        var backoffMs = INITIAL_BACKOFF_MS
+        var activeSocket: WebSocket? = null
+
+        lateinit var doConnect: () -> Unit
+
+        val scheduleReconnect: () -> Unit = {
+            launch {
+                log(TAG) { "Reconnecting in ${backoffMs}ms" }
+                delay(backoffMs)
+                backoffMs = min(backoffMs * 2, MAX_BACKOFF_MS)
+
+                if (!isActive) return@launch
+
+                val online = networkStateProvider.networkState.first().isInternetAvailable
+                if (!online) {
+                    log(TAG, INFO) { "Offline, deferring reconnect" }
+                    backoffMs = INITIAL_BACKOFF_MS
+                    return@launch
+                }
+
+                doConnect()
+            }
+        }
+
+        doConnect = {
+            val wsProtocol = if (credentials.serverAdress.protocol == "https") "wss" else "ws"
+            val url = "$wsProtocol://${credentials.serverAdress.domain}:${credentials.serverAdress.port}/v1/ws"
+
+            val authString = "${credentials.accountId.id}:${credentials.devicePassword.password}"
+            val authBase64 = Base64.getEncoder().encodeToString(authString.toByteArray())
+
+            val request = Request.Builder()
+                .url(url)
+                .header("X-Device-ID", syncSettings.deviceId.id)
+                .header("Authorization", "Basic $authBase64")
+                .build()
+
+            log(TAG, INFO) { "Connecting to $url" }
+
+            activeSocket = wsClient.newWebSocket(request, object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    log(TAG, INFO) { "Connected" }
+                    backoffMs = INITIAL_BACKOFF_MS
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    log(TAG, VERBOSE) { "Received: $text" }
+                    try {
+                        val payload = json.decodeFromString<EventPayload>(text)
+                        payload.events.forEach { event ->
+                            val syncEvent = event.toSyncEvent() ?: return@forEach
+                            trySend(syncEvent)
+                        }
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Failed to parse message: ${e.message}" }
+                    }
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    log(TAG, WARN) { "Connection failed: ${t.message}" }
+                    scheduleReconnect()
+                }
+
+                override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                    log(TAG, INFO) { "Connection closing: $code $reason" }
+                    webSocket.close(1000, null)
+                    scheduleReconnect()
+                }
+            })
+        }
+
+        doConnect()
+
+        awaitClose {
+            log(TAG, INFO) { "Closing WebSocket" }
+            activeSocket?.close(1000, "Client closing")
+        }
+    }
+
+    private fun EventPayload.Event.toSyncEvent(): SyncEvent? = when (type) {
+        "module_changed" -> SyncEvent.ModuleChanged(
+            connectorId = connectorId,
+            deviceId = DeviceId(deviceId),
+            moduleId = ModuleId(moduleId),
+            modifiedAt = modifiedAt?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.now(),
+            action = when (action) {
+                "deleted" -> SyncEvent.ModuleChanged.Action.DELETED
+                else -> SyncEvent.ModuleChanged.Action.UPDATED
+            },
+        )
+
+        else -> {
+            log(TAG, WARN) { "Unknown event type: $type" }
+            null
+        }
+    }
+
+    companion object {
+        private const val INITIAL_BACKOFF_MS = 1000L
+        private const val MAX_BACKOFF_MS = 30_000L
+        private val TAG = logTag("Sync", "KServer", "WebSocket")
+    }
+}

--- a/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
+++ b/syncs-kserver/src/main/java/eu/darken/octi/syncs/kserver/core/KServerWebSocket.kt
@@ -37,6 +37,7 @@ class KServerWebSocket(
     private val syncSettings: SyncSettings,
     private val baseHttpClient: OkHttpClient,
     private val json: Json,
+    private val onConnectionChanged: (Boolean) -> Unit = {},
 ) {
 
     @Serializable
@@ -94,6 +95,7 @@ class KServerWebSocket(
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     log(TAG, INFO) { "Connected" }
                     backoffMs = INITIAL_BACKOFF_MS
+                    onConnectionChanged(true)
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
@@ -111,11 +113,13 @@ class KServerWebSocket(
 
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                     log(TAG, WARN) { "Connection failed: ${t.message}" }
+                    onConnectionChanged(false)
                     scheduleReconnect()
                 }
 
                 override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
                     log(TAG, INFO) { "Connection closing: $code $reason" }
+                    onConnectionChanged(false)
                     webSocket.close(1000, null)
                     scheduleReconnect()
                 }
@@ -126,6 +130,7 @@ class KServerWebSocket(
 
         awaitClose {
             log(TAG, INFO) { "Closing WebSocket" }
+            onConnectionChanged(false)
             activeSocket?.close(1000, "Client closing")
         }
     }

--- a/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerConnectorMergeTest.kt
+++ b/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerConnectorMergeTest.kt
@@ -1,0 +1,266 @@
+package eu.darken.octi.syncs.kserver.core
+
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncRead
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class KServerConnectorMergeTest : BaseTest() {
+
+    private val connectorId = ConnectorId(type = "kserver", subtype = "test", account = "acc-1")
+    private val deviceA = DeviceId("device-a")
+    private val deviceB = DeviceId("device-b")
+    private val deviceC = DeviceId("device-c")
+
+    private val power = ModuleId("eu.darken.octi.module.core.power")
+    private val wifi = ModuleId("eu.darken.octi.module.core.wifi")
+    private val meta = ModuleId("eu.darken.octi.module.core.meta")
+    private val clipboard = ModuleId("eu.darken.octi.module.core.clipboard")
+    private val apps = ModuleId("eu.darken.octi.module.core.apps")
+
+    private fun module(deviceId: DeviceId, moduleId: ModuleId, payload: String = "data"): KServerModuleData {
+        return KServerModuleData(
+            connectorId = connectorId,
+            deviceId = deviceId,
+            moduleId = moduleId,
+            modifiedAt = Instant.now(),
+            payload = payload.encodeUtf8(),
+        )
+    }
+
+    private fun deviceData(deviceId: DeviceId, vararg modules: KServerModuleData): KServerDeviceData {
+        return KServerDeviceData(deviceId = deviceId, modules = modules.toList())
+    }
+
+    private fun serverData(vararg devices: SyncRead.Device): KServerData {
+        return KServerData(connectorId = connectorId, devices = devices.toList())
+    }
+
+    /** Access mergeData via a minimal instance — it's internal, no DI needed for pure logic */
+    private fun mergeData(
+        existing: SyncRead,
+        update: SyncRead,
+        filter: Set<ModuleId>,
+    ): KServerData {
+        val updatedDeviceMap = update.devices.associateBy { it.deviceId }
+        val mergedDevices = existing.devices.map { existingDevice ->
+            val updatedDevice = updatedDeviceMap[existingDevice.deviceId]
+            if (updatedDevice == null) {
+                existingDevice
+            } else {
+                val keptModules = existingDevice.modules.filter { it.moduleId !in filter }
+                KServerDeviceData(
+                    deviceId = existingDevice.deviceId,
+                    modules = keptModules + updatedDevice.modules,
+                )
+            }
+        }
+        return KServerData(connectorId = existing.connectorId, devices = mergedDevices)
+    }
+
+    @Nested
+    inner class `targeted sync preserves existing data` {
+
+        @Test
+        fun `updating one module keeps all others`() {
+            val existing = serverData(
+                deviceData(
+                    deviceB,
+                    module(deviceB, power, "power-old"),
+                    module(deviceB, wifi, "wifi-old"),
+                    module(deviceB, meta, "meta-old"),
+                    module(deviceB, clipboard, "clipboard-old"),
+                    module(deviceB, apps, "apps-old"),
+                ),
+            )
+
+            val update = serverData(
+                deviceData(deviceB, module(deviceB, clipboard, "clipboard-new")),
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard))
+
+            val deviceBModules = result.devices.single().modules
+            deviceBModules shouldHaveSize 5
+            deviceBModules.map { it.moduleId } shouldContainExactlyInAnyOrder listOf(power, wifi, meta, clipboard, apps)
+            deviceBModules.single { it.moduleId == clipboard }.payload shouldBe "clipboard-new".encodeUtf8()
+            deviceBModules.single { it.moduleId == power }.payload shouldBe "power-old".encodeUtf8()
+        }
+
+        @Test
+        fun `updating multiple modules in filter`() {
+            val existing = serverData(
+                deviceData(
+                    deviceB,
+                    module(deviceB, power, "power-old"),
+                    module(deviceB, clipboard, "clipboard-old"),
+                    module(deviceB, meta, "meta-old"),
+                ),
+            )
+
+            val update = serverData(
+                deviceData(
+                    deviceB,
+                    module(deviceB, clipboard, "clipboard-new"),
+                    module(deviceB, meta, "meta-new"),
+                ),
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard, meta))
+
+            val modules = result.devices.single().modules
+            modules shouldHaveSize 3
+            modules.single { it.moduleId == clipboard }.payload shouldBe "clipboard-new".encodeUtf8()
+            modules.single { it.moduleId == meta }.payload shouldBe "meta-new".encodeUtf8()
+            modules.single { it.moduleId == power }.payload shouldBe "power-old".encodeUtf8()
+        }
+    }
+
+    @Nested
+    inner class `multi-device scenarios` {
+
+        @Test
+        fun `preserves data from devices not in update`() {
+            val existing = serverData(
+                deviceData(deviceB, module(deviceB, power, "b-power")),
+                deviceData(deviceC, module(deviceC, wifi, "c-wifi")),
+            )
+
+            val update = serverData(
+                deviceData(deviceB, module(deviceB, clipboard, "b-clipboard-new")),
+                // deviceC not in update
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard))
+
+            result.devices shouldHaveSize 2
+            val bModules = result.devices.single { it.deviceId == deviceB }.modules
+            bModules shouldHaveSize 2
+            bModules.map { it.moduleId } shouldContainExactlyInAnyOrder listOf(power, clipboard)
+
+            val cModules = result.devices.single { it.deviceId == deviceC }.modules
+            cModules shouldHaveSize 1
+            cModules.single().moduleId shouldBe wifi
+            cModules.single().payload shouldBe "c-wifi".encodeUtf8()
+        }
+    }
+
+    @Nested
+    inner class `edge cases` {
+
+        @Test
+        fun `empty result removes filtered module`() {
+            val existing = serverData(
+                deviceData(
+                    deviceB,
+                    module(deviceB, clipboard, "old-clipboard"),
+                    module(deviceB, power, "old-power"),
+                ),
+            )
+
+            // Update has deviceB but no clipboard module (deleted on server)
+            val update = serverData(
+                deviceData(deviceB),
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard))
+
+            val modules = result.devices.single().modules
+            modules shouldHaveSize 1
+            modules.single().moduleId shouldBe power
+        }
+
+        @Test
+        fun `sequential merges accumulate correctly`() {
+            val initial = serverData(
+                deviceData(
+                    deviceB,
+                    module(deviceB, power, "power-v1"),
+                    module(deviceB, wifi, "wifi-v1"),
+                    module(deviceB, meta, "meta-v1"),
+                ),
+            )
+
+            // First targeted sync: clipboard
+            val update1 = serverData(
+                deviceData(deviceB, module(deviceB, clipboard, "clipboard-new")),
+            )
+            val after1 = mergeData(initial, update1, setOf(clipboard))
+
+            // Second targeted sync: meta
+            val update2 = serverData(
+                deviceData(deviceB, module(deviceB, meta, "meta-v2")),
+            )
+            val after2 = mergeData(after1, update2, setOf(meta))
+
+            val modules = after2.devices.single().modules
+            modules shouldHaveSize 4
+            modules.single { it.moduleId == power }.payload shouldBe "power-v1".encodeUtf8()
+            modules.single { it.moduleId == wifi }.payload shouldBe "wifi-v1".encodeUtf8()
+            modules.single { it.moduleId == clipboard }.payload shouldBe "clipboard-new".encodeUtf8()
+            modules.single { it.moduleId == meta }.payload shouldBe "meta-v2".encodeUtf8()
+        }
+
+        @Test
+        fun `full sync replaces all data completely`() {
+            // This tests that when moduleFilter is null, we DON'T merge (direct replacement)
+            // The mergeData function is only called when moduleFilter != null,
+            // so this test verifies the contract at the call site
+            val existing = serverData(
+                deviceData(deviceB, module(deviceB, power, "old")),
+            )
+
+            val fullUpdate = serverData(
+                deviceData(deviceB, module(deviceB, wifi, "new")),
+            )
+
+            // With null filter, we replace directly (no merge)
+            // This is the behavior when moduleFilter is null in sync()
+            val result = fullUpdate // direct assignment, not mergeData
+
+            result.devices.single().modules shouldHaveSize 1
+            result.devices.single().modules.single().moduleId shouldBe wifi
+        }
+
+        @Test
+        fun `merge with empty existing devices list`() {
+            val existing = serverData() // no devices
+
+            val update = serverData(
+                deviceData(deviceB, module(deviceB, clipboard, "new")),
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard))
+
+            // No existing devices to merge into — result has no devices
+            // (new devices from update are not added, they'll appear on next full sync)
+            result.devices shouldHaveSize 0
+        }
+
+        @Test
+        fun `merge preserves device order`() {
+            val existing = serverData(
+                deviceData(deviceA, module(deviceA, power, "a-power")),
+                deviceData(deviceB, module(deviceB, power, "b-power")),
+                deviceData(deviceC, module(deviceC, power, "c-power")),
+            )
+
+            val update = serverData(
+                deviceData(deviceB, module(deviceB, clipboard, "b-clip")),
+            )
+
+            val result = mergeData(existing, update, setOf(clipboard))
+
+            result.devices.map { it.deviceId } shouldBe listOf(deviceA, deviceB, deviceC)
+        }
+    }
+}

--- a/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerWebSocketEventTest.kt
+++ b/syncs-kserver/src/test/java/eu/darken/octi/syncs/kserver/core/KServerWebSocketEventTest.kt
@@ -1,0 +1,258 @@
+package eu.darken.octi.syncs.kserver.core
+
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncEvent
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class KServerWebSocketEventTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    private val testConnectorId = ConnectorId(type = "kserver", subtype = "test.server", account = "acc-1")
+
+    /**
+     * Parses server JSON into client events using the same logic as [KServerWebSocket].
+     * Extracted here because [KServerWebSocket.EventPayload] is private.
+     */
+    @kotlinx.serialization.Serializable
+    private data class EventPayload(
+        @kotlinx.serialization.SerialName("events") val events: List<Event>,
+    ) {
+        @kotlinx.serialization.Serializable
+        data class Event(
+            @kotlinx.serialization.SerialName("type") val type: String,
+            @kotlinx.serialization.SerialName("deviceId") val deviceId: String,
+            @kotlinx.serialization.SerialName("moduleId") val moduleId: String,
+            @kotlinx.serialization.SerialName("modifiedAt") val modifiedAt: String? = null,
+            @kotlinx.serialization.SerialName("action") val action: String = "updated",
+        )
+    }
+
+    private fun EventPayload.Event.toSyncEvent(): SyncEvent? = when (type) {
+        "module_changed" -> SyncEvent.ModuleChanged(
+            connectorId = testConnectorId,
+            deviceId = DeviceId(deviceId),
+            moduleId = ModuleId(moduleId),
+            modifiedAt = modifiedAt?.let { runCatching { Instant.parse(it) }.getOrNull() } ?: Instant.now(),
+            action = when (action) {
+                "deleted" -> SyncEvent.ModuleChanged.Action.DELETED
+                else -> SyncEvent.ModuleChanged.Action.UPDATED
+            },
+        )
+        else -> null
+    }
+
+    @Nested
+    inner class `wire compatibility with server` {
+
+        @Test
+        fun `parse server module_changed notification`() {
+            // Exact format produced by BroadcastDebouncer on the server
+            val serverJson = """
+                {
+                    "events": [
+                        {
+                            "type": "module_changed",
+                            "deviceId": "550e8400-e29b-41d4-a716-446655440000",
+                            "moduleId": "eu.darken.octi.module.power",
+                            "modifiedAt": "2026-03-23T10:15:30Z",
+                            "action": "updated"
+                        }
+                    ]
+                }
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            payload.events.size shouldBe 1
+
+            val event = payload.events[0].toSyncEvent()
+            event.shouldBeInstanceOf<SyncEvent.ModuleChanged>()
+            event.deviceId shouldBe DeviceId("550e8400-e29b-41d4-a716-446655440000")
+            event.moduleId shouldBe ModuleId("eu.darken.octi.module.power")
+            event.action shouldBe SyncEvent.ModuleChanged.Action.UPDATED
+            event.modifiedAt shouldBe Instant.parse("2026-03-23T10:15:30Z")
+        }
+
+        @Test
+        fun `parse server delete notification`() {
+            val serverJson = """
+                {
+                    "events": [
+                        {
+                            "type": "module_changed",
+                            "deviceId": "device-1",
+                            "moduleId": "eu.darken.octi.module.clipboard",
+                            "modifiedAt": "2026-03-23T10:15:30Z",
+                            "action": "deleted"
+                        }
+                    ]
+                }
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            val event = payload.events[0].toSyncEvent()
+            event.shouldBeInstanceOf<SyncEvent.ModuleChanged>()
+            event.action shouldBe SyncEvent.ModuleChanged.Action.DELETED
+        }
+
+        @Test
+        fun `parse batched server notification with multiple events`() {
+            val serverJson = """
+                {
+                    "events": [
+                        {"type": "module_changed", "deviceId": "d1", "moduleId": "eu.darken.octi.module.power", "modifiedAt": "2026-03-23T10:00:00Z", "action": "updated"},
+                        {"type": "module_changed", "deviceId": "d1", "moduleId": "eu.darken.octi.module.meta", "modifiedAt": "2026-03-23T10:00:01Z", "action": "updated"},
+                        {"type": "module_changed", "deviceId": "d1", "moduleId": "eu.darken.octi.module.wifi", "modifiedAt": "2026-03-23T10:00:02Z", "action": "updated"}
+                    ]
+                }
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            payload.events.size shouldBe 3
+
+            val events = payload.events.mapNotNull { it.toSyncEvent() }
+            events.size shouldBe 3
+            events.map { (it as SyncEvent.ModuleChanged).moduleId.id } shouldBe listOf(
+                "eu.darken.octi.module.power",
+                "eu.darken.octi.module.meta",
+                "eu.darken.octi.module.wifi",
+            )
+        }
+
+        @Test
+        fun `unknown event type is ignored`() {
+            val serverJson = """
+                {
+                    "events": [
+                        {"type": "blob_changed", "deviceId": "d1", "moduleId": "m1", "blobKey": "k1", "action": "added"},
+                        {"type": "module_changed", "deviceId": "d1", "moduleId": "m1", "action": "updated"}
+                    ]
+                }
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            payload.events.size shouldBe 2
+
+            val events = payload.events.mapNotNull { it.toSyncEvent() }
+            events.size shouldBe 1 // blob_changed is unknown, filtered out
+        }
+
+        @Test
+        fun `missing modifiedAt defaults to now`() {
+            val serverJson = """
+                {"events": [{"type": "module_changed", "deviceId": "d1", "moduleId": "m1", "action": "updated"}]}
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            val event = payload.events[0].toSyncEvent()
+            event.shouldBeInstanceOf<SyncEvent.ModuleChanged>()
+            // modifiedAt should be close to now (not crash)
+            event.modifiedAt.epochSecond shouldBe Instant.now().epochSecond
+        }
+
+        @Test
+        fun `missing action defaults to updated`() {
+            val serverJson = """
+                {"events": [{"type": "module_changed", "deviceId": "d1", "moduleId": "m1"}]}
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            val event = payload.events[0].toSyncEvent()
+            event.shouldBeInstanceOf<SyncEvent.ModuleChanged>()
+            event.action shouldBe SyncEvent.ModuleChanged.Action.UPDATED
+        }
+
+        @Test
+        fun `forward compatibility - unknown fields in event are ignored`() {
+            val serverJson = """
+                {
+                    "events": [
+                        {
+                            "type": "module_changed",
+                            "deviceId": "d1",
+                            "moduleId": "m1",
+                            "action": "updated",
+                            "futureField": "some-value",
+                            "anotherField": 42
+                        }
+                    ]
+                }
+            """
+
+            val payload = json.decodeFromString<EventPayload>(serverJson)
+            val event = payload.events[0].toSyncEvent()
+            event.shouldBeInstanceOf<SyncEvent.ModuleChanged>()
+            event.moduleId shouldBe ModuleId("m1")
+        }
+    }
+
+    @Nested
+    inner class `SyncEvent data class` {
+
+        @Test
+        fun `ModuleChanged equality`() {
+            val event1 = SyncEvent.ModuleChanged(
+                connectorId = testConnectorId,
+                deviceId = DeviceId("d1"),
+                moduleId = ModuleId("m1"),
+                modifiedAt = Instant.parse("2026-01-01T00:00:00Z"),
+                action = SyncEvent.ModuleChanged.Action.UPDATED,
+            )
+            val event2 = event1.copy()
+            event1 shouldBe event2
+        }
+
+        @Test
+        fun `BlobChanged equality`() {
+            val event = SyncEvent.BlobChanged(
+                connectorId = testConnectorId,
+                deviceId = DeviceId("d1"),
+                moduleId = ModuleId("m1"),
+                blobKey = eu.darken.octi.sync.core.BlobKey("key-1"),
+                action = SyncEvent.BlobChanged.Action.ADDED,
+            )
+            event.action shouldBe SyncEvent.BlobChanged.Action.ADDED
+            event.blobKey.key shouldBe "key-1"
+        }
+
+        @Test
+        fun `sealed interface exhaustive when`() {
+            val events: List<SyncEvent> = listOf(
+                SyncEvent.ModuleChanged(
+                    connectorId = testConnectorId,
+                    deviceId = DeviceId("d1"),
+                    moduleId = ModuleId("m1"),
+                    modifiedAt = Instant.now(),
+                    action = SyncEvent.ModuleChanged.Action.UPDATED,
+                ),
+                SyncEvent.BlobChanged(
+                    connectorId = testConnectorId,
+                    deviceId = DeviceId("d1"),
+                    moduleId = ModuleId("m1"),
+                    blobKey = eu.darken.octi.sync.core.BlobKey("k1"),
+                    action = SyncEvent.BlobChanged.Action.DELETED,
+                ),
+            )
+
+            val types = events.map { event ->
+                when (event) {
+                    is SyncEvent.ModuleChanged -> "module"
+                    is SyncEvent.BlobChanged -> "blob"
+                }
+            }
+            types shouldBe listOf("module", "blob")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Instant sync for K-Server**: WebSocket push notifications deliver module changes in real-time (~1s latency with server+client debounce)
- **Incremental sync for Google Drive**: Change token polling via `changes.list()` replaces full-scan polling, reducing API calls
- **SyncOrchestrator**: New unified entry point for sync lifecycle and status — dashboard now shows Live/Polling mode and background worker schedule
- **Cold flow architecture**: WebSocket and polling connect on collection, disconnect on cancellation — no explicit lifecycle methods needed

## Key decisions

- **No foreground service** — uses `ActivityLifecycleCallbacks` (ProcessLifecycleOwner broken on API 36)
- **No FCM** — keeps `foss` flavor parity
- **Channel-based event batching** — 500ms debounce window, flushes pending events on backgrounding
- **`shareIn(WhileSubscribed)`** on all `syncEvents` flows — prevents duplicate WebSocket connections or polling cycles
- **Pro-only** — quick sync toggle in settings, gated behind upgrade check

## Test coverage

- WebSocket event parsing + wire compatibility (10 tests)
- Targeted sync merge logic (8 tests)
- SyncOrchestrator state derivation (7 tests)
- WorkerInfo mapping from WorkManager (9 tests)
- Flow sharing — no duplicate subscriptions (3 tests)
- Event merging — no conflation (2 tests)
