### PR TITLE
Fix Live sync mode not showing on dashboard at startup

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -10,6 +10,9 @@ import eu.darken.octi.sync.core.worker.SyncWorkerControl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -44,14 +47,22 @@ class SyncOrchestrator @Inject constructor(
         )
     }
 
+    private val connectorModes: Flow<Map<ConnectorId, SyncConnector.EventMode>> = syncManager.connectors
+        .flatMapLatest { connectors ->
+            if (connectors.isEmpty()) {
+                flowOf(emptyMap())
+            } else {
+                kotlinx.coroutines.flow.combine(
+                    connectors.map { c -> c.syncEventMode.map { mode -> c.identifier to mode } }
+                ) { pairs -> pairs.toMap().filterValues { it != SyncConnector.EventMode.NONE } }
+            }
+        }
+
     val state: Flow<State> = combine(
         foregroundSyncControl.isActive,
-        syncManager.connectors,
+        connectorModes,
         syncWorkerControl.workerState,
-    ) { quickSyncActive, connectors, workerState ->
-        val modes = connectors
-            .associate { it.identifier to it.syncEventMode.value }
-            .filterValues { it != SyncConnector.EventMode.NONE }
+    ) { quickSyncActive, modes, workerState ->
         State(
             quickSync = QuickSyncState(isActive = quickSyncActive, connectorModes = modes),
             backgroundSync = BackgroundSyncState(


### PR DESCRIPTION
## Summary
- Fix dashboard not showing "Live" (WebSocket) sync mode for OctiServer until quick sync is toggled off/on
- `SyncOrchestrator` was reading `syncEventMode.value` (a point-in-time snapshot) instead of reactively observing the flow
- OctiServer's WebSocket connects asynchronously (~2s after startup), but the combine had already emitted with `NONE` and nothing triggered re-evaluation
- Replace snapshot read with a reactive `flatMapLatest` + inner `combine` that re-emits when any connector's mode changes

## Test plan
- [ ] Launch app fresh — verify "Live" appears on the sync status card without toggling quick sync
- [ ] Toggle quick sync off/on — verify it still works correctly after toggle
- [ ] Verify GDrive connector still shows "Polling" when active
