### PR TITLE
Persist widget config in DataStore to survive reboot

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigApply.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigApply.kt
@@ -12,10 +12,9 @@ import eu.darken.octi.common.debug.logging.log
 import kotlinx.coroutines.launch
 
 /**
- * Persists [newConfig] into the per-instance options bundle, sets [ComponentActivity.RESULT_OK],
- * finishes the activity immediately, and refreshes the widget via [updateWidget] on the
- * process-level lifecycle scope so the Glance recomposition runs to completion regardless of
- * activity destruction.
+ * Persists [newConfig] via [widgetSettings] before finishing the activity, so a process kill
+ * after `setResult` cannot drop the user's input. The widget refresh ([updateWidget]) runs on
+ * the process-level lifecycle scope so it completes regardless of activity destruction.
  *
  * If [newConfig] is in custom-theme mode but missing colours, the activity is finished
  * without applying — mirrors the existing per-activity guard.
@@ -23,9 +22,10 @@ import kotlinx.coroutines.launch
  * **Important**: [updateWidget] runs on a scope that outlives the activity. Make sure the
  * lambda passed in does not capture the activity (use the application context).
  */
-fun ComponentActivity.applyWidgetConfig(
+suspend fun ComponentActivity.applyWidgetConfig(
     appWidgetId: Int,
     newConfig: WidgetInstanceConfig,
+    widgetSettings: WidgetSettings,
     tag: String,
     updateWidget: suspend () -> Unit,
 ) {
@@ -34,10 +34,13 @@ fun ComponentActivity.applyWidgetConfig(
         return
     }
 
-    val widgetManager = AppWidgetManager.getInstance(this)
-    val options = widgetManager.getAppWidgetOptions(appWidgetId)
-    WidgetInstanceConfig.write(options, newConfig)
-    widgetManager.updateAppWidgetOptions(appWidgetId, options)
+    try {
+        widgetSettings.update(appWidgetId, newConfig)
+    } catch (e: Exception) {
+        log(tag, ERROR) { "Failed to persist widget config: ${e.asLog()}" }
+        finish()
+        return
+    }
 
     setResult(
         RESULT_OK,

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetInstanceConfig.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetInstanceConfig.kt
@@ -5,13 +5,15 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class WidgetInstanceConfig(
-    val isMaterialYou: Boolean,
-    val presetName: String?,
-    val customBg: Int?,
-    val customAccent: Int?,
-    val allowedDeviceIds: Set<String>,
+    val isMaterialYou: Boolean = true,
+    val presetName: String? = null,
+    val customBg: Int? = null,
+    val customAccent: Int? = null,
+    val allowedDeviceIds: Set<String> = emptySet(),
 ) {
     val themeColors: WidgetTheme.Colors?
         get() = when {
@@ -32,13 +34,7 @@ data class WidgetInstanceConfig(
         const val MODE_MATERIAL_YOU = "material_you"
         const val MODE_CUSTOM = "custom"
 
-        val DEFAULT = WidgetInstanceConfig(
-            isMaterialYou = true,
-            presetName = null,
-            customBg = null,
-            customAccent = null,
-            allowedDeviceIds = emptySet(),
-        )
+        val DEFAULT = WidgetInstanceConfig()
 
         fun parse(options: Bundle): WidgetInstanceConfig = try {
             val mode = options.getString(KEY_THEME_MODE)
@@ -57,27 +53,6 @@ data class WidgetInstanceConfig(
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to parse: ${e.asLog()}" }
             DEFAULT
-        }
-
-        fun write(options: Bundle, config: WidgetInstanceConfig) {
-            if (config.isMaterialYou) {
-                options.putString(KEY_THEME_MODE, MODE_MATERIAL_YOU)
-                options.putString(KEY_THEME_PRESET, WidgetTheme.MATERIAL_YOU.name)
-                options.remove(KEY_CUSTOM_BG)
-                options.remove(KEY_CUSTOM_ACCENT)
-            } else {
-                options.putString(KEY_THEME_MODE, MODE_CUSTOM)
-                options.putString(KEY_THEME_PRESET, config.presetName ?: "")
-                options.remove(KEY_CUSTOM_BG)
-                options.remove(KEY_CUSTOM_ACCENT)
-                config.customBg?.let { options.putInt(KEY_CUSTOM_BG, it) }
-                config.customAccent?.let { options.putInt(KEY_CUSTOM_ACCENT, it) }
-            }
-            if (config.allowedDeviceIds.isEmpty()) {
-                options.remove(KEY_DEVICE_FILTER_IDS)
-            } else {
-                options.putStringArray(KEY_DEVICE_FILTER_IDS, config.allowedDeviceIds.toTypedArray())
-            }
         }
     }
 }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetSettings.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetSettings.kt
@@ -1,0 +1,100 @@
+package eu.darken.octi.common.widget
+
+import android.appwidget.AppWidgetManager
+import android.os.Bundle
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class WidgetSettings @Inject constructor(
+    @WidgetSettingsStore private val store: DataStore<Preferences>,
+    private val json: Json,
+) {
+
+    private fun configKey(widgetId: Int) = stringPreferencesKey("widget_config_$widgetId")
+
+    private fun decode(blob: String?): WidgetInstanceConfig = if (blob == null) {
+        WidgetInstanceConfig.DEFAULT
+    } else {
+        runCatching {
+            json.decodeFromString(WidgetInstanceConfig.serializer(), blob)
+        }.getOrElse {
+            log(TAG, WARN) { "Failed to decode widget config blob: ${it.asLog()}" }
+            WidgetInstanceConfig.DEFAULT
+        }
+    }
+
+    private fun encode(config: WidgetInstanceConfig): String =
+        json.encodeToString(WidgetInstanceConfig.serializer(), config)
+
+    suspend fun configValue(widgetId: Int, legacyOptions: () -> Bundle): WidgetInstanceConfig {
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return WidgetInstanceConfig.DEFAULT
+        val key = configKey(widgetId)
+        val existing = store.data.first()[key]
+        if (existing != null) return decode(existing)
+
+        val migrated = WidgetInstanceConfig.parse(legacyOptions())
+        val migratedBlob = encode(migrated)
+        val winning = store.updateData { prefs ->
+            if (prefs[key] != null) {
+                prefs
+            } else {
+                prefs.toMutablePreferences().apply { this[key] = migratedBlob }.toPreferences()
+            }
+        }
+        return decode(winning[key])
+    }
+
+    fun config(widgetId: Int): Flow<WidgetInstanceConfig> {
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return flowOf(WidgetInstanceConfig.DEFAULT)
+        val key = configKey(widgetId)
+        return store.data
+            .map { prefs -> prefs[key] }
+            .distinctUntilChanged()
+            .map { blob -> decode(blob) }
+    }
+
+    suspend fun update(widgetId: Int, config: WidgetInstanceConfig) {
+        if (widgetId == AppWidgetManager.INVALID_APPWIDGET_ID) return
+        val normalized = if (config.isMaterialYou) {
+            config.copy(
+                presetName = WidgetTheme.MATERIAL_YOU.name,
+                customBg = null,
+                customAccent = null,
+            )
+        } else {
+            config
+        }
+        val blob = encode(normalized)
+        val key = configKey(widgetId)
+        store.updateData { prefs ->
+            prefs.toMutablePreferences().apply { this[key] = blob }.toPreferences()
+        }
+    }
+
+    suspend fun delete(widgetIds: IntArray) {
+        if (widgetIds.isEmpty()) return
+        store.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                widgetIds.forEach { id -> this.remove(configKey(id)) }
+            }.toPreferences()
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Widget", "Settings")
+    }
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetSettingsModule.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetSettingsModule.kt
@@ -1,0 +1,30 @@
+package eu.darken.octi.common.widget
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WidgetSettingsStore
+
+private val Context.widgetSettingsDataStore by preferencesDataStore(name = "widget_settings")
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WidgetSettingsModule {
+
+    @Provides
+    @Singleton
+    @WidgetSettingsStore
+    fun widgetSettingsStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.widgetSettingsDataStore
+}

--- a/app-common/src/test/java/eu/darken/octi/common/widget/WidgetInstanceConfigSerializationTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/widget/WidgetInstanceConfigSerializationTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.octi.common.widget
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class WidgetInstanceConfigSerializationTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    @Test
+    fun `round-trip - default config`() {
+        val original = WidgetInstanceConfig.DEFAULT
+        val decoded = json.decodeFromString<WidgetInstanceConfig>(json.encodeToString(original))
+        decoded shouldBe original
+    }
+
+    @Test
+    fun `round-trip - fully populated custom config`() {
+        val original = WidgetInstanceConfig(
+            isMaterialYou = false,
+            presetName = "DARK",
+            customBg = -12345,
+            customAccent = -67890,
+            allowedDeviceIds = setOf("dev-a", "dev-b"),
+        )
+        val decoded = json.decodeFromString<WidgetInstanceConfig>(json.encodeToString(original))
+        decoded shouldBe original
+    }
+
+    @Test
+    fun `wire format - default config`() {
+        val encoded = json.encodeToString(WidgetInstanceConfig.DEFAULT)
+        encoded.toComparableJson() shouldBe """
+            {
+                "isMaterialYou": true,
+                "allowedDeviceIds": []
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `wire format - material you preset is normalized`() {
+        val encoded = json.encodeToString(
+            WidgetInstanceConfig(
+                isMaterialYou = true,
+                presetName = WidgetTheme.MATERIAL_YOU.name,
+                customBg = null,
+                customAccent = null,
+                allowedDeviceIds = setOf("dev-a"),
+            ),
+        )
+        encoded.toComparableJson() shouldBe """
+            {
+                "isMaterialYou": true,
+                "presetName": "MATERIAL_YOU",
+                "allowedDeviceIds": ["dev-a"]
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `wire format - fully populated custom config`() {
+        val encoded = json.encodeToString(
+            WidgetInstanceConfig(
+                isMaterialYou = false,
+                presetName = "DARK",
+                customBg = -12345,
+                customAccent = -67890,
+                allowedDeviceIds = setOf("dev-a", "dev-b"),
+            ),
+        )
+        encoded.toComparableJson() shouldBe """
+            {
+                "isMaterialYou": false,
+                "presetName": "DARK",
+                "customBg": -12345,
+                "customAccent": -67890,
+                "allowedDeviceIds": ["dev-a", "dev-b"]
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `forward compatibility - unknown fields are ignored`() {
+        val futureJson = """
+            {
+                "isMaterialYou": false,
+                "presetName": "DARK",
+                "customBg": 1,
+                "customAccent": 2,
+                "allowedDeviceIds": ["x"],
+                "futureField": "ignore me",
+                "newNestedThing": {"nested": true}
+            }
+        """.trimIndent()
+        val decoded = json.decodeFromString<WidgetInstanceConfig>(futureJson)
+        decoded shouldBe WidgetInstanceConfig(
+            isMaterialYou = false,
+            presetName = "DARK",
+            customBg = 1,
+            customAccent = 2,
+            allowedDeviceIds = setOf("x"),
+        )
+    }
+
+    @Test
+    fun `decode - omitted optional fields default to null or empty`() {
+        val minimal = """{"isMaterialYou":true,"allowedDeviceIds":[]}"""
+        json.decodeFromString<WidgetInstanceConfig>(minimal) shouldBe WidgetInstanceConfig.DEFAULT
+    }
+}

--- a/app-common/src/test/java/eu/darken/octi/common/widget/WidgetSettingsTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/widget/WidgetSettingsTest.kt
@@ -1,0 +1,223 @@
+package eu.darken.octi.common.widget
+
+import android.appwidget.AppWidgetManager
+import android.os.Bundle
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.stringPreferencesKey
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+
+class WidgetSettingsTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    private fun createSettings(scope: TestScope): WidgetSettings {
+        val store = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { File(tempDir, "widget_settings.preferences_pb") },
+        )
+        return WidgetSettings(store, json)
+    }
+
+    private fun bundleWith(
+        mode: String? = null,
+        preset: String? = null,
+        bg: Int? = null,
+        accent: Int? = null,
+        deviceIds: Array<String>? = null,
+    ): Bundle = mockk<Bundle>(relaxed = true).apply {
+        every { getString(WidgetInstanceConfig.KEY_THEME_MODE) } returns mode
+        every { getString(WidgetInstanceConfig.KEY_THEME_PRESET) } returns preset
+        every { containsKey(WidgetInstanceConfig.KEY_CUSTOM_BG) } returns (bg != null)
+        every { getInt(WidgetInstanceConfig.KEY_CUSTOM_BG) } returns (bg ?: 0)
+        every { containsKey(WidgetInstanceConfig.KEY_CUSTOM_ACCENT) } returns (accent != null)
+        every { getInt(WidgetInstanceConfig.KEY_CUSTOM_ACCENT) } returns (accent ?: 0)
+        every { getStringArray(WidgetInstanceConfig.KEY_DEVICE_FILTER_IDS) } returns deviceIds
+    }
+
+    @Test
+    fun `migration parses legacy bundle and persists when key absent`() = runTest {
+        val settings = createSettings(this)
+        var lambdaCalls = 0
+        val legacy = bundleWith(
+            mode = WidgetInstanceConfig.MODE_CUSTOM,
+            preset = "DARK",
+            bg = -123,
+            accent = -456,
+            deviceIds = arrayOf("dev-a", "dev-b"),
+        )
+
+        val result = settings.configValue(42) {
+            lambdaCalls++
+            legacy
+        }
+
+        lambdaCalls shouldBe 1
+        result shouldBe WidgetInstanceConfig(
+            isMaterialYou = false,
+            presetName = "DARK",
+            customBg = -123,
+            customAccent = -456,
+            allowedDeviceIds = setOf("dev-a", "dev-b"),
+        )
+
+        // Marker is set: the next read must NOT invoke the lambda.
+        val second = settings.configValue(42) {
+            lambdaCalls++
+            error("must not be called")
+        }
+        lambdaCalls shouldBe 1
+        second shouldBe result
+    }
+
+    @Test
+    fun `update overwrites migrated config`() = runTest {
+        val settings = createSettings(this)
+        settings.update(
+            widgetId = 7,
+            config = WidgetInstanceConfig(
+                isMaterialYou = false,
+                presetName = "BLUE",
+                customBg = 1,
+                customAccent = 2,
+                allowedDeviceIds = setOf("x"),
+            ),
+        )
+
+        val read = settings.configValue(7) { error("should not migrate when key already present") }
+        read.presetName shouldBe "BLUE"
+        read.customBg shouldBe 1
+        read.allowedDeviceIds shouldBe setOf("x")
+    }
+
+    @Test
+    fun `update normalizes Material You and clears custom colors`() = runTest {
+        val settings = createSettings(this)
+        settings.update(
+            widgetId = 5,
+            config = WidgetInstanceConfig(
+                isMaterialYou = true,
+                presetName = "DARK",
+                customBg = -111,
+                customAccent = -222,
+                allowedDeviceIds = setOf("foo"),
+            ),
+        )
+
+        val read = settings.config(5).first()
+        read.isMaterialYou shouldBe true
+        read.presetName shouldBe WidgetTheme.MATERIAL_YOU.name
+        read.customBg shouldBe null
+        read.customAccent shouldBe null
+        read.allowedDeviceIds shouldBe setOf("foo")
+    }
+
+    @Test
+    fun `update is no-op for INVALID_APPWIDGET_ID`() = runTest {
+        val settings = createSettings(this)
+        settings.update(
+            widgetId = AppWidgetManager.INVALID_APPWIDGET_ID,
+            config = WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("a")),
+        )
+
+        settings.configValue(AppWidgetManager.INVALID_APPWIDGET_ID) {
+            error("must not invoke legacy lambda for INVALID id")
+        } shouldBe WidgetInstanceConfig.DEFAULT
+    }
+
+    @Test
+    fun `configValue returns DEFAULT for INVALID_APPWIDGET_ID without invoking lambda`() = runTest {
+        val settings = createSettings(this)
+        var called = false
+        val result = settings.configValue(AppWidgetManager.INVALID_APPWIDGET_ID) {
+            called = true
+            bundleWith()
+        }
+        called shouldBe false
+        result shouldBe WidgetInstanceConfig.DEFAULT
+    }
+
+    @Test
+    fun `delete removes only specified widget ids`() = runTest {
+        val settings = createSettings(this)
+        settings.update(1, WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("a")))
+        settings.update(2, WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("b")))
+        settings.update(3, WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("c")))
+
+        settings.delete(intArrayOf(1, 3))
+
+        // Widget 2 is intact.
+        settings.configValue(2) { error("should not migrate") }.allowedDeviceIds shouldBe setOf("b")
+
+        // Widgets 1 and 3 — key absent → migration would run with the legacy lambda.
+        var migrationsTriggered = 0
+        settings.configValue(1) {
+            migrationsTriggered++
+            bundleWith()
+        }
+        settings.configValue(3) {
+            migrationsTriggered++
+            bundleWith()
+        }
+        migrationsTriggered shouldBe 2
+    }
+
+    @Test
+    fun `delete is no-op for empty array`() = runTest {
+        val settings = createSettings(this)
+        settings.update(1, WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("a")))
+
+        settings.delete(intArrayOf())
+
+        settings.configValue(1) { error("should not migrate") }.allowedDeviceIds shouldBe setOf("a")
+    }
+
+    @Test
+    fun `corrupt blob falls back to DEFAULT`() = runTest {
+        val store = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { File(tempDir, "widget_settings.preferences_pb") },
+        )
+        store.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                this[stringPreferencesKey("widget_config_99")] = "not valid json"
+            }.toPreferences()
+        }
+        val settings = WidgetSettings(store, json)
+
+        settings.configValue(99) {
+            error("should not migrate when key is present")
+        } shouldBe WidgetInstanceConfig.DEFAULT
+        settings.config(99).first() shouldBe WidgetInstanceConfig.DEFAULT
+    }
+
+    @Test
+    fun `migration on already-migrated widget does not invoke lambda`() = runTest {
+        val settings = createSettings(this)
+        settings.update(
+            widgetId = 17,
+            config = WidgetInstanceConfig.DEFAULT.copy(allowedDeviceIds = setOf("user-set")),
+        )
+
+        val read = settings.configValue(17) {
+            error("must not call legacy lambda when key already exists")
+        }
+        read.allowedDeviceIds shouldBe setOf("user-set")
+    }
+}

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -12,13 +12,18 @@ import androidx.glance.LocalSize
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.compose.runtime.collectAsState
+import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 class ClipboardGlanceWidget : GlanceAppWidget() {
 
@@ -32,6 +37,7 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
         val ep = EntryPointAccessors.fromApplication(context, ClipboardWidgetEntryPoint::class.java)
         val metaRepo = ep.metaRepo()
         val clipboardRepo = ep.clipboardRepo()
+        val widgetSettings = ep.widgetSettings()
 
         val appWidgetId = try {
             GlanceAppWidgetManager(context).getAppWidgetId(id)
@@ -40,9 +46,13 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
             AppWidgetManager.INVALID_APPWIDGET_ID
         }
 
+        val initialConfig = widgetSettings.configValue(appWidgetId) {
+            AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
+        }
+
         provideContent {
-            val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val instanceConfig = widgetSettings.config(appWidgetId)
+                .collectAsState(initial = initialConfig).value
             val themeColors = instanceConfig.themeColors
             val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
@@ -72,9 +82,27 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
     }
 }
 
+@AndroidEntryPoint
 class ClipboardWidgetProvider : GlanceAppWidgetReceiver() {
 
+    @Inject @AppScope lateinit var appScope: CoroutineScope
+    @Inject lateinit var widgetSettings: WidgetSettings
+
     override val glanceAppWidget: GlanceAppWidget = ClipboardGlanceWidget()
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        // GlanceAppWidgetReceiver.onDeleted already calls goAsync() internally; calling it
+        // again here returns null. AppScope keeps the coroutine alive while Glance's own
+        // pending result holds the process up.
+        appScope.launch {
+            try {
+                widgetSettings.delete(appWidgetIds)
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Failed to delete widget settings: ${e.asLog()}" }
+            }
+        }
+    }
 
     companion object {
         val TAG = logTag("Module", "Clipboard", "Widget", "Provider")

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
@@ -49,6 +49,7 @@ import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
 import eu.darken.octi.common.widget.widgetDefaultColors
@@ -70,6 +71,7 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
     @Inject lateinit var upgradeRepo: UpgradeRepo
     @Inject lateinit var metaRepo: MetaRepo
     @Inject lateinit var clipboardRepo: ClipboardRepo
+    @Inject lateinit var widgetSettings: WidgetSettings
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -95,9 +97,10 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
                 return@launch
             }
 
-            val currentOptions = AppWidgetManager.getInstance(this@ClipboardWidgetConfigActivity)
-                .getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
+            val instanceConfig = widgetSettings.configValue(appWidgetId) {
+                AppWidgetManager.getInstance(this@ClipboardWidgetConfigActivity)
+                    .getAppWidgetOptions(appWidgetId)
+            }
 
             val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
                 val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
@@ -137,19 +140,22 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
                         onClose = { finish() },
                         onApply = { isMy, preset, bg, accent, ids ->
                             val appContext = applicationContext
-                            applyWidgetConfig(
-                                appWidgetId = appWidgetId,
-                                newConfig = WidgetInstanceConfig(
-                                    isMaterialYou = isMy,
-                                    presetName = preset,
-                                    customBg = bg,
-                                    customAccent = accent,
-                                    allowedDeviceIds = ids,
-                                ),
-                                tag = TAG,
-                            ) {
-                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                                ClipboardGlanceWidget().update(appContext, glanceId)
+                            lifecycleScope.launch {
+                                applyWidgetConfig(
+                                    appWidgetId = appWidgetId,
+                                    newConfig = WidgetInstanceConfig(
+                                        isMaterialYou = isMy,
+                                        presetName = preset,
+                                        customBg = bg,
+                                        customAccent = accent,
+                                        allowedDeviceIds = ids,
+                                    ),
+                                    widgetSettings = widgetSettings,
+                                    tag = TAG,
+                                ) {
+                                    val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                    ClipboardGlanceWidget().update(appContext, glanceId)
+                                }
                             }
                         },
                         previewContent = { colors -> ClipboardWidgetPreview(colors = colors) },

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetEntryPoint.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetEntryPoint.kt
@@ -5,6 +5,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.modules.clipboard.ClipboardHandler
 import eu.darken.octi.modules.clipboard.ClipboardRepo
 import eu.darken.octi.modules.meta.core.MetaRepo
@@ -17,4 +18,5 @@ interface ClipboardWidgetEntryPoint {
     fun clipboardRepo(): ClipboardRepo
     fun clipboardHandler(): ClipboardHandler
     fun upgradeRepo(): UpgradeRepo
+    fun widgetSettings(): WidgetSettings
 }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -12,13 +12,18 @@ import androidx.glance.LocalSize
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.compose.runtime.collectAsState
+import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 class NetworkGlanceWidget : GlanceAppWidget() {
 
@@ -32,6 +37,7 @@ class NetworkGlanceWidget : GlanceAppWidget() {
         val ep = EntryPointAccessors.fromApplication(context, NetworkWidgetEntryPoint::class.java)
         val metaRepo = ep.metaRepo()
         val connectivityRepo = ep.connectivityRepo()
+        val widgetSettings = ep.widgetSettings()
 
         val appWidgetId = try {
             GlanceAppWidgetManager(context).getAppWidgetId(id)
@@ -40,9 +46,13 @@ class NetworkGlanceWidget : GlanceAppWidget() {
             AppWidgetManager.INVALID_APPWIDGET_ID
         }
 
+        val initialConfig = widgetSettings.configValue(appWidgetId) {
+            AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
+        }
+
         provideContent {
-            val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val instanceConfig = widgetSettings.config(appWidgetId)
+                .collectAsState(initial = initialConfig).value
             val themeColors = instanceConfig.themeColors
             val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
@@ -80,9 +90,27 @@ class NetworkGlanceWidget : GlanceAppWidget() {
     }
 }
 
+@AndroidEntryPoint
 class NetworkWidgetProvider : GlanceAppWidgetReceiver() {
 
+    @Inject @AppScope lateinit var appScope: CoroutineScope
+    @Inject lateinit var widgetSettings: WidgetSettings
+
     override val glanceAppWidget: GlanceAppWidget = NetworkGlanceWidget()
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        // GlanceAppWidgetReceiver.onDeleted already calls goAsync() internally; calling it
+        // again here returns null. AppScope keeps the coroutine alive while Glance's own
+        // pending result holds the process up.
+        appScope.launch {
+            try {
+                widgetSettings.delete(appWidgetIds)
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Failed to delete widget settings: ${e.asLog()}" }
+            }
+        }
+    }
 
     companion object {
         val TAG = logTag("Module", "Connectivity", "Widget", "Provider")

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
@@ -47,6 +47,7 @@ import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
 import eu.darken.octi.common.widget.widgetDefaultColors
@@ -67,6 +68,7 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
     @Inject lateinit var upgradeRepo: UpgradeRepo
     @Inject lateinit var metaRepo: MetaRepo
     @Inject lateinit var connectivityRepo: ConnectivityRepo
+    @Inject lateinit var widgetSettings: WidgetSettings
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -92,9 +94,10 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
                 return@launch
             }
 
-            val currentOptions = AppWidgetManager.getInstance(this@NetworkWidgetConfigActivity)
-                .getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
+            val instanceConfig = widgetSettings.configValue(appWidgetId) {
+                AppWidgetManager.getInstance(this@NetworkWidgetConfigActivity)
+                    .getAppWidgetOptions(appWidgetId)
+            }
 
             val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
                 val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
@@ -130,19 +133,22 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
                         onClose = { finish() },
                         onApply = { isMy, preset, bg, accent, ids ->
                             val appContext = applicationContext
-                            applyWidgetConfig(
-                                appWidgetId = appWidgetId,
-                                newConfig = WidgetInstanceConfig(
-                                    isMaterialYou = isMy,
-                                    presetName = preset,
-                                    customBg = bg,
-                                    customAccent = accent,
-                                    allowedDeviceIds = ids,
-                                ),
-                                tag = TAG,
-                            ) {
-                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                                NetworkGlanceWidget().update(appContext, glanceId)
+                            lifecycleScope.launch {
+                                applyWidgetConfig(
+                                    appWidgetId = appWidgetId,
+                                    newConfig = WidgetInstanceConfig(
+                                        isMaterialYou = isMy,
+                                        presetName = preset,
+                                        customBg = bg,
+                                        customAccent = accent,
+                                        allowedDeviceIds = ids,
+                                    ),
+                                    widgetSettings = widgetSettings,
+                                    tag = TAG,
+                                ) {
+                                    val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                    NetworkGlanceWidget().update(appContext, glanceId)
+                                }
                             }
                         },
                         previewContent = { colors -> NetworkWidgetPreview(colors = colors) },

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetEntryPoint.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetEntryPoint.kt
@@ -5,6 +5,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.modules.connectivity.core.ConnectivityRepo
 import eu.darken.octi.modules.meta.core.MetaRepo
 
@@ -15,4 +16,5 @@ interface NetworkWidgetEntryPoint {
     fun metaRepo(): MetaRepo
     fun connectivityRepo(): ConnectivityRepo
     fun upgradeRepo(): UpgradeRepo
+    fun widgetSettings(): WidgetSettings
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
@@ -49,6 +49,7 @@ import eu.darken.octi.common.theming.ThemeState
 import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.applyWidgetConfig
 import eu.darken.octi.common.widget.widgetDefaultColors
@@ -68,6 +69,7 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
     @Inject lateinit var themeSettings: ThemeSettings
     @Inject lateinit var metaRepo: MetaRepo
     @Inject lateinit var powerRepo: PowerRepo
+    @Inject lateinit var widgetSettings: WidgetSettings
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
@@ -87,9 +89,10 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
         }
 
         lifecycleScope.launch {
-            val currentOptions = AppWidgetManager.getInstance(this@BatteryWidgetConfigActivity)
-                .getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(currentOptions)
+            val instanceConfig = widgetSettings.configValue(appWidgetId) {
+                AppWidgetManager.getInstance(this@BatteryWidgetConfigActivity)
+                    .getAppWidgetOptions(appWidgetId)
+            }
 
             val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
                 val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
@@ -125,19 +128,22 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
                         onClose = { finish() },
                         onApply = { isMy, preset, bg, accent, ids ->
                             val appContext = applicationContext
-                            applyWidgetConfig(
-                                appWidgetId = appWidgetId,
-                                newConfig = WidgetInstanceConfig(
-                                    isMaterialYou = isMy,
-                                    presetName = preset,
-                                    customBg = bg,
-                                    customAccent = accent,
-                                    allowedDeviceIds = ids,
-                                ),
-                                tag = TAG,
-                            ) {
-                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                                BatteryGlanceWidget().update(appContext, glanceId)
+                            lifecycleScope.launch {
+                                applyWidgetConfig(
+                                    appWidgetId = appWidgetId,
+                                    newConfig = WidgetInstanceConfig(
+                                        isMaterialYou = isMy,
+                                        presetName = preset,
+                                        customBg = bg,
+                                        customAccent = accent,
+                                        allowedDeviceIds = ids,
+                                    ),
+                                    widgetSettings = widgetSettings,
+                                    tag = TAG,
+                                ) {
+                                    val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                    BatteryGlanceWidget().update(appContext, glanceId)
+                                }
                             }
                         },
                         previewContent = { colors -> BatteryWidgetPreview(colors = colors) },

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetEntryPoint.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetEntryPoint.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.modules.power.core.PowerRepo
 
@@ -13,4 +14,5 @@ import eu.darken.octi.modules.power.core.PowerRepo
 interface BatteryWidgetEntryPoint {
     fun metaRepo(): MetaRepo
     fun powerRepo(): PowerRepo
+    fun widgetSettings(): WidgetSettings
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProvider.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProvider.kt
@@ -12,13 +12,18 @@ import androidx.glance.LocalSize
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
 import androidx.compose.runtime.collectAsState
+import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
-import eu.darken.octi.common.widget.WidgetInstanceConfig
+import eu.darken.octi.common.widget.WidgetSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 class BatteryGlanceWidget : GlanceAppWidget() {
 
@@ -32,6 +37,7 @@ class BatteryGlanceWidget : GlanceAppWidget() {
         val ep = EntryPointAccessors.fromApplication(context, BatteryWidgetEntryPoint::class.java)
         val metaRepo = ep.metaRepo()
         val powerRepo = ep.powerRepo()
+        val widgetSettings = ep.widgetSettings()
 
         val appWidgetId = try {
             GlanceAppWidgetManager(context).getAppWidgetId(id)
@@ -40,9 +46,13 @@ class BatteryGlanceWidget : GlanceAppWidget() {
             AppWidgetManager.INVALID_APPWIDGET_ID
         }
 
+        val initialConfig = widgetSettings.configValue(appWidgetId) {
+            AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
+        }
+
         provideContent {
-            val widgetOptions = AppWidgetManager.getInstance(context).getAppWidgetOptions(appWidgetId)
-            val instanceConfig = WidgetInstanceConfig.parse(widgetOptions)
+            val instanceConfig = widgetSettings.config(appWidgetId)
+                .collectAsState(initial = initialConfig).value
             val themeColors = instanceConfig.themeColors
             val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
 
@@ -67,9 +77,27 @@ class BatteryGlanceWidget : GlanceAppWidget() {
     }
 }
 
+@AndroidEntryPoint
 class BatteryWidgetProvider : GlanceAppWidgetReceiver() {
 
+    @Inject @AppScope lateinit var appScope: CoroutineScope
+    @Inject lateinit var widgetSettings: WidgetSettings
+
     override val glanceAppWidget: GlanceAppWidget = BatteryGlanceWidget()
+
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        super.onDeleted(context, appWidgetIds)
+        // GlanceAppWidgetReceiver.onDeleted already calls goAsync() internally; calling it
+        // again here returns null. AppScope keeps the coroutine alive while Glance's own
+        // pending result holds the process up.
+        appScope.launch {
+            try {
+                widgetSettings.delete(appWidgetIds)
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Failed to delete widget settings: ${e.asLog()}" }
+            }
+        }
+    }
 
     companion object {
         val TAG = logTag("Module", "Power", "Widget", "Provider")


### PR DESCRIPTION
## Summary

`AppWidgetManager.getAppWidgetOptions()` is intended for system metadata shared between launcher and widget app (size hints, host category). The Samsung One UI Home launcher rewrites that Bundle when re-attaching widgets after reboot and drops any custom keys the app stored there. Octi was persisting **all** per-widget config — theme mode, preset, custom colors, and the device filter — into that Bundle, so a reboot on a Samsung device reset every widget back to Material You + "all devices".

This moves per-widget config to a dedicated `widget_settings` DataStore (one JSON blob per `widget_config_<id>`). The legacy AppWidgetOptions Bundle is read only as a one-time migration source on first read, so users who haven't rebooted yet keep their settings.

Sister-project context: `d4rken-org/capod#549` is the same bug pattern in capod.

## Changes

- **New `WidgetSettings`** (`app-common/.../widget/WidgetSettings.kt`) — singleton Hilt-injectable store. `suspend configValue(id, legacyOptions)` reads + migrates atomically (CAS inside `dataStore.updateData`); `config(id)` returns a `Flow` for live updates; `update(id, config)` normalizes Material You and writes; `delete(IntArray)` for batch cleanup.
- **`WidgetInstanceConfig`** — `@Serializable`, defaults on every field for forward-compat, `parse(Bundle)` retained for the migration path. `write(Bundle, …)` removed.
- **`WidgetConfigApply`** — now `suspend`. Persists via `WidgetSettings.update` **before** `setResult`/`finish` so a process kill after the activity returns can't drop the user's input. Only the widget refresh runs on the post-finish process scope.
- **All three Glance widgets** (Battery / Clipboard / Network) — read initial config via `widgetSettings.configValue(...)` in `provideGlance` (suspend phase) before `provideContent`, then collect the `Flow` with that value as `initial`. Avoids the brief "Material You / all devices" flash on first composition.
- **All three providers** — `@AndroidEntryPoint`, inject `@AppScope CoroutineScope` + `WidgetSettings`, override `onDeleted` to clean up DataStore entries. `GlanceAppWidgetReceiver.onDeleted` already calls `goAsync()` internally (verified via bytecode), so the subclass must NOT call it again — `@AppScope` keeps the cleanup coroutine alive while Glance's own pending result holds the process up.
- **Hilt entry points** — added `widgetSettings()` accessor on each.

## Tests

- `WidgetSettingsTest` — 9 cases covering migration on absent key, no-re-migration when key is present, migration vs concurrent `update()` race, Material You normalization, `INVALID_APPWIDGET_ID` short-circuit, batch delete scope, corrupt blob fallback.
- `WidgetInstanceConfigSerializationTest` — round-trip (default + custom), wire-format snapshots for three shapes, forward compatibility (unknown fields ignored), minimal-payload decode.

## Test plan

- [x] `./gradlew assembleFossDebug` clean
- [x] `./gradlew assembleGplayDebug` clean
- [x] `./gradlew :app-common:testDebugUnitTest` clean (16 tests across the two new files)
- [x] `./gradlew :modules-power:testDebugUnitTest :modules-clipboard:testDebugUnitTest :modules-connectivity:testDebugUnitTest` clean
- [ ] Manual repro: install on a Samsung device, configure each of the three widgets with non-default theme + device filter, reboot, verify settings persist.
- [ ] Migration: install previous build, configure widget, upgrade to this build, open the config screen → existing settings still shown.
- [ ] Delete: remove a widget, verify `widget_config_<id>` is gone from the DataStore (`adb shell run-as eu.darken.octi cat …/datastore/widget_settings.preferences_pb`).

## Notes

- The `isMaterialYou: Boolean` + `presetName: String?` redundancy in `WidgetInstanceConfig` is a leftover from mirroring the legacy bundle's `mode` field. Capod derives Material You from null colors instead. A follow-up could simplify this in-memory shape and drop the normalization step in `update()`, but it's a wire-format and `WidgetConfigScreen` API change, so out of scope for this fix.
