### PR TITLE
Show server device metadata on sync devices screen

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.sync.ui.devices
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -8,7 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Android
 import androidx.compose.material.icons.twotone.DeleteSweep
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -16,11 +21,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import android.text.format.DateUtils
 import eu.darken.octi.R
+import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -28,6 +36,9 @@ import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @Composable
 fun DeviceActionsSheet(
@@ -44,14 +55,80 @@ fun DeviceActionsSheet(
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-            Text(
-                text = device.metaInfo?.labelOrFallback ?: "?",
-                style = MaterialTheme.typography.titleMedium,
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = when (device.metaInfo?.deviceType) {
+                        MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+                        MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+                        else -> Icons.TwoTone.QuestionMark
+                    },
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = device.metaInfo?.labelOrFallback ?: "?",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.weight(1f),
+                )
+                Column(horizontalAlignment = Alignment.End) {
+                    device.serverVersion?.let { version ->
+                        Text(
+                            text = version,
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                    device.serverPlatform?.let { platform ->
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = when (platform.lowercase()) {
+                                    "android" -> Icons.TwoTone.Android
+                                    else -> Icons.TwoTone.QuestionMark
+                                },
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = platform.replaceFirstChar { it.uppercase() },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                    }
+                }
+            }
+
             Text(
                 text = device.deviceId.id,
                 style = MaterialTheme.typography.labelMedium,
             )
+
+            device.lastSeen?.let { lastSeen ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        SyncR.string.sync_device_last_seen_label,
+                        DateUtils.getRelativeTimeSpanString(lastSeen.toEpochMilli()).toString(),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            device.serverAddedAt?.let { addedAt ->
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(
+                        R.string.sync_device_added_at_label,
+                        DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                            .withZone(ZoneId.systemDefault())
+                            .format(addedAt),
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
@@ -111,8 +188,9 @@ private fun DeviceActionsSheetPreview() = PreviewWrapper {
             ),
             lastSeen = Instant.now(),
             error = null,
-            serverVersion = null,
-            serverAddedAt = null,
+            serverVersion = "0.14.0",
+            serverAddedAt = Instant.now().minusSeconds(86400 * 30),
+            serverPlatform = "android",
         ),
         connectorType = ConnectorType.OCTISERVER,
         onDismiss = {},

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.Android
 import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material.icons.twotone.QuestionMark
 import androidx.compose.material.icons.twotone.Tablet
@@ -125,81 +126,95 @@ private fun DeviceRow(
 ) {
     val context = LocalContext.current
 
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(16.dp),
     ) {
-        Icon(
-            imageVector = when (item.metaInfo?.deviceType) {
-                MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
-                MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
-                else -> Icons.TwoTone.QuestionMark
-            },
-            contentDescription = null,
-            modifier = Modifier.size(24.dp),
-        )
-
-        Spacer(modifier = Modifier.width(16.dp))
-
-        Column(modifier = Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = item.metaInfo?.labelOrFallback ?: "",
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.weight(1f),
-                )
-                item.metaInfo?.octiVersionName?.let { version ->
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = when (item.metaInfo?.deviceType) {
+                    MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+                    MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+                    else -> Icons.TwoTone.QuestionMark
+                },
+                contentDescription = null,
+                modifier = Modifier.size(20.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = item.metaInfo?.labelOrFallback ?: "",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier.weight(1f),
+            )
+            Column(horizontalAlignment = Alignment.End) {
+                item.serverVersion?.let { version ->
                     Text(
                         text = version,
                         style = MaterialTheme.typography.labelMedium,
                     )
                 }
+                item.serverPlatform?.let { platform ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            imageVector = when (platform.lowercase()) {
+                                "android" -> Icons.TwoTone.Android
+                                else -> Icons.TwoTone.QuestionMark
+                            },
+                            contentDescription = null,
+                            modifier = Modifier.size(12.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(
+                            text = platform.replaceFirstChar { it.uppercase() },
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
+        }
 
+        item.lastSeen?.let { lastSeen ->
             Text(
-                text = item.deviceId.id,
+                text = stringResource(
+                    SyncR.string.sync_device_last_seen_label,
+                    DateUtils.getRelativeTimeSpanString(lastSeen.toEpochMilli()).toString(),
+                ),
                 style = MaterialTheme.typography.bodySmall,
             )
+        }
 
-            item.lastSeen?.let { lastSeen ->
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = DateUtils.getRelativeTimeSpanString(lastSeen.toEpochMilli()).toString(),
-                    style = MaterialTheme.typography.bodyMedium,
-                )
-            }
+        val isStale = StalenessUtil.isStale(item.lastSeen)
+        if (isStale && item.lastSeen != null) {
+            val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSeen)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(SyncR.string.sync_device_stale_warning_text, stalePeriod),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
 
-            val isStale = StalenessUtil.isStale(item.lastSeen)
-            if (isStale && item.lastSeen != null) {
-                val stalePeriod = StalenessUtil.formatStalePeriod(context, item.lastSeen)
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(SyncR.string.sync_device_stale_warning_text, stalePeriod),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
+        item.error?.let { error ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = error.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                maxLines = 10,
+            )
+        }
 
-            item.error?.let { error ->
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = error.toString(),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                    maxLines = 10,
-                )
-            }
-
-            if (item.isEncryptionIncompatible(encryptionType)) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(OctiServerR.string.sync_octiserver_device_encryption_incompatible),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
+        if (item.isEncryptionIncompatible(encryptionType)) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(OctiServerR.string.sync_octiserver_device_encryption_incompatible),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
         }
     }
 }
@@ -232,6 +247,7 @@ private fun SyncDevicesScreenPreview() = PreviewWrapper {
                     error = null,
                     serverVersion = "0.14.0",
                     serverAddedAt = Instant.now(),
+                    serverPlatform = "android",
                 ),
                 SyncDevicesVM.DeviceItem(
                     deviceId = deviceId2,
@@ -252,6 +268,7 @@ private fun SyncDevicesScreenPreview() = PreviewWrapper {
                     error = RuntimeException("Connection timed out"),
                     serverVersion = "0.13.0",
                     serverAddedAt = Instant.now().minusSeconds(86400 * 60),
+                    serverPlatform = "android",
                 ),
             ),
         ),

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -61,6 +61,7 @@ class SyncDevicesVM @Inject constructor(
         val error: Exception?,
         val serverVersion: String?,
         val serverAddedAt: Instant?,
+        val serverPlatform: String?,
     ) {
         val hasNoModuleData: Boolean get() = metaInfo == null && error == null
 
@@ -113,6 +114,7 @@ class SyncDevicesVM @Inject constructor(
                                     error = error,
                                     serverVersion = linked?.version,
                                     serverAddedAt = linked?.addedAt,
+                                    serverPlatform = linked?.platform,
                                 )
                             }
                                 ?.sortedBy { it.metaInfo?.labelOrFallback?.lowercase() }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
         <item quantity="other">%d devices</item>
     </plurals>
     <string name="sync_device_compatibility_hint">compatibility issue</string>
+    <string name="sync_device_added_at_label">Added %1$s</string>
     <plurals name="general_unique_devices_count_label">
         <item quantity="one">%d unique, only available here</item>
         <item quantity="other">%d unique, only available here</item>

--- a/app/src/test/java/eu/darken/octi/sync/ui/devices/DeviceItemTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/ui/devices/DeviceItemTest.kt
@@ -23,6 +23,7 @@ class DeviceItemTest : BaseTest() {
         error = error,
         serverVersion = null,
         serverAddedAt = serverAddedAt,
+        serverPlatform = null,
     )
 
     private fun metaInfo() = MetaInfo(

--- a/sync-core/src/main/res/values/strings.xml
+++ b/sync-core/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="sync_device_last_seen_label">Last seen %1$s</string>
     <string name="sync_device_stale_warning_text">Device hasn\'t synced in %s</string>
     <string name="sync_device_clock_skew_warning_text">Device clock appears out of sync</string>
     <string name="sync_clock_discrepancy_chip_label">Clock skew</string>


### PR DESCRIPTION
## Summary

- Display server-reported version and platform (icon + label) in the top-right corner of each device row and the actions bottom sheet
- Show "Last seen" with a label prefix and "Added" date from the server's device list API
- Move detail-only fields (device ID, added-at) to the actions bottom sheet to keep list rows compact
- Inline the device-type icon into the title row for tighter layout in both the list and bottom sheet

## Changes

- **SyncDevicesVM**: Add `serverPlatform` field to `DeviceItem`, mapped from `LinkedDevice.platform`
- **SyncDevicesScreen**: Replace MetaInfo version with server version, add platform icon, restructure row to flat `Column` with inline icon
- **DeviceActionsSheet**: Mirror row layout structure, add version/platform/last-seen/added-at details
- **strings.xml**: Add `sync_device_last_seen_label` (sync-core) and `sync_device_added_at_label` (app)
