### PR TITLE
Improve onboarding and add adaptive multi-column dashboard

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -11,8 +11,11 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -23,9 +26,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Apps
 import androidx.compose.material.icons.twotone.BatteryFull
@@ -57,6 +61,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -365,15 +370,25 @@ fun DashboardScreen(
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
     ) { innerPadding ->
-        LazyColumn(
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding),
-            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
         ) {
-            // Sync status bar
+            val columns = when {
+                maxWidth >= 900.dp -> 3
+                maxWidth >= 600.dp -> 2
+                else -> 1
+            }
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(columns),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+            // Sync status bar (full-span)
             state.syncStatus?.let { syncStatus ->
-                item(key = "sync_status") {
+                item(key = "sync_status", span = { GridItemSpan(maxLineSpan) }) {
                     SyncStatusBar(
                         syncStatus = syncStatus,
                         isExpanded = state.isSyncExpanded,
@@ -383,31 +398,26 @@ fun DashboardScreen(
                 }
             }
 
-            // Sync setup card
-            if (state.showSyncSetup) {
-                item(key = "sync_setup") {
-                    SyncSetupCard(
-                        onDismiss = onDismissSyncSetup,
-                        onSetup = onSetupSync,
+            // Action chips row (sync setup + permissions + upgrade)
+            val hasActionChips = state.showSyncSetup || state.missingPermissions.isNotEmpty() || !state.upgradeInfo.isPro
+            if (hasActionChips) {
+                item(key = "action_chips", span = { GridItemSpan(maxLineSpan) }) {
+                    ActionChipsRow(
+                        showSyncSetup = state.showSyncSetup,
+                        missingPermissions = state.missingPermissions,
+                        showUpgrade = !state.upgradeInfo.isPro,
+                        onSetupSync = onSetupSync,
+                        onDismissSyncSetup = onDismissSyncSetup,
+                        onGrantPermission = onGrantPermission,
+                        onDismissPermission = onDismissPermission,
+                        onUpgrade = onUpgrade,
                     )
                 }
             }
 
-            // Permission cards
-            items(
-                items = state.missingPermissions,
-                key = { "perm_${it.permissionId}" },
-            ) { permission ->
-                PermissionCard(
-                    permission = permission,
-                    onGrant = onGrantPermission,
-                    onDismiss = onDismissPermission,
-                )
-            }
-
-            // Update card
+            // Update card (full-span)
             if (state.update != null) {
-                item(key = "update") {
+                item(key = "update", span = { GridItemSpan(maxLineSpan) }) {
                     UpdateCard(
                         update = state.update,
                         onDismiss = onDismissUpdate,
@@ -417,25 +427,17 @@ fun DashboardScreen(
                 }
             }
 
-            // Device cards with limit card interleaved
+            // Device cards
             val devices = state.devices
             val deviceLimit = state.deviceLimit
             val showLimitCard = state.deviceLimitReached
+            val freeDevices = if (showLimitCard) devices.take(deviceLimit) else devices
 
-            itemsIndexed(
-                items = devices,
-                key = { _, device -> device.meta.deviceId.id },
-            ) { index, device ->
-                // Insert device limit card before the first limited device
-                if (showLimitCard && index == deviceLimit) {
-                    DeviceLimitCard(
-                        current = devices.size,
-                        maximum = deviceLimit,
-                        onManageDevices = onSyncServices,
-                        onUpgrade = onUpgrade,
-                    )
-                }
-
+            items(
+                items = freeDevices,
+                key = { it.meta.deviceId.id },
+            ) { device ->
+                val index = devices.indexOf(device)
                 DeviceCardOrEditor(
                     device = device,
                     editingDeviceId = editingDeviceId,
@@ -469,15 +471,57 @@ fun DashboardScreen(
                 )
             }
 
-            // Upgrade card at bottom
-            if (!state.upgradeInfo.isPro) {
-                item(key = "upgrade") {
-                    UpgradeCard(
-                        deviceLimit = state.deviceLimit,
+            // Device limit card (full-span)
+            if (showLimitCard) {
+                item(key = "device_limit", span = { GridItemSpan(maxLineSpan) }) {
+                    DeviceLimitCard(
+                        current = devices.size,
+                        maximum = deviceLimit,
+                        onManageDevices = onSyncServices,
                         onUpgrade = onUpgrade,
                     )
                 }
+
+                items(
+                    items = devices.drop(deviceLimit),
+                    key = { it.meta.deviceId.id },
+                ) { device ->
+                    val index = devices.indexOf(device)
+                    DeviceCardOrEditor(
+                        device = device,
+                        editingDeviceId = editingDeviceId,
+                        isFirst = false,
+                        isLast = index == devices.lastIndex,
+                        onToggleCollapse = onToggleDeviceCollapsed,
+                        onEditCard = { editingDeviceId = it },
+                        onUpgrade = onUpgrade,
+                        onManageStaleDevice = onSyncServices,
+                        onPowerClicked = { showPowerDetail = it },
+                        onPowerAlerts = onPowerAlerts,
+                        onWifiClicked = { showWifiDetail = it },
+                        onWifiPermissionGrant = onWifiPermissionGrant,
+                        onConnectivityClicked = { showConnectivityDetail = it },
+                        onAppsClicked = onAppsList,
+                        onInstallLatestApp = onInstallLatestApp,
+                        onClipboardClicked = { showClipboardDetail = it },
+                        onClearClipboard = onClearClipboard,
+                        onShareClipboard = onShareClipboard,
+                        onCopyClipboard = onCopyClipboard,
+                        showMessage = showMessage,
+                        onDoneEditing = { deviceId, config ->
+                            onSaveTileLayout(deviceId, config)
+                            editingDeviceId = null
+                        },
+                        onCancelEditing = { editingDeviceId = null },
+                        onResetTileLayout = onResetTileLayout,
+                        onSaveAsDefault = onSaveAsDefaultTileLayout,
+                        onMoveUp = onMoveDeviceUp,
+                        onMoveDown = onMoveDeviceDown,
+                    )
+                }
             }
+
+        }
         }
     }
 
@@ -906,6 +950,97 @@ private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
         )
     } else {
         Text(text = appName)
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@Composable
+private fun ActionChipsRow(
+    showSyncSetup: Boolean,
+    missingPermissions: List<Permission>,
+    showUpgrade: Boolean,
+    onSetupSync: () -> Unit,
+    onDismissSyncSetup: () -> Unit,
+    onGrantPermission: (Permission) -> Unit,
+    onDismissPermission: (Permission) -> Unit,
+    onUpgrade: () -> Unit,
+) {
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (showSyncSetup) {
+            ActionChip(
+                icon = Icons.TwoTone.CloudSync,
+                label = stringResource(R.string.onboarding_setupsync_title),
+                onClick = onSetupSync,
+                onLongClick = onDismissSyncSetup,
+            )
+        }
+        missingPermissions.forEach { permission ->
+            ActionChip(
+                icon = when (permission) {
+                    Permission.IGNORE_BATTERY_OPTIMIZATION -> Icons.TwoTone.BatteryFull
+                    Permission.POST_NOTIFICATIONS -> Icons.TwoTone.Info
+                    else -> Icons.TwoTone.Info
+                },
+                label = stringResource(
+                    when (permission) {
+                        Permission.IGNORE_BATTERY_OPTIMIZATION -> R.string.permission_battery_optimization_label
+                        Permission.POST_NOTIFICATIONS -> R.string.permission_notifications_post_label
+                        else -> R.string.permission_required_label
+                    }
+                ),
+                onClick = { onGrantPermission(permission) },
+                onLongClick = { onDismissPermission(permission) },
+            )
+        }
+        if (showUpgrade) {
+            ActionChip(
+                icon = Icons.TwoTone.Stars,
+                label = stringResource(CommonR.string.general_upgrade_action),
+                onClick = onUpgrade,
+                onLongClick = null,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ActionChip(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)?,
+) {
+    Surface(
+        modifier = Modifier.combinedClickable(
+            onClick = onClick,
+            onLongClick = onLongClick,
+        ),
+        shape = MaterialTheme.shapes.small,
+        tonalElevation = 2.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.labelLarge,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -257,7 +257,7 @@ class DashboardVM @Inject constructor(
 
         val filteredPermissions = missingPermissions
             .filterNot { WIFI_PERMISSIONS.contains(it) }
-            .toList()
+            .take(1)
 
         // Clean config to remove stale device data, then apply custom ordering
         val currentDeviceIds = deviceItems.map { it.meta.deviceId.id }.toSet()

--- a/app/src/main/java/eu/darken/octi/main/ui/onboarding/StepIndicator.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/onboarding/StepIndicator.kt
@@ -1,0 +1,50 @@
+package eu.darken.octi.main.ui.onboarding
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+
+@Composable
+fun StepIndicator(
+    totalSteps: Int,
+    currentStep: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.semantics {
+            contentDescription = "Step $currentStep of $totalSteps"
+        },
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        repeat(totalSteps) { index ->
+            val isActive = index + 1 == currentStep
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (isActive) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.outlineVariant
+                    ),
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun StepIndicatorPreview() = PreviewWrapper {
+    StepIndicator(totalSteps = 2, currentStep = 1)
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/onboarding/privacy/PrivacyScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/onboarding/privacy/PrivacyScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -36,6 +37,7 @@ import eu.darken.octi.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.main.ui.onboarding.StepIndicator
 
 @Composable
 fun PrivacyScreenHost(vm: PrivacyVM = hiltViewModel()) {
@@ -64,92 +66,125 @@ fun PrivacyScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState()),
+                .padding(innerPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(modifier = Modifier.height(62.dp))
-
-            OctiMascot(modifier = Modifier.size(96.dp))
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = stringResource(CommonR.string.app_name),
-                style = MaterialTheme.typography.headlineLarge,
-            )
-
-            Text(
-                text = stringResource(R.string.settings_privacy_policy_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = stringResource(R.string.onboarding_privacy_body1),
-                style = MaterialTheme.typography.bodyLarge,
+            // Scrollable content fills available space
+            Column(
                 modifier = Modifier
+                    .weight(1f)
                     .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
-            )
+                    .verticalScroll(rememberScrollState()),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(modifier = Modifier.height(48.dp))
 
-            Spacer(modifier = Modifier.height(32.dp))
-
-            FilledTonalButton(onClick = onPrivacyPolicy) {
-                Text(text = stringResource(R.string.settings_privacy_policy_label))
-            }
-
-            if (state.isUpdateCheckSupported) {
-                Spacer(modifier = Modifier.height(32.dp))
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = onToggleUpdateCheck)
-                        .padding(horizontal = 16.dp, vertical = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                Column(
+                    modifier = Modifier.widthIn(max = 600.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    Icon(
-                        imageVector = Icons.TwoTone.SystemUpdateAlt,
-                        contentDescription = null,
-                        modifier = Modifier.size(24.dp),
+                    OctiMascot(modifier = Modifier.size(96.dp))
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(CommonR.string.app_name),
+                        style = MaterialTheme.typography.headlineLarge,
                     )
 
-                    Spacer(modifier = Modifier.width(16.dp))
+                    Text(
+                        text = stringResource(R.string.settings_privacy_policy_label),
+                        style = MaterialTheme.typography.titleLarge,
+                    )
 
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.updatecheck_setting_enabled_label),
-                            style = MaterialTheme.typography.titleMedium,
-                        )
-                        Text(
-                            text = stringResource(R.string.updatecheck_setting_enabled_explanation),
-                            style = MaterialTheme.typography.bodyMedium,
-                        )
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    Text(
+                        text = stringResource(R.string.onboarding_privacy_body1),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp),
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = stringResource(R.string.onboarding_privacy_sync_explanation),
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 32.dp),
+                    )
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    FilledTonalButton(onClick = onPrivacyPolicy) {
+                        Text(text = stringResource(R.string.settings_privacy_policy_label))
                     }
 
-                    Spacer(modifier = Modifier.width(16.dp))
+                    if (state.isUpdateCheckSupported) {
+                        Spacer(modifier = Modifier.height(32.dp))
 
-                    Switch(
-                        checked = state.isUpdateCheckEnabled,
-                        onCheckedChange = null,
-                    )
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable(onClick = onToggleUpdateCheck)
+                                .padding(horizontal = 16.dp, vertical = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Icon(
+                                imageVector = Icons.TwoTone.SystemUpdateAlt,
+                                contentDescription = null,
+                                modifier = Modifier.size(24.dp),
+                            )
+
+                            Spacer(modifier = Modifier.width(16.dp))
+
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = stringResource(R.string.updatecheck_setting_enabled_label),
+                                    style = MaterialTheme.typography.titleMedium,
+                                )
+                                Text(
+                                    text = stringResource(R.string.updatecheck_setting_enabled_explanation),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.width(16.dp))
+
+                            Switch(
+                                checked = state.isUpdateCheckEnabled,
+                                onCheckedChange = null,
+                            )
+                        }
+                    }
                 }
+
+                Spacer(modifier = Modifier.height(32.dp))
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = onContinue,
+            // Fixed bottom section
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .widthIn(max = 600.dp)
                     .padding(horizontal = 64.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Text(text = stringResource(CommonR.string.general_continue))
-            }
+                Button(
+                    onClick = onContinue,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(CommonR.string.general_continue))
+                }
 
-            Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(24.dp))
+
+                StepIndicator(totalSteps = 2, currentStep = 2)
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
         }
     }
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/onboarding/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/onboarding/welcome/WelcomeScreen.kt
@@ -1,15 +1,23 @@
 package eu.darken.octi.main.ui.onboarding.welcome
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.CloudSync
+import androidx.compose.material.icons.twotone.ContentPaste
+import androidx.compose.material.icons.twotone.Devices
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -17,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.octi.R
@@ -27,6 +36,7 @@ import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.main.ui.onboarding.StepIndicator
 
 @Composable
 fun WelcomeScreenHost(vm: WelcomeVM = hiltViewModel()) {
@@ -48,74 +58,124 @@ fun WelcomeScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 32.dp)
-                .verticalScroll(rememberScrollState()),
+                .padding(innerPadding),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Spacer(modifier = Modifier.height(48.dp))
+            // Scrollable content fills available space
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Spacer(modifier = Modifier.height(48.dp))
 
-            OctiMascot(modifier = Modifier.size(96.dp))
+                OctiMascot(modifier = Modifier.size(96.dp))
 
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Text(
-                text = stringResource(CommonR.string.app_name),
-                style = MaterialTheme.typography.headlineLarge,
-            )
-
-            Text(
-                text = stringResource(R.string.onboarding_welcome_subtitle),
-                style = MaterialTheme.typography.titleLarge,
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = stringResource(R.string.onboarding_welcome_body1),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(R.string.onboarding_welcome_body2),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Text(
-                text = stringResource(R.string.onboarding_welcome_body3),
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            if (showBetaHint) {
-                Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(16.dp))
 
                 Text(
-                    text = stringResource(R.string.onboarding_welcome_beta_hint),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.error,
-                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(CommonR.string.app_name),
+                    style = MaterialTheme.typography.headlineLarge,
                 )
+
+                Text(
+                    text = stringResource(R.string.onboarding_welcome_subtitle),
+                    style = MaterialTheme.typography.titleLarge,
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Column(
+                    modifier = Modifier.widthIn(max = 600.dp),
+                ) {
+                    FeatureRow(
+                        icon = { Icon(Icons.TwoTone.Devices, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.primary) },
+                        title = stringResource(R.string.onboarding_features_page1_title),
+                        body = stringResource(R.string.onboarding_features_page1_body),
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    FeatureRow(
+                        icon = { Icon(Icons.TwoTone.ContentPaste, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.primary) },
+                        title = stringResource(R.string.onboarding_features_page2_title),
+                        body = stringResource(R.string.onboarding_features_page2_body),
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    FeatureRow(
+                        icon = { Icon(Icons.TwoTone.CloudSync, contentDescription = null, modifier = Modifier.size(32.dp), tint = MaterialTheme.colorScheme.primary) },
+                        title = stringResource(R.string.onboarding_features_page3_title),
+                        body = stringResource(R.string.onboarding_features_page3_body),
+                    )
+                }
+
+                if (showBetaHint) {
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Text(
+                        text = stringResource(R.string.onboarding_welcome_beta_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.widthIn(max = 600.dp).fillMaxWidth(),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = onContinue,
+            // Fixed bottom section
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
+                    .widthIn(max = 600.dp)
+                    .padding(horizontal = 64.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Text(text = stringResource(CommonR.string.general_continue))
-            }
+                Button(
+                    onClick = onContinue,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(CommonR.string.general_continue))
+                }
 
-            Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(24.dp))
+
+                StepIndicator(totalSteps = 2, currentStep = 1)
+
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FeatureRow(
+    icon: @Composable () -> Unit,
+    title: String,
+    body: String,
+) {
+    Row(
+        verticalAlignment = Alignment.Top,
+    ) {
+        icon()
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = body,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,8 +14,16 @@
     <string name="onboarding_welcome_body3">Upgrade to Octi Pro to gain extra features and support development.</string>
     <string name="onboarding_welcome_beta_hint">Just a heads-up, this is a beta version, so thanks for your patience as I keep improving the app!</string>
 
+    <string name="onboarding_features_page1_title">All your devices at a glance</string>
+    <string name="onboarding_features_page1_body">See battery, WiFi, and connectivity across all your Android devices.</string>
+    <string name="onboarding_features_page2_title">Seamless clipboard sync</string>
+    <string name="onboarding_features_page2_body">Copy on one device, paste on another. Your clipboard travels with you.</string>
+    <string name="onboarding_features_page3_title">Better together</string>
+    <string name="onboarding_features_page3_body">Install Octi on multiple devices and connect them through a sync service. The more devices, the more useful Octi becomes.</string>
+
     <string name="onboarding_privacy_subtitle">Privacy policy</string>
     <string name="onboarding_privacy_body1">Octi has no ads and does not sell user data.</string>
+    <string name="onboarding_privacy_sync_explanation">Your data is synced via Google Drive or Octi Server. Octi does not have access to your synced data.</string>
 
     <string name="updatecheck_setting_enabled_label">Update check</string>
     <string name="updatecheck_setting_enabled_explanation">Allow Octi to check for updates to let you know if a newer version is available.</string>


### PR DESCRIPTION
## Summary

- Rework welcome screen with icon+text feature highlights (devices, clipboard, sync) and Octi mascot, replacing the old wall-of-text layout
- Add step indicator dots and pin Continue button to a consistent bottom position across onboarding screens
- Add sync data privacy explanation to the privacy screen
- Replace dashboard `LazyColumn` with `LazyVerticalGrid` using `BoxWithConstraints` for adaptive columns (1 on phones, 2 on small tablets, 3 on large tablets)
- Consolidate sync setup, permission, and upgrade prompts into compact action chips row, replacing the old full-height cards
- Show permissions one at a time to reduce first-launch card clutter
- Constrain onboarding content width for tablet layouts

## Test plan

- [ ] Fresh install: verify Welcome → Privacy → Dashboard flow
- [ ] Welcome screen: mascot visible, 3 feature rows, beta hint centered, step 1/2 dots
- [ ] Privacy screen: sync data explanation visible, update check toggle, step 2/2 dots
- [ ] Continue button stays at same screen position across both pages
- [ ] Phone layout: single column dashboard, chips wrap naturally
- [ ] Tablet layout: 2-3 column dashboard with device cards in grid
- [ ] Action chips: tap sync chip navigates to sync setup, long-press dismisses
- [ ] Permissions show one at a time, next appears after grant/dismiss
- [ ] Existing users (onboarding done): skip straight to dashboard
