### PR TITLE
Migrate Long milliseconds to kotlin.time.Duration

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/flow/FlowExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/flow/FlowExtensions.kt
@@ -17,7 +17,7 @@ import kotlin.time.Duration
  */
 fun <T : Any> Flow<T>.shareLatest(
     scope: CoroutineScope,
-    started: SharingStarted = SharingStarted.WhileSubscribed(replayExpirationMillis = 0),
+    started: SharingStarted = SharingStarted.WhileSubscribed(replayExpiration = Duration.ZERO),
     tag: String? = null,
 ) = this
     .onStart { if (tag != null) log(tag, VERBOSE) { "shareLatest(...) start" } }

--- a/app-common/src/main/java/eu/darken/octi/common/flow/throttleLatest.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/flow/throttleLatest.kt
@@ -4,11 +4,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.transform
+import kotlin.time.Duration
 
 
-fun <T> Flow<T>.throttleLatest(delayMillis: Long): Flow<T> = this
+fun <T> Flow<T>.throttleLatest(window: Duration): Flow<T> = this
     .conflate()
     .transform {
         emit(it)
-        delay(delayMillis)
+        delay(window)
     }

--- a/app-common/src/main/java/eu/darken/octi/common/uix/ViewModel2.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/uix/ViewModel2.kt
@@ -11,12 +11,14 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.seconds
 
 
 abstract class ViewModel2(
@@ -50,7 +52,7 @@ abstract class ViewModel2(
         defaultValue: T? = null,
     ): Flow<T> = stateIn(
         vmScope,
-        started = SharingStarted.WhileSubscribed(5_000),
+        started = SharingStarted.WhileSubscribed(stopTimeout = 5.seconds),
         initialValue = defaultValue,
     ).filterNotNull()
 

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import javax.inject.Inject
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
@@ -51,7 +53,7 @@ class UpgradeViewModel @Inject constructor(
         val elapsed = Clock.System.now().toEpochMilliseconds() - openedAt
         log(TAG) { "onResumed(): elapsed=${elapsed}ms" }
 
-        if (elapsed < MIN_SPONSOR_TIME_MS) {
+        if (elapsed.milliseconds < MIN_SPONSOR_TIME) {
             log(TAG) { "onResumed(): too fast, showing snackbar" }
             snackbarEvents.tryEmit(Unit)
         } else {
@@ -62,7 +64,7 @@ class UpgradeViewModel @Inject constructor(
     }
 
     companion object {
-        private const val MIN_SPONSOR_TIME_MS = 5_000L
+        private val MIN_SPONSOR_TIME = 5.seconds
         private val TAG = logTag("Upgrade", "ViewModel")
     }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -20,6 +20,7 @@ import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -30,6 +31,10 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 @Singleton
@@ -58,7 +63,7 @@ class UpgradeRepoGplay @Inject constructor(
                     Info(billingData = data)
                 }
 
-                (now - lastProStateAt) < 7 * 24 * 60 * 1000L -> { // 7 days
+                (now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD -> {
                     log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                     Info(gracePeriod = true, billingData = null)
                 }
@@ -74,7 +79,7 @@ class UpgradeRepoGplay @Inject constructor(
             val now = Clock.System.now().toEpochMilliseconds()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, error=$it" }
-            if ((now - lastProStateAt) < 7 * 24 * 60 * 1000L) { // 7 days
+            if ((now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just and an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
@@ -82,7 +87,7 @@ class UpgradeRepoGplay @Inject constructor(
             }
         }
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
-        .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
+        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
     fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
@@ -138,6 +143,7 @@ class UpgradeRepoGplay @Inject constructor(
 
     companion object {
         private const val SITE = "https://play.google.com/store/apps/details?id=eu.darken.octi"
+        private val PRO_GRACE_PERIOD = 7.days
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
     }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -18,7 +18,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -32,6 +33,8 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class BillingManager @Inject constructor(
@@ -49,17 +52,17 @@ class BillingManager @Inject constructor(
         }
         .catch { log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" } }
         .setupCommonEventHandlers(TAG) { "connection" }
-        .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
     private val purchases = connection
         .flatMapLatest { it.purchases }
         .distinctUntilChanged()
         .setupCommonEventHandlers(TAG) { "purchases" }
-        .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
     val billingData: Flow<BillingData> = purchases
         .map { BillingData(purchases = it) }
-        .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
     init {
         purchases
@@ -108,7 +111,7 @@ class BillingManager @Inject constructor(
                 }
 
                 log(TAG) { "Will retry ACK" }
-                delay(3000 * attempt)
+                delay((3 * attempt).seconds)
                 true
             }
             .launchIn(scope)

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class BillingConnectionProvider @Inject constructor(
@@ -117,7 +118,7 @@ class BillingConnectionProvider @Inject constructor(
             }
 
             log(TAG) { "Will retry BillingClient connection... *sigh*" }
-            delay(2000 * attempt)
+            delay((2 * attempt).seconds)
             true
         }
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
@@ -52,7 +53,7 @@ class UpgradeViewModel @Inject constructor(
 
     val state: Flow<Pricing> = combine(
         flow {
-            val data = withTimeoutOrNull(5000) {
+            val data = withTimeoutOrNull(5.seconds) {
                 try {
                     upgradeRepo.querySkus(OurSku.Iap.PRO_UPGRADE)
                 } catch (e: Exception) {
@@ -63,7 +64,7 @@ class UpgradeViewModel @Inject constructor(
             emit(data)
         },
         flow {
-            val data = withTimeoutOrNull(5000) {
+            val data = withTimeoutOrNull(5.seconds) {
                 try {
                     upgradeRepo.querySkus(OurSku.Sub.PRO_UPGRADE)
                 } catch (e: Exception) {

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
@@ -26,6 +26,8 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class RecorderModule @Inject constructor(
@@ -233,7 +235,7 @@ class RecorderModule @Inject constructor(
 
         val sessionDir = currentState.recorder?.sessionDir ?: return StopResult.NotRecording
         val elapsed = Clock.System.now().toEpochMilliseconds() - (currentState.recordingStartedAt ?: 0L)
-        if (elapsed < MIN_RECORDING_MS) return StopResult.TooShort
+        if (elapsed.milliseconds < MIN_RECORDING) return StopResult.TooShort
 
         stopRecorder()
         return StopResult.Stopped(LogSession(sessionDir))
@@ -261,6 +263,6 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "force_debug_run"
-        internal const val MIN_RECORDING_MS = 5_000L
+        internal val MIN_RECORDING = 5.seconds
     }
 }

--- a/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
@@ -14,9 +14,10 @@ import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
-import java.util.concurrent.TimeUnit
 import javax.inject.Qualifier
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -41,9 +42,9 @@ class HttpModule {
         userAgentInterceptor: UserAgentInterceptor,
     ): OkHttpClient = OkHttpClient().newBuilder().apply {
         cache(cache)
-        connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
-        writeTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        connectTimeout(TIMEOUT.toJavaDuration())
+        readTimeout(TIMEOUT.toJavaDuration())
+        writeTimeout(TIMEOUT.toJavaDuration())
         retryOnConnectionFailure(true)
         addInterceptor(loggingInterceptor)
         addInterceptor(userAgentInterceptor)
@@ -64,6 +65,6 @@ class HttpModule {
 
     companion object {
         private val TAG = logTag("Http")
-        const val TIMEOUT_SECONDS = 20L
+        private val TIMEOUT = 20.seconds
     }
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -62,6 +62,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
 @HiltViewModel
@@ -100,7 +101,7 @@ class DashboardVM @Inject constructor(
     private val tickerUiRefresh = flow {
         while (currentCoroutineContext().isActive) {
             emit(Clock.System.now())
-            delay(60 * 1000)
+            delay(1.minutes)
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -77,8 +77,8 @@ class ForegroundSyncControl @Inject constructor(
             override fun onStop(owner: LifecycleOwner) {
                 backgroundDebounceJob?.cancel()
                 backgroundDebounceJob = scope.launch {
-                    log(TAG) { "Process backgrounded, debouncing ${BACKGROUND_DEBOUNCE.inWholeMilliseconds}ms..." }
-                    delay(BACKGROUND_DEBOUNCE.inWholeMilliseconds)
+                    log(TAG) { "Process backgrounded, debouncing $BACKGROUND_DEBOUNCE..." }
+                    delay(BACKGROUND_DEBOUNCE)
                     isForeground.value = false
                     log(TAG) { "Background debounce elapsed, isForeground=false" }
                 }
@@ -173,16 +173,16 @@ class ForegroundSyncControl @Inject constructor(
                         pending.getOrPut(first.connectorId) { PendingSync() }.add(first)
 
                         // Drain events arriving within the debounce window
-                        withTimeoutOrNull(CLIENT_DEBOUNCE.inWholeMilliseconds) {
+                        withTimeoutOrNull(CLIENT_DEBOUNCE) {
                             while (true) {
                                 val event = eventChannel.receive()
                                 pending.getOrPut(event.connectorId) { PendingSync() }.add(event)
                             }
                         }
 
-                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT.inWholeMilliseconds) {
+                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT) {
                             syncPendingModules(pending)
-                        } ?: log(TAG, WARN) { "In-flight sync timed out after ${SYNC_COMPLETION_TIMEOUT.inWholeMilliseconds}ms" }
+                        } ?: log(TAG, WARN) { "In-flight sync timed out after $SYNC_COMPLETION_TIMEOUT" }
                     }
                 }
             } finally {
@@ -199,9 +199,9 @@ class ForegroundSyncControl @Inject constructor(
                     }
                     if (remaining.isNotEmpty()) {
                         log(TAG, INFO) { "Flushing ${remaining.values.sumOf { it.modules.size }} pending events on shutdown" }
-                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT.inWholeMilliseconds) {
+                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT) {
                             syncPendingModules(remaining)
-                        } ?: log(TAG, WARN) { "Flush sync timed out after ${SYNC_COMPLETION_TIMEOUT.inWholeMilliseconds}ms" }
+                        } ?: log(TAG, WARN) { "Flush sync timed out after $SYNC_COMPLETION_TIMEOUT" }
                     }
                 }
             }

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncExecutor.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncExecutor.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
 @Singleton
@@ -34,7 +35,7 @@ class SyncExecutor @Inject constructor(
             log(TAG, ERROR) { "Failed to refresh modules: ${e.asLog()}" }
         }
 
-        delay(3000)
+        delay(3.seconds)
 
         try {
             syncManager.sync()

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.flow.onEach
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 @Singleton
@@ -103,8 +105,8 @@ class SyncOrchestrator @Inject constructor(
                     consecutiveFailures++
                     log(TAG, ERROR) { "pendingSyncTrigger: sync failed ($consecutiveFailures/$MAX_RETRIES): ${e.asLog()}" }
                     if (consecutiveFailures < MAX_RETRIES && e.hasCause(IOException::class)) {
-                        val backoff = RETRY_BASE_DELAY_MS * (1L shl (consecutiveFailures - 1))
-                        log(TAG, WARN) { "pendingSyncTrigger: retrying in ${backoff}ms" }
+                        val backoff: Duration = RETRY_BASE_DELAY * (1 shl (consecutiveFailures - 1))
+                        log(TAG, WARN) { "pendingSyncTrigger: retrying in $backoff" }
                         delay(backoff)
                         syncManager.requestSync()
                     } else {
@@ -118,7 +120,7 @@ class SyncOrchestrator @Inject constructor(
 
     companion object {
         private const val MAX_RETRIES = 3
-        private const val RETRY_BASE_DELAY_MS = 2_000L
+        private val RETRY_BASE_DELAY = 2.seconds
         private val TAG = logTag("App", "Sync", "Orchestrator")
 
         private fun SyncWorkerControl.WorkerState.WorkerInfo.toOrchestratorInfo() = BackgroundSyncState.WorkerInfo(

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class SyncListVM @Inject constructor(
@@ -98,7 +99,7 @@ class SyncListVM @Inject constructor(
                     newIds.forEach { id ->
                         highlightJobs[id]?.cancel()
                         highlightJobs[id] = vmScope.launch {
-                            delay(2_000)
+                            delay(2.seconds)
                             highlightedIds.value = highlightedIds.value - id
                             highlightJobs.remove(id)
                         }

--- a/app/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
+++ b/app/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class OctiServerLinkHostVM @Inject constructor(
@@ -67,7 +68,7 @@ class OctiServerLinkHostVM @Inject constructor(
             val connector = connectorFlow.first()
             while (currentCoroutineContext().isActive) {
                 connector.sync(SyncOptions(writeData = false))
-                delay(3000)
+                delay(3.seconds)
             }
         }
     }

--- a/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleRepo.kt
+++ b/module-core/src/main/java/eu/darken/octi/module/core/BaseModuleRepo.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import java.util.UUID
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 
 abstract class BaseModuleRepo<T : Any>(
@@ -109,7 +110,7 @@ abstract class BaseModuleRepo<T : Any>(
                 flowOf(null)
             } else {
                 refreshTrigger.flatMapLatest {
-                    infoSource.info.throttleLatest(1000)
+                    infoSource.info.throttleLatest(1.seconds)
                 }
             }
         }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/core/PublicIpProvider.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/core/PublicIpProvider.kt
@@ -21,6 +21,8 @@ import okhttp3.Request
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class PublicIpProvider @Inject constructor(
@@ -47,7 +49,7 @@ class PublicIpProvider @Inject constructor(
             return@mapLatest null
         }
 
-        delay(SETTLE_DELAY_MS)
+        delay(SETTLE_DELAY)
 
         for (url in endpointUrls) {
             val result = fetchPublicIp(url)
@@ -65,7 +67,7 @@ class PublicIpProvider @Inject constructor(
                 .build()
 
             val call = httpClient.newCall(request).also {
-                it.timeout().timeout(TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                it.timeout().timeout(TIMEOUT.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             }
 
             call.execute().use { response ->
@@ -84,8 +86,8 @@ class PublicIpProvider @Inject constructor(
     }
 
     companion object {
-        private const val SETTLE_DELAY_MS = 500L
-        private const val TIMEOUT_MS = 5_000L
+        private val SETTLE_DELAY = 500.milliseconds
+        private val TIMEOUT = 5.seconds
         private val TAG = logTag("Module", "Connectivity", "PublicIpProvider")
     }
 }

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfoSource.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfoSource.kt
@@ -21,6 +21,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 @Singleton
@@ -60,7 +61,7 @@ class MetaInfoSource @Inject constructor(
                         deviceBootedAt = deviceBootedAt,
                     )
                     emit(info)
-                    delay(10 * 1000)
+                    delay(10.seconds)
                 }
             }
         }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class PowerAlertManager @Inject constructor(
@@ -55,7 +56,7 @@ class PowerAlertManager @Inject constructor(
 
     init {
         combine(
-            powerRepo.state.throttleLatest(1000),
+            powerRepo.state.throttleLatest(1.seconds),
             powerSettings.alertRules.flow,
         ) { powerStates, alertRules ->
             processAlerts(powerStates, alertRules)

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotificationReceiver.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotificationReceiver.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class PowerAlertNotificationReceiver : BroadcastReceiver() {
@@ -42,7 +43,7 @@ class PowerAlertNotificationReceiver : BroadcastReceiver() {
                 log(TAG, ERROR) { "Unknown action: ${intent.action}" }
             }
 
-            delay(1000)
+            delay(1.seconds)
             log(TAG) { "Finished notification receiver" }
             asyncPi.finish()
         }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 
 @Singleton
 class SyncManager @Inject constructor(
@@ -57,8 +58,7 @@ class SyncManager @Inject constructor(
 
     private val syncRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    @Suppress("MagicNumber")
-    val pendingSyncTrigger: Flow<Unit> = syncRequests.debounce(2_000L)
+    val pendingSyncTrigger: Flow<Unit> = syncRequests.debounce(2.seconds)
 
     private val disabledConnectors = MutableStateFlow(emptySet<SyncConnector>())
 

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -68,6 +68,7 @@ import okio.ByteString.Companion.toByteString
 import okio.IOException
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 import kotlin.time.TimeSource
 import com.google.api.services.drive.model.File as GDriveFile
@@ -136,7 +137,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     override val syncEvents: Flow<SyncEvent> = flow {
         while (true) {
-            delay(POLL_INTERVAL_MS)
+            delay(POLL_INTERVAL)
             try {
                 val changes = withDrive { checkForChanges() }
                 changes.forEach { emit(it) }
@@ -793,7 +794,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     companion object {
         private const val DEVICE_DATA_DIR_NAME = "devices"
         private const val DEVICE_INFO_FILE = "_device.json"
-        private const val POLL_INTERVAL_MS = 2 * 60 * 1000L // 2 minutes
+        private val POLL_INTERVAL = 2.minutes
         private val TAG = logTag("Sync", "GDrive", "Connector")
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -59,6 +59,7 @@ import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okio.ByteString
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 import kotlin.time.TimeSource
 
@@ -329,7 +330,7 @@ class OctiServerConnector @AssistedInject constructor(
                         null
                     }
                     log(TAG, VERBOSE) { "Module fetched: $fetchResult" }
-                    if (!isTargeted) delay(1000)
+                    if (!isTargeted) delay(1.seconds)
                     fetchResult
                 }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
@@ -28,8 +28,8 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import java.util.Base64
 import java.util.concurrent.TimeUnit
-import kotlin.math.min
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 class OctiServerWebSocket(
@@ -60,16 +60,16 @@ class OctiServerWebSocket(
             .pingInterval(30, TimeUnit.SECONDS)
             .build()
 
-        var backoffMs = INITIAL_BACKOFF_MS
+        var backoff = INITIAL_BACKOFF
         var activeSocket: WebSocket? = null
 
         lateinit var doConnect: () -> Unit
 
         val scheduleReconnect: () -> Unit = {
             launch {
-                log(TAG) { "Reconnecting in ${backoffMs}ms" }
-                delay(backoffMs)
-                backoffMs = min(backoffMs * 2, MAX_BACKOFF_MS)
+                log(TAG) { "Reconnecting in $backoff" }
+                delay(backoff)
+                backoff = minOf(backoff * 2, MAX_BACKOFF)
 
                 if (!isActive) return@launch
 
@@ -95,7 +95,7 @@ class OctiServerWebSocket(
             activeSocket = wsClient.newWebSocket(request, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     log(TAG, INFO) { "Connected" }
-                    backoffMs = INITIAL_BACKOFF_MS
+                    backoff = INITIAL_BACKOFF
                     onConnectionChanged(true)
                 }
 
@@ -155,8 +155,8 @@ class OctiServerWebSocket(
     }
 
     companion object {
-        private const val INITIAL_BACKOFF_MS = 1000L
-        private const val MAX_BACKOFF_MS = 30_000L
+        private val INITIAL_BACKOFF = 1.seconds
+        private val MAX_BACKOFF = 30.seconds
         private val TAG = logTag("Sync", "OctiServer", "WebSocket")
     }
 }


### PR DESCRIPTION
## Summary
- Convert time-related `Long` millisecond values to `kotlin.time.Duration` across 25 files in sync, module, flow, and UI layers for type safety and KMP readiness.
- Affects `delay()`, `withTimeout()`, `debounce()`, `throttleLatest()`, `SharingStarted.WhileSubscribed`, and OkHttp timeouts (via `.toJavaDuration()`).
- **Behavioral fix**: `UpgradeRepoGplay` Pro grace period was labeled `// 7 days` but computed to `7 * 24 * 60 * 1000L` = ~168 minutes (missing a `* 60` factor for seconds→ms). Now correctly `PRO_GRACE_PERIOD = 7.days` as originally intended.

## Test plan
- [x] `./gradlew :app:assembleFossDebug :app:assembleGplayDebug` — builds
- [x] `./gradlew testFossDebugUnitTest testGplayDebugUnitTest` — 287 tests pass
- [ ] Manual smoke: sync still works, Pro upgrade flow still works