### PR TITLE
Choose which devices each widget shows

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigApply.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigApply.kt
@@ -1,0 +1,55 @@
+package eu.darken.octi.common.widget
+
+import android.app.Activity.RESULT_OK
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import kotlinx.coroutines.launch
+
+/**
+ * Persists [newConfig] into the per-instance options bundle, sets [ComponentActivity.RESULT_OK],
+ * finishes the activity immediately, and refreshes the widget via [updateWidget] on the
+ * process-level lifecycle scope so the Glance recomposition runs to completion regardless of
+ * activity destruction.
+ *
+ * If [newConfig] is in custom-theme mode but missing colours, the activity is finished
+ * without applying — mirrors the existing per-activity guard.
+ *
+ * **Important**: [updateWidget] runs on a scope that outlives the activity. Make sure the
+ * lambda passed in does not capture the activity (use the application context).
+ */
+fun ComponentActivity.applyWidgetConfig(
+    appWidgetId: Int,
+    newConfig: WidgetInstanceConfig,
+    tag: String,
+    updateWidget: suspend () -> Unit,
+) {
+    if (!newConfig.isMaterialYou && (newConfig.customBg == null || newConfig.customAccent == null)) {
+        finish()
+        return
+    }
+
+    val widgetManager = AppWidgetManager.getInstance(this)
+    val options = widgetManager.getAppWidgetOptions(appWidgetId)
+    WidgetInstanceConfig.write(options, newConfig)
+    widgetManager.updateAppWidgetOptions(appWidgetId, options)
+
+    setResult(
+        RESULT_OK,
+        Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
+    )
+    finish()
+
+    ProcessLifecycleOwner.get().lifecycleScope.launch {
+        try {
+            updateWidget()
+        } catch (e: Exception) {
+            log(tag, ERROR) { "Failed to update widget: ${e.asLog()}" }
+        }
+    }
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigColorPicker.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigColorPicker.kt
@@ -1,0 +1,177 @@
+package eu.darken.octi.common.widget
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.R
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+
+@Composable
+fun WidgetColorPickerCard(
+    title: String,
+    selectedColor: Int?,
+    hexValue: String,
+    onColorSelected: (Int) -> Unit,
+    onHexValueChange: (String) -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            WidgetColorSwatchGrid(
+                selectedColor = selectedColor,
+                onColorSelected = onColorSelected,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            WidgetHexColorInput(
+                value = hexValue,
+                onValueChange = onHexValueChange,
+                onClear = onClear,
+            )
+        }
+    }
+}
+
+@Composable
+private fun WidgetColorSwatchGrid(
+    selectedColor: Int?,
+    onColorSelected: (Int) -> Unit,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        maxItemsInEachRow = 6,
+    ) {
+        WidgetTheme.SWATCH_COLORS.forEach { color ->
+            val isSelected = selectedColor == color
+            val contrastColor = WidgetTheme.bestContrast(color)
+
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(color))
+                    .then(
+                        if (isSelected) {
+                            Modifier.border(
+                                BorderStroke(3.dp, Color(contrastColor)),
+                                RoundedCornerShape(8.dp),
+                            )
+                        } else {
+                            Modifier.border(
+                                BorderStroke(1.dp, Color(0x33000000)),
+                                RoundedCornerShape(8.dp),
+                            )
+                        }
+                    )
+                    .clickable { onColorSelected(color) },
+                contentAlignment = Alignment.Center,
+            ) {
+                if (isSelected) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        tint = Color(contrastColor),
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetHexColorInput(
+    value: String,
+    onValueChange: (String) -> Unit,
+    onClear: () -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { input ->
+            val filtered = input.filter { it.isLetterOrDigit() }.take(6).uppercase()
+            onValueChange(filtered)
+        },
+        label = { Text(stringResource(R.string.widget_config_hex_hint)) },
+        prefix = { Text("#") },
+        textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
+        singleLine = true,
+        trailingIcon = {
+            if (value.isNotEmpty()) {
+                IconButton(onClick = onClear) {
+                    Icon(Icons.Filled.Close, contentDescription = null)
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
+@Preview2
+@Composable
+private fun WidgetColorPickerCardPreview() = PreviewWrapper {
+    WidgetColorPickerCard(
+        title = stringResource(R.string.widget_config_background_label),
+        selectedColor = WidgetTheme.BLUE.presetBg,
+        hexValue = "1565C0",
+        onColorSelected = {},
+        onHexValueChange = {},
+        onClear = {},
+        modifier = Modifier.padding(16.dp),
+    )
+}
+
+@Preview2
+@Composable
+private fun WidgetColorPickerCardEmptyPreview() = PreviewWrapper {
+    WidgetColorPickerCard(
+        title = stringResource(R.string.widget_config_accent_label),
+        selectedColor = null,
+        hexValue = "",
+        onColorSelected = {},
+        onHexValueChange = {},
+        onClear = {},
+        modifier = Modifier.padding(16.dp),
+    )
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigDeviceFilter.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigDeviceFilter.kt
@@ -1,0 +1,170 @@
+package eu.darken.octi.common.widget
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.Tablet
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.R
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+
+data class WidgetConfigDevice(
+    val id: String,
+    val label: String,
+    val subtitle: String?,
+    val icon: ImageVector,
+)
+
+@Composable
+fun WidgetDeviceFilterCard(
+    devices: List<WidgetConfigDevice>,
+    selectedDeviceIds: Set<String>,
+    onDeviceToggle: (id: String, checked: Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(vertical = 16.dp)) {
+            Text(
+                text = stringResource(R.string.widget_config_devices_label),
+                style = MaterialTheme.typography.titleSmall,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            val hintRes = when {
+                devices.isEmpty() -> R.string.widget_config_devices_none_known
+                selectedDeviceIds.isEmpty() -> R.string.widget_config_devices_empty_hint
+                else -> R.string.widget_config_devices_selected_hint
+            }
+            Text(
+                text = stringResource(hintRes),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            if (devices.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                devices.forEach { device ->
+                    WidgetDeviceFilterRow(
+                        device = device,
+                        checked = device.id in selectedDeviceIds,
+                        onCheckedChange = { checked -> onDeviceToggle(device.id, checked) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetDeviceFilterRow(
+    device: WidgetConfigDevice,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                role = Role.Switch,
+                onValueChange = onCheckedChange,
+            )
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = device.icon,
+            contentDescription = null,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+        )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 16.dp),
+        ) {
+            Text(
+                text = device.label,
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.Normal,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            if (device.subtitle != null) {
+                Text(
+                    text = device.subtitle,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                )
+            }
+        }
+        Switch(
+            checked = checked,
+            onCheckedChange = null,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}
+
+internal fun widgetConfigPreviewDevices() = listOf(
+    WidgetConfigDevice(
+        id = "pixel-9-pro",
+        label = "Pixel 9 Pro",
+        subtitle = "Last seen 2m ago",
+        icon = Icons.TwoTone.PhoneAndroid,
+    ),
+    WidgetConfigDevice(
+        id = "pixel-tablet",
+        label = "Pixel Tablet",
+        subtitle = "Last seen 8m ago",
+        icon = Icons.TwoTone.Tablet,
+    ),
+)
+
+@Preview2
+@Composable
+private fun WidgetDeviceFilterCardPreview() = PreviewWrapper {
+    WidgetDeviceFilterCard(
+        devices = widgetConfigPreviewDevices(),
+        selectedDeviceIds = setOf("pixel-9-pro"),
+        onDeviceToggle = { _, _ -> },
+        modifier = Modifier.padding(16.dp),
+    )
+}
+
+@Preview2
+@Composable
+private fun WidgetDeviceFilterCardEmptyPreview() = PreviewWrapper {
+    WidgetDeviceFilterCard(
+        devices = emptyList(),
+        selectedDeviceIds = emptySet(),
+        onDeviceToggle = { _, _ -> },
+        modifier = Modifier.padding(16.dp),
+    )
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
@@ -1,9 +1,6 @@
 package eu.darken.octi.common.widget
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,7 +16,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -29,24 +25,24 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
 
 @Composable
 fun WidgetConfigScreen(
@@ -54,36 +50,67 @@ fun WidgetConfigScreen(
     initialPresetName: String?,
     initialBgColor: Int?,
     initialAccentColor: Int?,
+    availableDevices: List<WidgetConfigDevice>? = null,
+    initialSelectedDeviceIds: Set<String> = emptySet(),
     onClose: () -> Unit,
-    onApply: (isMaterialYou: Boolean, presetName: String?, bgColor: Int?, accentColor: Int?) -> Unit,
+    onApply: (
+        isMaterialYou: Boolean,
+        presetName: String?,
+        bgColor: Int?,
+        accentColor: Int?,
+        selectedDeviceIds: Set<String>,
+    ) -> Unit,
     previewContent: @Composable (WidgetTheme.Colors?) -> Unit,
 ) {
     val initialTheme = WidgetTheme.fromName(initialPresetName)
-    val isInitiallyCustom = initialMode == WidgetTheme.MODE_CUSTOM && initialTheme == null
-    val isInitiallyPreset = initialMode == WidgetTheme.MODE_CUSTOM && initialTheme != null
+    val isInitiallyCustom = initialMode == WidgetInstanceConfig.MODE_CUSTOM && initialTheme == null
+    val isInitiallyPreset = initialMode == WidgetInstanceConfig.MODE_CUSTOM && initialTheme != null
 
     var selectedPreset by rememberSaveable { mutableStateOf(initialTheme ?: WidgetTheme.MATERIAL_YOU) }
     var isCustomMode by rememberSaveable { mutableStateOf(isInitiallyCustom) }
     var bgColor by rememberSaveable { mutableStateOf(initialBgColor) }
     var accentColor by rememberSaveable { mutableStateOf(initialAccentColor) }
-    var bgHex by rememberSaveable { mutableStateOf(initialBgColor?.let { String.format("%06X", it and 0xFFFFFF) } ?: "") }
-    var accentHex by rememberSaveable { mutableStateOf(initialAccentColor?.let { String.format("%06X", it and 0xFFFFFF) } ?: "") }
+    var bgHex by rememberSaveable { mutableStateOf(initialBgColor?.toHexColorString().orEmpty()) }
+    var accentHex by rememberSaveable { mutableStateOf(initialAccentColor?.toHexColorString().orEmpty()) }
+    var selectedDeviceIds by rememberSaveable(
+        stateSaver = listSaver<Set<String>, String>(
+            save = { it.toList() },
+            restore = { it.toSet() },
+        ),
+    ) { mutableStateOf(initialSelectedDeviceIds) }
+
+    fun setBgColor(color: Int?) {
+        bgColor = color
+        bgHex = color?.toHexColorString().orEmpty()
+    }
+
+    fun setAccentColor(color: Int?) {
+        accentColor = color
+        accentHex = color?.toHexColorString().orEmpty()
+    }
+
+    fun applyPreset(theme: WidgetTheme) {
+        isCustomMode = false
+        selectedPreset = theme
+        if (theme != WidgetTheme.MATERIAL_YOU) {
+            setBgColor(theme.presetBg)
+            setAccentColor(theme.presetAccent)
+        }
+    }
 
     LaunchedEffect(Unit) {
         if (isInitiallyPreset && bgColor == null) {
-            bgColor = initialTheme.presetBg
-            accentColor = initialTheme.presetAccent
+            setBgColor(initialTheme.presetBg)
+            setAccentColor(initialTheme.presetAccent)
         }
     }
 
     val isMaterialYou = !isCustomMode && selectedPreset == WidgetTheme.MATERIAL_YOU
     val canApply = isMaterialYou || (bgColor != null && accentColor != null)
 
-    val bg = bgColor
-    val accent = accentColor
     val currentColors = when {
         isMaterialYou -> null
-        bg != null && accent != null -> WidgetTheme.deriveColors(bg, accent)
+        bgColor != null && accentColor != null -> WidgetTheme.deriveColors(bgColor!!, accentColor!!)
         else -> null
     }
 
@@ -108,6 +135,7 @@ fun WidgetConfigScreen(
                             if (isCustomMode) null else selectedPreset.name,
                             bgColor,
                             accentColor,
+                            selectedDeviceIds,
                         )
                     },
                     enabled = canApply,
@@ -126,7 +154,6 @@ fun WidgetConfigScreen(
                 .verticalScroll(rememberScrollState())
                 .padding(16.dp),
         ) {
-            // Preview
             Text(
                 text = stringResource(R.string.widget_config_preview_label),
                 style = MaterialTheme.typography.labelMedium,
@@ -136,205 +163,161 @@ fun WidgetConfigScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Presets
             Text(
                 text = stringResource(R.string.widget_config_presets_label),
                 style = MaterialTheme.typography.labelMedium,
             )
             Spacer(modifier = Modifier.height(12.dp))
 
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                WidgetTheme.entries.forEach { theme ->
-                    FilterChip(
-                        selected = !isCustomMode && selectedPreset == theme,
-                        onClick = {
-                            isCustomMode = false
-                            selectedPreset = theme
-                            if (theme != WidgetTheme.MATERIAL_YOU) {
-                                bgColor = theme.presetBg
-                                accentColor = theme.presetAccent
-                                bgHex = theme.presetBg?.let { String.format("%06X", it and 0xFFFFFF) } ?: ""
-                                accentHex = theme.presetAccent?.let { String.format("%06X", it and 0xFFFFFF) } ?: ""
-                            }
-                        },
-                        label = { Text(stringResource(theme.labelRes)) },
-                        leadingIcon = if (theme.presetBg != null) {
-                            {
-                                Box(
-                                    modifier = Modifier
-                                        .size(12.dp)
-                                        .clip(CircleShape)
-                                        .background(Color(theme.presetBg)),
-                                )
-                            }
-                        } else null,
-                    )
-                }
+            WidgetThemePresetSelector(
+                selectedPreset = selectedPreset,
+                isCustomMode = isCustomMode,
+                onPresetSelected = { theme -> applyPreset(theme) },
+                onCustomSelected = {
+                    isCustomMode = true
+                    selectedPreset = WidgetTheme.MATERIAL_YOU
+                },
+            )
 
-                FilterChip(
-                    selected = isCustomMode,
-                    onClick = {
-                        isCustomMode = true
-                        selectedPreset = WidgetTheme.MATERIAL_YOU
+            if (isCustomMode) {
+                Spacer(modifier = Modifier.height(16.dp))
+                WidgetColorPickerCard(
+                    title = stringResource(R.string.widget_config_background_label),
+                    selectedColor = bgColor,
+                    hexValue = bgHex,
+                    onColorSelected = { color -> setBgColor(color) },
+                    onHexValueChange = { hex ->
+                        bgHex = hex
+                        WidgetTheme.parseHexColor(hex)?.let { bgColor = it }
                     },
-                    label = { Text(stringResource(R.string.widget_config_custom_label)) },
+                    onClear = { setBgColor(null) },
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+                WidgetColorPickerCard(
+                    title = stringResource(R.string.widget_config_accent_label),
+                    selectedColor = accentColor,
+                    hexValue = accentHex,
+                    onColorSelected = { color -> setAccentColor(color) },
+                    onHexValueChange = { hex ->
+                        accentHex = hex
+                        WidgetTheme.parseHexColor(hex)?.let { accentColor = it }
+                    },
+                    onClear = { setAccentColor(null) },
                 )
             }
 
-            // Custom colors
-            if (isCustomMode) {
+            if (availableDevices != null) {
                 Spacer(modifier = Modifier.height(16.dp))
-
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                    ),
-                    shape = RoundedCornerShape(16.dp),
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = stringResource(R.string.widget_config_background_label),
-                            style = MaterialTheme.typography.titleSmall,
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        ColorSwatchGrid(
-                            selectedColor = bgColor,
-                            onColorSelected = { color ->
-                                bgColor = color
-                                bgHex = String.format("%06X", color and 0xFFFFFF)
-                            },
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        HexColorInput(
-                            value = bgHex,
-                            onValueChange = { hex ->
-                                bgHex = hex
-                                val color = WidgetTheme.parseHexColor(hex)
-                                if (color != null) bgColor = color
-                            },
-                            onClear = {
-                                bgHex = ""
-                                bgColor = null
-                            },
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Card(
-                    colors = CardDefaults.cardColors(
-                        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
-                    ),
-                    shape = RoundedCornerShape(16.dp),
-                ) {
-                    Column(modifier = Modifier.padding(16.dp)) {
-                        Text(
-                            text = stringResource(R.string.widget_config_accent_label),
-                            style = MaterialTheme.typography.titleSmall,
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        ColorSwatchGrid(
-                            selectedColor = accentColor,
-                            onColorSelected = { color ->
-                                accentColor = color
-                                accentHex = String.format("%06X", color and 0xFFFFFF)
-                            },
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        HexColorInput(
-                            value = accentHex,
-                            onValueChange = { hex ->
-                                accentHex = hex
-                                val color = WidgetTheme.parseHexColor(hex)
-                                if (color != null) accentColor = color
-                            },
-                            onClear = {
-                                accentHex = ""
-                                accentColor = null
-                            },
-                        )
-                    }
-                }
+                WidgetDeviceFilterCard(
+                    devices = availableDevices,
+                    selectedDeviceIds = selectedDeviceIds,
+                    onDeviceToggle = { id, checked ->
+                        selectedDeviceIds = if (checked) selectedDeviceIds + id else selectedDeviceIds - id
+                    },
+                )
             }
         }
     }
 }
 
 @Composable
-fun ColorSwatchGrid(
-    selectedColor: Int?,
-    onColorSelected: (Int) -> Unit,
+private fun WidgetThemePresetSelector(
+    selectedPreset: WidgetTheme,
+    isCustomMode: Boolean,
+    onPresetSelected: (WidgetTheme) -> Unit,
+    onCustomSelected: () -> Unit,
 ) {
     FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
-        maxItemsInEachRow = 6,
     ) {
-        WidgetTheme.SWATCH_COLORS.forEach { color ->
-            val isSelected = selectedColor == color
-            val contrastColor = WidgetTheme.bestContrast(color)
-
-            Box(
-                modifier = Modifier
-                    .size(44.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(Color(color))
-                    .then(
-                        if (isSelected) {
-                            Modifier.border(
-                                BorderStroke(3.dp, Color(contrastColor)),
-                                RoundedCornerShape(8.dp),
-                            )
-                        } else {
-                            Modifier.border(
-                                BorderStroke(1.dp, Color(0x33000000)),
-                                RoundedCornerShape(8.dp),
-                            )
-                        }
-                    )
-                    .clickable { onColorSelected(color) },
-                contentAlignment = Alignment.Center,
-            ) {
-                if (isSelected) {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = null,
-                        tint = Color(contrastColor),
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-            }
+        WidgetTheme.entries.forEach { theme ->
+            FilterChip(
+                selected = !isCustomMode && selectedPreset == theme,
+                onClick = { onPresetSelected(theme) },
+                label = { Text(stringResource(theme.labelRes)) },
+                leadingIcon = if (theme.presetBg != null) {
+                    {
+                        Box(
+                            modifier = Modifier
+                                .size(12.dp)
+                                .clip(CircleShape)
+                                .background(Color(theme.presetBg)),
+                        )
+                    }
+                } else {
+                    null
+                },
+            )
         }
+
+        FilterChip(
+            selected = isCustomMode,
+            onClick = onCustomSelected,
+            label = { Text(stringResource(R.string.widget_config_custom_label)) },
+        )
     }
 }
 
 @Composable
-fun HexColorInput(
-    value: String,
-    onValueChange: (String) -> Unit,
-    onClear: () -> Unit,
-) {
-    OutlinedTextField(
-        value = value,
-        onValueChange = { input ->
-            val filtered = input.filter { it.isLetterOrDigit() }.take(6).uppercase()
-            onValueChange(filtered)
-        },
-        label = { Text(stringResource(R.string.widget_config_hex_hint)) },
-        prefix = { Text("#") },
-        textStyle = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace),
-        singleLine = true,
-        trailingIcon = {
-            if (value.isNotEmpty()) {
-                IconButton(onClick = onClear) {
-                    Icon(Icons.Filled.Close, contentDescription = null)
-                }
-            }
-        },
+private fun WidgetConfigPreviewContent(colors: WidgetTheme.Colors?) {
+    val previewColors = colors ?: WidgetTheme.deriveColors(
+        bg = WidgetTheme.CLASSIC_GREEN.presetBg!!,
+        accent = WidgetTheme.CLASSIC_GREEN.presetAccent!!,
+    )
+
+    Card(
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(previewColors.containerBg)),
         modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Pixel 9 Pro",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color(previewColors.onContainer),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(10.dp)
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(Color(previewColors.barTrack)),
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.68f)
+                        .height(10.dp)
+                        .clip(RoundedCornerShape(999.dp))
+                        .background(Color(previewColors.barFill)),
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "68% battery",
+                style = MaterialTheme.typography.bodyMedium,
+                color = Color(previewColors.onContainer),
+            )
+        }
+    }
+}
+
+private fun Int.toHexColorString(): String = String.format("%06X", this and 0xFFFFFF)
+
+@Preview2
+@Composable
+private fun WidgetConfigScreenPreview() = PreviewWrapper {
+    WidgetConfigScreen(
+        initialMode = WidgetInstanceConfig.MODE_CUSTOM,
+        initialPresetName = null,
+        initialBgColor = WidgetTheme.BLUE.presetBg,
+        initialAccentColor = WidgetTheme.BLUE.presetAccent,
+        availableDevices = widgetConfigPreviewDevices(),
+        initialSelectedDeviceIds = setOf("pixel-9-pro"),
+        onClose = {},
+        onApply = { _, _, _, _, _ -> },
+        previewContent = { colors -> WidgetConfigPreviewContent(colors) },
     )
 }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
@@ -284,14 +284,14 @@ private fun WidgetConfigPreviewContent(colors: WidgetTheme.Colors?) {
                     .fillMaxWidth()
                     .height(10.dp)
                     .clip(RoundedCornerShape(999.dp))
-                    .background(Color(previewColors.barTrack)),
+                    .background(Color(previewColors.tileBg)),
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(0.68f)
                         .height(10.dp)
                         .clip(RoundedCornerShape(999.dp))
-                        .background(Color(previewColors.barFill)),
+                        .background(Color(previewColors.accentBg)),
                 )
             }
             Spacer(modifier = Modifier.height(8.dp))

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetInstanceConfig.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetInstanceConfig.kt
@@ -1,0 +1,83 @@
+package eu.darken.octi.common.widget
+
+import android.os.Bundle
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+
+data class WidgetInstanceConfig(
+    val isMaterialYou: Boolean,
+    val presetName: String?,
+    val customBg: Int?,
+    val customAccent: Int?,
+    val allowedDeviceIds: Set<String>,
+) {
+    val themeColors: WidgetTheme.Colors?
+        get() = when {
+            isMaterialYou -> null
+            customBg != null && customAccent != null -> WidgetTheme.deriveColors(customBg, customAccent)
+            else -> null
+        }
+
+    companion object {
+        private val TAG = logTag("Widget", "InstanceConfig")
+
+        const val KEY_THEME_MODE = "theme_mode"
+        const val KEY_THEME_PRESET = "theme_preset"
+        const val KEY_CUSTOM_BG = "custom_bg"
+        const val KEY_CUSTOM_ACCENT = "custom_accent"
+        const val KEY_DEVICE_FILTER_IDS = "device_filter_ids"
+
+        const val MODE_MATERIAL_YOU = "material_you"
+        const val MODE_CUSTOM = "custom"
+
+        val DEFAULT = WidgetInstanceConfig(
+            isMaterialYou = true,
+            presetName = null,
+            customBg = null,
+            customAccent = null,
+            allowedDeviceIds = emptySet(),
+        )
+
+        fun parse(options: Bundle): WidgetInstanceConfig = try {
+            val mode = options.getString(KEY_THEME_MODE)
+            val isMaterialYou = mode != MODE_CUSTOM
+            val presetName = options.getString(KEY_THEME_PRESET)
+            val customBg = if (options.containsKey(KEY_CUSTOM_BG)) options.getInt(KEY_CUSTOM_BG) else null
+            val customAccent = if (options.containsKey(KEY_CUSTOM_ACCENT)) options.getInt(KEY_CUSTOM_ACCENT) else null
+            val allowedDeviceIds = options.getStringArray(KEY_DEVICE_FILTER_IDS)?.toSet().orEmpty()
+            WidgetInstanceConfig(
+                isMaterialYou = isMaterialYou,
+                presetName = presetName,
+                customBg = customBg,
+                customAccent = customAccent,
+                allowedDeviceIds = allowedDeviceIds,
+            )
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to parse: ${e.asLog()}" }
+            DEFAULT
+        }
+
+        fun write(options: Bundle, config: WidgetInstanceConfig) {
+            if (config.isMaterialYou) {
+                options.putString(KEY_THEME_MODE, MODE_MATERIAL_YOU)
+                options.putString(KEY_THEME_PRESET, WidgetTheme.MATERIAL_YOU.name)
+                options.remove(KEY_CUSTOM_BG)
+                options.remove(KEY_CUSTOM_ACCENT)
+            } else {
+                options.putString(KEY_THEME_MODE, MODE_CUSTOM)
+                options.putString(KEY_THEME_PRESET, config.presetName ?: "")
+                options.remove(KEY_CUSTOM_BG)
+                options.remove(KEY_CUSTOM_ACCENT)
+                config.customBg?.let { options.putInt(KEY_CUSTOM_BG, it) }
+                config.customAccent?.let { options.putInt(KEY_CUSTOM_ACCENT, it) }
+            }
+            if (config.allowedDeviceIds.isEmpty()) {
+                options.remove(KEY_DEVICE_FILTER_IDS)
+            } else {
+                options.putStringArray(KEY_DEVICE_FILTER_IDS, config.allowedDeviceIds.toTypedArray())
+            }
+        }
+    }
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
@@ -1,14 +1,9 @@
 package eu.darken.octi.common.widget
 
 import android.graphics.Color
-import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.core.graphics.ColorUtils
 import eu.darken.octi.common.R
-import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
-import eu.darken.octi.common.debug.logging.asLog
-import eu.darken.octi.common.debug.logging.log
-import eu.darken.octi.common.debug.logging.logTag
 
 enum class WidgetTheme(
     @StringRes val labelRes: Int,
@@ -48,28 +43,6 @@ enum class WidgetTheme(
 
         fun fromName(name: String?): WidgetTheme? = entries.find { it.name == name }
 
-        private val TAG = logTag("Widget", "Theme")
-
-        fun parseThemeColors(options: Bundle): Colors? = try {
-            val mode = options.getString(KEY_THEME_MODE)
-            when (mode) {
-                MODE_CUSTOM -> {
-                    if (options.containsKey(KEY_CUSTOM_BG) && options.containsKey(KEY_CUSTOM_ACCENT)) {
-                        val bg = options.getInt(KEY_CUSTOM_BG)
-                        val accent = options.getInt(KEY_CUSTOM_ACCENT)
-                        deriveColors(bg, accent)
-                    } else {
-                        null
-                    }
-                }
-
-                else -> null
-            }
-        } catch (e: Exception) {
-            log(TAG, WARN) { "Failed to parse theme colors: ${e.asLog()}" }
-            null
-        }
-
         fun parseHexColor(input: String?): Int? {
             if (input.isNullOrBlank()) return null
             val cleaned = input.trim().removePrefix("#").uppercase()
@@ -90,13 +63,5 @@ enum class WidgetTheme(
             0xFF795548.toInt(), 0xFF9E9E9E.toInt(), 0xFF607D8B.toInt(), 0xFFFFFFFF.toInt(),
             0xFF1E1E1E.toInt(), 0xFF263238.toInt(), 0xFF1B5E20.toInt(), 0xFF0D47A1.toInt(),
         )
-
-        const val KEY_THEME_MODE = "theme_mode"
-        const val KEY_THEME_PRESET = "theme_preset"
-        const val KEY_CUSTOM_BG = "custom_bg"
-        const val KEY_CUSTOM_ACCENT = "custom_accent"
-
-        const val MODE_MATERIAL_YOU = "material_you"
-        const val MODE_CUSTOM = "custom"
     }
 }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
@@ -20,10 +20,12 @@ enum class WidgetTheme(
 
     data class Colors(
         val containerBg: Int,
-        val barFill: Int,
-        val barTrack: Int,
-        val icon: Int,
         val onContainer: Int,
+        val tileBg: Int,
+        val onTile: Int,
+        val onTileVariant: Int,
+        val accentBg: Int,
+        val onAccent: Int,
     )
 
     companion object {
@@ -33,13 +35,38 @@ enum class WidgetTheme(
             return if (contrastWhite >= contrastBlack) Color.WHITE else Color.BLACK
         }
 
-        fun deriveColors(bg: Int, accent: Int): Colors = Colors(
-            containerBg = bg,
-            barFill = accent,
-            barTrack = ColorUtils.setAlphaComponent(accent, 0x55),
-            icon = bestContrast(accent),
-            onContainer = bestContrast(bg),
-        )
+        fun deriveColors(bg: Int, accent: Int): Colors {
+            val onContainer = bestContrast(bg)
+            val tileBg = deriveTileBackground(bg, accent, onContainer)
+            val onTile = bestContrast(tileBg)
+
+            return Colors(
+                containerBg = bg,
+                onContainer = onContainer,
+                tileBg = tileBg,
+                onTile = onTile,
+                onTileVariant = ColorUtils.blendARGB(onTile, tileBg, 0.38f),
+                accentBg = accent,
+                onAccent = bestContrast(accent),
+            )
+        }
+
+        private fun deriveTileBackground(bg: Int, accent: Int, onContainer: Int): Int {
+            val elevatedSurface = ColorUtils.blendARGB(
+                bg,
+                onContainer,
+                if (onContainer == Color.WHITE) 0.14f else 0.10f,
+            )
+            var tileBg = ColorUtils.blendARGB(elevatedSurface, accent, 0.08f)
+            if (ColorUtils.calculateContrast(tileBg, bg) < 1.15) {
+                tileBg = ColorUtils.blendARGB(
+                    bg,
+                    onContainer,
+                    if (onContainer == Color.WHITE) 0.18f else 0.14f,
+                )
+            }
+            return tileBg
+        }
 
         fun fromName(name: String?): WidgetTheme? = entries.find { it.name == name }
 

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetThemeDefaults.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetThemeDefaults.kt
@@ -1,0 +1,17 @@
+package eu.darken.octi.common.widget
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.res.colorResource
+import eu.darken.octi.common.R
+
+@Composable
+fun widgetDefaultColors(): WidgetTheme.Colors = WidgetTheme.Colors(
+    containerBg = colorResource(R.color.widgetContainerBackground).toArgb(),
+    onContainer = colorResource(R.color.widgetOnContainer).toArgb(),
+    tileBg = colorResource(R.color.widgetTileBackground).toArgb(),
+    onTile = colorResource(R.color.widgetOnTile).toArgb(),
+    onTileVariant = colorResource(R.color.widgetOnTileVariant).toArgb(),
+    accentBg = colorResource(R.color.widgetAccentBackground).toArgb(),
+    onAccent = colorResource(R.color.widgetOnAccent).toArgb(),
+)

--- a/app-common/src/main/res/drawable/widget_preview_accent_tile.xml
+++ b/app-common/src/main/res/drawable/widget_preview_accent_tile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <corners android:radius="12dp" />
-    <solid android:color="@color/widgetBarFill" />
+    <solid android:color="@color/widgetAccentBackground" />
 </shape>

--- a/app-common/src/main/res/drawable/widget_preview_accent_tile.xml
+++ b/app-common/src/main/res/drawable/widget_preview_accent_tile.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="12dp" />
+    <solid android:color="@color/widgetBarFill" />
+</shape>

--- a/app-common/src/main/res/drawable/widget_preview_container.xml
+++ b/app-common/src/main/res/drawable/widget_preview_container.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="16dp" />
+    <solid android:color="@color/widgetContainerBackground" />
+    <stroke
+        android:width="1dp"
+        android:color="#26FFFFFF" />
+</shape>

--- a/app-common/src/main/res/drawable/widget_preview_tile.xml
+++ b/app-common/src/main/res/drawable/widget_preview_tile.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="12dp" />
+    <solid android:color="@color/widgetBarTrack" />
+</shape>

--- a/app-common/src/main/res/drawable/widget_preview_tile.xml
+++ b/app-common/src/main/res/drawable/widget_preview_tile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
     <corners android:radius="12dp" />
-    <solid android:color="@color/widgetBarTrack" />
+    <solid android:color="@color/widgetTileBackground" />
 </shape>

--- a/app-common/src/main/res/values-night-v31/colors.xml
+++ b/app-common/src/main/res/values-night-v31/colors.xml
@@ -2,8 +2,10 @@
 <resources>
     <!-- Material You dynamic colors for widget (Android 12+, dark mode) -->
     <color name="widgetContainerBackground">@android:color/system_accent1_700</color>
-    <color name="widgetBarFill">@android:color/system_accent1_100</color>
-    <color name="widgetBarTrack">#33FFFFFF</color>
-    <color name="widgetBarIcon">@android:color/system_accent1_700</color>
-    <color name="widgetOnContainer">@android:color/system_accent1_100</color>
+    <color name="widgetOnContainer">@android:color/system_accent1_50</color>
+    <color name="widgetTileBackground">@android:color/system_accent2_600</color>
+    <color name="widgetOnTile">@android:color/system_neutral1_50</color>
+    <color name="widgetOnTileVariant">@android:color/system_neutral2_200</color>
+    <color name="widgetAccentBackground">@android:color/system_accent1_100</color>
+    <color name="widgetOnAccent">@android:color/system_accent1_900</color>
 </resources>

--- a/app-common/src/main/res/values-night/colors.xml
+++ b/app-common/src/main/res/values-night/colors.xml
@@ -2,8 +2,10 @@
 <resources>
     <!-- Dark mode widget colors (pre-API 31) -->
     <color name="widgetContainerBackground">#FF11512E</color>
-    <color name="widgetBarFill">#FFB1F1C2</color>
-    <color name="widgetBarTrack">#33FFFFFF</color>
-    <color name="widgetBarIcon">#FF11512E</color>
-    <color name="widgetOnContainer">#FFB1F1C2</color>
+    <color name="widgetOnContainer">#FFE4F7E8</color>
+    <color name="widgetTileBackground">#FF39634A</color>
+    <color name="widgetOnTile">#FFE4F7E8</color>
+    <color name="widgetOnTileVariant">#FFB4CCBA</color>
+    <color name="widgetAccentBackground">#FFB1F1C2</color>
+    <color name="widgetOnAccent">#FF00210E</color>
 </resources>

--- a/app-common/src/main/res/values-v31/colors.xml
+++ b/app-common/src/main/res/values-v31/colors.xml
@@ -2,8 +2,10 @@
 <resources>
     <!-- Material You dynamic colors for widget (Android 12+, light mode) -->
     <color name="widgetContainerBackground">@android:color/system_accent1_600</color>
-    <color name="widgetBarFill">@android:color/system_accent1_100</color>
-    <color name="widgetBarTrack">#33FFFFFF</color>
-    <color name="widgetBarIcon">@android:color/system_accent1_900</color>
-    <color name="widgetOnContainer">@android:color/system_accent1_0</color>
+    <color name="widgetOnContainer">@android:color/system_accent1_50</color>
+    <color name="widgetTileBackground">@android:color/system_accent2_500</color>
+    <color name="widgetOnTile">@android:color/system_neutral1_50</color>
+    <color name="widgetOnTileVariant">@android:color/system_neutral2_200</color>
+    <color name="widgetAccentBackground">@android:color/system_accent1_100</color>
+    <color name="widgetOnAccent">@android:color/system_accent1_900</color>
 </resources>

--- a/app-common/src/main/res/values/colors.xml
+++ b/app-common/src/main/res/values/colors.xml
@@ -2,8 +2,10 @@
 <resources>
     <!-- Light mode widget colors (pre-API 31) -->
     <color name="widgetContainerBackground">#FF2D6A44</color>
-    <color name="widgetBarFill">#FFB1F1C2</color>
-    <color name="widgetBarTrack">#33FFFFFF</color>
-    <color name="widgetBarIcon">#FF00210E</color>
     <color name="widgetOnContainer">#FFFFFFFF</color>
+    <color name="widgetTileBackground">#FF4A7057</color>
+    <color name="widgetOnTile">#FFF3FFF4</color>
+    <color name="widgetOnTileVariant">#FFCEE0D2</color>
+    <color name="widgetAccentBackground">#FFB1F1C2</color>
+    <color name="widgetOnAccent">#FF00210E</color>
 </resources>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -65,6 +65,14 @@
     <string name="widget_config_preview_label">Preview</string>
     <string name="widget_config_custom_label">Custom</string>
 
+    <!-- Widget device filter -->
+    <string name="widget_config_devices_label">Devices</string>
+    <string name="widget_config_devices_empty_hint">If no devices are selected, all devices will be shown.</string>
+    <string name="widget_config_devices_selected_hint">Only selected devices will be shown.</string>
+    <string name="widget_config_devices_none_known">No sync devices known yet.</string>
+    <string name="widget_empty_label">No matching devices</string>
+    <string name="widget_no_sync_devices_label">No sync devices yet</string>
+
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">No %1$s data for this device</string>
     <string name="widget_deeplink_module_power">battery</string>

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -18,7 +18,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 
 class ClipboardGlanceWidget : GlanceAppWidget() {
 
@@ -42,7 +42,9 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
 
         provideContent {
             val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val themeColors = WidgetTheme.parseThemeColors(widgetOptions)
+            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val themeColors = instanceConfig.themeColors
+            val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
             val metaState = metaRepo.state.collectAsState(initial = null)
             val clipboardState = clipboardRepo.state.collectAsState(initial = null)
@@ -60,6 +62,7 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
                 clipboardState = clipboardState.value,
                 themeColors = themeColors,
                 maxRows = maxRows,
+                allowedDeviceIds = allowedDeviceIds,
             )
         }
     }

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.clipboard.ui.widget
 
 import android.appwidget.AppWidgetManager
 import android.os.Bundle
+import android.text.format.DateUtils
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -16,6 +17,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -27,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -37,26 +43,34 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.common.R as CommonR
-import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.octi.common.debug.logging.asLog
-import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.theming.OctiTheme
 import eu.darken.octi.common.theming.ThemeSettings
 import eu.darken.octi.common.theming.ThemeState
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.applyWidgetConfig
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.modules.clipboard.ClipboardRepo
 import eu.darken.octi.modules.clipboard.R
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.core.MetaRepo
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
     @Inject lateinit var themeSettings: ThemeSettings
     @Inject lateinit var upgradeRepo: UpgradeRepo
+    @Inject lateinit var metaRepo: MetaRepo
+    @Inject lateinit var clipboardRepo: ClipboardRepo
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -84,26 +98,60 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
             val currentOptions = AppWidgetManager.getInstance(this@ClipboardWidgetConfigActivity)
                 .getAppWidgetOptions(appWidgetId)
-            val initialMode = currentOptions.getString(WidgetTheme.KEY_THEME_MODE)
-            val initialPreset = currentOptions.getString(WidgetTheme.KEY_THEME_PRESET)
-            val initialBg = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_BG)) {
-                currentOptions.getInt(WidgetTheme.KEY_CUSTOM_BG)
-            } else null
-            val initialAccent = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_ACCENT)) {
-                currentOptions.getInt(WidgetTheme.KEY_CUSTOM_ACCENT)
-            } else null
+            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
+
+            val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
+                val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
+                val clipState = clipboardRepo.state.first()
+                val selfId = (clipState as? BaseModuleRepo.State<*>)?.self?.deviceId?.id
+                val now = System.currentTimeMillis()
+                clipState.all
+                    .filter { it.deviceId.id != selfId }
+                    .mapNotNull { c ->
+                        val m = metaById[c.deviceId] ?: return@mapNotNull null
+                        WidgetConfigDevice(
+                            id = c.deviceId.id,
+                            label = m.data.labelOrFallback,
+                            subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
+                            icon = composeIconFor(m.data.deviceType),
+                        )
+                    }
+            }
+                .orEmpty()
+                .distinctBy { it.id }
+                .sortedBy { it.label.lowercase() }
 
             setContent {
                 val themeState by themeSettings.themeState.collectAsState(ThemeState())
                 OctiTheme(state = themeState) {
                     WidgetConfigScreen(
-                        initialMode = initialMode,
-                        initialPresetName = initialPreset,
-                        initialBgColor = initialBg,
-                        initialAccentColor = initialAccent,
+                        initialMode = if (instanceConfig.isMaterialYou) {
+                            WidgetInstanceConfig.MODE_MATERIAL_YOU
+                        } else {
+                            WidgetInstanceConfig.MODE_CUSTOM
+                        },
+                        initialPresetName = instanceConfig.presetName,
+                        initialBgColor = instanceConfig.customBg,
+                        initialAccentColor = instanceConfig.customAccent,
+                        availableDevices = availableDevices,
+                        initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
                         onClose = { finish() },
-                        onApply = { isMaterialYou, presetName, bgColor, accentColor ->
-                            applyAndFinish(isMaterialYou, presetName, bgColor, accentColor)
+                        onApply = { isMy, preset, bg, accent, ids ->
+                            val appContext = applicationContext
+                            applyWidgetConfig(
+                                appWidgetId = appWidgetId,
+                                newConfig = WidgetInstanceConfig(
+                                    isMaterialYou = isMy,
+                                    presetName = preset,
+                                    customBg = bg,
+                                    customAccent = accent,
+                                    allowedDeviceIds = ids,
+                                ),
+                                tag = TAG,
+                            ) {
+                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                ClipboardGlanceWidget().update(appContext, glanceId)
+                            }
                         },
                         previewContent = { colors -> ClipboardWidgetPreview(colors = colors) },
                     )
@@ -112,51 +160,26 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
         }
     }
 
-    private fun applyAndFinish(
-        isMaterialYou: Boolean,
-        presetName: String?,
-        bgColor: Int?,
-        accentColor: Int?,
-    ) {
-        val widgetManager = AppWidgetManager.getInstance(this)
-        val options = widgetManager.getAppWidgetOptions(appWidgetId)
-
-        if (isMaterialYou) {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_MATERIAL_YOU)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, WidgetTheme.MATERIAL_YOU.name)
-            options.remove(WidgetTheme.KEY_CUSTOM_BG)
-            options.remove(WidgetTheme.KEY_CUSTOM_ACCENT)
-        } else {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_CUSTOM)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, presetName ?: "")
-            val bg = bgColor ?: run { finish(); return }
-            val accent = accentColor ?: run { finish(); return }
-            options.putInt(WidgetTheme.KEY_CUSTOM_BG, bg)
-            options.putInt(WidgetTheme.KEY_CUSTOM_ACCENT, accent)
-        }
-
-        widgetManager.updateAppWidgetOptions(appWidgetId, options)
-
-        val appContext = applicationContext
-        lifecycleScope.launch {
-            try {
-                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                ClipboardGlanceWidget().update(appContext, glanceId)
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to update widget: ${e.asLog()}" }
-            }
-        }
-
-        setResult(
-            RESULT_OK,
-            android.content.Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
+    private fun lastSeenSubtitle(modifiedAtMillis: Long, nowMillis: Long): String {
+        val relative = DateUtils.getRelativeTimeSpanString(
+            modifiedAtMillis,
+            nowMillis,
+            DateUtils.MINUTE_IN_MILLIS,
+            DateUtils.FORMAT_ABBREV_RELATIVE,
         )
-        finish()
+        return getString(eu.darken.octi.sync.R.string.sync_device_last_seen_label, relative.toString())
     }
 
     companion object {
         private val TAG = logTag("Module", "Clipboard", "Widget", "Config")
+        private val DEVICE_LOAD_TIMEOUT = 2.seconds
     }
+}
+
+private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type) {
+    MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+    MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+    MetaInfo.DeviceType.UNKNOWN -> Icons.TwoTone.QuestionMark
 }
 
 @Composable

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -53,6 +51,7 @@ import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
+import eu.darken.octi.common.widget.widgetDefaultColors
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.modules.clipboard.ClipboardRepo
 import eu.darken.octi.modules.clipboard.R
@@ -184,13 +183,7 @@ private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type)
 
 @Composable
 private fun ClipboardWidgetPreview(colors: WidgetTheme.Colors?) {
-    val previewColors = colors ?: WidgetTheme.Colors(
-        containerBg = colorResource(CommonR.color.widgetContainerBackground).toArgb(),
-        barFill = colorResource(CommonR.color.widgetBarFill).toArgb(),
-        barTrack = colorResource(CommonR.color.widgetBarTrack).toArgb(),
-        icon = colorResource(CommonR.color.widgetBarIcon).toArgb(),
-        onContainer = colorResource(CommonR.color.widgetOnContainer).toArgb(),
-    )
+    val previewColors = colors ?: widgetDefaultColors()
 
     Card(shape = RoundedCornerShape(16.dp)) {
         Column(
@@ -204,7 +197,7 @@ private fun ClipboardWidgetPreview(colors: WidgetTheme.Colors?) {
                     .fillMaxWidth()
                     .height(36.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(previewColors.barTrack)),
+                    .background(Color(previewColors.tileBg)),
             ) {
                 Row(
                     modifier = Modifier
@@ -216,21 +209,21 @@ private fun ClipboardWidgetPreview(colors: WidgetTheme.Colors?) {
                         painter = painterResource(R.drawable.widget_device_phone_24),
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
-                        tint = Color(previewColors.icon),
+                        tint = Color(previewColors.onTile),
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         text = "Pixel 8",
                         fontSize = 11.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onTile),
                         maxLines = 1,
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         text = "Hello world\u2026",
                         fontSize = 10.sp,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onTileVariant),
                         maxLines = 1,
                     )
                 }
@@ -241,7 +234,7 @@ private fun ClipboardWidgetPreview(colors: WidgetTheme.Colors?) {
                     .fillMaxWidth()
                     .height(36.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(previewColors.barFill)),
+                    .background(Color(previewColors.accentBg)),
             ) {
                 Row(
                     modifier = Modifier
@@ -253,21 +246,21 @@ private fun ClipboardWidgetPreview(colors: WidgetTheme.Colors?) {
                         painter = painterResource(R.drawable.widget_clipboard_24),
                         contentDescription = null,
                         modifier = Modifier.size(18.dp),
-                        tint = Color(previewColors.icon),
+                        tint = Color(previewColors.onAccent),
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         text = stringResource(R.string.module_clipboard_widget_self_label),
                         fontSize = 11.sp,
                         fontWeight = FontWeight.Bold,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onAccent),
                         maxLines = 1,
                     )
                     Spacer(modifier = Modifier.width(6.dp))
                     Text(
                         text = "Hello world",
                         fontSize = 11.sp,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onAccent),
                         maxLines = 1,
                     )
                 }

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -107,13 +107,16 @@ fun ClipboardWidgetContent(
     clipboardState: ModuleRepo.State<*>?,
     themeColors: WidgetTheme.Colors?,
     maxRows: Int,
+    allowedDeviceIds: Set<String>? = null,
 ) {
     val self = extractSelf(clipboardState)
-    val devices = buildDeviceRows(metaState, clipboardState, self?.deviceId, maxRows)
+    val devices = buildDeviceRows(metaState, clipboardState, self?.deviceId, maxRows, allowedDeviceIds)
     val containerBg = themeColors?.containerBg
     val context = LocalContext.current
     val openApp = context.packageManager.getLaunchIntentForPackage(context.packageName)
         ?.let { actionStartActivity(it) }
+    val onContainer = colorOrDefault(themeColors?.onContainer, CommonR.color.widgetOnContainer)
+    val showEmptyState = devices.isEmpty() && maxRows > 0 && metaState != null && clipboardState != null
 
     GlanceTheme {
         Box(
@@ -133,13 +136,36 @@ fun ClipboardWidgetContent(
                 .padding(ClipboardWidgetSizing.OUTER_PADDING),
         ) {
             Column(modifier = GlanceModifier.fillMaxSize()) {
-                devices.forEachIndexed { index, device ->
-                    ClipboardDeviceRowContent(
-                        device = device,
-                        themeColors = themeColors,
-                    )
-                    if (index < devices.lastIndex) {
-                        Spacer(modifier = GlanceModifier.height(ClipboardWidgetSizing.ROW_SPACER))
+                if (showEmptyState) {
+                    val emptyStateRes = if (allowedDeviceIds.isNullOrEmpty()) {
+                        CommonR.string.widget_no_sync_devices_label
+                    } else {
+                        CommonR.string.widget_empty_label
+                    }
+                    Box(
+                        modifier = GlanceModifier
+                            .fillMaxWidth()
+                            .defaultWeight(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = context.getString(emptyStateRes),
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                color = onContainer,
+                            ),
+                            maxLines = 1,
+                        )
+                    }
+                } else {
+                    devices.forEachIndexed { index, device ->
+                        ClipboardDeviceRowContent(
+                            device = device,
+                            themeColors = themeColors,
+                        )
+                        if (index < devices.lastIndex) {
+                            Spacer(modifier = GlanceModifier.height(ClipboardWidgetSizing.ROW_SPACER))
+                        }
                     }
                 }
                 Spacer(modifier = GlanceModifier.height(ClipboardWidgetSizing.SELF_SECTION_SPACER))
@@ -169,6 +195,7 @@ private fun buildDeviceRows(
     clipboardState: ModuleRepo.State<*>?,
     selfDeviceId: String?,
     maxRows: Int,
+    allowedDeviceIds: Set<String>?,
 ): List<ClipboardDeviceRow> {
     if (metaState == null || clipboardState == null) return emptyList()
     if (maxRows <= 0) return emptyList()
@@ -180,6 +207,7 @@ private fun buildDeviceRows(
     return clipboardAll
         .asSequence()
         .filter { it.deviceId.id != selfDeviceId }
+        .filter { allowedDeviceIds.isNullOrEmpty() || it.deviceId.id in allowedDeviceIds }
         .mapNotNull { clipData ->
             val metaData = metaAll.firstOrNull { it.deviceId == clipData.deviceId }
             metaData?.let { clipData to it }

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -35,7 +35,6 @@ import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
-import androidx.core.content.ContextCompat
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
@@ -239,11 +238,9 @@ private fun ClipboardDeviceRowContent(
     themeColors: WidgetTheme.Colors?,
 ) {
     val context = LocalContext.current
-    val iconColorRaw = themeColors?.icon
-        ?: ContextCompat.getColor(context, CommonR.color.widgetBarIcon)
-    val iconColor = ColorProvider(Color(iconColorRaw))
-    val fadedIconColor = ColorProvider(Color(iconColorRaw).copy(alpha = 0.5f))
-    val barTrack = colorOrDefault(themeColors?.barTrack, CommonR.color.widgetBarTrack)
+    val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
+    val primaryColor = colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
+    val secondaryColor = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
 
     val rowAction = if (device.hasCopyableContent) {
         actionRunCallback<CopyClipboardCallback>(
@@ -253,14 +250,15 @@ private fun ClipboardDeviceRowContent(
         actionRunCallback<NoOpClickCallback>()
     }
 
-    val textColor = if (device.hasCopyableContent) iconColor else fadedIconColor
+    val titleColor = if (device.hasCopyableContent) primaryColor else secondaryColor
+    val bodyColor = secondaryColor
 
     Box(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(ClipboardWidgetSizing.ROW_HEIGHT)
             .cornerRadius(12.dp)
-            .background(barTrack)
+            .background(tileBg)
             .clickable(rowAction),
     ) {
         Row(
@@ -275,7 +273,7 @@ private fun ClipboardDeviceRowContent(
                     null
                 },
                 modifier = GlanceModifier.size(18.dp),
-                colorFilter = ColorFilter.tint(textColor),
+                colorFilter = ColorFilter.tint(titleColor),
             )
             Spacer(modifier = GlanceModifier.width(6.dp))
             Text(
@@ -283,7 +281,7 @@ private fun ClipboardDeviceRowContent(
                 style = TextStyle(
                     fontWeight = FontWeight.Bold,
                     fontSize = 11.sp,
-                    color = textColor,
+                    color = titleColor,
                 ),
                 maxLines = 1,
             )
@@ -293,7 +291,7 @@ private fun ClipboardDeviceRowContent(
                     text = device.clipboardText ?: "",
                     style = TextStyle(
                         fontSize = 10.sp,
-                        color = textColor,
+                        color = bodyColor,
                     ),
                     maxLines = 1,
                     modifier = GlanceModifier.defaultWeight(),
@@ -304,7 +302,7 @@ private fun ClipboardDeviceRowContent(
                     style = TextStyle(
                         fontSize = 10.sp,
                         fontStyle = FontStyle.Italic,
-                        color = textColor,
+                        color = bodyColor,
                     ),
                     maxLines = 1,
                     modifier = GlanceModifier.defaultWeight(),
@@ -320,8 +318,8 @@ private fun SelfClipboardRow(
     themeColors: WidgetTheme.Colors?,
 ) {
     val context = LocalContext.current
-    val iconColor = colorOrDefault(themeColors?.icon, CommonR.color.widgetBarIcon)
-    val barFill = colorOrDefault(themeColors?.barFill, CommonR.color.widgetBarFill)
+    val accentContent = colorOrDefault(themeColors?.onAccent, CommonR.color.widgetOnAccent)
+    val accentBg = colorOrDefault(themeColors?.accentBg, CommonR.color.widgetAccentBackground)
 
     val shareAction = actionStartActivity(ClipboardShareActivity.createIntent(context))
 
@@ -330,7 +328,7 @@ private fun SelfClipboardRow(
             .fillMaxWidth()
             .height(ClipboardWidgetSizing.ROW_HEIGHT)
             .cornerRadius(12.dp)
-            .background(barFill)
+            .background(accentBg)
             .clickable(shareAction),
     ) {
         Row(
@@ -341,7 +339,7 @@ private fun SelfClipboardRow(
                 provider = ImageProvider(R.drawable.widget_clipboard_24),
                 contentDescription = context.getString(R.string.module_clipboard_widget_share_action),
                 modifier = GlanceModifier.size(18.dp),
-                colorFilter = ColorFilter.tint(iconColor),
+                colorFilter = ColorFilter.tint(accentContent),
             )
             Spacer(modifier = GlanceModifier.width(6.dp))
             Text(
@@ -349,7 +347,7 @@ private fun SelfClipboardRow(
                 style = TextStyle(
                     fontWeight = FontWeight.Bold,
                     fontSize = 11.sp,
-                    color = iconColor,
+                    color = accentContent,
                 ),
                 maxLines = 1,
             )
@@ -359,7 +357,7 @@ private fun SelfClipboardRow(
                 style = TextStyle(
                     fontStyle = if (self?.text == null) FontStyle.Italic else FontStyle.Normal,
                     fontSize = 11.sp,
-                    color = iconColor,
+                    color = accentContent,
                 ),
                 maxLines = 1,
                 modifier = GlanceModifier.defaultWeight(),

--- a/modules-clipboard/src/main/res/layout/module_clipboard_widget_preview.xml
+++ b/modules-clipboard/src/main/res/layout/module_clipboard_widget_preview.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/widgetContainerBackground"
+    android:background="@drawable/widget_preview_container"
     android:clipToOutline="true"
     android:orientation="vertical"
     android:padding="8dp">
@@ -10,7 +10,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="36dp"
-        android:background="@color/widgetBarTrack"
+        android:background="@drawable/widget_preview_tile"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="10dp"
@@ -43,14 +43,11 @@
             android:textSize="10sp" />
     </LinearLayout>
 
-    <Space
-        android:layout_width="match_parent"
-        android:layout_height="2dp" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="36dp"
-        android:background="@color/widgetBarTrack"
+        android:layout_marginTop="2dp"
+        android:background="@drawable/widget_preview_tile"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="10dp"
@@ -83,14 +80,11 @@
             android:textSize="10sp" />
     </LinearLayout>
 
-    <Space
-        android:layout_width="match_parent"
-        android:layout_height="4dp" />
-
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="36dp"
-        android:background="@color/widgetBarTrack"
+        android:layout_marginTop="4dp"
+        android:background="@drawable/widget_preview_accent_tile"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="10dp"

--- a/modules-clipboard/src/main/res/layout/module_clipboard_widget_preview.xml
+++ b/modules-clipboard/src/main/res/layout/module_clipboard_widget_preview.xml
@@ -20,14 +20,14 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/widget_device_phone_24"
-            android:tint="@color/widgetBarIcon" />
+            android:tint="@color/widgetOnTile" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
             android:text="Pixel 8"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTile"
             android:textSize="11sp"
             android:textStyle="bold" />
 
@@ -39,7 +39,7 @@
             android:ellipsize="end"
             android:singleLine="true"
             android:text="Meeting notes…"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
     </LinearLayout>
 
@@ -57,14 +57,14 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/widget_device_tablet_24"
-            android:tint="@color/widgetBarIcon" />
+            android:tint="@color/widgetOnTile" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
             android:text="Galaxy Tab"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTile"
             android:textSize="11sp"
             android:textStyle="bold" />
 
@@ -76,7 +76,7 @@
             android:ellipsize="end"
             android:singleLine="true"
             android:text="Shopping list…"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
     </LinearLayout>
 
@@ -94,14 +94,14 @@
             android:layout_width="18dp"
             android:layout_height="18dp"
             android:src="@drawable/widget_clipboard_24"
-            android:tint="@color/widgetBarIcon" />
+            android:tint="@color/widgetOnAccent" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="6dp"
             android:text="@string/module_clipboard_widget_self_label"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnAccent"
             android:textSize="11sp"
             android:textStyle="bold" />
 
@@ -113,7 +113,7 @@
             android:ellipsize="end"
             android:singleLine="true"
             android:text="Hello world"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnAccent"
             android:textSize="11sp" />
     </LinearLayout>
 </LinearLayout>

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
@@ -1,9 +1,11 @@
 package eu.darken.octi.modules.clipboard.ui.widget
 
+import android.content.Context
 import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
 import androidx.glance.testing.unit.hasContentDescription
 import androidx.glance.testing.unit.hasText
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleId
@@ -64,25 +66,29 @@ class ClipboardWidgetContentGlanceTest {
     private fun fakeClipboardState(
         self: ClipboardInfo = ClipboardInfo(),
         remote: ClipboardInfo? = null,
+        extraRemotes: List<Pair<DeviceId, ClipboardInfo>> = emptyList(),
     ): BaseModuleRepo.State<ClipboardInfo> = BaseModuleRepo.State(
         moduleId = clipboardModuleId,
         self = clipboardModuleData(selfDeviceId, self),
         isOthersInitialized = true,
-        others = listOfNotNull(
-            remote?.let { clipboardModuleData(remoteDeviceId, it) },
-        ),
+        others = buildList {
+            remote?.let { add(clipboardModuleData(remoteDeviceId, it)) }
+            extraRemotes.forEach { (id, info) -> add(clipboardModuleData(id, info)) }
+        },
     )
 
     private fun fakeMetaState(
         selfLabel: String = "MyPhone",
         remoteLabel: String? = null,
+        extraRemotes: List<Pair<DeviceId, String>> = emptyList(),
     ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
         moduleId = metaModuleId,
         self = metaModuleData(selfDeviceId, selfLabel),
         isOthersInitialized = true,
-        others = listOfNotNull(
-            remoteLabel?.let { metaModuleData(remoteDeviceId, it) },
-        ),
+        others = buildList {
+            remoteLabel?.let { add(metaModuleData(remoteDeviceId, it)) }
+            extraRemotes.forEach { (id, label) -> add(metaModuleData(id, label)) }
+        },
     )
 
     @Test
@@ -137,5 +143,120 @@ class ClipboardWidgetContentGlanceTest {
         MetaInfo.DeviceType.PHONE.widgetIconRes() shouldBe R.drawable.widget_device_phone_24
         MetaInfo.DeviceType.TABLET.widgetIconRes() shouldBe R.drawable.widget_device_tablet_24
         MetaInfo.DeviceType.UNKNOWN.widgetIconRes() shouldBe R.drawable.widget_device_unknown_24
+    }
+
+    @Test
+    fun `filter with matching remote id keeps remote row and self row`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(remoteLabel = "Pixel 9"),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(
+                        type = ClipboardInfo.Type.SIMPLE_TEXT,
+                        data = "Hello".encodeUtf8(),
+                    ),
+                ),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf(remoteDeviceId.id),
+            )
+        }
+        onNode(hasText("Pixel 9")).assertExists()
+        onNode(hasText("You")).assertExists()
+    }
+
+    @Test
+    fun `filter with unknown id hides remote rows but keeps self row`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(remoteLabel = "Pixel 9"),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(
+                        type = ClipboardInfo.Type.SIMPLE_TEXT,
+                        data = "Hello".encodeUtf8(),
+                    ),
+                ),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf("unknown-device-id"),
+            )
+        }
+        onNode(hasText("Pixel 9")).assertDoesNotExist()
+        onNode(hasText("You")).assertExists()
+        onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertExists()
+    }
+
+    @Test
+    fun `filter targeting self id renders empty state and keeps self share row`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(remoteLabel = "Pixel 9"),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(
+                        type = ClipboardInfo.Type.SIMPLE_TEXT,
+                        data = "Hello".encodeUtf8(),
+                    ),
+                ),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf(selfDeviceId.id),
+            )
+        }
+        onNode(hasText("Pixel 9")).assertDoesNotExist()
+        onNode(hasText("You")).assertExists()
+        onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertExists()
+    }
+
+    @Test
+    fun `unfiltered empty remote list renders the no-sync-devices label`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(remoteLabel = null),
+                clipboardState = fakeClipboardState(remote = null),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = null,
+            )
+        }
+        onNode(hasText(context.getString(CommonR.string.widget_no_sync_devices_label))).assertExists()
+        onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertDoesNotExist()
+        onNode(hasText("You")).assertExists()
+    }
+
+    @Test
+    fun `filter is applied before take so a late-sorting selection survives small maxRows`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        val aId = DeviceId("a-phone")
+        val mId = DeviceId("m-phone")
+        val zId = DeviceId("z-phone")
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(
+                    remoteLabel = null,
+                    extraRemotes = listOf(aId to "Alpha", mId to "Mike", zId to "Zulu"),
+                ),
+                clipboardState = fakeClipboardState(
+                    remote = null,
+                    extraRemotes = listOf(
+                        aId to ClipboardInfo(type = ClipboardInfo.Type.SIMPLE_TEXT, data = "a".encodeUtf8()),
+                        mId to ClipboardInfo(type = ClipboardInfo.Type.SIMPLE_TEXT, data = "m".encodeUtf8()),
+                        zId to ClipboardInfo(type = ClipboardInfo.Type.SIMPLE_TEXT, data = "z".encodeUtf8()),
+                    ),
+                ),
+                themeColors = null,
+                maxRows = 1,
+                allowedDeviceIds = setOf(zId.id),
+            )
+        }
+        onNode(hasText("Zulu")).assertExists()
+        onNode(hasText("Alpha")).assertDoesNotExist()
+        onNode(hasText("Mike")).assertDoesNotExist()
     }
 }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -18,7 +18,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 
 class NetworkGlanceWidget : GlanceAppWidget() {
 
@@ -42,7 +42,9 @@ class NetworkGlanceWidget : GlanceAppWidget() {
 
         provideContent {
             val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val themeColors = WidgetTheme.parseThemeColors(widgetOptions)
+            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val themeColors = instanceConfig.themeColors
+            val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
             val metaState = metaRepo.state.collectAsState(initial = null)
             val connectivityState = connectivityRepo.state.collectAsState(initial = null)
@@ -68,6 +70,7 @@ class NetworkGlanceWidget : GlanceAppWidget() {
                 themeColors = themeColors,
                 maxRows = maxRows,
                 widthDp = widthDp,
+                allowedDeviceIds = allowedDeviceIds,
             )
         }
     }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.connectivity.ui.widget
 
 import android.appwidget.AppWidgetManager
 import android.os.Bundle
+import android.text.format.DateUtils
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -15,6 +16,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -26,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -35,26 +41,33 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.common.R as CommonR
-import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.octi.common.debug.logging.asLog
-import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.theming.OctiTheme
 import eu.darken.octi.common.theming.ThemeSettings
 import eu.darken.octi.common.theming.ThemeState
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.applyWidgetConfig
 import eu.darken.octi.modules.connectivity.R
+import eu.darken.octi.modules.connectivity.core.ConnectivityRepo
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.core.MetaRepo
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
     @Inject lateinit var themeSettings: ThemeSettings
     @Inject lateinit var upgradeRepo: UpgradeRepo
+    @Inject lateinit var metaRepo: MetaRepo
+    @Inject lateinit var connectivityRepo: ConnectivityRepo
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -82,26 +95,56 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
             val currentOptions = AppWidgetManager.getInstance(this@NetworkWidgetConfigActivity)
                 .getAppWidgetOptions(appWidgetId)
-            val initialMode = currentOptions.getString(WidgetTheme.KEY_THEME_MODE)
-            val initialPreset = currentOptions.getString(WidgetTheme.KEY_THEME_PRESET)
-            val initialBg = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_BG)) {
-                currentOptions.getInt(WidgetTheme.KEY_CUSTOM_BG)
-            } else null
-            val initialAccent = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_ACCENT)) {
-                currentOptions.getInt(WidgetTheme.KEY_CUSTOM_ACCENT)
-            } else null
+            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
+
+            val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
+                val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
+                val now = System.currentTimeMillis()
+                connectivityRepo.state.first().all.mapNotNull { c ->
+                    val m = metaById[c.deviceId] ?: return@mapNotNull null
+                    WidgetConfigDevice(
+                        id = c.deviceId.id,
+                        label = m.data.labelOrFallback,
+                        subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
+                        icon = composeIconFor(m.data.deviceType),
+                    )
+                }
+            }
+                .orEmpty()
+                .distinctBy { it.id }
+                .sortedBy { it.label.lowercase() }
 
             setContent {
                 val themeState by themeSettings.themeState.collectAsState(ThemeState())
                 OctiTheme(state = themeState) {
                     WidgetConfigScreen(
-                        initialMode = initialMode,
-                        initialPresetName = initialPreset,
-                        initialBgColor = initialBg,
-                        initialAccentColor = initialAccent,
+                        initialMode = if (instanceConfig.isMaterialYou) {
+                            WidgetInstanceConfig.MODE_MATERIAL_YOU
+                        } else {
+                            WidgetInstanceConfig.MODE_CUSTOM
+                        },
+                        initialPresetName = instanceConfig.presetName,
+                        initialBgColor = instanceConfig.customBg,
+                        initialAccentColor = instanceConfig.customAccent,
+                        availableDevices = availableDevices,
+                        initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
                         onClose = { finish() },
-                        onApply = { isMaterialYou, presetName, bgColor, accentColor ->
-                            applyAndFinish(isMaterialYou, presetName, bgColor, accentColor)
+                        onApply = { isMy, preset, bg, accent, ids ->
+                            val appContext = applicationContext
+                            applyWidgetConfig(
+                                appWidgetId = appWidgetId,
+                                newConfig = WidgetInstanceConfig(
+                                    isMaterialYou = isMy,
+                                    presetName = preset,
+                                    customBg = bg,
+                                    customAccent = accent,
+                                    allowedDeviceIds = ids,
+                                ),
+                                tag = TAG,
+                            ) {
+                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                NetworkGlanceWidget().update(appContext, glanceId)
+                            }
                         },
                         previewContent = { colors -> NetworkWidgetPreview(colors = colors) },
                     )
@@ -110,51 +153,26 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
         }
     }
 
-    private fun applyAndFinish(
-        isMaterialYou: Boolean,
-        presetName: String?,
-        bgColor: Int?,
-        accentColor: Int?,
-    ) {
-        val widgetManager = AppWidgetManager.getInstance(this)
-        val options = widgetManager.getAppWidgetOptions(appWidgetId)
-
-        if (isMaterialYou) {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_MATERIAL_YOU)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, WidgetTheme.MATERIAL_YOU.name)
-            options.remove(WidgetTheme.KEY_CUSTOM_BG)
-            options.remove(WidgetTheme.KEY_CUSTOM_ACCENT)
-        } else {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_CUSTOM)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, presetName ?: "")
-            val bg = bgColor ?: run { finish(); return }
-            val accent = accentColor ?: run { finish(); return }
-            options.putInt(WidgetTheme.KEY_CUSTOM_BG, bg)
-            options.putInt(WidgetTheme.KEY_CUSTOM_ACCENT, accent)
-        }
-
-        widgetManager.updateAppWidgetOptions(appWidgetId, options)
-
-        val appContext = applicationContext
-        lifecycleScope.launch {
-            try {
-                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                NetworkGlanceWidget().update(appContext, glanceId)
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to update widget: ${e.asLog()}" }
-            }
-        }
-
-        setResult(
-            RESULT_OK,
-            android.content.Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
+    private fun lastSeenSubtitle(modifiedAtMillis: Long, nowMillis: Long): String {
+        val relative = DateUtils.getRelativeTimeSpanString(
+            modifiedAtMillis,
+            nowMillis,
+            DateUtils.MINUTE_IN_MILLIS,
+            DateUtils.FORMAT_ABBREV_RELATIVE,
         )
-        finish()
+        return getString(eu.darken.octi.sync.R.string.sync_device_last_seen_label, relative.toString())
     }
 
     companion object {
         private val TAG = logTag("Module", "Connectivity", "Widget", "Config")
+        private val DEVICE_LOAD_TIMEOUT = 2.seconds
     }
+}
+
+private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type) {
+    MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+    MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+    MetaInfo.DeviceType.UNKNOWN -> Icons.TwoTone.QuestionMark
 }
 
 @Composable

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
@@ -30,9 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -51,6 +49,7 @@ import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
+import eu.darken.octi.common.widget.widgetDefaultColors
 import eu.darken.octi.modules.connectivity.R
 import eu.darken.octi.modules.connectivity.core.ConnectivityRepo
 import eu.darken.octi.modules.meta.core.MetaInfo
@@ -177,13 +176,7 @@ private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type)
 
 @Composable
 private fun NetworkWidgetPreview(colors: WidgetTheme.Colors?) {
-    val previewColors = colors ?: WidgetTheme.Colors(
-        containerBg = colorResource(CommonR.color.widgetContainerBackground).toArgb(),
-        barFill = colorResource(CommonR.color.widgetBarFill).toArgb(),
-        barTrack = colorResource(CommonR.color.widgetBarTrack).toArgb(),
-        icon = colorResource(CommonR.color.widgetBarIcon).toArgb(),
-        onContainer = colorResource(CommonR.color.widgetOnContainer).toArgb(),
-    )
+    val previewColors = colors ?: widgetDefaultColors()
 
     Card(shape = RoundedCornerShape(16.dp)) {
         Column(
@@ -196,7 +189,7 @@ private fun NetworkWidgetPreview(colors: WidgetTheme.Colors?) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(previewColors.barTrack))
+                    .background(Color(previewColors.tileBg))
                     .padding(horizontal = 10.dp, vertical = 6.dp),
             ) {
                 Column(modifier = Modifier.fillMaxWidth()) {
@@ -208,21 +201,21 @@ private fun NetworkWidgetPreview(colors: WidgetTheme.Colors?) {
                             painter = painterResource(R.drawable.widget_network_wifi_24),
                             contentDescription = null,
                             modifier = Modifier.size(18.dp),
-                            tint = Color(previewColors.icon),
+                            tint = Color(previewColors.onTile),
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = "Pixel 8",
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Bold,
-                            color = Color(previewColors.icon),
+                            color = Color(previewColors.onTile),
                             maxLines = 1,
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
                             text = "\u00b7 Wi-Fi",
                             fontSize = 10.sp,
-                            color = Color(previewColors.icon),
+                            color = Color(previewColors.onTileVariant),
                             maxLines = 1,
                         )
                     }
@@ -230,13 +223,13 @@ private fun NetworkWidgetPreview(colors: WidgetTheme.Colors?) {
                     Text(
                         text = "192.168.1.5",
                         fontSize = 10.sp,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onTileVariant),
                         maxLines = 1,
                     )
                     Text(
                         text = "203.0.113.1",
                         fontSize = 10.sp,
-                        color = Color(previewColors.icon),
+                        color = Color(previewColors.onTileVariant),
                         maxLines = 1,
                     )
                 }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -72,13 +72,16 @@ fun NetworkWidgetContent(
     themeColors: WidgetTheme.Colors?,
     maxRows: Int,
     widthDp: Float,
+    allowedDeviceIds: Set<String>? = null,
 ) {
-    val devices = buildDeviceTiles(metaState, connectivityState, maxRows)
+    val devices = buildDeviceTiles(metaState, connectivityState, maxRows, allowedDeviceIds)
     val containerBg = themeColors?.containerBg
     val context = LocalContext.current
     val openApp = context.packageManager.getLaunchIntentForPackage(context.packageName)
         ?.let { actionStartActivity(it) }
     val useTwoColumn = widthDp >= NetworkWidgetSizing.TWO_COLUMN_MIN_WIDTH_DP
+    val onContainer = colorOrDefault(themeColors?.onContainer, CommonR.color.widgetOnContainer)
+    val showEmptyState = devices.isEmpty() && maxRows > 0 && metaState != null && connectivityState != null
 
     GlanceTheme {
         Box(
@@ -97,7 +100,26 @@ fun NetworkWidgetContent(
                 )
                 .padding(NetworkWidgetSizing.OUTER_PADDING),
         ) {
-            Column(modifier = GlanceModifier.fillMaxSize()) {
+            if (showEmptyState) {
+                val emptyStateRes = if (allowedDeviceIds.isNullOrEmpty()) {
+                    CommonR.string.widget_no_sync_devices_label
+                } else {
+                    CommonR.string.widget_empty_label
+                }
+                Box(
+                    modifier = GlanceModifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = context.getString(emptyStateRes),
+                        style = TextStyle(
+                            fontSize = 12.sp,
+                            color = onContainer,
+                        ),
+                        maxLines = 1,
+                    )
+                }
+            } else Column(modifier = GlanceModifier.fillMaxSize()) {
                 if (useTwoColumn) {
                     val pairs = devices.chunked(2)
                     pairs.forEachIndexed { rowIndex, pair ->
@@ -143,6 +165,7 @@ private fun buildDeviceTiles(
     metaState: ModuleRepo.State<*>?,
     connectivityState: ModuleRepo.State<*>?,
     maxRows: Int,
+    allowedDeviceIds: Set<String>?,
 ): List<NetworkDeviceTile> {
     if (metaState == null || connectivityState == null) return emptyList()
     if (maxRows <= 0) return emptyList()
@@ -156,6 +179,10 @@ private fun buildDeviceTiles(
         .mapNotNull { connData ->
             val metaData = metaAll.firstOrNull { it.deviceId == connData.deviceId }
             metaData?.let { connData to it }
+        }
+        .let { pairs ->
+            if (allowedDeviceIds.isNullOrEmpty()) pairs
+            else pairs.filter { (connData, _) -> connData.deviceId.id in allowedDeviceIds }
         }
         .sortedBy { (_, metaData) -> metaData.data.labelOrFallback.lowercase() }
         .take(maxRows)

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -227,8 +227,9 @@ private fun NetworkDeviceTileContent(
     modifier: GlanceModifier = GlanceModifier,
 ) {
     val context = LocalContext.current
-    val iconColor = colorOrDefault(themeColors?.icon, CommonR.color.widgetBarIcon)
-    val barTrack = colorOrDefault(themeColors?.barTrack, CommonR.color.widgetBarTrack)
+    val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
+    val titleColor = colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
+    val detailColor = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
     val iconRes = connectionIconRes(device.connectionType)
 
     val copyAction = actionRunCallback<CopyNetworkAddressesCallback>(
@@ -239,7 +240,7 @@ private fun NetworkDeviceTileContent(
         modifier = modifier
             .height(NetworkWidgetSizing.TILE_HEIGHT)
             .cornerRadius(12.dp)
-            .background(barTrack)
+            .background(tileBg)
             .clickable(copyAction),
     ) {
         Column(
@@ -253,7 +254,7 @@ private fun NetworkDeviceTileContent(
                     provider = ImageProvider(iconRes),
                     contentDescription = null,
                     modifier = GlanceModifier.size(16.dp),
-                    colorFilter = ColorFilter.tint(iconColor),
+                    colorFilter = ColorFilter.tint(titleColor),
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
@@ -261,7 +262,7 @@ private fun NetworkDeviceTileContent(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 11.sp,
-                        color = iconColor,
+                        color = titleColor,
                     ),
                     maxLines = 1,
                 )
@@ -271,7 +272,7 @@ private fun NetworkDeviceTileContent(
                 text = "${connectionTypeLabel(context, device.connectionType)} \u00b7 ${device.lastSeen}",
                 style = TextStyle(
                     fontSize = 10.sp,
-                    color = iconColor,
+                    color = detailColor,
                 ),
                 maxLines = 1,
             )
@@ -280,7 +281,7 @@ private fun NetworkDeviceTileContent(
                 text = device.localIp,
                 style = TextStyle(
                     fontSize = 10.sp,
-                    color = iconColor,
+                    color = detailColor,
                 ),
                 maxLines = 1,
             )
@@ -288,7 +289,7 @@ private fun NetworkDeviceTileContent(
                 text = device.publicIp,
                 style = TextStyle(
                     fontSize = 10.sp,
-                    color = iconColor,
+                    color = detailColor,
                 ),
                 maxLines = 1,
             )
@@ -302,8 +303,9 @@ private fun NetworkDeviceCompactRow(
     themeColors: WidgetTheme.Colors?,
 ) {
     val context = LocalContext.current
-    val iconColor = colorOrDefault(themeColors?.icon, CommonR.color.widgetBarIcon)
-    val barTrack = colorOrDefault(themeColors?.barTrack, CommonR.color.widgetBarTrack)
+    val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
+    val titleColor = colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
+    val detailColor = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
     val iconRes = connectionIconRes(device.connectionType)
 
     val copyAction = actionRunCallback<CopyNetworkAddressesCallback>(
@@ -315,7 +317,7 @@ private fun NetworkDeviceCompactRow(
             .fillMaxWidth()
             .height(NetworkWidgetSizing.SINGLE_ROW_HEIGHT)
             .cornerRadius(12.dp)
-            .background(barTrack)
+            .background(tileBg)
             .clickable(copyAction),
     ) {
         Column(
@@ -329,7 +331,7 @@ private fun NetworkDeviceCompactRow(
                     provider = ImageProvider(iconRes),
                     contentDescription = null,
                     modifier = GlanceModifier.size(16.dp),
-                    colorFilter = ColorFilter.tint(iconColor),
+                    colorFilter = ColorFilter.tint(titleColor),
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
@@ -337,7 +339,7 @@ private fun NetworkDeviceCompactRow(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 11.sp,
-                        color = iconColor,
+                        color = titleColor,
                     ),
                     maxLines = 1,
                 )
@@ -346,7 +348,7 @@ private fun NetworkDeviceCompactRow(
                     text = "\u00b7 ${device.lastSeen}",
                     style = TextStyle(
                         fontSize = 10.sp,
-                        color = iconColor,
+                        color = detailColor,
                     ),
                     maxLines = 1,
                 )
@@ -355,7 +357,7 @@ private fun NetworkDeviceCompactRow(
                 text = "${device.localIp} \u00b7 ${device.publicIp}",
                 style = TextStyle(
                     fontSize = 10.sp,
-                    color = iconColor,
+                    color = detailColor,
                 ),
                 maxLines = 1,
             )

--- a/modules-connectivity/src/main/res/layout/module_connectivity_widget_preview.xml
+++ b/modules-connectivity/src/main/res/layout/module_connectivity_widget_preview.xml
@@ -29,14 +29,14 @@
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:src="@drawable/widget_network_wifi_24"
-                android:tint="@color/widgetBarIcon" />
+                android:tint="@color/widgetOnTile" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="Pixel 8"
-                android:textColor="@color/widgetBarIcon"
+                android:textColor="@color/widgetOnTile"
                 android:textSize="11sp"
                 android:textStyle="bold" />
 
@@ -45,7 +45,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="· 5m ago"
-                android:textColor="@color/widgetBarIcon"
+                android:textColor="@color/widgetOnTileVariant"
                 android:textSize="10sp" />
         </LinearLayout>
 
@@ -53,14 +53,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="192.168.1.5"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="203.0.113.1"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
     </LinearLayout>
 
@@ -86,14 +86,14 @@
                 android:layout_width="18dp"
                 android:layout_height="18dp"
                 android:src="@drawable/widget_network_cellular_24"
-                android:tint="@color/widgetBarIcon" />
+                android:tint="@color/widgetOnTile" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="Galaxy S24"
-                android:textColor="@color/widgetBarIcon"
+                android:textColor="@color/widgetOnTile"
                 android:textSize="11sp"
                 android:textStyle="bold" />
 
@@ -102,7 +102,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="4dp"
                 android:text="· 10m ago"
-                android:textColor="@color/widgetBarIcon"
+                android:textColor="@color/widgetOnTileVariant"
                 android:textSize="10sp" />
         </LinearLayout>
 
@@ -110,14 +110,14 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="10.0.0.12"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="198.51.100.7"
-            android:textColor="@color/widgetBarIcon"
+            android:textColor="@color/widgetOnTileVariant"
             android:textSize="10sp" />
     </LinearLayout>
 </LinearLayout>

--- a/modules-connectivity/src/main/res/layout/module_connectivity_widget_preview.xml
+++ b/modules-connectivity/src/main/res/layout/module_connectivity_widget_preview.xml
@@ -2,19 +2,22 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/widgetContainerBackground"
+    android:background="@drawable/widget_preview_container"
     android:clipToOutline="true"
+    android:gravity="center_vertical"
     android:orientation="vertical"
     android:padding="8dp">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:background="@drawable/widget_preview_tile"
         android:orientation="vertical"
         android:paddingStart="10dp"
         android:paddingEnd="10dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp">
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -49,20 +52,29 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="192.168.1.5 · 203.0.113.1"
+            android:text="192.168.1.5"
+            android:textColor="@color/widgetBarIcon"
+            android:textSize="10sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="203.0.113.1"
             android:textColor="@color/widgetBarIcon"
             android:textSize="10sp" />
     </LinearLayout>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="2dp"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="4dp"
+        android:background="@drawable/widget_preview_tile"
         android:orientation="vertical"
         android:paddingStart="10dp"
         android:paddingEnd="10dp"
-        android:paddingTop="4dp"
-        android:paddingBottom="4dp">
+        android:paddingTop="6dp"
+        android:paddingBottom="6dp">
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -97,7 +109,14 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="10.0.0.12 · 198.51.100.7"
+            android:text="10.0.0.12"
+            android:textColor="@color/widgetBarIcon"
+            android:textSize="10sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="198.51.100.7"
             android:textColor="@color/widgetBarIcon"
             android:textSize="10sp" />
     </LinearLayout>

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.power.ui.widget
 
 import android.appwidget.AppWidgetManager
 import android.os.Bundle
+import android.text.format.DateUtils
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -16,6 +17,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -27,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -38,23 +44,31 @@ import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.octi.common.debug.logging.asLog
-import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.theming.OctiTheme
 import eu.darken.octi.common.theming.ThemeSettings
 import eu.darken.octi.common.theming.ThemeState
+import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.applyWidgetConfig
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.modules.power.R
+import eu.darken.octi.modules.power.core.PowerRepo
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
 
 @AndroidEntryPoint
 class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
     @Inject lateinit var themeSettings: ThemeSettings
+    @Inject lateinit var metaRepo: MetaRepo
+    @Inject lateinit var powerRepo: PowerRepo
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -73,79 +87,87 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
             return
         }
 
-        val currentOptions = AppWidgetManager.getInstance(this).getAppWidgetOptions(appWidgetId)
-        val initialMode = currentOptions.getString(WidgetTheme.KEY_THEME_MODE)
-        val initialPreset = currentOptions.getString(WidgetTheme.KEY_THEME_PRESET)
-        val initialBg = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_BG)) {
-            currentOptions.getInt(WidgetTheme.KEY_CUSTOM_BG)
-        } else null
-        val initialAccent = if (currentOptions.containsKey(WidgetTheme.KEY_CUSTOM_ACCENT)) {
-            currentOptions.getInt(WidgetTheme.KEY_CUSTOM_ACCENT)
-        } else null
+        lifecycleScope.launch {
+            val currentOptions = AppWidgetManager.getInstance(this@BatteryWidgetConfigActivity)
+                .getAppWidgetOptions(appWidgetId)
+            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
 
-        setContent {
-            val themeState by themeSettings.themeState.collectAsState(ThemeState())
-            OctiTheme(state = themeState) {
-                WidgetConfigScreen(
-                    initialMode = initialMode,
-                    initialPresetName = initialPreset,
-                    initialBgColor = initialBg,
-                    initialAccentColor = initialAccent,
-                    onClose = { finish() },
-                    onApply = { isMaterialYou, presetName, bgColor, accentColor ->
-                        applyAndFinish(isMaterialYou, presetName, bgColor, accentColor)
-                    },
-                    previewContent = { colors -> BatteryWidgetPreview(colors = colors) },
-                )
+            val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
+                val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
+                val now = System.currentTimeMillis()
+                powerRepo.state.first().all.mapNotNull { p ->
+                    val m = metaById[p.deviceId] ?: return@mapNotNull null
+                    WidgetConfigDevice(
+                        id = p.deviceId.id,
+                        label = m.data.labelOrFallback,
+                        subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
+                        icon = composeIconFor(m.data.deviceType),
+                    )
+                }
+            }
+                .orEmpty()
+                .distinctBy { it.id }
+                .sortedBy { it.label.lowercase() }
+
+            setContent {
+                val themeState by themeSettings.themeState.collectAsState(ThemeState())
+                OctiTheme(state = themeState) {
+                    WidgetConfigScreen(
+                        initialMode = if (instanceConfig.isMaterialYou) {
+                            WidgetInstanceConfig.MODE_MATERIAL_YOU
+                        } else {
+                            WidgetInstanceConfig.MODE_CUSTOM
+                        },
+                        initialPresetName = instanceConfig.presetName,
+                        initialBgColor = instanceConfig.customBg,
+                        initialAccentColor = instanceConfig.customAccent,
+                        availableDevices = availableDevices,
+                        initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
+                        onClose = { finish() },
+                        onApply = { isMy, preset, bg, accent, ids ->
+                            val appContext = applicationContext
+                            applyWidgetConfig(
+                                appWidgetId = appWidgetId,
+                                newConfig = WidgetInstanceConfig(
+                                    isMaterialYou = isMy,
+                                    presetName = preset,
+                                    customBg = bg,
+                                    customAccent = accent,
+                                    allowedDeviceIds = ids,
+                                ),
+                                tag = TAG,
+                            ) {
+                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                BatteryGlanceWidget().update(appContext, glanceId)
+                            }
+                        },
+                        previewContent = { colors -> BatteryWidgetPreview(colors = colors) },
+                    )
+                }
             }
         }
     }
 
-    private fun applyAndFinish(
-        isMaterialYou: Boolean,
-        presetName: String?,
-        bgColor: Int?,
-        accentColor: Int?,
-    ) {
-        val widgetManager = AppWidgetManager.getInstance(this)
-        val options = widgetManager.getAppWidgetOptions(appWidgetId)
-
-        if (isMaterialYou) {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_MATERIAL_YOU)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, WidgetTheme.MATERIAL_YOU.name)
-            options.remove(WidgetTheme.KEY_CUSTOM_BG)
-            options.remove(WidgetTheme.KEY_CUSTOM_ACCENT)
-        } else {
-            options.putString(WidgetTheme.KEY_THEME_MODE, WidgetTheme.MODE_CUSTOM)
-            options.putString(WidgetTheme.KEY_THEME_PRESET, presetName ?: "")
-            val bg = bgColor ?: run { finish(); return }
-            val accent = accentColor ?: run { finish(); return }
-            options.putInt(WidgetTheme.KEY_CUSTOM_BG, bg)
-            options.putInt(WidgetTheme.KEY_CUSTOM_ACCENT, accent)
-        }
-
-        widgetManager.updateAppWidgetOptions(appWidgetId, options)
-
-        val appContext = applicationContext
-        lifecycleScope.launch {
-            try {
-                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                BatteryGlanceWidget().update(appContext, glanceId)
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to update widget: ${e.asLog()}" }
-            }
-        }
-
-        setResult(
-            RESULT_OK,
-            android.content.Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId),
+    private fun lastSeenSubtitle(modifiedAtMillis: Long, nowMillis: Long): String {
+        val relative = DateUtils.getRelativeTimeSpanString(
+            modifiedAtMillis,
+            nowMillis,
+            DateUtils.MINUTE_IN_MILLIS,
+            DateUtils.FORMAT_ABBREV_RELATIVE,
         )
-        finish()
+        return getString(eu.darken.octi.sync.R.string.sync_device_last_seen_label, relative.toString())
     }
 
     companion object {
         private val TAG = logTag("Module", "Power", "Widget", "Config")
+        private val DEVICE_LOAD_TIMEOUT = 2.seconds
     }
+}
+
+private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type) {
+    MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+    MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+    MetaInfo.DeviceType.UNKNOWN -> Icons.TwoTone.QuestionMark
 }
 
 @Composable
@@ -252,7 +274,7 @@ private fun WidgetConfigScreenPreview() = PreviewWrapper {
         initialBgColor = null,
         initialAccentColor = null,
         onClose = {},
-        onApply = { _, _, _, _ -> },
+        onApply = { _, _, _, _, _ -> },
         previewContent = { colors -> BatteryWidgetPreview(colors = colors) },
     )
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
@@ -31,9 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -53,6 +51,7 @@ import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
+import eu.darken.octi.common.widget.widgetDefaultColors
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.modules.power.R
@@ -172,13 +171,7 @@ private fun composeIconFor(type: MetaInfo.DeviceType): ImageVector = when (type)
 
 @Composable
 private fun BatteryWidgetPreview(colors: WidgetTheme.Colors?) {
-    val previewColors = colors ?: WidgetTheme.Colors(
-        containerBg = colorResource(CommonR.color.widgetContainerBackground).toArgb(),
-        barFill = colorResource(CommonR.color.widgetBarFill).toArgb(),
-        barTrack = colorResource(CommonR.color.widgetBarTrack).toArgb(),
-        icon = colorResource(CommonR.color.widgetBarIcon).toArgb(),
-        onContainer = colorResource(CommonR.color.widgetOnContainer).toArgb(),
-    )
+    val previewColors = colors ?: widgetDefaultColors()
 
     Card(shape = RoundedCornerShape(16.dp)) {
         Column(
@@ -215,14 +208,14 @@ private fun PreviewWidgetRow(
                 .weight(1f)
                 .height(30.dp)
                 .clip(RoundedCornerShape(12.dp))
-                .background(Color(colors.barTrack)),
+                .background(Color(colors.tileBg)),
         ) {
             Box(
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(percent / 100f)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(colors.barFill)),
+                    .background(Color(colors.accentBg)),
             )
             Row(
                 modifier = Modifier
@@ -234,21 +227,21 @@ private fun PreviewWidgetRow(
                     painter = painterResource(R.drawable.widget_battery_full_24),
                     contentDescription = null,
                     modifier = Modifier.size(20.dp),
-                    tint = Color(colors.icon),
+                    tint = Color(colors.onAccent),
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
                     text = name,
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Bold,
-                    color = Color(colors.icon),
+                    color = Color(colors.onAccent),
                     maxLines = 1,
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
                     text = "\u00b7 $lastSeen",
                     fontSize = 11.sp,
-                    color = Color(colors.icon),
+                    color = Color(colors.onAccent),
                     maxLines = 1,
                 )
             }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -60,14 +60,17 @@ fun BatteryWidgetContent(
     powerState: ModuleRepo.State<*>?,
     themeColors: WidgetTheme.Colors?,
     maxRows: Int,
+    allowedDeviceIds: Set<String>? = null,
 ) {
-    val devices = buildDeviceRows(metaState, powerState, maxRows)
+    val devices = buildDeviceRows(metaState, powerState, maxRows, allowedDeviceIds)
     val containerBg = themeColors?.containerBg
     val context = LocalContext.current
     val openApp = context.packageManager.getLaunchIntentForPackage(context.packageName)
         ?.let { actionStartActivity(it) }
     val barWidthDp = (LocalSize.current.width.value - BatteryWidgetSizing.BAR_HORIZONTAL_OVERHEAD_DP)
         .coerceAtLeast(0f)
+    val onContainer = colorOrDefault(themeColors?.onContainer, CommonR.color.widgetOnContainer)
+    val showEmptyState = devices.isEmpty() && maxRows > 0 && metaState != null && powerState != null
 
     GlanceTheme {
         Box(
@@ -86,15 +89,36 @@ fun BatteryWidgetContent(
                 )
                 .padding(8.dp),
         ) {
-            Column(modifier = GlanceModifier.fillMaxSize()) {
-                devices.forEachIndexed { index, device ->
-                    BatteryDeviceRowContent(
-                        device = device,
-                        themeColors = themeColors,
-                        barWidthDp = barWidthDp,
+            if (showEmptyState) {
+                val emptyStateRes = if (allowedDeviceIds.isNullOrEmpty()) {
+                    CommonR.string.widget_no_sync_devices_label
+                } else {
+                    CommonR.string.widget_empty_label
+                }
+                Box(
+                    modifier = GlanceModifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = context.getString(emptyStateRes),
+                        style = TextStyle(
+                            fontSize = 12.sp,
+                            color = onContainer,
+                        ),
+                        maxLines = 1,
                     )
-                    if (index < devices.lastIndex) {
-                        Spacer(modifier = GlanceModifier.height(2.dp))
+                }
+            } else {
+                Column(modifier = GlanceModifier.fillMaxSize()) {
+                    devices.forEachIndexed { index, device ->
+                        BatteryDeviceRowContent(
+                            device = device,
+                            themeColors = themeColors,
+                            barWidthDp = barWidthDp,
+                        )
+                        if (index < devices.lastIndex) {
+                            Spacer(modifier = GlanceModifier.height(2.dp))
+                        }
                     }
                 }
             }
@@ -107,16 +131,22 @@ private fun buildDeviceRows(
     metaState: ModuleRepo.State<*>?,
     powerState: ModuleRepo.State<*>?,
     maxRows: Int,
+    allowedDeviceIds: Set<String>?,
 ): List<BatteryDeviceRow> {
     if (metaState == null || powerState == null) return emptyList()
+    if (maxRows <= 0) return emptyList()
 
     val metaAll = metaState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.meta.core.MetaInfo>> ?: return emptyList()
-    val powerOthers = powerState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.power.core.PowerInfo>> ?: return emptyList()
+    val powerAll = powerState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.power.core.PowerInfo>> ?: return emptyList()
 
-    return powerOthers
+    return powerAll
         .mapNotNull { powerData ->
             val metaData = metaAll.firstOrNull { it.deviceId == powerData.deviceId }
             metaData?.let { powerData to it }
+        }
+        .let { pairs ->
+            if (allowedDeviceIds.isNullOrEmpty()) pairs
+            else pairs.filter { (powerData, _) -> powerData.deviceId.id in allowedDeviceIds }
         }
         .sortedBy { (_, metaData) -> metaData.data.labelOrFallback.lowercase() }
         .take(maxRows)

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -173,9 +173,9 @@ private fun BatteryDeviceRowContent(
     barWidthDp: Float,
 ) {
     val context = LocalContext.current
-    val barFill = colorOrDefault(themeColors?.barFill, CommonR.color.widgetBarFill)
-    val barTrack = colorOrDefault(themeColors?.barTrack, CommonR.color.widgetBarTrack)
-    val iconColor = colorOrDefault(themeColors?.icon, CommonR.color.widgetBarIcon)
+    val accentBg = colorOrDefault(themeColors?.accentBg, CommonR.color.widgetAccentBackground)
+    val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
+    val accentContent = colorOrDefault(themeColors?.onAccent, CommonR.color.widgetOnAccent)
     val onContainer = colorOrDefault(themeColors?.onContainer, CommonR.color.widgetOnContainer)
 
     val rowClick = WidgetDeeplink.buildIntent(context, device.deviceId, WidgetDeeplink.ModuleType.POWER)
@@ -192,7 +192,7 @@ private fun BatteryDeviceRowContent(
                 .defaultWeight()
                 .height(30.dp)
                 .cornerRadius(12.dp)
-                .background(barTrack)
+                .background(tileBg)
                 .then(
                     if (rowClick != null) GlanceModifier.clickable(rowClick) else GlanceModifier
                 ),
@@ -204,7 +204,7 @@ private fun BatteryDeviceRowContent(
                         .width(fillWidth.dp)
                         .height(30.dp)
                         .cornerRadius(12.dp)
-                        .background(barFill),
+                        .background(accentBg),
                 ) {}
             }
             Row(
@@ -218,7 +218,7 @@ private fun BatteryDeviceRowContent(
                     ),
                     contentDescription = null,
                     modifier = GlanceModifier.size(20.dp),
-                    colorFilter = ColorFilter.tint(iconColor),
+                    colorFilter = ColorFilter.tint(accentContent),
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
@@ -226,7 +226,7 @@ private fun BatteryDeviceRowContent(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 11.sp,
-                        color = iconColor,
+                        color = accentContent,
                     ),
                     maxLines = 1,
                 )
@@ -235,7 +235,7 @@ private fun BatteryDeviceRowContent(
                     text = "\u00b7 ${device.lastSeen}",
                     style = TextStyle(
                         fontSize = 11.sp,
-                        color = iconColor,
+                        color = accentContent,
                     ),
                     maxLines = 1,
                 )
@@ -253,4 +253,3 @@ private fun BatteryDeviceRowContent(
         )
     }
 }
-

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProvider.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProvider.kt
@@ -18,7 +18,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.WidgetInstanceConfig
 
 class BatteryGlanceWidget : GlanceAppWidget() {
 
@@ -42,7 +42,9 @@ class BatteryGlanceWidget : GlanceAppWidget() {
 
         provideContent {
             val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val themeColors = WidgetTheme.parseThemeColors(widgetOptions)
+            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val themeColors = instanceConfig.themeColors
+            val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
             val metaState = metaRepo.state.collectAsState(initial = null)
             val powerState = powerRepo.state.collectAsState(initial = null)
@@ -55,6 +57,7 @@ class BatteryGlanceWidget : GlanceAppWidget() {
                 powerState = powerState.value,
                 themeColors = themeColors,
                 maxRows = maxRows,
+                allowedDeviceIds = allowedDeviceIds,
             )
         }
     }

--- a/modules-power/src/main/res/drawable/widget_bar_progress.xml
+++ b/modules-power/src/main/res/drawable/widget_bar_progress.xml
@@ -3,14 +3,14 @@
     <item android:id="@android:id/background">
         <shape>
             <corners android:radius="12dp" />
-            <solid android:color="@color/widgetBarTrack" />
+            <solid android:color="@color/widgetTileBackground" />
         </shape>
     </item>
     <item android:id="@android:id/progress">
         <scale android:scaleWidth="100%">
             <shape>
                 <corners android:radius="12dp" />
-                <solid android:color="@color/widgetBarFill" />
+                <solid android:color="@color/widgetAccentBackground" />
             </shape>
         </scale>
     </item>

--- a/modules-power/src/main/res/drawable/widget_battery_charging_full_24.xml
+++ b/modules-power/src/main/res/drawable/widget_battery_charging_full_24.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/widgetBarIcon"
+        android:fillColor="@color/widgetOnAccent"
         android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4zM11,20v-5.5H9L13,7v5.5h2L11,20z" />
 </vector>

--- a/modules-power/src/main/res/drawable/widget_battery_full_24.xml
+++ b/modules-power/src/main/res/drawable/widget_battery_full_24.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@color/widgetBarIcon"
+        android:fillColor="@color/widgetOnAccent"
         android:pathData="M15.67,4H14V2h-4v2H8.33C7.6,4 7,4.6 7,5.33v15.33C7,21.4 7.6,22 8.33,22h7.33c0.74,0 1.34,-0.6 1.34,-1.33V5.33C17,4.6 16.4,4 15.67,4z" />
 </vector>

--- a/modules-power/src/main/res/drawable/widget_preview_bar_progress.xml
+++ b/modules-power/src/main/res/drawable/widget_preview_bar_progress.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape>
+            <corners android:radius="12dp" />
+            <solid android:color="@color/widgetBarTrack" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <scale android:scaleWidth="100%">
+            <shape>
+                <corners android:radius="12dp" />
+                <solid android:color="@color/widgetBarFill" />
+            </shape>
+        </scale>
+    </item>
+</layer-list>

--- a/modules-power/src/main/res/drawable/widget_preview_bar_progress.xml
+++ b/modules-power/src/main/res/drawable/widget_preview_bar_progress.xml
@@ -3,14 +3,14 @@
     <item android:id="@android:id/background">
         <shape>
             <corners android:radius="12dp" />
-            <solid android:color="@color/widgetBarTrack" />
+            <solid android:color="@color/widgetTileBackground" />
         </shape>
     </item>
     <item android:id="@android:id/progress">
         <scale android:scaleWidth="100%">
             <shape>
                 <corners android:radius="12dp" />
-                <solid android:color="@color/widgetBarFill" />
+                <solid android:color="@color/widgetAccentBackground" />
             </shape>
         </scale>
     </item>

--- a/modules-power/src/main/res/layout/module_power_widget_preview.xml
+++ b/modules-power/src/main/res/layout/module_power_widget_preview.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/widgetContainerBackground"
+    android:background="@drawable/widget_preview_container"
     android:clipToOutline="true"
     android:orientation="vertical"
     android:padding="8dp">
@@ -27,7 +27,7 @@
                 android:indeterminate="false"
                 android:max="100"
                 android:progress="75"
-                android:progressDrawable="@drawable/widget_bar_progress" />
+                android:progressDrawable="@drawable/widget_preview_bar_progress" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -102,7 +102,7 @@
                 android:indeterminate="false"
                 android:max="100"
                 android:progress="42"
-                android:progressDrawable="@drawable/widget_bar_progress" />
+                android:progressDrawable="@drawable/widget_preview_bar_progress" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/modules-power/src/main/res/layout/module_power_widget_preview.xml
+++ b/modules-power/src/main/res/layout/module_power_widget_preview.xml
@@ -42,7 +42,7 @@
                     android:layout_width="20dp"
                     android:layout_height="20dp"
                     android:src="@drawable/widget_battery_full_24"
-                    android:tint="@color/widgetBarIcon" />
+                    android:tint="@color/widgetOnAccent" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -51,7 +51,7 @@
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:text="Pixel 8"
-                    android:textColor="@color/widgetBarIcon"
+                    android:textColor="@color/widgetOnAccent"
                     android:textSize="11sp"
                     android:textStyle="bold" />
 
@@ -62,7 +62,7 @@
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:text="\u00b7 5m ago"
-                    android:textColor="@color/widgetBarIcon"
+                    android:textColor="@color/widgetOnAccent"
                     android:textSize="11sp" />
 
             </LinearLayout>
@@ -117,7 +117,7 @@
                     android:layout_width="20dp"
                     android:layout_height="20dp"
                     android:src="@drawable/widget_battery_full_24"
-                    android:tint="@color/widgetBarIcon" />
+                    android:tint="@color/widgetOnAccent" />
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -126,7 +126,7 @@
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:text="Galaxy S24"
-                    android:textColor="@color/widgetBarIcon"
+                    android:textColor="@color/widgetOnAccent"
                     android:textSize="11sp"
                     android:textStyle="bold" />
 
@@ -137,7 +137,7 @@
                     android:ellipsize="end"
                     android:singleLine="true"
                     android:text="\u00b7 10m ago"
-                    android:textColor="@color/widgetBarIcon"
+                    android:textColor="@color/widgetOnAccent"
                     android:textSize="11sp" />
 
             </LinearLayout>


### PR DESCRIPTION
## Summary

- Each home-screen widget (battery, network, clipboard) now has a **Devices** card in its configuration screen. Pick the devices you want this widget to show; leaving everything off keeps the existing behaviour and shows all devices.
- The selection is stored per widget instance, so you can pin one widget to your laptop, another to your tablet, and so on.
- The widget renders a friendly placeholder when the filter excludes everything, distinct from the empty state shown when no sync devices are known yet.

## Notes

- Per-widget bundle storage (theme + filter) is centralised in a new `WidgetInstanceConfig`, removing duplicated reads/writes across the three config activities.
- Filtering happens before `take(maxRows)` so a selection that sorts late alphabetically can never be silently dropped by row truncation.
- The Glance refresh after Apply runs on `ProcessLifecycleOwner.lifecycleScope` so it survives activity destruction — fixes a race where filter changes were not being applied when the activity finished too quickly.
- Drive-by: replaced `<Space>` in the clipboard preview layout with `layout_marginTop` (Space is not in the `RemoteViews` allowlist and crashed the launcher widget picker).
- Per-row "last seen" subtitle reuses the existing `sync_device_last_seen_label` string from `sync-core`.

## Test plan

- [ ] Add a battery widget. Open config → Devices card lists every synced device with "Last seen X ago" as subtitle.
- [ ] Toggle one device on, Apply → widget immediately shows only that device.
- [ ] Re-open config → selection persists.
- [ ] Toggle all devices off, Apply → widget reverts to showing every device.
- [ ] Repeat the above for network and clipboard widgets. Confirm the clipboard "self" share row is always visible regardless of filter state.
- [ ] Configure a filter that excludes all currently-syncing devices for that module → widget renders the "No matching devices" placeholder.
- [ ] With no sync devices configured at all → widget renders the "No sync devices yet" placeholder.
- [ ] `./gradlew :modules-clipboard:testDebugUnitTest` passes (5 new Glance unit tests cover the filter, the empty-state strings, the self row, and a filter-before-take regression).
