### PR TITLE
Centralize experimental API opt-ins in Gradle compiler args

### DIFF
--- a/app-common-test/src/main/java/testhelpers/json/JsonExtensions.kt
+++ b/app-common-test/src/main/java/testhelpers/json/JsonExtensions.kt
@@ -1,6 +1,5 @@
 package testhelpers.json
 
-import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import okio.ByteString.Companion.encode
@@ -8,7 +7,6 @@ import okio.buffer
 import okio.sink
 import java.io.File
 
-@OptIn(ExperimentalSerializationApi::class)
 private val prettyJson = Json {
     prettyPrint = true
     prettyPrintIndent = "    "

--- a/app-common/src/main/java/eu/darken/octi/common/collections/ByteArrayExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/collections/ByteArrayExtensions.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalUnsignedTypes::class)
-
 package eu.darken.octi.common.collections
 
 import okio.ByteString.Companion.toByteString

--- a/app-common/src/main/java/eu/darken/octi/common/settings/SettingsBaseItem.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/settings/SettingsBaseItem.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.common.settings
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun SettingsBaseItem(
     title: String,

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -8,10 +8,8 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -970,7 +968,6 @@ private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ActionChipsRow(
     showSyncSetup: Boolean,
@@ -1037,7 +1034,6 @@ private fun ActionChipsRow(
     }
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ActionChip(
     icon: ImageVector,
@@ -1309,7 +1305,6 @@ private fun UpgradeCard(
 
 // region Device Card
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DashboardDeviceCard(
     device: DashboardVM.DeviceItem,

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/support/ContactSupportScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/support/ContactSupportScreen.kt
@@ -4,7 +4,6 @@ import android.text.format.DateUtils
 import android.text.format.Formatter
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -83,7 +82,6 @@ fun ContactSupportScreenHost(vm: ContactSupportVM = hiltViewModel()) {
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun ContactSupportScreen(
     state: ContactSupportVM.State,

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -49,6 +49,10 @@ fun Project.setupModule() {
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=androidx.compose.material3.ExperimentalMaterial3Api",
                 "-opt-in=kotlinx.serialization.InternalSerializationApi",
+                "-opt-in=androidx.compose.foundation.ExperimentalFoundationApi",
+                "-opt-in=androidx.compose.foundation.layout.ExperimentalLayoutApi",
+                "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
+                "-opt-in=kotlin.ExperimentalUnsignedTypes",
             )
         }
     }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -193,7 +192,6 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun WidgetConfigScreen(
     initialMode: String?,
@@ -408,7 +406,6 @@ private fun WidgetConfigScreen(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ColorSwatchGrid(
     selectedColor: Int?,


### PR DESCRIPTION
## Summary

- Add `ExperimentalFoundationApi`, `ExperimentalLayoutApi`, `ExperimentalSerializationApi`, and `ExperimentalUnsignedTypes` to the shared `-opt-in=` compiler args in `setupModule()` (`Dependencies.kt`)
- Remove all scattered `@OptIn` annotations and their unused imports from 6 source files
- Aligns with the existing pattern where 7 other experimental APIs are already centralized via Gradle
