### PR TITLE
Fix crashes from uncaught errors in ViewModel background flows

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/uix/ViewModel2.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/uix/ViewModel2.kt
@@ -25,7 +25,10 @@ abstract class ViewModel2(
     private val dispatcherProvider: DispatcherProvider = DefaultDispatcherProvider(),
 ) : ViewModel1() {
 
-    val vmScope = viewModelScope + dispatcherProvider.Default
+    val vmScope: CoroutineScope
+        get() = launchErrorHandler
+            ?.let { viewModelScope + dispatcherProvider.Default + it }
+            ?: (viewModelScope + dispatcherProvider.Default)
 
     var launchErrorHandler: CoroutineExceptionHandler? = null
 


### PR DESCRIPTION
## Summary

Uncaught exceptions in ViewModel background flows (those shared via `asStateFlow()` or `launchInViewModel()`) bypassed the ViewModel4 error handler and crashed the app. A concrete example: on the gplay Upgrade screen, if both IAP and subscription queries time out, `UpgradeViewModel.state` throws `GplayServiceUnavailableException` inside a `combine` lambda. With the old setup, this would terminate the shared flow coroutine and surface through `collectAsState()` as an app crash instead of an error dialog. Other ViewModels with explicit `throw`/`.single()`/`.first()` calls in shared flows (e.g. `SyncDevicesVM`, `OctiServerLinkHostVM`, `SyncListVM`) had the same latent risk.

## Root cause

`vmScope` was a stored `val` initialized in `ViewModel2`'s property init — before `ViewModel4.init` sets `launchErrorHandler`. `asStateFlow()`, `launchInViewModel()`, and every subclass usage of `vmScope` therefore captured a scope without the handler, while only the `launch()` helper (which uses `getVMContext()` at call time) was protected.

## Fix

Convert `vmScope` to a computed property (getter) that folds in `launchErrorHandler` when available. Kotlin init order guarantees the handler is set before any subclass property initializer touches the getter, so all shared flows now route exceptions through `errorEvents` instead of crashing.

## Test plan

- [x] `./gradlew assembleFossDebug` — passes
- [x] `./gradlew testFossDebugUnitTest` — all tests pass
- [ ] Manual: open Upgrade screen with Play Services unavailable — should surface an error dialog instead of crashing
