### PR TITLE
Enable Quick Sync by default for pro users

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/flow/FlowCombineExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/flow/FlowCombineExtensions.kt
@@ -37,6 +37,27 @@ inline fun <T1, T2, T3, R> combine(
 }
 
 @Suppress("UNCHECKED_CAST", "LongParameterList")
+inline fun <T1, T2, T3, T4, R> combine(
+    flow: Flow<T1>,
+    flow2: Flow<T2>,
+    flow3: Flow<T3>,
+    flow4: Flow<T4>,
+    crossinline transform: suspend (T1, T2, T3, T4) -> R
+): Flow<R> = kotlinx.coroutines.flow.combine(
+    flow,
+    flow2,
+    flow3,
+    flow4,
+) { args: Array<*> ->
+    transform(
+        args[0] as T1,
+        args[1] as T2,
+        args[2] as T3,
+        args[3] as T4,
+    )
+}
+
+@Suppress("UNCHECKED_CAST", "LongParameterList")
 inline fun <T1, T2, T3, T4, T5, R> combine(
     flow: Flow<T1>,
     flow2: Flow<T2>,

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
@@ -41,9 +41,7 @@ class SyncSettings @Inject constructor(
 
     val backgroundSyncChargingInterval = dataStore.createValue("sync.background.charging.interval.minutes", 15)
 
-    val foregroundSyncEnabled = dataStore.createValue("sync.foreground.enabled", false)
-
-    val foregroundSyncInterval = dataStore.createValue("sync.foreground.interval.minutes", 5)
+    val foregroundSyncEnabled = dataStore.createValue("sync.foreground.enabled", true)
 
     val showDashboardCard = dataStore.createValue("sync.dashboard.card.show", true)
 


### PR DESCRIPTION
## Summary
- Change foreground sync default from disabled to enabled, so pro users get Quick Sync out of the box without needing to find the setting
- The runtime isPro check in ForegroundSyncControl still prevents free users from getting the feature
- Add missing 4-arg combine overload to FlowCombineExtensions

## Test plan
- [ ] Fresh install with pro: verify Quick Sync is active when app is in foreground
- [ ] Fresh install without pro: verify Quick Sync does not activate
- [ ] Existing pro user who never toggled the setting: verify Quick Sync activates after update
- [ ] Existing pro user who explicitly disabled Quick Sync: verify it stays disabled