### PR TITLE
Replace @file:UseSerializers with per-property annotations

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -58,7 +58,7 @@ Access with `.flow` (reactive), `value()` (suspend read), `value(newVal)` (suspe
 - `@Serializable` for data classes (replaces Moshi's `@JsonClass(generateAdapter = true)`)
 - `@SerialName("fieldName")` for field mapping (replaces Moshi's `@Json(name = "fieldName")`)
 - Inject the project `Json` instance from `SerializationModule` — do not create ad-hoc `Json {}` in production code
-- Custom serializers (e.g., `InstantSerializer`, `ByteStringSerializer`) via `@UseSerializers`
+- Custom serializers (e.g., `InstantSerializer`, `ByteStringSerializer`) via per-property `@Serializable(with = ...)` or contextual serializers in `SerializationModule`
 - `ByteString` from okio for binary data serialization in sync payloads
 - Each module has a `ModuleSerializer<T>` using `json.toByteString()` / `json.fromJson()`
 - Navigation routes also use `@Serializable` (same framework)

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/core/FossUpgrade.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/core/FossUpgrade.kt
@@ -1,16 +1,13 @@
-@file:UseSerializers(InstantSerializer::class)
-
 package eu.darken.octi.common.upgrade.core
 
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 
 @Serializable
 data class FossUpgrade(
-    @SerialName("upgradedAt") val upgradedAt: Instant,
+    @Serializable(with = InstantSerializer::class) @SerialName("upgradedAt") val upgradedAt: Instant,
     @SerialName("reason") val upgradeType: Type,
 ) {
     @Serializable

--- a/app/src/foss/java/eu/darken/octi/main/core/GithubApi.kt
+++ b/app/src/foss/java/eu/darken/octi/main/core/GithubApi.kt
@@ -1,11 +1,8 @@
-@file:UseSerializers(OffsetDateTimeSerializer::class)
-
 package eu.darken.octi.main.core
 
 import eu.darken.octi.common.serialization.serializer.OffsetDateTimeSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import retrofit2.http.GET
 import retrofit2.http.Path
 import java.time.OffsetDateTime
@@ -18,7 +15,7 @@ interface GithubApi {
         @SerialName("tag_name") val tagName: String,
         @SerialName("prerelease") val isPreRelease: Boolean,
         @SerialName("html_url") val htmlUrl: String,
-        @SerialName("published_at") val publishedAt: OffsetDateTime,
+        @Serializable(with = OffsetDateTimeSerializer::class) @SerialName("published_at") val publishedAt: OffsetDateTime,
         @SerialName("body") val body: String,
         @SerialName("assets") val assets: List<Asset>,
     ) {

--- a/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleCache.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleCache.kt
@@ -1,5 +1,3 @@
-@file:UseSerializers(InstantSerializer::class, ByteStringSerializer::class)
-
 package eu.darken.octi.module.core
 
 import android.content.Context
@@ -17,7 +15,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.Json
 import okio.ByteString
 import java.io.File
@@ -48,10 +45,10 @@ abstract class BaseModuleCache<T : Any> constructor(
 
     @Serializable
     data class CachedModuleData(
-        @SerialName("modifiedAt") val modifiedAt: Instant,
+        @Serializable(with = InstantSerializer::class) @SerialName("modifiedAt") val modifiedAt: Instant,
         @SerialName("deviceId") val deviceId: DeviceId,
         @SerialName("moduleId") val moduleId: ModuleId,
-        @SerialName("data") val data: ByteString,
+        @Serializable(with = ByteStringSerializer::class) @SerialName("data") val data: ByteString,
     )
 
     private fun ModuleData<T>.toCachedModuleData() = CachedModuleData(

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfo.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/AppsInfo.kt
@@ -1,11 +1,8 @@
-@file:UseSerializers(InstantSerializer::class)
-
 package eu.darken.octi.modules.apps.core
 
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 
 @Serializable
@@ -19,9 +16,9 @@ data class AppsInfo(
         @SerialName("label") val label: String?,
         @SerialName("versionCode") val versionCode: Long,
         @SerialName("versionName") val versionName: String?,
-        @SerialName("installedAt") val installedAt: Instant,
+        @Serializable(with = InstantSerializer::class) @SerialName("installedAt") val installedAt: Instant,
         @SerialName("installerPkg") val installerPkg: String?,
-        @SerialName("updatedAt") val updatedAt: Instant? = null,
+        @Serializable(with = InstantSerializer::class) @SerialName("updatedAt") val updatedAt: Instant? = null,
     )
 
     override fun toString(): String = "AppsInfo(size=${installedPackages.size})"

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ClipboardInfo.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ClipboardInfo.kt
@@ -1,17 +1,14 @@
-@file:UseSerializers(ByteStringSerializer::class)
-
 package eu.darken.octi.modules.clipboard
 
 import eu.darken.octi.common.serialization.serializer.ByteStringSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import okio.ByteString
 
 @Serializable
 data class ClipboardInfo(
     @SerialName("type") val type: Type = Type.EMPTY,
-    @SerialName("data") val data: ByteString = ByteString.EMPTY,
+    @Serializable(with = ByteStringSerializer::class) @SerialName("data") val data: ByteString = ByteString.EMPTY,
 ) {
 
     init {

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfo.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfo.kt
@@ -1,12 +1,9 @@
-@file:UseSerializers(InstantSerializer::class)
-
 package eu.darken.octi.modules.meta.core
 
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import eu.darken.octi.sync.core.DeviceId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 
 @Serializable
@@ -21,7 +18,7 @@ data class MetaInfo(
     @SerialName("deviceManufacturer") val deviceManufacturer: String,
     @SerialName("deviceName") val deviceName: String,
     @SerialName("deviceType") val deviceType: DeviceType,
-    @SerialName("deviceBootedAt") val deviceBootedAt: Instant,
+    @Serializable(with = InstantSerializer::class) @SerialName("deviceBootedAt") val deviceBootedAt: Instant,
 
     @SerialName("androidVersionName") val androidVersionName: String,
     @SerialName("androidApiLevel") val androidApiLevel: Int,

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfo.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfo.kt
@@ -1,12 +1,9 @@
-@file:UseSerializers(InstantSerializer::class)
-
 package eu.darken.octi.modules.power.core
 
 import android.os.BatteryManager
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 
 @Serializable
@@ -22,9 +19,9 @@ data class PowerInfo(
     data class ChargeIO(
         @SerialName("currentNow") val currentNow: Int?,
         @SerialName("currentAvg") val currenAvg: Int?,
-        @SerialName("fullSince") val fullSince: Instant?,
-        @SerialName("fullAt") val fullAt: Instant?,
-        @SerialName("emptyAt") val emptyAt: Instant?,
+        @Serializable(with = InstantSerializer::class) @SerialName("fullSince") val fullSince: Instant?,
+        @Serializable(with = InstantSerializer::class) @SerialName("fullAt") val fullAt: Instant?,
+        @Serializable(with = InstantSerializer::class) @SerialName("emptyAt") val emptyAt: Instant?,
     ) {
         val speed: Speed
             get() = when {

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
@@ -1,12 +1,9 @@
-@file:UseSerializers(InstantSerializer::class)
-
 package eu.darken.octi.modules.power.core.alert
 
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import eu.darken.octi.sync.core.DeviceId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 
 @Serializable
@@ -17,8 +14,8 @@ sealed interface PowerAlertRule {
     @Serializable
     data class Event(
         val id: PowerAlertRuleId,
-        val triggeredAt: Instant = Instant.now(),
-        val dismissedAt: Instant? = null,
+        @Serializable(with = InstantSerializer::class) val triggeredAt: Instant = Instant.now(),
+        @Serializable(with = InstantSerializer::class) val dismissedAt: Instant? = null,
     )
 }
 

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/cache/CachedSyncRead.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/cache/CachedSyncRead.kt
@@ -1,5 +1,3 @@
-@file:UseSerializers(InstantSerializer::class, ByteStringSerializer::class)
-
 package eu.darken.octi.sync.core.cache
 
 import eu.darken.octi.common.serialization.serializer.ByteStringSerializer
@@ -10,7 +8,6 @@ import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncRead
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import okio.ByteString
 import java.time.Instant
 
@@ -31,8 +28,8 @@ data class CachedSyncRead(
             @SerialName("accountId") override val connectorId: ConnectorId,
             @SerialName("deviceId") override val deviceId: DeviceId,
             @SerialName("moduleId") override val moduleId: ModuleId,
-            @SerialName("modifiedAt") override val modifiedAt: Instant,
-            @SerialName("payload") override val payload: ByteString,
+            @Serializable(with = InstantSerializer::class) @SerialName("modifiedAt") override val modifiedAt: Instant,
+            @Serializable(with = ByteStringSerializer::class) @SerialName("payload") override val payload: ByteString,
         ) : SyncRead.Device.Module
     }
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
@@ -1,5 +1,3 @@
-@file:UseSerializers(ByteStringSerializer::class)
-
 package eu.darken.octi.sync.core.encryption
 
 import android.os.Parcelable
@@ -21,7 +19,6 @@ import kotlinx.parcelize.Parcelize
 import kotlinx.parcelize.TypeParceler
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
 
@@ -84,7 +81,7 @@ class PayloadEncryption constructor(
     @TypeParceler<ByteString, ByteStringParcelizer>
     data class KeySet(
         @SerialName("type") val type: String,
-        @SerialName("key") val key: ByteString,
+        @Serializable(with = ByteStringSerializer::class) @SerialName("key") val key: ByteString,
     ) : Parcelable {
         override fun toString(): String = "ShareCode(key=${key.base64().take(4)}...)"
     }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionKeySetSerializationTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionKeySetSerializationTest.kt
@@ -1,0 +1,45 @@
+package eu.darken.octi.sync.core.encryption
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PayloadEncryptionKeySetSerializationTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `round-trip serialization`() {
+        val keyset = PayloadEncryption.KeySet(
+            type = "AES256_SIV",
+            key = "testkey".encodeUtf8(),
+        )
+        val encoded = json.encodeToString(keyset)
+        val decoded = json.decodeFromString<PayloadEncryption.KeySet>(encoded)
+        decoded shouldBe keyset
+    }
+
+    @Test
+    fun `ByteString is serialized as base64`() {
+        val keyset = PayloadEncryption.KeySet(
+            type = "AES256_SIV",
+            key = "testkey".encodeUtf8(),
+        )
+        val encoded = json.encodeToString(keyset)
+        encoded.contains("\"dGVzdGtleQ==\"") shouldBe true
+    }
+
+    @Test
+    fun `backward compatibility - deserialize Moshi-written JSON`() {
+        val moshiJson = """{"type":"AES256_SIV","key":"dGVzdGtleQ=="}"""
+        val decoded = json.decodeFromString<PayloadEncryption.KeySet>(moshiJson)
+        decoded.type shouldBe "AES256_SIV"
+        decoded.key shouldBe "testkey".encodeUtf8()
+    }
+}

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt
@@ -1,16 +1,12 @@
-@file:UseSerializers(ByteStringSerializer::class)
-
 package eu.darken.octi.syncs.octiserver.core
 
 import android.os.Parcelable
 import eu.darken.octi.common.collections.fromGzip
 import eu.darken.octi.common.collections.toGzip
-import eu.darken.octi.common.serialization.serializer.ByteStringSerializer
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.Json
 import okio.ByteString.Companion.decodeBase64
 import okio.ByteString.Companion.toByteString

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServer.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServer.kt
@@ -1,15 +1,11 @@
-@file:UseSerializers(InstantSerializer::class, ByteStringSerializer::class)
-
 package eu.darken.octi.syncs.octiserver.core
 
 import android.os.Parcelable
-import eu.darken.octi.common.serialization.serializer.ByteStringSerializer
 import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
 import java.time.Instant
 import java.util.UUID
 
@@ -40,7 +36,7 @@ interface OctiServer {
         @SerialName("accountId") val accountId: AccountId,
         @SerialName("devicePassword") val devicePassword: DevicePassword,
         @SerialName("encryptionKeyset") val encryptionKeyset: PayloadEncryption.KeySet,
-        @SerialName("createdAt") val createdAt: Instant = Instant.now(),
+        @Serializable(with = InstantSerializer::class) @SerialName("createdAt") val createdAt: Instant = Instant.now(),
     ) {
 
         override fun toString(): String =


### PR DESCRIPTION
## Summary
- Replaced `@file:UseSerializers` with per-property `@Serializable(with = ...)` across 12 files (17 properties)
- File-level annotations silently apply to all classes in a file, including any added later — per-property is explicit and scoped
- Added direct `PayloadEncryption.KeySet` JSON round-trip test

## Test plan
- [x] `./gradlew assembleDebug` passes
- [x] `./gradlew testDebugUnitTest` passes
- [x] `./gradlew :app:testFossDebugUnitTest` passes
- [x] No `@file:UseSerializers` remaining (grep verified)