### PR TITLE
Surface auth-issue pause for unregistered OctiServer device

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -318,13 +318,13 @@ class DashboardVM @Inject constructor(
         updateService.availableUpdate.onStart { emit(null) },
         generalSettings.dashboardConfig.flow,
         filteredIssues,
-        syncSettings.pausedConnectors.flow,
+        syncSettings.pausedConnectorIds,
     ) { now, networkState, isSyncSetupDismissed, deviceItems, missingPermissions, syncStatus, upgradeInfo, update, uiConfig, allIssues, pausedIds ->
 
         val connectorCount = syncManager.allConnectors.first().size
         val showSyncSetup = !isSyncSetupDismissed && connectorCount == 0
 
-        val issues = allIssues.filter { it.connectorId !in pausedIds }
+        val issues = filterDashboardIssues(allIssues, pausedIds)
 
         val filteredPermissions = missingPermissions
             .filterNot { WIFI_PERMISSIONS.contains(it) }
@@ -689,6 +689,13 @@ class DashboardVM @Inject constructor(
             return allIssues
                 .filter { it.deviceId == item.deviceId }
                 .sortedWith(compareBy({ if (it.severity == IssueSeverity.ERROR) 0 else 1 }, { it::class.simpleName }))
+        }
+
+        internal fun filterDashboardIssues(
+            allIssues: List<ConnectorIssue>,
+            pausedIds: Set<ConnectorId>,
+        ): List<ConnectorIssue> = allIssues.filter {
+            it.connectorId !in pausedIds || it is OctiServerIssue.CurrentDeviceNotRegistered
         }
 
         private val INFO_ORDER = listOf(

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
@@ -45,6 +45,7 @@ import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import androidx.compose.ui.graphics.Color
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
@@ -191,6 +192,7 @@ private fun previewContribution(
         connector: SyncConnector,
         state: SyncConnectorState,
         isPaused: Boolean,
+        pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
         onDismiss: () -> Unit,
         onTogglePause: () -> Unit,

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -3,7 +3,6 @@ package eu.darken.octi.sync.ui.devices
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
-import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
@@ -107,7 +106,7 @@ class SyncDevicesVM @Inject constructor(
                 },
                 connector.operations,
                 issueAggregator.issues,
-                syncSettings.pausedConnectors.flow,
+                syncSettings.pausedConnectorIds,
             ) { deviceMetadata, metaDatas, operations, allIssues, pausedIds ->
                 log(TAG) { "Loading devices, ${deviceMetadata.size} metadata, ${allIssues.size} issues" }
 

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorCardState.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorCardState.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.sync.ui.list
 
 import eu.darken.octi.sync.core.ConnectorIssue
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.blob.StorageStatus
@@ -14,6 +15,7 @@ data class ConnectorCardState(
     val connector: SyncConnector,
     val syncState: SyncConnectorState,
     val storageStatus: StorageStatus,
+    val pauseReason: ConnectorPauseReason?,
     val isPaused: Boolean,
     val isBusy: Boolean,
     val issues: List<ConnectorIssue>,

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorOverviewProvider.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorOverviewProvider.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.sync.core.ConnectorIssueAggregator
 import eu.darken.octi.sync.core.ConnectorOperation
 import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.reasonFor
 import eu.darken.octi.sync.core.blob.StorageStatus
 import eu.darken.octi.sync.core.blob.StorageStatusManager
 import kotlinx.coroutines.CoroutineScope
@@ -40,23 +41,25 @@ class ConnectorOverviewProvider @Inject constructor(
 
     val cards: Flow<List<ConnectorCardState>> = combine(
         syncManager.allConnectors,
-        syncSettings.pausedConnectors.flow,
+        syncSettings.connectorPauseStates,
         storageStatusManager.statuses,
         issueAggregator.issues,
-    ) { connectors, paused, statuses, allIssues ->
-        Quad(connectors, paused, statuses, allIssues)
+    ) { connectors, pauseStates, statuses, allIssues ->
+        Quad(connectors, pauseStates, statuses, allIssues)
     }
-        .flatMapLatest { (connectors, paused, statuses, allIssues) ->
+        .flatMapLatest { (connectors, pauseStates, statuses, allIssues) ->
             if (connectors.isEmpty()) flowOf(emptyList())
             else combine(connectors.map { c ->
                 combine(c.state, c.operations) { state, ops ->
                     val issues = allIssues.filter { it.connectorId == c.identifier }
                     val isBusy = ops.any { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
+                    val pauseReason = pauseStates.reasonFor(c.identifier)
                     ConnectorCardState(
                         connector = c,
                         syncState = state,
                         storageStatus = statuses[c.identifier] ?: StorageStatus.Unsupported(c.identifier),
-                        isPaused = c.identifier in paused,
+                        pauseReason = pauseReason,
+                        isPaused = pauseReason != null,
                         isBusy = isBusy,
                         issues = issues,
                     )

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
@@ -48,6 +48,7 @@ import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.error.ErrorEventHandler
+import eu.darken.octi.common.error.localized
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
@@ -169,6 +170,7 @@ fun SyncListScreen(
             connector = item.connector,
             state = item.ourState,
             isPaused = item.isPaused,
+            pauseReason = item.pauseReason,
             isPro = state.isPro,
             onDismiss = { showActionsForId = null },
             onTogglePause = { onTogglePause(item.connectorId) },
@@ -293,6 +295,8 @@ private fun LabeledField(label: String, value: String) {
 
 @Composable
 private fun LastSyncField(state: SyncConnectorState) {
+    val context = LocalContext.current
+    val lastError = state.lastError
     Text(
         text = stringResource(R.string.sync_last_action_label),
         style = MaterialTheme.typography.labelMedium,
@@ -302,15 +306,15 @@ private fun LastSyncField(state: SyncConnectorState) {
             ?.let { DateUtils.getRelativeTimeSpanString(it.toEpochMilliseconds()).toString() }
             ?: stringResource(R.string.sync_last_never_label),
         style = MaterialTheme.typography.bodyMedium,
-        color = if (state.lastError != null) {
+        color = if (lastError != null) {
             MaterialTheme.colorScheme.error
         } else {
             MaterialTheme.colorScheme.onSurface
         },
     )
-    if (state.lastError != null) {
+    if (lastError != null) {
         Text(
-            text = state.lastError.toString(),
+            text = lastError.localized(context).description.get(context),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.error,
         )

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
@@ -15,6 +15,7 @@ import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.SyncManager
@@ -58,6 +59,7 @@ class SyncListVM @Inject constructor(
         val ourState: SyncConnectorState,
         val storageStatus: StorageStatus,
         val otherStates: Collection<SyncConnectorState>,
+        val pauseReason: ConnectorPauseReason?,
         val isPaused: Boolean,
         val isBusy: Boolean,
         val issues: List<ConnectorIssue> = emptyList(),
@@ -105,6 +107,7 @@ class SyncListVM @Inject constructor(
                     storageStatus = card.storageStatus,
                     otherStates = cards.filter { it.connector.identifier != card.connector.identifier }
                         .map { it.syncState },
+                    pauseReason = card.pauseReason,
                     isPaused = card.isPaused,
                     isBusy = card.isBusy,
                     issues = card.issues,
@@ -129,7 +132,9 @@ class SyncListVM @Inject constructor(
 
     fun togglePause(connectorId: ConnectorId) = launch {
         log(TAG) { "togglePause($connectorId)" }
-        if (!upgradeRepo.isPro()) {
+        val pauseReason = syncSettings.pauseReason(connectorId)
+        val isRepairResume = pauseReason == ConnectorPauseReason.AuthIssue
+        if (!upgradeRepo.isPro() && !isRepairResume) {
             navTo(Nav.Main.Upgrade())
             return@launch
         }

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.syncs.octiserver.core.OctiServerIssue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -132,6 +133,25 @@ class DeviceInfoBuilderTest : BaseTest() {
             infos shouldHaveSize 2
             // StaleDevice is WARNING, ClockSkew is WARNING — both same severity, sorted by class name
             infos.all { it.severity == IssueSeverity.WARNING } shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `dashboard issue filtering` {
+        @Test
+        fun `paused connector issues are hidden unless current device is no longer registered`() {
+            val hiddenIssue = CommonIssue.ClockSkew(connectorId = connectorId, deviceId = currentDeviceId)
+            val visibleIssue = OctiServerIssue.CurrentDeviceNotRegistered(
+                connectorId = connectorId,
+                deviceId = currentDeviceId,
+            )
+
+            val result = DashboardVM.filterDashboardIssues(
+                allIssues = listOf(hiddenIssue, visibleIssue),
+                pausedIds = setOf(connectorId),
+            )
+
+            result shouldBe listOf(visibleIssue)
         }
     }
 

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorCommand.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorCommand.kt
@@ -8,7 +8,7 @@ sealed interface ConnectorCommand {
 
     data object Reset : ConnectorCommand
 
-    data object Pause : ConnectorCommand
+    data class Pause(val reason: ConnectorPauseReason = ConnectorPauseReason.Manual) : ConnectorCommand
 
     data object Resume : ConnectorCommand
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorPauseState.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorPauseState.kt
@@ -1,0 +1,25 @@
+package eu.darken.octi.sync.core
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class ConnectorPauseReason {
+    @SerialName("manual")
+    Manual,
+
+    @SerialName("auth_issue")
+    AuthIssue,
+}
+
+@Serializable
+data class ConnectorPauseState(
+    @SerialName("connector_id") val connectorId: ConnectorId,
+    @SerialName("reason") val reason: ConnectorPauseReason,
+)
+
+fun Set<ConnectorPauseState>.reasonFor(connectorId: ConnectorId): ConnectorPauseReason? =
+    firstOrNull { it.connectorId == connectorId }?.reason
+
+val Set<ConnectorPauseState>.connectorIds: Set<ConnectorId>
+    get() = mapTo(mutableSetOf()) { it.connectorId }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.sync.core
 
-import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
@@ -194,8 +193,8 @@ class ConnectorProcessor(
     }
 
     private suspend fun guardPauseIfNeeded(command: ConnectorCommand) {
-        if (command == ConnectorCommand.Pause || command == ConnectorCommand.Resume) return
-        if (syncSettings.pausedConnectors.value().contains(connectorId)) {
+        if (command is ConnectorCommand.Pause || command == ConnectorCommand.Resume) return
+        if (syncSettings.isPaused(connectorId)) {
             log(TAG, WARN) { "guard($connectorId): paused, rejecting $command" }
             throw ConnectorPausedException(connectorId)
         }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
@@ -52,6 +52,7 @@ interface ConnectorUiContribution {
         connector: SyncConnector,
         state: SyncConnectorState,
         isPaused: Boolean,
+        pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
         onDismiss: () -> Unit,
         onTogglePause: () -> Unit,

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -3,7 +3,6 @@ package eu.darken.octi.sync.core
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
-import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
@@ -62,6 +61,12 @@ class SyncManager @Inject constructor(
 
     private val disabledConnectors = MutableStateFlow(emptySet<SyncConnector>())
 
+    init {
+        scope.launch(dispatcherProvider.Default) {
+            syncSettings.migrateLegacyPauseStates()
+        }
+    }
+
     private val hubs: Flow<Collection<ConnectorHub>> = flow {
         emit(connectorHubs)
         awaitCancellation()
@@ -87,7 +92,7 @@ class SyncManager @Inject constructor(
      * unless it explicitly needs paused entries too.
      */
     val connectors: Flow<List<SyncConnector>> = allConnectors
-        .combine(syncSettings.pausedConnectors.flow) { conns, paused ->
+        .combine(syncSettings.pausedConnectorIds) { conns, paused ->
             conns.filter { !paused.contains(it.identifier) }
         }
         .setupCommonEventHandlers(TAG) { "connectors" }
@@ -189,7 +194,7 @@ class SyncManager @Inject constructor(
         log(TAG) { "sync(${connectorId.logLabel}, ${options.logLabel})" }
         // Fast-path defense: avoid submitting work we already know the processor will reject.
         // The processor also enforces the pause guard authoritatively.
-        if (syncSettings.pausedConnectors.value().contains(connectorId)) {
+        if (syncSettings.isPaused(connectorId)) {
             log(TAG, INFO) { "sync(${connectorId.logLabel}): connector is paused, skipping" }
             return
         }
@@ -235,7 +240,7 @@ class SyncManager @Inject constructor(
 
     suspend fun resetData(identifier: ConnectorId) = withContext(NonCancellable) {
         log(TAG) { "resetData(identifier=$identifier)" }
-        if (syncSettings.pausedConnectors.value().contains(identifier)) {
+        if (syncSettings.isPaused(identifier)) {
             log(TAG, INFO) { "resetData($identifier): connector is paused, skipping" }
             return@withContext
         }
@@ -252,9 +257,9 @@ class SyncManager @Inject constructor(
 
         disabledConnectors.value += connector
 
-        if (syncSettings.pausedConnectors.value().contains(identifier)) {
+        if (syncSettings.isPaused(identifier)) {
             log(TAG) { "disconnect(...) was paused, clearing it" }
-            syncSettings.pausedConnectors.update { it - identifier }
+            syncSettings.resumeConnector(identifier)
         }
 
         try {
@@ -273,7 +278,7 @@ class SyncManager @Inject constructor(
 
     suspend fun togglePause(identifier: ConnectorId, paused: Boolean? = null) {
         log(TAG, INFO) { "togglePause($identifier, enabled=$paused)" }
-        val wasPaused = syncSettings.pausedConnectors.value().contains(identifier)
+        val wasPaused = syncSettings.isPaused(identifier)
         val pause = paused ?: !wasPaused
         if (wasPaused == pause) {
             log(TAG) { "togglePause($identifier): no-op, already in target state" }
@@ -286,7 +291,7 @@ class SyncManager @Inject constructor(
         // Route through the queue so the setting write is serialized with the connector's other
         // work. After a successful Resume, the processor enqueues a Sync on its own queue — no
         // fire-and-forget launch needed here.
-        connector.execute(if (pause) ConnectorCommand.Pause else ConnectorCommand.Resume)
+        connector.execute(if (pause) ConnectorCommand.Pause() else ConnectorCommand.Resume)
     }
 
     companion object {

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
@@ -9,9 +9,15 @@ import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.datastore.createSetValue
 import eu.darken.octi.common.datastore.createValue
+import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import java.util.UUID
@@ -47,9 +53,68 @@ class SyncSettings @Inject constructor(
 
     val showDashboardCard = dataStore.createValue("sync.dashboard.card.show", true)
 
-    val pausedConnectors = dataStore.createSetValue<ConnectorId>("sync.connectors.paused", emptySet(), json)
+    private val legacyPausedConnectors = dataStore.createSetValue<ConnectorId>(
+        "sync.connectors.paused",
+        emptySet(),
+        json,
+    )
+
+    private val storedConnectorPauseStates = dataStore.createSetValue<ConnectorPauseState>(
+        "sync.connectors.paused.states",
+        emptySet(),
+        json,
+        onErrorFallbackToDefault = true,
+    )
+
+    val connectorPauseStates: Flow<Set<ConnectorPauseState>> = combine(
+        storedConnectorPauseStates.flow,
+        legacyPausedConnectors.flow,
+    ) { storedStates, legacyIds ->
+        val storedIds = storedStates.connectorIds
+        storedStates + legacyIds
+            .filterNot { it in storedIds }
+            .map { ConnectorPauseState(connectorId = it, reason = ConnectorPauseReason.Manual) }
+    }.distinctUntilChanged()
+
+    val pausedConnectorIds: Flow<Set<ConnectorId>> = connectorPauseStates
+        .map { it.connectorIds }
+        .distinctUntilChanged()
 
     val clockSkewThreshold = dataStore.createValue("sync.clock.skew.threshold", 2.minutes, json)
+
+    suspend fun migrateLegacyPauseStates() {
+        val legacyIds = legacyPausedConnectors.value()
+        if (legacyIds.isEmpty()) return
+
+        storedConnectorPauseStates.update { storedStates ->
+            val storedIds = storedStates.connectorIds
+            storedStates + legacyIds
+                .filterNot { it in storedIds }
+                .map { ConnectorPauseState(connectorId = it, reason = ConnectorPauseReason.Manual) }
+        }
+        legacyPausedConnectors.update { emptySet() }
+    }
+
+    suspend fun pauseReason(connectorId: ConnectorId): ConnectorPauseReason? =
+        connectorPauseStates.first().reasonFor(connectorId)
+
+    suspend fun isPaused(connectorId: ConnectorId): Boolean = pauseReason(connectorId) != null
+
+    suspend fun pauseConnector(connectorId: ConnectorId, reason: ConnectorPauseReason) {
+        storedConnectorPauseStates.update { storedStates ->
+            storedStates
+                .filterNot { it.connectorId == connectorId }
+                .toSet() + ConnectorPauseState(connectorId = connectorId, reason = reason)
+        }
+        legacyPausedConnectors.update { it - connectorId }
+    }
+
+    suspend fun resumeConnector(connectorId: ConnectorId) {
+        storedConnectorPauseStates.update { storedStates ->
+            storedStates.filterNot { it.connectorId == connectorId }.toSet()
+        }
+        legacyPausedConnectors.update { it - connectorId }
+    }
 
     val deviceId by lazy {
         val key = stringPreferencesKey("sync.identifier.device")

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/blob/BlobManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/blob/BlobManager.kt
@@ -105,7 +105,7 @@ class BlobManager @Inject constructor(
     }
 
     private val allStores: Flow<List<BlobStore>> = rawStores
-        .combine(syncSettings.pausedConnectors.flow) { stores, paused ->
+        .combine(syncSettings.pausedConnectorIds) { stores, paused ->
             stores.filter { it.connectorId !in paused }
         }
         .setupCommonEventHandlers(TAG) { "allStores" }
@@ -118,7 +118,7 @@ class BlobManager @Inject constructor(
         // survive; QuotaExceeded is similarly preserved because freeing space is the user's job.
         scope.launch(dispatcherProvider.Default) {
             var previous = emptySet<ConnectorId>()
-            syncSettings.pausedConnectors.flow.collect { paused ->
+            syncSettings.pausedConnectorIds.collect { paused ->
                 val resumed = previous - paused
                 if (resumed.isNotEmpty()) {
                     var changed = false

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorPauseStateSerializationTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorPauseStateSerializationTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.sync.ConnectorType
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class ConnectorPauseStateSerializationTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    private val connectorId = ConnectorId(
+        type = ConnectorType.OCTISERVER,
+        subtype = "prod",
+        account = "acc-123",
+    )
+
+    @Test
+    fun `pause reason wire values are stable`() {
+        json.encodeToString(ConnectorPauseReason.Manual) shouldBe "\"manual\""
+        json.encodeToString(ConnectorPauseReason.AuthIssue) shouldBe "\"auth_issue\""
+    }
+
+    @Test
+    fun `round-trip serialization`() {
+        val states = setOf(
+            ConnectorPauseState(
+                connectorId = connectorId,
+                reason = ConnectorPauseReason.AuthIssue,
+            )
+        )
+
+        val encoded = json.encodeToString(states)
+        val decoded = json.decodeFromString<Set<ConnectorPauseState>>(encoded)
+
+        decoded shouldBe states
+    }
+
+    @Test
+    fun `wire format stability`() {
+        val encoded = json.encodeToString(
+            setOf(
+                ConnectorPauseState(
+                    connectorId = connectorId,
+                    reason = ConnectorPauseReason.AuthIssue,
+                )
+            )
+        )
+
+        encoded.toComparableJson() shouldBe """
+            [
+                {
+                    "connector_id": {
+                        "type": "kserver",
+                        "subtype": "prod",
+                        "account": "acc-123"
+                    },
+                    "reason": "auth_issue"
+                }
+            ]
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `forward compatibility - unknown fields are ignored`() {
+        val futureJson = """
+            [
+                {
+                    "connector_id": {
+                        "type": "kserver",
+                        "subtype": "prod",
+                        "account": "acc-123",
+                        "new_connector_field": "ignored"
+                    },
+                    "reason": "manual",
+                    "new_pause_field": "ignored"
+                }
+            ]
+        """
+
+        val decoded = json.decodeFromString<Set<ConnectorPauseState>>(futureJson)
+
+        decoded shouldBe setOf(
+            ConnectorPauseState(
+                connectorId = connectorId,
+                reason = ConnectorPauseReason.Manual,
+            )
+        )
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.sync.core
 
-import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.errors.ConnectorPausedException
 import io.kotest.matchers.collections.shouldContain
@@ -29,21 +28,15 @@ class ConnectorProcessorTest : BaseTest() {
 
     private val connectorId = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "test", account = "acc")
     private lateinit var syncSettings: SyncSettings
-    private lateinit var pausedConnectorsValue: MutableStateFlow<Set<ConnectorId>>
+    private lateinit var pauseStatesValue: MutableStateFlow<Set<ConnectorPauseState>>
 
     @BeforeEach
     fun setup() {
-        pausedConnectorsValue = MutableStateFlow(emptySet())
+        pauseStatesValue = MutableStateFlow(emptySet())
         syncSettings = mockk(relaxed = true) {
-            every { pausedConnectors } returns mockk<DataStoreValue<Set<ConnectorId>>>(relaxed = true) {
-                every { flow } returns pausedConnectorsValue
-                coEvery { update(any()) } coAnswers {
-                    val transform = firstArg<(Set<ConnectorId>) -> Set<ConnectorId>?>()
-                    val old = pausedConnectorsValue.value
-                    val new = transform(old) ?: old
-                    pausedConnectorsValue.value = new
-                    mockk(relaxed = true)
-                }
+            every { connectorPauseStates } returns pauseStatesValue
+            coEvery { isPaused(any()) } coAnswers {
+                pauseStatesValue.value.reasonFor(firstArg<ConnectorId>()) != null
             }
         }
     }
@@ -88,13 +81,17 @@ class ConnectorProcessorTest : BaseTest() {
         val (proc, job) = buildProcessor(executor = { cmd ->
             // Pause/Resume handlers are inline here (not via SyncSettings) so the guard reads it.
             when (cmd) {
-                ConnectorCommand.Pause -> pausedConnectorsValue.value = pausedConnectorsValue.value + connectorId
-                ConnectorCommand.Resume -> pausedConnectorsValue.value = pausedConnectorsValue.value - connectorId
+                is ConnectorCommand.Pause -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet() + ConnectorPauseState(connectorId, cmd.reason)
+                ConnectorCommand.Resume -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet()
                 else -> executed += cmd
             }
         })
 
-        proc.submit(ConnectorCommand.Pause)
+        proc.submit(ConnectorCommand.Pause())
         val syncId = proc.submit(ConnectorCommand.Sync())
         advanceUntilIdle()
 
@@ -113,12 +110,16 @@ class ConnectorProcessorTest : BaseTest() {
         val (proc, job) = buildProcessor(executor = { cmd ->
             executed += cmd
             when (cmd) {
-                ConnectorCommand.Pause -> pausedConnectorsValue.value = pausedConnectorsValue.value + connectorId
-                ConnectorCommand.Resume -> pausedConnectorsValue.value = pausedConnectorsValue.value - connectorId
+                is ConnectorCommand.Pause -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet() + ConnectorPauseState(connectorId, cmd.reason)
+                ConnectorCommand.Resume -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet()
                 else -> Unit
             }
         })
-        pausedConnectorsValue.value = setOf(connectorId)
+        pauseStatesValue.value = setOf(ConnectorPauseState(connectorId, ConnectorPauseReason.Manual))
 
         proc.submit(ConnectorCommand.Resume)
         advanceUntilIdle()
@@ -137,12 +138,16 @@ class ConnectorProcessorTest : BaseTest() {
         val (proc, job) = buildProcessor(executor = { cmd ->
             executed += cmd
             when (cmd) {
-                ConnectorCommand.Pause -> pausedConnectorsValue.value = pausedConnectorsValue.value + connectorId
-                ConnectorCommand.Resume -> pausedConnectorsValue.value = pausedConnectorsValue.value - connectorId
+                is ConnectorCommand.Pause -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet() + ConnectorPauseState(connectorId, cmd.reason)
+                ConnectorCommand.Resume -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet()
                 else -> Unit
             }
         })
-        pausedConnectorsValue.value = setOf(connectorId)
+        pauseStatesValue.value = setOf(ConnectorPauseState(connectorId, ConnectorPauseReason.Manual))
 
         // User first awaits Resume (as happens via togglePause → execute(Resume)) — by the time
         // Resume's terminal resolves, the side-effect Sync has already been submitted into the
@@ -151,7 +156,7 @@ class ConnectorProcessorTest : BaseTest() {
         advanceUntilIdle()
         proc.await(resumeId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
 
-        proc.submit(ConnectorCommand.Pause)
+        proc.submit(ConnectorCommand.Pause())
         advanceUntilIdle()
 
         // Executed order: Resume → Sync → Pause.

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.sync.core
 
-import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.cache.SyncCache
@@ -18,6 +17,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestScope
@@ -41,7 +41,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
     private lateinit var connector1: SyncConnector
     private lateinit var connector2: SyncConnector
     private lateinit var syncSettings: SyncSettings
-    private lateinit var pausedConnectorsValue: MutableStateFlow<Set<ConnectorId>>
+    private lateinit var pauseStatesValue: MutableStateFlow<Set<ConnectorPauseState>>
     private lateinit var syncCache: SyncCache
     private lateinit var connectorHub: ConnectorHub
     private lateinit var connectorsFlow: MutableStateFlow<List<SyncConnector>>
@@ -51,6 +51,11 @@ class SyncManagerSyncWriteTest : BaseTest() {
         every { this@mockk.moduleId } returns moduleId
         every { this@mockk.payload } returns payload.encodeUtf8()
     }
+
+    private fun pausedState(
+        connectorId: ConnectorId,
+        reason: ConnectorPauseReason = ConnectorPauseReason.Manual,
+    ) = ConnectorPauseState(connectorId = connectorId, reason = reason)
 
     /**
      * Set up a mocked connector that behaves like a real one for SyncManager's purposes:
@@ -63,8 +68,12 @@ class SyncManagerSyncWriteTest : BaseTest() {
         every { submit(any()) } answers {
             val cmd = firstArg<ConnectorCommand>()
             when (cmd) {
-                ConnectorCommand.Pause -> pausedConnectorsValue.value = pausedConnectorsValue.value + cid
-                ConnectorCommand.Resume -> pausedConnectorsValue.value = pausedConnectorsValue.value - cid
+                is ConnectorCommand.Pause -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == cid }
+                    .toSet() + ConnectorPauseState(cid, cmd.reason)
+                ConnectorCommand.Resume -> pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == cid }
+                    .toSet()
                 else -> Unit
             }
             OperationId.create()
@@ -118,18 +127,30 @@ class SyncManagerSyncWriteTest : BaseTest() {
         }
         connectorsFlow = MutableStateFlow(listOf(connector1))
 
-        pausedConnectorsValue = MutableStateFlow(emptySet())
+        pauseStatesValue = MutableStateFlow(emptySet())
         syncSettings = mockk(relaxed = true) {
-            every { pausedConnectors } returns mockk<DataStoreValue<Set<ConnectorId>>>(relaxed = true) {
-                every { flow } returns pausedConnectorsValue
-                coEvery { update(any()) } coAnswers {
-                    val transform = firstArg<(Set<ConnectorId>) -> Set<ConnectorId>?>()
-                    val old = pausedConnectorsValue.value
-                    val new = transform(old) ?: old
-                    pausedConnectorsValue.value = new
-                    mockk(relaxed = true)
-                }
+            every { connectorPauseStates } returns pauseStatesValue
+            every { pausedConnectorIds } returns pauseStatesValue.map { it.connectorIds }
+            coEvery { isPaused(any()) } coAnswers {
+                pauseStatesValue.value.reasonFor(firstArg<ConnectorId>()) != null
             }
+            coEvery { pauseReason(any()) } coAnswers {
+                pauseStatesValue.value.reasonFor(firstArg<ConnectorId>())
+            }
+            coEvery { pauseConnector(any(), any()) } coAnswers {
+                val connectorId = firstArg<ConnectorId>()
+                val reason = secondArg<ConnectorPauseReason>()
+                pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet() + ConnectorPauseState(connectorId, reason)
+            }
+            coEvery { resumeConnector(any()) } coAnswers {
+                val connectorId = firstArg<ConnectorId>()
+                pauseStatesValue.value = pauseStatesValue.value
+                    .filterNot { it.connectorId == connectorId }
+                    .toSet()
+            }
+            coEvery { migrateLegacyPauseStates() } coAnswers { }
         }
         every { syncSettings.deviceId } returns deviceId
 
@@ -429,7 +450,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             sm.updatePayload(createModule(powerModuleId, "data"))
 
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
@@ -445,7 +466,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
 
             sm.resetData(connectorId1)
 
@@ -461,7 +482,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             sm.updatePayload(createModule(powerModuleId, "data"))
 
             sm.sync(SyncOptions(writeData = true, readData = false, stats = false))
@@ -479,13 +500,13 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             sm.updatePayload(createModule(powerModuleId, "data"))
 
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
             coVerify(exactly = 0) { connector1.submit(match { it is ConnectorCommand.Sync }) }
 
-            pausedConnectorsValue.value = emptySet()
+            pauseStatesValue.value = emptySet()
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             coVerify(exactly = 1) { connector1.submit(match { it is ConnectorCommand.Sync }) }
@@ -502,8 +523,8 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.togglePause(connectorId1, paused = true)
             advanceUntilIdle()
 
-            coVerify { connector1.submit(ConnectorCommand.Pause) }
-            pausedConnectorsValue.value shouldBe setOf(connectorId1)
+            coVerify { connector1.submit(ConnectorCommand.Pause()) }
+            pauseStatesValue.value shouldBe setOf(pausedState(connectorId1))
 
             job.cancel()
             advanceUntilIdle()
@@ -511,7 +532,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
 
         @Test
         fun `togglePause unpause submits Resume command and flips setting`() = runTest2 {
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
@@ -521,7 +542,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             coVerify { connector1.submit(ConnectorCommand.Resume) }
             // Processor-side post-resume Sync is covered by ConnectorProcessor tests; here we
             // only verify SyncManager delegated correctly.
-            pausedConnectorsValue.value shouldBe emptySet()
+            pauseStatesValue.value shouldBe emptySet()
 
             job.cancel()
             advanceUntilIdle()
@@ -542,6 +563,21 @@ class SyncManagerSyncWriteTest : BaseTest() {
             advanceUntilIdle()
         }
 
+        @Test
+        fun `disconnect clears pause reason`() = runTest2 {
+            pauseStatesValue.value = setOf(pausedState(connectorId1, ConnectorPauseReason.AuthIssue))
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.disconnect(connectorId1)
+            advanceUntilIdle()
+
+            pauseStatesValue.value shouldBe emptySet()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
         // See plan section "Auto-sync-after-resume" — the sync after Resume is now enqueued as
         // a side effect of the processor's Resume handling, so it's strictly ordered in the
         // queue relative to any subsequent Pause. That behavior is covered by
@@ -554,7 +590,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             advanceUntilIdle()
 
             val active = sm.connectors.first()
@@ -570,7 +606,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
-            pausedConnectorsValue.value = setOf(connectorId1)
+            pauseStatesValue.value = setOf(pausedState(connectorId1))
             advanceUntilIdle()
 
             val all = sm.allConnectors.first()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/blob/BlobManagerTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/blob/BlobManagerTest.kt
@@ -483,9 +483,7 @@ class BlobManagerTest : BaseTest() {
         }
 
         val syncSettings = mockk<SyncSettings>()
-        every { syncSettings.pausedConnectors } returns mockk {
-            every { flow } returns pausedConnectorsFlow
-        }
+        every { syncSettings.pausedConnectorIds } returns pausedConnectorsFlow
 
         return BlobManager(
             scope = scope,

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -179,8 +179,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
             is ConnectorCommand.Sync -> handleSync(command.options)
             is ConnectorCommand.DeleteDevice -> handleDeleteDevice(command.deviceId)
             ConnectorCommand.Reset -> handleReset()
-            ConnectorCommand.Pause -> syncSettings.pausedConnectors.update { it + identifier }
-            ConnectorCommand.Resume -> syncSettings.pausedConnectors.update { it - identifier }
+            is ConnectorCommand.Pause -> syncSettings.pauseConnector(identifier, command.reason)
+            ConnectorCommand.Resume -> syncSettings.resumeConnector(identifier)
         }
     }
 

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
@@ -35,6 +35,7 @@ import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.sync.core.SyncConnector
@@ -80,6 +81,7 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
         connector: SyncConnector,
         state: SyncConnectorState,
         isPaused: Boolean,
+        pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
         onDismiss: () -> Unit,
         onTogglePause: () -> Unit,

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
 import okio.ByteString.Companion.encodeUtf8
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -94,13 +95,9 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         )
         every { syncSettings.dataStore } returns testDataStore
         every { syncSettings.deviceId } returns DeviceId("test-device")
-        // Processor's pause guard reads syncSettings.pausedConnectors on every command —
+        // Processor's pause guard reads syncSettings.isPaused() on every command —
         // supply an empty flow so guardPauseIfNeeded doesn't NoSuchElementException on flow.first().
-        every {
-            syncSettings.pausedConnectors
-        } returns mockk<eu.darken.octi.common.datastore.DataStoreValue<Set<eu.darken.octi.sync.core.ConnectorId>>>(relaxed = true) {
-            every { flow } returns kotlinx.coroutines.flow.MutableStateFlow(emptySet())
-        }
+        coEvery { syncSettings.isPaused(any()) } returns false
 
         val testAccount = GoogleAccount(accountId = "test-account", email = "test@example.com")
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -7,6 +7,7 @@ import eu.darken.octi.common.collections.fromGzip
 import eu.darken.octi.common.collections.toGzip
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
@@ -24,6 +25,7 @@ import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorOperation
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorProcessor
 import eu.darken.octi.sync.core.ConnectorSyncState
 import eu.darken.octi.sync.core.DeviceId
@@ -102,6 +104,12 @@ class OctiServerConnector @AssistedInject constructor(
     private fun buildAssociatedData(deviceId: DeviceId, moduleId: ModuleId): ByteArray =
         "${deviceId.id}:${moduleId.id}".toByteArray()
 
+    override val identifier: ConnectorId = ConnectorId(
+        type = ConnectorType.OCTISERVER,
+        subtype = credentials.serverAdress.domain,
+        account = credentials.accountId.id,
+    )
+
     data class State(
         override val lastActionAt: Instant? = null,
         override val lastError: Exception? = null,
@@ -115,7 +123,7 @@ class OctiServerConnector @AssistedInject constructor(
         parentScope = scope + dispatcherProvider.IO,
         loggingTag = TAG,
     ) {
-        State()
+        State(issues = buildCurrentDeviceRegistrationIssues())
     }
 
     override val state: Flow<State> = _state.flow
@@ -135,12 +143,6 @@ class OctiServerConnector @AssistedInject constructor(
 
     override val capabilities: ConnectorCapabilities = ConnectorCapabilities(
         deviceRemovalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
-    )
-
-    override val identifier: ConnectorId = ConnectorId(
-        type = ConnectorType.OCTISERVER,
-        subtype = credentials.serverAdress.domain,
-        account = credentials.accountId.id,
     )
 
     private val processor = ConnectorProcessor(
@@ -229,8 +231,14 @@ class OctiServerConnector @AssistedInject constructor(
             is ConnectorCommand.Sync -> handleSync(command.options)
             is ConnectorCommand.DeleteDevice -> handleDeleteDevice(command.deviceId)
             ConnectorCommand.Reset -> handleReset()
-            ConnectorCommand.Pause -> syncSettings.pausedConnectors.update { it + identifier }
-            ConnectorCommand.Resume -> syncSettings.pausedConnectors.update { it - identifier }
+            is ConnectorCommand.Pause -> {
+                syncSettings.pauseConnector(identifier, command.reason)
+                computeIssues()
+            }
+            ConnectorCommand.Resume -> {
+                syncSettings.resumeConnector(identifier)
+                computeIssues()
+            }
         }
     }
 
@@ -388,6 +396,7 @@ class OctiServerConnector @AssistedInject constructor(
         val dataDeviceIds = data?.devices?.filter { it.modules.isNotEmpty() }?.map { it.deviceId }?.toSet() ?: emptySet()
         val encType = credentials.encryptionKeyset.type
         val isGcmSiv = EncryptionMode.fromTypeString(encType) == EncryptionMode.AES256_GCM_SIV
+        val registrationIssues = buildCurrentDeviceRegistrationIssues()
 
         val encIssues = if (!isGcmSiv) emptyList() else metadata.mapNotNull { device ->
             if (device.deviceId == syncSettings.deviceId) return@mapNotNull null
@@ -421,9 +430,23 @@ class OctiServerConnector @AssistedInject constructor(
             }
         }
 
-        val issues = encIssues + blobIssues + commitIssues
+        val issues = registrationIssues + encIssues + blobIssues + commitIssues
         log(TAG) { "computeIssues(): ${issues.size} issues" }
         _state.updateBlocking { copy(issues = issues) }
+    }
+
+    private suspend fun buildCurrentDeviceRegistrationIssues(): List<ConnectorIssue> {
+        val isUnknownDevicePause = syncSettings.pauseReason(identifier) == ConnectorPauseReason.AuthIssue
+        return if (isUnknownDevicePause) {
+            listOf(
+                OctiServerIssue.CurrentDeviceNotRegistered(
+                    connectorId = identifier,
+                    deviceId = syncSettings.deviceId,
+                )
+            )
+        } else {
+            emptyList()
+        }
     }
 
     private suspend fun fetchModule(deviceId: DeviceId, moduleId: ModuleId): OctiServerModuleData? {
@@ -627,11 +650,11 @@ class OctiServerConnector @AssistedInject constructor(
         log(TAG, VERBOSE) { "writeServer(): Done" }
     }
 
-    private fun handleDeviceUnknown(e: Exception, operation: String): Boolean {
+    private suspend fun handleDeviceUnknown(e: Exception, operation: String): Boolean {
         if ((e as? OctiServerHttpException)?.isDeviceUnknown != true) return false
         log(TAG, WARN) { "$operation: device no longer registered, pausing connector" }
         // Route through the queue so pause is serialized with the rest of this connector's work.
-        submit(ConnectorCommand.Pause)
+        submit(ConnectorCommand.Pause(ConnectorPauseReason.AuthIssue))
         return true
     }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerHttpException.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerHttpException.kt
@@ -35,7 +35,10 @@ class OctiServerHttpException(
 
     override fun getLocalizedError(): LocalizedError = LocalizedError(
         throwable = this,
-        label = caString { cause.message() },
+        label = when {
+            isDeviceUnknown -> caString { it.getString(R.string.sync_octiserver_issues_type_device_not_registered) }
+            else -> caString { cause.message() }
+        },
         description = when {
             isDeviceUnknown -> caString { it.getString(R.string.sync_octiserver_error_device_not_registered) }
             else -> caString { errorMessage }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
@@ -10,6 +10,15 @@ import eu.darken.octi.syncs.octiserver.R
 
 sealed interface OctiServerIssue : ConnectorIssue {
 
+    data class CurrentDeviceNotRegistered(
+        override val connectorId: ConnectorId,
+        override val deviceId: DeviceId,
+    ) : OctiServerIssue {
+        override val severity: IssueSeverity = IssueSeverity.ERROR
+        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_device_not_registered) }
+        override val description: CaString = caString { it.getString(R.string.sync_octiserver_error_device_not_registered) }
+    }
+
     data class EncryptionIncompatible(
         override val connectorId: ConnectorId,
         override val deviceId: DeviceId,

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
@@ -27,18 +27,21 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.syncs.octiserver.R
 import eu.darken.octi.syncs.octiserver.core.OctiServerConnector
+import eu.darken.octi.syncs.octiserver.core.OctiServerIssue
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -79,6 +82,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
         connector: SyncConnector,
         state: SyncConnectorState,
         isPaused: Boolean,
+        pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
         onDismiss: () -> Unit,
         onTogglePause: () -> Unit,
@@ -91,6 +95,9 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
         val octi = connector as? OctiServerConnector ?: return
         var showDisconnectConfirmation by remember { mutableStateOf(false) }
         var showResetConfirmation by remember { mutableStateOf(false) }
+        val unknownDeviceIssue = state.issues.filterIsInstance<OctiServerIssue.CurrentDeviceNotRegistered>().firstOrNull()
+        val context = LocalContext.current
+        val canTogglePause = isPro || pauseReason == ConnectorPauseReason.AuthIssue
 
         ModalBottomSheet(onDismissRequest = onDismiss) {
             Column(modifier = Modifier.padding(horizontal = 24.dp)) {
@@ -105,6 +112,20 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
 
                 Spacer(modifier = Modifier.height(16.dp))
 
+                if (unknownDeviceIssue != null) {
+                    Text(
+                        text = unknownDeviceIssue.label.get(context),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                    Text(
+                        text = unknownDeviceIssue.description.get(context),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
@@ -116,7 +137,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                         text = stringResource(SyncR.string.sync_connector_paused_label),
                         modifier = Modifier.weight(1f),
                     )
-                    if (isPro) {
+                    if (canTogglePause) {
                         Switch(
                             checked = isPaused,
                             onCheckedChange = null,
@@ -132,6 +153,15 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))
+
+                if (unknownDeviceIssue != null && isPaused) {
+                    FilledTonalButton(
+                        onClick = onTogglePause,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(text = stringResource(R.string.sync_octiserver_resume_sync_action))
+                    }
+                }
 
                 Button(
                     onClick = onForceSync,

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.DispatcherProvider
-import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
@@ -74,7 +73,7 @@ class OctiServerLinkHostVM @Inject constructor(
 
         launch {
             val connector = connectorFlow.first()
-            syncSettings.pausedConnectors.flow
+            syncSettings.pausedConnectorIds
                 .map { it.contains(connector.identifier) }
                 .distinctUntilChanged()
                 .collectLatest { isPaused ->
@@ -104,7 +103,7 @@ class OctiServerLinkHostVM @Inject constructor(
                 _state.value = _state.value.copy(encodedLinkCode = null)
             }
             val connector = connectorFlow.first()
-            if (syncSettings.pausedConnectors.value().contains(connector.identifier)) {
+            if (syncSettings.isPaused(connector.identifier)) {
                 log(TAG, WARN) { "onScreenVisible(): connector ${connector.identifier} is paused, navigating up" }
                 navUp()
                 return@launch

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -20,7 +20,9 @@
     <string name="sync_octiserver_link_client_option_qrcode">Scan a QR code from another device</string>
     <string name="sync_octiserver_link_client_startcamera_action">Start camera</string>
     <string name="sync_octiserver_link_client_link_action">Link device</string>
+    <string name="sync_octiserver_issues_type_device_not_registered">Device no longer linked</string>
     <string name="sync_octiserver_error_device_not_registered">This device is no longer registered on the server. Disconnect and re-link from another device, or create a new account.</string>
+    <string name="sync_octiserver_resume_sync_action">Resume synchronization</string>
     <string name="sync_octiserver_add_legacy_encryption_label">Legacy encryption</string>
     <string name="sync_octiserver_add_legacy_encryption_hint">New accounts use improved encryption. App versions older than %1$s cannot sync with new-style accounts.</string>
     <string name="sync_octiserver_device_encryption_incompatible">This device may not support this account\'s encryption. Update the app on this device or recreate the account with legacy encryption.</string>


### PR DESCRIPTION
## Summary

When the OctiServer returns 401/404/410 for the current device's record (i.e. the device was unlinked from another client or the account was reset), the connector now pauses with a typed `AuthIssue` reason rather than silently re-failing each sync. The dashboard surfaces a "Device no longer linked" ERROR card that punches through the paused-connector filter, and the connector bottom sheet exposes a dedicated "Resume synchronization" action so non-Pro users can recover (or disconnect + re-link) without hitting the Pro upsell.

## What changed

- **New `ConnectorPauseState` model** (`sync-core`): replaces the flat `Set<ConnectorId>` of paused connectors with `Set<ConnectorPauseState>` carrying `ConnectorPauseReason.Manual | AuthIssue`. `ConnectorCommand.Pause` now takes the reason; the processor's pause guard rejects all non-pause/resume commands while paused.
- **Migration**: `SyncManager.init` launches a one-shot `migrateLegacyPauseStates()` that promotes any legacy `sync.connectors.paused` entries to `Manual`. The `connectorPauseStates` flow also overlays legacy entries at read time, so collectors see correct state before the migration commits.
- **OctiServerConnector** (`syncs-octiserver`): `handleDeviceUnknown` now submits `Pause(AuthIssue)`. `_state` initial value seeds the `CurrentDeviceNotRegistered` issue when restoring the persisted AuthIssue tag (handles app restart while paused). Disconnect clears the tag via `SyncManager.disconnect`.
- **GDriveAppDataConnector**: rewired to the new `Pause/Resume` shape (no AuthIssue path yet).
- **UI**:
  - `OctiServerUiContribution`: bottom-sheet shows the friendly label/description; Switch is interactive when `pauseReason == AuthIssue` (free repair-resume); a `FilledTonalButton` "Resume synchronization" appears below the Pause row.
  - `LastSyncField` (sync list): now renders `lastError.localized(context).description` instead of `toString()` — the device-unknown text surfaces directly on the connector card.
  - `DashboardVM.filterDashboardIssues`: `CurrentDeviceNotRegistered` joins the existing `BlobEncryptionUnsupported` punch-through so the dashboard error card stays visible while the connector is paused.
  - `SyncListVM.togglePause`: bypasses the Pro upsell when `pauseReason == AuthIssue` so non-Pro users can resume.
- **Tests**: `SyncManagerSyncWriteTest`, `ConnectorProcessorTest`, and `BlobManagerTest` were rewired to the typed pause-state model. Added `disconnect clears pause reason` (AuthIssue case), a new `ConnectorPauseStateSerializationTest` covering the wire format + forward-compat, and a `dashboard issue filtering` case in `DeviceInfoBuilderTest`.

## Test plan

- [x] `./gradlew :syncs-octiserver:assembleDebug :sync-core:compileDebugUnitTestKotlin` — green
- [x] `./gradlew :syncs-octiserver:testDebugUnitTest :sync-core:testDebugUnitTest :app:testFossDebugUnitTest` — green
- [x] Manual smoke test on octi-1 + octi-2 emulators (FOSS debug):
  - Baseline both devices linked, 0 errors.
  - Removed octi-2 from octi-1's synced-devices list.
  - Force-synced on octi-2 → connector paused with AuthIssue (logcat: `device no longer registered, pausing connector`).
  - Dashboard showed "1 error" chip + "Device no longer linked" card.
  - Bottom sheet showed label + description + "Resume synchronization" button; other actions correctly disabled while paused.
  - Tapped Resume → cycle confirmed in logcat: `pauseReason: AuthIssue → null` → auto-Sync → 404 → `pauseReason: null → AuthIssue`. Self-correcting.
  - Disconnect cleared the AuthIssue tag — dashboard returned to clean state.
  - No crashes in `eu.darken.octi`.
