### PR TITLE
Upgrade addressable to 2.9.0 and json to 2.19.4

### DIFF
--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     artifactory (3.0.17)
     atomos (0.1.3)
@@ -169,7 +169,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.4)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -185,7 +185,7 @@ GEM
     os (1.1.4)
     ostruct (0.6.3)
     plist (3.7.2)
-    public_suffix (7.0.2)
+    public_suffix (7.0.5)
     rake (13.3.1)
     representable (3.2.0)
       declarative (< 0.1.0)


### PR DESCRIPTION
Lock regenerated via `bundle lock --update addressable json` (bundler 2.2.8, the version pinned in the lock). Fastlane is only used for Play Store metadata uploads — no test or build path depends on these gems.