### PR TITLE
Skip directory traversal for event-driven Google Drive syncs

### DIFF
--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okio.IOException
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 import com.google.api.services.drive.model.File as GDriveFile
 
 
@@ -112,6 +113,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
     )
 
     private val parentCache = mutableMapOf<String, String>()
+    private val fileIdCache = ConcurrentHashMap<Pair<DeviceId, ModuleId>, String>()
+    private val fileIdReverseCache = ConcurrentHashMap<String, Pair<DeviceId, ModuleId>>()
 
     private val _syncEventMode = MutableStateFlow(EventMode.NONE)
     override val syncEventMode: StateFlow<EventMode> = _syncEventMode.asStateFlow()
@@ -164,7 +167,10 @@ class GDriveAppDataConnector @AssistedInject constructor(
             log(TAG) { "checkForChanges(): ${allChanges.size} changes detected" }
 
             allChanges.mapNotNull { change ->
-                if (change.removed) return@mapNotNull null
+                if (change.removed) {
+                    fileIdReverseCache.remove(change.fileId)?.let { fileIdCache.remove(it) }
+                    return@mapNotNull null
+                }
                 val file = change.file ?: return@mapNotNull null
                 val parentId = file.parents?.firstOrNull() ?: return@mapNotNull null
 
@@ -177,10 +183,17 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     }
                 }
 
+                val moduleId = ModuleId(file.name)
+                if (moduleId in supportedModuleIds) {
+                    val cacheKey = DeviceId(parentName) to moduleId
+                    fileIdCache[cacheKey] = file.id
+                    fileIdReverseCache[file.id] = cacheKey
+                }
+
                 SyncEvent.ModuleChanged(
                     connectorId = identifier,
                     deviceId = DeviceId(parentName),
-                    moduleId = ModuleId(file.name),
+                    moduleId = moduleId,
                     modifiedAt = Instant.now(),
                     action = SyncEvent.ModuleChanged.Action.UPDATED,
                 )
@@ -189,6 +202,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
             if (e.statusCode == 410) {
                 log(TAG, WARN) { "checkForChanges(): Token invalidated, resetting" }
                 parentCache.clear()
+                clearFileIdCache()
                 pollToken.value(null)
             } else {
                 log(TAG, ERROR) { "checkForChanges(): API error: ${e.message}" }
@@ -221,6 +235,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     override suspend fun resetData(): Unit = withContext(NonCancellable) {
         log(TAG, INFO) { "resetData()" }
+        clearFileIdCache()
         runDriveAction("reset-data") {
             appDataRoot.child(DEVICE_DATA_DIR_NAME)
                 ?.listFiles()
@@ -233,6 +248,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     override suspend fun deleteDevice(deviceId: DeviceId): Unit = withContext(NonCancellable) {
         log(TAG, INFO) { "deleteDevice(deviceId=$deviceId)" }
+        evictFileIdCache(deviceId)
         runDriveAction("delete-device: $deviceId") {
             appDataRoot.child(DEVICE_DATA_DIR_NAME)
                 ?.listFiles()
@@ -245,6 +261,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 ?.deleteAll()
             if (deviceId == syncSettings.deviceId) {
                 log(TAG, WARN) { "We just deleted ourselves, this connector is dead now" }
+                clearFileIdCache()
                 _state.updateBlocking { copy(isDead = true) }
             }
         }
@@ -296,10 +313,16 @@ class GDriveAppDataConnector @AssistedInject constructor(
                             return@moduleFetch null
                         }
 
+                        val deviceId = DeviceId(deviceDir.name)
+                        val moduleId = ModuleId(moduleFile.name)
+                        val cacheKey = deviceId to moduleId
+                        fileIdCache[cacheKey] = moduleFile.id
+                        fileIdReverseCache[moduleFile.id] = cacheKey
+
                         GDriveModuleData(
                             connectorId = identifier,
-                            deviceId = DeviceId(deviceDir.name),
-                            moduleId = ModuleId(moduleFile.name),
+                            deviceId = deviceId,
+                            moduleId = moduleId,
                             modifiedAt = Instant.ofEpochMilli(moduleFile.modifiedTime.value),
                             payload = payload,
                         ).also { log(TAG, VERBOSE) { "readDrive(): Got module data: $it" } }
@@ -322,6 +345,52 @@ class GDriveAppDataConnector @AssistedInject constructor(
         return GDriveData(
             connectorId = identifier,
             devices = devices,
+        )
+    }
+
+    private suspend fun GDriveEnvironment.readDriveByFileIds(
+        cachedIds: Map<Pair<DeviceId, ModuleId>, String>,
+    ): GDriveData {
+        log(TAG, DEBUG) { "readDriveByFileIds(): Fetching ${cachedIds.size} files directly by ID" }
+        val start = System.currentTimeMillis()
+
+        val fetchJobs = cachedIds.map { (key, fileId) ->
+            val (deviceId, moduleId) = key
+            scope.async(dispatcherProvider.IO) {
+                val file = getFileMetadata(fileId)
+
+                if (file.name != moduleId.id) {
+                    log(TAG, WARN) { "readDriveByFileIds(): Name mismatch for $fileId: expected=${moduleId.id}, got=${file.name}" }
+                    fileIdCache.remove(key)
+                    fileIdReverseCache.remove(fileId)
+                    return@async null
+                }
+
+                val payload = file.readData()
+                if (payload == null) {
+                    log(TAG, WARN) { "readDriveByFileIds(): Empty payload for $fileId" }
+                    return@async null
+                }
+
+                GDriveModuleData(
+                    connectorId = identifier,
+                    deviceId = deviceId,
+                    moduleId = moduleId,
+                    modifiedAt = Instant.ofEpochMilli(file.modifiedTime.value),
+                    payload = payload,
+                )
+            }
+        }
+
+        val modules = fetchJobs.awaitAll().filterNotNull()
+        log(TAG) { "readDriveByFileIds() took ${System.currentTimeMillis() - start}ms" }
+
+        val deviceGroups = modules.groupBy { it.deviceId }
+        return GDriveData(
+            connectorId = identifier,
+            devices = deviceGroups.map { (deviceId, mods) ->
+                GDriveDeviceData(deviceId = deviceId, modules = mods)
+            },
         )
     }
 
@@ -369,6 +438,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
             if (e.statusCode == 410) {
                 log(TAG, WARN) { "checkSyncChanges(): Token invalidated, resetting" }
+                clearFileIdCache()
                 syncToken.value(null)
             }
             SyncChangeResult.ForceFullSync
@@ -405,6 +475,48 @@ class GDriveAppDataConnector @AssistedInject constructor(
             .map { GDriveDeviceData(deviceId = it.deviceId, modules = it.modules.toList()) }
 
         return GDriveData(connectorId = existing.connectorId, devices = mergedDevices + newDevices)
+    }
+
+    private fun clearFileIdCache() {
+        fileIdCache.clear()
+        fileIdReverseCache.clear()
+    }
+
+    private fun evictFileIdCache(deviceId: DeviceId) {
+        fileIdCache.keys.filter { it.first == deviceId }.forEach { key ->
+            fileIdCache.remove(key)?.let { fileIdReverseCache.remove(it) }
+        }
+    }
+
+    private suspend fun GDriveEnvironment.readTargeted(
+        options: SyncOptions,
+        existing: SyncRead,
+    ): GDriveData {
+        val mFilter = options.moduleFilter
+        val dFilter = options.deviceFilter
+
+        if (mFilter != null && dFilter != null) {
+            val targetModules = mFilter.intersect(supportedModuleIds)
+            val requested = dFilter.flatMap { deviceId ->
+                targetModules.map { moduleId -> deviceId to moduleId }
+            }.toSet()
+            val cached = requested.mapNotNull { key -> fileIdCache[key]?.let { key to it } }.toMap()
+
+            if (cached.size == requested.size) {
+                log(TAG) { "readTargeted(): All ${cached.size} fileIds cached, using direct fetch" }
+                try {
+                    return readDriveByFileIds(cached)
+                } catch (e: kotlin.coroutines.cancellation.CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "readTargeted(): Direct fetch failed, falling back: ${e.asLog()}" }
+                }
+            } else {
+                log(TAG) { "readTargeted(): Cache miss (${cached.size}/${requested.size}), using readDrive" }
+            }
+        }
+
+        return readDrive(mFilter, dFilter)
     }
 
     private val syncLock = Mutex()
@@ -486,7 +598,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                                     .execute().startPageToken
                                 syncToken.value(startToken)
                             } else {
-                                val newData = readDrive(options.moduleFilter, options.deviceFilter)
+                                val newData = readTargeted(options, existing)
                                 _data.value = mergeData(existing, newData, options.moduleFilter)
                             }
                         } else {

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveEnvironment.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveEnvironment.kt
@@ -80,6 +80,14 @@ interface GDriveEnvironment {
         }
     }
 
+    suspend fun getFileMetadata(
+        fileId: String,
+        fields: String = "id,name,parents,modifiedTime",
+    ): GDriveFile {
+        log(TAG, VERBOSE) { "getFileMetadata($fileId)" }
+        return drive.files().get(fileId).setFields(fields).execute()
+    }
+
     suspend fun GDriveFile.readData(): ByteString? {
         log(TAG, VERBOSE) { "readData($name)" }
 

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.syncs.gdrive.core
 import android.content.Context
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.google.api.services.drive.Drive
+import com.google.api.client.util.DateTime
 import com.google.api.services.drive.model.Change
 import com.google.api.services.drive.model.ChangeList
 import com.google.api.services.drive.model.FileList
@@ -14,12 +15,17 @@ import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
+import okio.ByteString.Companion.encodeUtf8
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
@@ -365,6 +371,225 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 .createValue("gdrive.sync_token.test-account", null as String?)
                 .value()
             token shouldBe "final-token"
+        }
+    }
+
+    @Nested
+    inner class `fileId cache` {
+
+        private val deviceA = DeviceId("device-a")
+        private val powerFileId = "power-file-id-123"
+
+        private fun setupDriveWithPowerModule(payload: String = "power-data") {
+            val rootFile = GDriveFile().apply {
+                id = "root-id"
+                name = "appDataFolder"
+                mimeType = "application/vnd.google-apps.folder"
+            }
+            val devicesDir = GDriveFile().apply {
+                id = "devices-dir-id"
+                name = "devices"
+                mimeType = "application/vnd.google-apps.folder"
+            }
+            val deviceADir = GDriveFile().apply {
+                id = "device-a-dir-id"
+                name = "device-a"
+                mimeType = "application/vnd.google-apps.folder"
+            }
+            val powerFile = GDriveFile().apply {
+                id = powerFileId
+                name = power.id
+                mimeType = "application/octet-stream"
+                modifiedTime = DateTime(1000L)
+            }
+
+            val rootGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.execute() } returns rootFile
+            }
+            val moduleGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns powerFile
+                every { it.executeMediaAndDownloadTo(any()) } answers {
+                    firstArg<java.io.OutputStream>().write(payload.toByteArray())
+                }
+            }
+
+            every { mockFiles.get(any()) } answers {
+                when (firstArg<String>()) {
+                    "appDataFolder" -> rootGet
+                    powerFileId -> moduleGet
+                    else -> mockk(relaxed = true)
+                }
+            }
+
+            var listCallIdx = 0
+            every { mockFilesList.execute() } answers {
+                listCallIdx++
+                when (listCallIdx) {
+                    1 -> FileList().apply { files = listOf(devicesDir) }
+                    2 -> FileList().apply { files = listOf(deviceADir) }
+                    3 -> FileList().apply { files = listOf(powerFile) }
+                    else -> FileList().apply { files = emptyList() }
+                }
+            }
+        }
+
+        @Test
+        fun `targeted sync uses direct fetch when cache is warm`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("original")
+
+            // Full sync populates _data + fileIdCache
+            connector.sync(SyncOptions(stats = false, readData = true, writeData = false))
+            connector.data.first().shouldNotBeNull()
+
+            // Override module mock with updated payload for direct fetch
+            val updatedPowerFile = GDriveFile().apply {
+                id = powerFileId
+                name = power.id
+                parents = listOf("device-a-dir-id")
+                modifiedTime = DateTime(2000L)
+            }
+            val updatedGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns updatedPowerFile
+                every { it.executeMediaAndDownloadTo(any()) } answers {
+                    firstArg<java.io.OutputStream>().write("updated".toByteArray())
+                }
+            }
+            every { mockFiles.get(powerFileId) } returns updatedGet
+
+            // Break directory traversal — readDrive would return empty
+            every { mockFilesList.execute() } returns FileList().apply { files = emptyList() }
+
+            // Targeted sync with BOTH filters → should use direct fetch
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = true,
+                    writeData = false,
+                    moduleFilter = setOf(power),
+                    deviceFilter = setOf(deviceA),
+                ),
+            )
+
+            // Data should have updated payload — proves direct fetch was used
+            val data = connector.data.first()
+            data.shouldNotBeNull()
+            val module = data.devices
+                .first { it.deviceId == deviceA }
+                .modules
+                .first { it.moduleId == power }
+            module.payload.utf8() shouldBe "updated"
+        }
+
+        @Test
+        fun `targeted sync with only moduleFilter uses readDrive not cache`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("original")
+
+            // Full sync
+            connector.sync(SyncOptions(stats = false, readData = true, writeData = false))
+
+            // Re-setup drive with different payload
+            setupDriveWithPowerModule("from-readDrive")
+
+            // Targeted sync with ONLY moduleFilter → readDrive, not cache
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = true,
+                    writeData = false,
+                    moduleFilter = setOf(power),
+                ),
+            )
+
+            val data = connector.data.first()
+            data.shouldNotBeNull()
+            val module = data.devices
+                .first { it.deviceId == deviceA }
+                .modules
+                .first { it.moduleId == power }
+            module.payload.utf8() shouldBe "from-readDrive"
+        }
+
+        @Test
+        fun `targeted sync falls back to readDrive when cache is empty`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupEmptyDriveRead()
+
+            // First sync: empty drive → _data populated but cache empty
+            connector.sync(SyncOptions(stats = false, readData = true, writeData = false))
+
+            // Setup populated drive for fallback
+            setupDriveWithPowerModule("fallback-data")
+
+            // Targeted sync — cache miss → falls back to readDrive
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = true,
+                    writeData = false,
+                    moduleFilter = setOf(power),
+                    deviceFilter = setOf(deviceA),
+                ),
+            )
+
+            val data = connector.data.first()
+            data.shouldNotBeNull()
+            val module = data.devices
+                .first { it.deviceId == deviceA }
+                .modules
+                .first { it.moduleId == power }
+            module.payload.utf8() shouldBe "fallback-data"
+        }
+
+        @Test
+        fun `direct fetch validates file name and falls back on mismatch`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("original")
+
+            // Full sync populates cache
+            connector.sync(SyncOptions(stats = false, readData = true, writeData = false))
+
+            // Override getFileMetadata to return wrong name (stale cache)
+            val wrongNameFile = GDriveFile().apply {
+                id = powerFileId
+                name = "wrong-module-name"
+                parents = listOf("device-a-dir-id")
+                modifiedTime = DateTime(2000L)
+            }
+            val wrongGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns wrongNameFile
+            }
+            every { mockFiles.get(powerFileId) } returns wrongGet
+
+            // Re-setup list mock for fallback readDrive
+            setupDriveWithPowerModule("fallback-after-mismatch")
+
+            // Targeted sync — direct fetch detects mismatch, falls back
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = true,
+                    writeData = false,
+                    moduleFilter = setOf(power),
+                    deviceFilter = setOf(deviceA),
+                ),
+            )
+
+            val data = connector.data.first()
+            data.shouldNotBeNull()
+            val module = data.devices
+                .first { it.deviceId == deviceA }
+                .modules
+                .first { it.moduleId == power }
+            module.payload.utf8() shouldBe "fallback-after-mismatch"
         }
     }
 }


### PR DESCRIPTION
## Summary

- Cache Google Drive file IDs internally during change polling and full reads
- Event-driven targeted syncs (foreground) now fetch files directly by ID instead of traversing the folder hierarchy (5 API calls → 2 per module)
- Includes metadata validation to detect stale cache entries, with automatic fallback to directory traversal
- Cache invalidation on 410 errors, data resets, device deletion, and file removal

## Details

When `checkForChanges()` detects modified files via the Drive changes API, it already has the file IDs but was discarding them. The subsequent targeted sync would re-traverse `appDataFolder → devices → device → module` just to locate the same file.

This adds a `ConcurrentHashMap`-based cache (`fileIdCache` + reverse map for eviction) that stores `(DeviceId, ModuleId) → fileId`. The direct fetch path is only used when **both** `moduleFilter` and `deviceFilter` are present (event-driven syncs always provide both), preserving the existing discovery behavior for single-filter or full syncs.

## Test plan

- [x] Unit tests: cache population, direct fetch, fallback on miss/mismatch, invalidation
- [x] Manual: confirmed via logcat that targeted sync uses `readDriveByFileIds()` path (12 files in 1.2s vs 4.6s full read)
