### PR TITLE
Support adding multiple Google Drive accounts

### DIFF
--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveEvents.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveEvents.kt
@@ -3,5 +3,7 @@ package eu.darken.octi.syncs.gdrive.ui.add
 import android.app.PendingIntent
 
 sealed class AddGDriveEvents {
-    data class AuthConsent(val pendingIntent: PendingIntent) : AddGDriveEvents()
+    data object ShowAccountPicker : AddGDriveEvents()
+    data class AuthConsent(val pendingIntent: PendingIntent, val email: String) : AddGDriveEvents()
+    data class AccountAlreadyConnected(val email: String) : AddGDriveEvents()
 }

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveScreen.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveScreen.kt
@@ -1,5 +1,7 @@
 package eu.darken.octi.syncs.gdrive.ui.add
 
+import android.accounts.AccountManager
+import android.app.Activity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -18,12 +20,19 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -38,24 +47,54 @@ fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    var pendingAuthEmail by remember { mutableStateOf<String?>(null) }
+
     val authLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartIntentSenderForResult()
     ) { result ->
-        vm.onAuthResult(result)
+        vm.onAuthResult(result, expectedEmail = pendingAuthEmail)
+        pendingAuthEmail = null
+    }
+
+    val accountPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode != Activity.RESULT_OK) return@rememberLauncherForActivityResult
+        val email = result.data?.getStringExtra(AccountManager.KEY_ACCOUNT_NAME)
+            ?: return@rememberLauncherForActivityResult
+        vm.onAccountPicked(email)
     }
 
     LaunchedEffect(vm.events) {
         vm.events.collect { event ->
             when (event) {
+                is AddGDriveEvents.ShowAccountPicker -> {
+                    @Suppress("DEPRECATION")
+                    val intent = AccountManager.newChooseAccountIntent(
+                        null, null, arrayOf("com.google"), false, null, null, null, null,
+                    )
+                    accountPickerLauncher.launch(intent)
+                }
+
                 is AddGDriveEvents.AuthConsent -> {
+                    pendingAuthEmail = event.email
                     val request = IntentSenderRequest.Builder(event.pendingIntent).build()
                     authLauncher.launch(request)
+                }
+
+                is AddGDriveEvents.AccountAlreadyConnected -> {
+                    snackbarHostState.showSnackbar(
+                        context.getString(GDriveR.string.sync_gdrive_error_account_already_connected)
+                    )
                 }
             }
         }
     }
 
     AddGDriveScreen(
+        snackbarHostState = snackbarHostState,
         onNavigateUp = { vm.navUp() },
         onSignIn = { vm.startSignIn() },
     )
@@ -63,10 +102,12 @@ fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
 
 @Composable
 fun AddGDriveScreen(
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
     onNavigateUp: () -> Unit,
     onSignIn: () -> Unit,
 ) {
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveVM.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveVM.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.syncs.gdrive.ui.add
 
+import android.accounts.Account
 import android.app.Activity
 import androidx.activity.result.ActivityResult
 import androidx.lifecycle.SavedStateHandle
@@ -22,21 +23,37 @@ class AddGDriveVM @Inject constructor(
 
     val events = SingleEventFlow<AddGDriveEvents>()
 
-    fun startSignIn() = launch {
+    fun startSignIn() {
         log(TAG) { "startSignIn()" }
-        when (val action = accRepo.startNewAuth()) {
+        events.tryEmit(AddGDriveEvents.ShowAccountPicker)
+    }
+
+    fun onAccountPicked(email: String) = launch {
+        log(TAG) { "onAccountPicked(email=$email)" }
+
+        if (accRepo.isAccountConnected(email)) {
+            log(TAG) { "onAccountPicked(): Account already connected" }
+            events.tryEmit(AddGDriveEvents.AccountAlreadyConnected(email))
+            return@launch
+        }
+
+        when (val action = accRepo.startNewAuth(Account(email, "com.google"))) {
             is GoogleAccountRepo.AuthAction.AlreadyAuthorized -> {
-                accRepo.add(action.account)
-                popTo(Nav.Sync.List)
+                val added = accRepo.add(action.account)
+                if (added) {
+                    popTo(Nav.Sync.List)
+                } else {
+                    events.tryEmit(AddGDriveEvents.AccountAlreadyConnected(email))
+                }
             }
 
             is GoogleAccountRepo.AuthAction.NeedsConsent -> {
-                events.tryEmit(AddGDriveEvents.AuthConsent(action.pendingIntent))
+                events.tryEmit(AddGDriveEvents.AuthConsent(action.pendingIntent, email))
             }
         }
     }
 
-    fun onAuthResult(result: ActivityResult) = launch {
+    fun onAuthResult(result: ActivityResult, expectedEmail: String?) = launch {
         log(TAG) { "onAuthResult(resultCode=${result.resultCode})" }
         if (result.resultCode != Activity.RESULT_OK) {
             log(TAG) { "onAuthResult(): User cancelled" }
@@ -47,9 +64,13 @@ class AddGDriveVM @Inject constructor(
             log(TAG) { "onAuthResult(): No data in result" }
             return@launch
         }
-        val account = accRepo.handleAuthResult(data)
-        accRepo.add(account)
-        popTo(Nav.Sync.List)
+        val account = accRepo.handleAuthResult(data, expectedEmail = expectedEmail)
+        val added = accRepo.add(account)
+        if (added) {
+            popTo(Nav.Sync.List)
+        } else {
+            events.tryEmit(AddGDriveEvents.AccountAlreadyConnected(account.email))
+        }
     }
 
     companion object {

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GoogleAccountRepo.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GoogleAccountRepo.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import android.accounts.Account
 import java.net.HttpURLConnection
 import java.net.URL
 import javax.inject.Inject
@@ -99,10 +100,11 @@ class GoogleAccountRepo @Inject constructor(
         data class NeedsConsent(val pendingIntent: PendingIntent) : AuthAction()
     }
 
-    suspend fun startNewAuth(): AuthAction {
-        log(TAG) { "startNewAuth()" }
+    suspend fun startNewAuth(targetAccount: Account? = null): AuthAction {
+        log(TAG) { "startNewAuth(targetAccount=$targetAccount)" }
         val request = AuthorizationRequest.builder()
             .setRequestedScopes(listOf(SCOPE_DRIVE_APPDATA, SCOPE_EMAIL, SCOPE_OPENID))
+            .apply { if (targetAccount != null) setAccount(targetAccount) }
             .build()
 
         val result = Identity.getAuthorizationClient(context).authorize(request).await()
@@ -114,18 +116,25 @@ class GoogleAccountRepo @Inject constructor(
             AuthAction.NeedsConsent(pendingIntent)
         } else {
             log(TAG) { "startNewAuth(): Already authorized" }
-            val account = resolveAccountIdentity(result)
+            val account = resolveAccountIdentity(result, expectedEmail = targetAccount?.name)
             AuthAction.AlreadyAuthorized(account)
         }
     }
 
-    suspend fun handleAuthResult(intent: Intent): GoogleAccount {
-        log(TAG) { "handleAuthResult()" }
+    suspend fun handleAuthResult(intent: Intent, expectedEmail: String? = null): GoogleAccount {
+        log(TAG) { "handleAuthResult(expectedEmail=$expectedEmail)" }
         val result = Identity.getAuthorizationClient(context).getAuthorizationResultFromIntent(intent)
-        return resolveAccountIdentity(result)
+        return resolveAccountIdentity(result, expectedEmail)
     }
 
-    private suspend fun resolveAccountIdentity(result: AuthorizationResult): GoogleAccount {
+    suspend fun isAccountConnected(email: String): Boolean {
+        return _accounts.flow.first().any { it.email == email }
+    }
+
+    private suspend fun resolveAccountIdentity(
+        result: AuthorizationResult,
+        expectedEmail: String? = null,
+    ): GoogleAccount {
         val accessToken = result.accessToken
             ?: throw IllegalStateException("No access token in AuthorizationResult")
 
@@ -158,6 +167,12 @@ class GoogleAccountRepo @Inject constructor(
                     ?: throw IllegalStateException("No 'sub' in userinfo response")
                 val email = jsonObj["email"]?.jsonPrimitive?.content
                     ?: throw IllegalStateException("No 'email' in userinfo response")
+
+                if (expectedEmail != null && !email.equals(expectedEmail, ignoreCase = true)) {
+                    throw IllegalStateException(
+                        "Account mismatch: expected $expectedEmail but resolved $email"
+                    )
+                }
 
                 GoogleAccount(accountId = sub, email = email).also {
                     log(TAG) { "resolveAccountIdentity(): Resolved accountId=$sub" }

--- a/syncs-gdrive/src/main/res/values/strings.xml
+++ b/syncs-gdrive/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="sync_gdrive_reset_confirmation_desc">Reset all Octi data stored on Google Drive. Your device stays logged into Google Drive.</string>
     <string name="sync_gdrive_disconnect_confirmation_desc">Log out from Google Drive and delete data related to this device.</string>
     <string name="sync_gdrive_error_no_account_on_device">This device is not signed into any Google account.</string>
+    <string name="sync_gdrive_error_account_already_connected">This account is already connected.</string>
 </resources>


### PR DESCRIPTION
## Summary

- Show a system account picker when adding a Google Drive account, allowing users to choose which account to connect
- Use `AuthorizationRequest.setAccount()` to authorize the specific selected account instead of defaulting to the previously authorized one
- Detect and report duplicate accounts via snackbar ("This account is already connected")
- Validate resolved identity matches the picked account to prevent silent mismatches

The sync infrastructure (SyncManager, ConnectorHub, ConnectorId, SyncCache) already supported multiple connectors per hub — only the auth/account-addition UI flow needed changes.

## Test plan

- [ ] Add first GDrive account — verify account picker appears, select account, connector appears in sync list
- [ ] Add second GDrive account — verify picker shows all device accounts, select different account, second card appears
- [ ] Try adding same account again — verify "already connected" snackbar
- [ ] Cancel picker — verify nothing happens, stays on add screen
- [ ] Verify both connectors sync independently
- [ ] Verify pausing/disconnecting one doesn't affect the other
- [ ] Kill app and reopen — verify both accounts persist
