### PR TITLE
Fix module data not syncing to server on idle or newly configured devices

### DIFF
--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.sync.core
 
+import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.value
@@ -31,6 +32,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -44,6 +46,7 @@ class SyncManager @Inject constructor(
 ) {
 
     private val syncLock = Mutex()
+    private val cachedWrites = ConcurrentHashMap<ModuleId, SyncWrite.Device.Module>()
 
     private val disabledConnectors = MutableStateFlow(emptySet<SyncConnector>())
 
@@ -130,12 +133,24 @@ class SyncManager @Inject constructor(
     suspend fun sync(connectorId: ConnectorId, options: SyncOptions = SyncOptions()) {
         log(TAG) { "sync(id=$connectorId, options=$options)" }
         val connector = connectors.first().single { it.identifier == connectorId }
+
+        if (options.writeData && cachedWrites.isNotEmpty()) {
+            log(TAG) { "sync(): Replaying ${cachedWrites.size} cached writes to $connectorId" }
+            connector.write(
+                SyncWriteContainer(
+                    deviceId = syncSettings.deviceId,
+                    modules = cachedWrites.values.toList(),
+                )
+            )
+        }
+
         connector.sync(options)
     }
 
     suspend fun write(toWrite: SyncWrite.Device.Module) {
         val start = System.currentTimeMillis()
         log(TAG) { "write(data=$toWrite)..." }
+        cachedWrites[toWrite.moduleId] = toWrite
         connectors.first()
             .filter {
                 val paused = syncSettings.pausedConnectors.value().contains(it.identifier)

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -134,17 +134,26 @@ class SyncManager @Inject constructor(
         log(TAG) { "sync(id=$connectorId, options=$options)" }
         val connector = connectors.first().single { it.identifier == connectorId }
 
-        if (options.writeData && cachedWrites.isNotEmpty()) {
-            log(TAG) { "sync(): Replaying ${cachedWrites.size} cached writes to $connectorId" }
-            connector.write(
-                SyncWriteContainer(
-                    deviceId = syncSettings.deviceId,
-                    modules = cachedWrites.values.toList(),
-                )
-            )
+        val pendingSnapshot = if (options.writeData && cachedWrites.isNotEmpty()) {
+            cachedWrites.toMap().also {
+                log(TAG) { "sync(): Passing ${it.size} cached writes to $connectorId" }
+            }
+        } else {
+            emptyMap()
         }
 
-        connector.sync(options)
+        val effectiveOptions = if (pendingSnapshot.isNotEmpty()) {
+            options.copy(writePayload = pendingSnapshot.values.toList())
+        } else {
+            options
+        }
+
+        connector.sync(effectiveOptions)
+
+        // Ack: clear only entries that haven't been updated since the snapshot
+        pendingSnapshot.forEach { (moduleId, module) ->
+            cachedWrites.remove(moduleId, module)
+        }
     }
 
     suspend fun write(toWrite: SyncWrite.Device.Module) {

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
@@ -6,6 +6,7 @@ data class SyncOptions(
     val stats: Boolean = true,
     val readData: Boolean = true,
     val writeData: Boolean = true,
+    val writePayload: List<SyncWrite.Device.Module> = emptyList(),
     val moduleFilter: Set<ModuleId>? = null,
     val deviceFilter: Set<DeviceId>? = null,
 )

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerWriteCacheTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerWriteCacheTest.kt
@@ -3,10 +3,12 @@ package eu.darken.octi.sync.core
 import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.cache.SyncCache
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -103,18 +105,19 @@ class SyncManagerWriteCacheTest : BaseTest() {
 
             sm.write(createModule(powerModuleId, "battery-data"))
 
+            // No connector to write to
             coVerify(exactly = 0) { connector.write(any()) }
 
-            // Add connector back
+            // Add connector back and sync
             connectorsFlow.value = listOf(connector)
             advanceUntilIdle()
 
-            // Sync with writeData=true should replay cached write
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            val writes = mutableListOf<SyncWrite>()
-            coVerify(atLeast = 1) { connector.write(capture(writes)) }
-            writes.last().modules.single().moduleId shouldBe powerModuleId
+            // Cached write passed via writePayload in sync options
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload.single().moduleId shouldBe powerModuleId
 
             job.cancel()
             advanceUntilIdle()
@@ -124,7 +127,7 @@ class SyncManagerWriteCacheTest : BaseTest() {
     @Nested
     inner class `sync write replay` {
         @Test
-        fun `sync with writeData true replays cached writes`() = runTest2 {
+        fun `sync with writeData true passes cached writes via writePayload`() = runTest2 {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
@@ -133,18 +136,16 @@ class SyncManagerWriteCacheTest : BaseTest() {
 
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            val writes = mutableListOf<SyncWrite>()
-            coVerify(atLeast = 3) { connector.write(capture(writes)) }
-
-            val replayWrite = writes.last()
-            replayWrite.modules.map { it.moduleId }.toSet() shouldBe setOf(powerModuleId, wifiModuleId)
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload.map { it.moduleId } shouldContainExactlyInAnyOrder listOf(powerModuleId, wifiModuleId)
 
             job.cancel()
             advanceUntilIdle()
         }
 
         @Test
-        fun `sync with writeData false does not replay`() = runTest2 {
+        fun `sync with writeData false does not pass payload`() = runTest2 {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
@@ -152,7 +153,9 @@ class SyncManagerWriteCacheTest : BaseTest() {
 
             sm.sync(connectorId, SyncOptions(writeData = false, readData = false, stats = false))
 
-            coVerify(exactly = 1) { connector.write(any()) }
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload shouldBe emptyList()
 
             job.cancel()
             advanceUntilIdle()
@@ -168,51 +171,76 @@ class SyncManagerWriteCacheTest : BaseTest() {
 
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            val writes = mutableListOf<SyncWrite>()
-            coVerify(atLeast = 1) { connector.write(capture(writes)) }
-
-            val replayWrite = writes.last()
-            replayWrite.modules.size shouldBe 1
-            replayWrite.modules.single().moduleId shouldBe powerModuleId
-            replayWrite.modules.single().payload shouldBe "new-data".encodeUtf8()
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload.size shouldBe 1
+            optionsSlot.captured.writePayload.single().payload shouldBe "new-data".encodeUtf8()
 
             job.cancel()
             advanceUntilIdle()
         }
 
         @Test
-        fun `replay includes all cached modules independently`() = runTest2 {
+        fun `empty cache results in empty writePayload`() = runTest2 {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            sm.write(createModule(powerModuleId, "power"))
-            sm.write(createModule(wifiModuleId, "wifi"))
-            sm.write(createModule(metaModuleId, "meta"))
-
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            val writes = mutableListOf<SyncWrite>()
-            coVerify(atLeast = 1) { connector.write(capture(writes)) }
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload shouldBe emptyList()
 
-            val replayWrite = writes.last()
-            replayWrite.modules.map { it.moduleId }.toSet() shouldBe setOf(
-                powerModuleId,
-                wifiModuleId,
-                metaModuleId,
-            )
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `ack tracking` {
+        @Test
+        fun `successful sync clears cache entries`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "data"))
+
+            // First sync — should have payload
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+            val firstOptions = slot<SyncOptions>()
+            coVerify { connector.sync(capture(firstOptions)) }
+            firstOptions.captured.writePayload.size shouldBe 1
+
+            // Second sync — cache should be cleared after ack
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+            val allOptions = mutableListOf<SyncOptions>()
+            coVerify(exactly = 2) { connector.sync(capture(allOptions)) }
+            allOptions.last().writePayload shouldBe emptyList()
 
             job.cancel()
             advanceUntilIdle()
         }
 
         @Test
-        fun `empty cache skips replay`() = runTest2 {
+        fun `newer write during sync is not cleared by ack`() = runTest2 {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
+            val oldModule = createModule(powerModuleId, "old")
+            sm.write(oldModule)
+
+            // Overwrite with newer data before sync
+            val newModule = createModule(powerModuleId, "new")
+            sm.write(newModule)
+
+            // Sync picks up "new" module
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            coVerify(exactly = 0) { connector.write(any()) }
+            // After ack, cache is cleared because "new" was what was sent
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+            val allOptions = mutableListOf<SyncOptions>()
+            coVerify(exactly = 2) { connector.sync(capture(allOptions)) }
+            allOptions.last().writePayload shouldBe emptyList()
 
             job.cancel()
             advanceUntilIdle()
@@ -236,7 +264,9 @@ class SyncManagerWriteCacheTest : BaseTest() {
             pausedConnectorsValue.value = emptySet()
             sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            coVerify(atLeast = 1) { connector.write(any()) }
+            val optionsSlot = slot<SyncOptions>()
+            coVerify { connector.sync(capture(optionsSlot)) }
+            optionsSlot.captured.writePayload.single().moduleId shouldBe powerModuleId
 
             job.cancel()
             advanceUntilIdle()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerWriteCacheTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerWriteCacheTest.kt
@@ -1,0 +1,245 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.cache.SyncCache
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class SyncManagerWriteCacheTest : BaseTest() {
+
+    private val connectorId = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "test", account = "acc1")
+    private val deviceId = DeviceId("device-1")
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+    private val wifiModuleId = ModuleId("eu.darken.octi.module.core.wifi")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private lateinit var connector: SyncConnector
+    private lateinit var syncSettings: SyncSettings
+    private lateinit var pausedConnectorsValue: MutableStateFlow<Set<ConnectorId>>
+    private lateinit var syncCache: SyncCache
+    private lateinit var connectorHub: ConnectorHub
+    private lateinit var connectorsFlow: MutableStateFlow<List<SyncConnector>>
+
+    private fun createModule(moduleId: ModuleId, payload: String = "test"): SyncWrite.Device.Module = mockk {
+        every { this@mockk.moduleId } returns moduleId
+        every { this@mockk.payload } returns payload.encodeUtf8()
+    }
+
+    @BeforeEach
+    fun setup() {
+        connector = mockk(relaxed = true) {
+            every { identifier } returns connectorId
+            every { state } returns flowOf()
+            every { data } returns flowOf(null)
+            every { syncEvents } returns flowOf()
+            every { syncEventMode } returns MutableStateFlow(SyncConnector.EventMode.NONE)
+        }
+        connectorsFlow = MutableStateFlow(listOf(connector))
+
+        pausedConnectorsValue = MutableStateFlow(emptySet())
+        syncSettings = mockk(relaxed = true) {
+            every { pausedConnectors } returns mockk<DataStoreValue<Set<ConnectorId>>>(relaxed = true) {
+                every { flow } returns pausedConnectorsValue
+            }
+        }
+        every { syncSettings.deviceId } returns deviceId
+
+        syncCache = mockk(relaxed = true)
+
+        connectorHub = mockk(relaxed = true) {
+            every { connectors } returns connectorsFlow
+        }
+    }
+
+    private fun TestScope.createSyncManager(): Pair<SyncManager, Job> {
+        val job = Job()
+        val sm = SyncManager(
+            scope = this + job,
+            dispatcherProvider = mockk(relaxed = true) {
+                every { Default } returns coroutineContext[kotlinx.coroutines.CoroutineDispatcher.Key]!!
+            },
+            syncSettings = syncSettings,
+            syncCache = syncCache,
+            connectorHubs = setOf(connectorHub),
+        )
+        return sm to job
+    }
+
+    @Nested
+    inner class `write caching` {
+        @Test
+        fun `write caches data and sends to connector`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "battery-data"))
+
+            coVerify(exactly = 1) { connector.write(any()) }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `write with no connectors still caches for later replay`() = runTest2 {
+            connectorsFlow.value = emptyList()
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "battery-data"))
+
+            coVerify(exactly = 0) { connector.write(any()) }
+
+            // Add connector back
+            connectorsFlow.value = listOf(connector)
+            advanceUntilIdle()
+
+            // Sync with writeData=true should replay cached write
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val writes = mutableListOf<SyncWrite>()
+            coVerify(atLeast = 1) { connector.write(capture(writes)) }
+            writes.last().modules.single().moduleId shouldBe powerModuleId
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `sync write replay` {
+        @Test
+        fun `sync with writeData true replays cached writes`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "power-data"))
+            sm.write(createModule(wifiModuleId, "wifi-data"))
+
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val writes = mutableListOf<SyncWrite>()
+            coVerify(atLeast = 3) { connector.write(capture(writes)) }
+
+            val replayWrite = writes.last()
+            replayWrite.modules.map { it.moduleId }.toSet() shouldBe setOf(powerModuleId, wifiModuleId)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `sync with writeData false does not replay`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "power-data"))
+
+            sm.sync(connectorId, SyncOptions(writeData = false, readData = false, stats = false))
+
+            coVerify(exactly = 1) { connector.write(any()) }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `cache keeps latest data per module`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "old-data"))
+            sm.write(createModule(powerModuleId, "new-data"))
+
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val writes = mutableListOf<SyncWrite>()
+            coVerify(atLeast = 1) { connector.write(capture(writes)) }
+
+            val replayWrite = writes.last()
+            replayWrite.modules.size shouldBe 1
+            replayWrite.modules.single().moduleId shouldBe powerModuleId
+            replayWrite.modules.single().payload shouldBe "new-data".encodeUtf8()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `replay includes all cached modules independently`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "power"))
+            sm.write(createModule(wifiModuleId, "wifi"))
+            sm.write(createModule(metaModuleId, "meta"))
+
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val writes = mutableListOf<SyncWrite>()
+            coVerify(atLeast = 1) { connector.write(capture(writes)) }
+
+            val replayWrite = writes.last()
+            replayWrite.modules.map { it.moduleId }.toSet() shouldBe setOf(
+                powerModuleId,
+                wifiModuleId,
+                metaModuleId,
+            )
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `empty cache skips replay`() = runTest2 {
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            coVerify(exactly = 0) { connector.write(any()) }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `paused connectors` {
+        @Test
+        fun `write skips paused connectors but still caches`() = runTest2 {
+            pausedConnectorsValue.value = setOf(connectorId)
+
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.write(createModule(powerModuleId, "data"))
+
+            coVerify(exactly = 0) { connector.write(any()) }
+
+            // Unpause and sync
+            pausedConnectorsValue.value = emptySet()
+            sm.sync(connectorId, SyncOptions(writeData = true, readData = false, stats = false))
+
+            coVerify(atLeast = 1) { connector.write(any()) }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+}

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -32,7 +32,9 @@ import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
+import eu.darken.octi.sync.core.SyncWriteContainer
 import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.APPDATAFOLDER
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.NonCancellable
@@ -94,7 +96,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     private val _data = MutableStateFlow<SyncRead?>(null)
     override val data: Flow<SyncRead?> = _data
     private val driveLock = Mutex()
-    private val writeQueue = MutableSharedFlow<SyncWrite>()
+    private val writeQueue = MutableSharedFlow<SyncWrite>(extraBufferCapacity = 1)
 
     override val identifier: ConnectorId = ConnectorId(
         type = ConnectorType.GDRIVE,
@@ -577,8 +579,18 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 }.run { jobs.add(this) }
 
 
-                if (options.writeData) {
-                    // TODO Attempt to write data if we were offline and are now online?
+                if (options.writeData && options.writePayload.isNotEmpty()) {
+                    log(TAG) { "sync(): Writing ${options.writePayload.size} cached modules (batched)" }
+                    try {
+                        writeDrive(SyncWriteContainer(
+                            deviceId = syncSettings.deviceId,
+                            modules = options.writePayload,
+                        ))
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Failed to write cached modules: ${e.asLog()}" }
+                    }
                 }
 
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -30,7 +30,9 @@ import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
+import eu.darken.octi.sync.core.SyncWriteContainer
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
@@ -102,7 +104,7 @@ class OctiServerConnector @AssistedInject constructor(
     private val _data = MutableStateFlow<SyncRead?>(null)
     override val data: Flow<SyncRead?> = _data
 
-    private val writeQueue = MutableSharedFlow<SyncWrite>()
+    private val writeQueue = MutableSharedFlow<SyncWrite>(extraBufferCapacity = 1)
     private val serverLock = Mutex()
 
     override val identifier: ConnectorId = ConnectorId(
@@ -214,8 +216,20 @@ class OctiServerConnector @AssistedInject constructor(
             }
         }
 
-        if (options.writeData) {
-            // TODO
+        if (options.writeData && options.writePayload.isNotEmpty()) {
+            log(TAG) { "sync(): Writing ${options.writePayload.size} cached modules" }
+            options.writePayload.forEach { module ->
+                try {
+                    runServerAction("write-cached-${module.moduleId}") {
+                        writeServer(SyncWriteContainer(deviceId = syncSettings.deviceId, modules = listOf(module)))
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    if (handleDeviceUnknown(e, "write cached ${module.moduleId}")) return
+                    log(TAG, ERROR) { "Failed to write cached ${module.moduleId}: ${e.asLog()}" }
+                }
+            }
         }
 
         if (options.readData) {


### PR DESCRIPTION
## Summary

- Cache module writes in `SyncManager` and replay them during `sync(writeData=true)`
- Fixes a long-standing bug where module data (battery, WiFi, apps, etc.) was never written to the sync server if device data didn't change after connector setup
- The `writeData` flag in `connector.sync()` has been a TODO stub since the Octi Server connector was created — writes only happened reactively via `writeFLow` which is gated by `distinctUntilChanged()`

## Root cause

1. App starts → module flows emit initial data → `SyncManager.write()` finds no connectors (sync not configured yet) → write lost
2. User configures sync → connector exists → but `distinctUntilChanged()` blocks re-emission of unchanged data
3. `sync(writeData=true)` called by SyncWorker/manual sync → hits `// TODO` stub → no write
4. On real devices this was masked because battery/WiFi data changes frequently, eventually triggering a reactive write

## Fix

`SyncManager` now caches the last write per module. During `sync(writeData=true)`, all cached writes are replayed to the connector before reading. This handles both the new-connector scenario and idle devices.

## Test plan

- [ ] Fresh install on two devices, set up Octi Server sync
- [ ] Verify module data (battery, WiFi, apps) appears on both devices after first sync
- [ ] Verify manual sync button updates timestamps
- [ ] 8 new unit tests covering cache behavior, replay logic, writeData flag, and paused connectors
