### PR TITLE
Improve apps tile to show full app name on its own line

### DIFF
--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/AppsModuleTile.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/dashboard/AppsModuleTile.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -43,6 +42,7 @@ fun AppsModuleTile(
 ) {
     val count = info.installedPackages.size
     val last = info.installedPackages.maxByOrNull { it.installedAt }
+    val countLabel = pluralStringResource(AppsR.plurals.module_apps_tile_count, count, count)
     val installedLabel = pluralStringResource(AppsR.plurals.module_apps_x_installed, count, count)
 
     val tileColor = if (isWide) {
@@ -71,7 +71,7 @@ fun AppsModuleTile(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = "$count",
+                    text = countLabel,
                     style = MaterialTheme.typography.titleMedium,
                 )
                 Spacer(modifier = Modifier.weight(1f))
@@ -88,17 +88,13 @@ fun AppsModuleTile(
                     }
                 }
             }
-            Text(
-                text = stringResource(AppsR.string.module_apps_tile_apps_installed_label),
-                style = MaterialTheme.typography.bodySmall,
-            )
             if (last != null) {
-                Spacer(modifier = Modifier.height(2.dp))
                 Text(
-                    text = stringResource(
-                        AppsR.string.module_apps_last_installed_x,
-                        last.label ?: last.packageName,
-                    ),
+                    text = stringResource(AppsR.string.module_apps_tile_last_installed_label),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                Text(
+                    text = last.label ?: last.packageName,
                     style = MaterialTheme.typography.labelSmall,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,

--- a/modules-apps/src/main/res/values/strings.xml
+++ b/modules-apps/src/main/res/values/strings.xml
@@ -9,6 +9,11 @@
     </plurals>
     <string name="module_apps_last_installed_x">Last installed app: %s</string>
     <string name="module_apps_tile_apps_installed_label">apps installed</string>
+    <plurals name="module_apps_tile_count">
+        <item quantity="one">%d app</item>
+        <item quantity="other">%d apps</item>
+    </plurals>
+    <string name="module_apps_tile_last_installed_label">Last installed</string>
     <string name="module_apps_list_title">Installed apps</string>
 
     <string name="module_apps_sort_label">Sort</string>


### PR DESCRIPTION
## Summary
- Merge app count and label on the header line ("4 apps" instead of "4" + "apps installed" on separate lines)
- Move "Last installed" label to line 2, freeing line 3 entirely for the app name
- Empty state (0 apps) now shows just "0 apps" with no extra lines

## Test plan
- [ ] Verify tile renders "X apps" (singular/plural) correctly on dashboard
- [ ] Verify "Last installed" label and full app name display on lines 2-3
- [ ] Verify empty state shows only "0 apps"
- [ ] Check both narrow and wide tile variants
