### PR TITLE
Fix foreground sync and WebSocket never activating

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,13 @@
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            tools:node="remove" />
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
         <activity
             android:name="com.journeyapps.barcodescanner.CaptureActivity"


### PR DESCRIPTION
## Summary

- Foreground sync (WebSocket live events) never activated because `ProcessLifecycleOwner` was never initialized
- The manifest's blanket `tools:node="remove"` on `InitializationProvider` prevented all AndroidX Startup initializers — including `ProcessLifecycleInitializer` — from running
- `ForegroundSyncControl` always evaluated `foreground=false`, so the WebSocket event collector never started
- Fix: selectively remove only `WorkManagerInitializer` (which the app replaces via `Configuration.Provider`) while keeping the rest of AndroidX Startup intact

## Root cause

Added in commit e7e2bfd (Sept 2022) when WorkManager was introduced — the `tools:node="remove"` was intended to prevent WorkManager auto-init, but it also killed `ProcessLifecycleInitializer` as collateral damage.

## Test plan

- [ ] On cold start, logcat shows `"Process foregrounded, isForeground=true"` from ForegroundSyncControl
- [ ] `combine: foreground=true` evaluates correctly
- [ ] WebSocket connects: `"Connecting to wss://..."` from OctiServerWebSocket
- [ ] Backgrounding app shows `"Process backgrounded, debouncing..."`
- [ ] WorkManager still initializes correctly with custom HiltWorkerFactory config
