### PR TITLE
Fix last synced timestamp updating on failed or skipped sync

### DIFF
--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -748,7 +748,12 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     block()
                 }
             }.also {
-                _state.updateBlocking { copy(lastError = null) }
+                _state.updateBlocking {
+                    copy(
+                        lastError = null,
+                        lastActionAt = Instant.now(),
+                    )
+                }
             }
         } catch (e: CancellationException) {
             throw e
@@ -759,10 +764,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         } finally {
             _state.updateBlocking {
                 log(TAG, VERBOSE) { "runDriveAction($tag) finished" }
-                copy(
-                    activeActions = activeActions - 1,
-                    lastActionAt = Instant.now(),
-                )
+                copy(activeActions = activeActions - 1)
             }
             log(TAG, VERBOSE) { "runDriveAction($tag) finished after ${System.currentTimeMillis() - start}ms" }
         }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -392,7 +392,12 @@ class OctiServerConnector @AssistedInject constructor(
             serverLock.withLock {
                 withContext(NonCancellable) { block() }
             }.also {
-                _state.updateBlocking { copy(lastError = null) }
+                _state.updateBlocking {
+                    copy(
+                        lastError = null,
+                        lastActionAt = Instant.now(),
+                    )
+                }
             }
         } catch (e: CancellationException) {
             throw e
@@ -403,10 +408,7 @@ class OctiServerConnector @AssistedInject constructor(
         } finally {
             _state.updateBlocking {
                 log(TAG, VERBOSE) { "runServerAction($tag) finished" }
-                copy(
-                    activeActions = activeActions - 1,
-                    lastActionAt = Instant.now(),
-                )
+                copy(activeActions = activeActions - 1)
             }
             log(TAG, VERBOSE) { "runServerAction($tag) finished after ${System.currentTimeMillis() - start}ms" }
         }


### PR DESCRIPTION
## Summary
- `lastActionAt` was updated in the `finally` block of `runServerAction`/`runDriveAction`, so it reset to now even on failures
- Combined with offline scenarios, this kept the dashboard showing "Last synced 0 minutes ago" perpetually while offline

## Changes
- Move `lastActionAt = Instant.now()` from `finally` to the success-only `.also` block in both connectors

## Test plan
- [ ] Go offline (airplane mode), verify "last synced" time grows stale instead of staying at 0 minutes
- [ ] Go online, trigger sync, verify "last synced" updates after successful sync
- [ ] Force a sync failure while online (e.g. revoke auth), verify timestamp does not update