### PR TITLE
Replace battery optimization chip with reliability bottom sheet

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -611,12 +611,12 @@ fun DashboardScreen(
     if (showReliabilitySheet) {
         ReliabilitySheet(
             onGoToSettings = {
-                onGrantPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
                 showReliabilitySheet = false
+                onGrantPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
             },
             onDismissPermission = {
-                onDismissPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
                 showReliabilitySheet = false
+                onDismissPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
             },
             onDismiss = { showReliabilitySheet = false },
         )

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -337,6 +337,7 @@ fun DashboardScreen(
     var showConnectivityDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Connectivity?>(null) }
     var showClipboardDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Clipboard?>(null) }
     var showIssuesSheetSeverity by remember { mutableStateOf<IssueSeverity?>(null) }
+    var showReliabilitySheet by remember { mutableStateOf(false) }
 
     LaunchedEffect(state.isOffline) {
         if (state.isOffline) {
@@ -427,7 +428,13 @@ fun DashboardScreen(
                         warningCount = warningCount,
                         onSetupSync = onSetupSync,
                         onDismissSyncSetup = onDismissSyncSetup,
-                        onGrantPermission = onGrantPermission,
+                        onGrantPermission = { permission ->
+                            if (permission == Permission.IGNORE_BATTERY_OPTIMIZATION) {
+                                showReliabilitySheet = true
+                            } else {
+                                onGrantPermission(permission)
+                            }
+                        },
                         onDismissPermission = onDismissPermission,
                         onUpgrade = onUpgrade,
                         onErrorsClick = { showIssuesSheetSeverity = IssueSeverity.ERROR },
@@ -599,6 +606,20 @@ fun DashboardScreen(
         } else {
             showIssuesSheetSeverity = null
         }
+    }
+
+    if (showReliabilitySheet) {
+        ReliabilitySheet(
+            onGoToSettings = {
+                onGrantPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
+                showReliabilitySheet = false
+            },
+            onDismissPermission = {
+                onDismissPermission(Permission.IGNORE_BATTERY_OPTIMIZATION)
+                showReliabilitySheet = false
+            },
+            onDismiss = { showReliabilitySheet = false },
+        )
     }
 }
 
@@ -1053,7 +1074,7 @@ private fun ActionChipsRow(
                 },
                 label = stringResource(
                     when (permission) {
-                        Permission.IGNORE_BATTERY_OPTIMIZATION -> R.string.permission_battery_optimization_label
+                        Permission.IGNORE_BATTERY_OPTIMIZATION -> R.string.permission_reliability_label
                         Permission.POST_NOTIFICATIONS -> R.string.permission_notifications_post_label
                         else -> R.string.permission_required_label
                     }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/ReliabilitySheet.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/ReliabilitySheet.kt
@@ -1,0 +1,70 @@
+package eu.darken.octi.main.ui.dashboard
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.BatteryFull
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
+
+@Composable
+fun ReliabilitySheet(
+    onGoToSettings: () -> Unit,
+    onDismissPermission: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.BatteryFull,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(R.string.permission_reliability_title),
+                style = MaterialTheme.typography.titleLarge,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.permission_reliability_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                onClick = onGoToSettings,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(R.string.permission_reliability_settings_action))
+            }
+            TextButton(
+                onClick = onDismissPermission,
+            ) {
+                Text(text = stringResource(CommonR.string.general_dismiss_action))
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/ReliabilitySheet.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/ReliabilitySheet.kt
@@ -16,6 +16,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -61,10 +63,21 @@ fun ReliabilitySheet(
             }
             TextButton(
                 onClick = onDismissPermission,
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(text = stringResource(CommonR.string.general_dismiss_action))
             }
             Spacer(modifier = Modifier.height(16.dp))
         }
     }
+}
+
+@Preview2
+@Composable
+private fun ReliabilitySheetPreview() = PreviewWrapper {
+    ReliabilitySheet(
+        onGoToSettings = {},
+        onDismissPermission = {},
+        onDismiss = {},
+    )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,10 @@
     <string name="permission_location_desc">Location permission enable Octi to display your Wifi names, or show you the current position of your device.</string>
     <string name="permission_battery_optimization_label">Battery optimizations</string>
     <string name="permission_battery_optimization_desc">Disable battery optimizations to allow synchronisation without opening the app.</string>
+    <string name="permission_reliability_label">Reliability</string>
+    <string name="permission_reliability_title">Improve Reliability</string>
+    <string name="permission_reliability_desc">Octi needs to run in the background to keep your devices in sync. Disabling battery optimizations ensures reliable synchronization without needing to open the app.</string>
+    <string name="permission_reliability_settings_action">Open settings</string>
     <string name="permission_notifications_post_label">Post notifications</string>
     <string name="permission_notifications_post_desc">The post notification permission allows Octi to notify you about events on other devices that you have configured.</string>
 


### PR DESCRIPTION
## Summary
- Rename dashboard chip from "Battery optimizations" to "Reliability"
- Show a bottom sheet on chip click with explanation, "Open settings" CTA, and "Dismiss" button
- Dismiss permanently hides the chip (same DataStore persistence as existing long-press dismiss)
- Long-press dismiss on the chip is preserved as a shortcut

## Test plan
- [ ] Verify chip shows "Reliability" with battery icon
- [ ] Click chip opens bottom sheet with icon, title, explanation, two buttons
- [ ] "Open settings" opens system battery optimization settings
- [ ] "Dismiss" hides chip permanently
- [ ] Long-press on chip still dismisses directly
- [ ] Swiping sheet away does not permanently dismiss