### PR TITLE
OctiServer: simpler create-account flow and clearer device warning

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -285,7 +285,7 @@ class DashboardVM @Inject constructor(
         fileShareRepo.isEnabled,
     ) { issues, fileShareEnabled ->
         if (fileShareEnabled) issues
-        else issues.filterNot { it is OctiServerIssue.BlobEncryptionUnsupported }
+        else issues.filterNot { it is OctiServerIssue.LegacyEncryptionAccount }
     }
 
     // NOTE: must be declared before `state` (which references it via `deviceItems()`).

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/VersionCompat.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/VersionCompat.kt
@@ -8,6 +8,11 @@ object VersionCompat {
         return compareVersions(version, MIN_COMPATIBLE_VERSION) < 0
     }
 
+    fun isAtLeast(version: String?, minimum: String?): Boolean {
+        if (version.isNullOrBlank() || minimum.isNullOrBlank()) return false
+        return compareVersions(version, minimum) >= 0
+    }
+
     /**
      * Compares two version strings using major.minor.patch components.
      * Strips any `-rc*`, `-beta*`, or other suffixes before comparing.

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/AccountCompatibility.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/AccountCompatibility.kt
@@ -1,0 +1,15 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import eu.darken.octi.sync.core.encryption.EncryptionMode
+import eu.darken.octi.sync.core.encryption.PayloadEncryption
+
+object AccountCompatibility {
+    const val MIN_ENCRYPTION_V2_CLIENT_VERSION = "1.0.0"
+
+    fun expectedMinClientVersion(keyset: PayloadEncryption.KeySet): String? =
+        when (EncryptionMode.fromTypeString(keyset.type)) {
+            EncryptionMode.AES256_GCM_SIV -> MIN_ENCRYPTION_V2_CLIENT_VERSION
+            EncryptionMode.AES256_SIV,
+            null -> null
+        }
+}

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -43,6 +43,7 @@ import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.SyncWriteContainer
+import eu.darken.octi.sync.core.VersionCompat
 import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import kotlinx.coroutines.CancellationException
@@ -397,18 +398,7 @@ class OctiServerConnector @AssistedInject constructor(
         val encType = credentials.encryptionKeyset.type
         val isGcmSiv = EncryptionMode.fromTypeString(encType) == EncryptionMode.AES256_GCM_SIV
         val registrationIssues = buildCurrentDeviceRegistrationIssues()
-
-        val encIssues = if (!isGcmSiv) emptyList() else metadata.mapNotNull { device ->
-            if (device.deviceId == syncSettings.deviceId) return@mapNotNull null
-            if (device.deviceId in dataDeviceIds) return@mapNotNull null
-            val addedAt = device.addedAt ?: return@mapNotNull null
-            if ((Clock.System.now() - addedAt) < SyncSettings.FIRST_SYNC_GRACE_PERIOD) return@mapNotNull null
-            OctiServerIssue.EncryptionIncompatible(
-                connectorId = identifier,
-                deviceId = device.deviceId,
-                deviceLabel = device.label,
-            )
-        }
+        val compatibilityIssues = buildAccountCompatibilityIssues(metadata, dataDeviceIds)
 
         val blobIssues = if (!isGcmSiv) {
             listOf(
@@ -430,9 +420,34 @@ class OctiServerConnector @AssistedInject constructor(
             }
         }
 
-        val issues = registrationIssues + encIssues + blobIssues + commitIssues
+        val issues = registrationIssues + compatibilityIssues + blobIssues + commitIssues
         log(TAG) { "computeIssues(): ${issues.size} issues" }
         _state.updateBlocking { copy(issues = issues) }
+    }
+
+    private fun buildAccountCompatibilityIssues(
+        metadata: List<DeviceMetadata>,
+        dataDeviceIds: Set<DeviceId>,
+    ): List<ConnectorIssue> {
+        val minClientVersion = AccountCompatibility.expectedMinClientVersion(credentials.encryptionKeyset)
+            ?: return emptyList()
+        return metadata.mapNotNull { device ->
+            if (device.deviceId == syncSettings.deviceId) return@mapNotNull null
+
+            val version = device.version
+            val knownTooOld = version != null && !VersionCompat.isAtLeast(version, minClientVersion)
+            val unknownAndNotSyncing = version == null &&
+                device.deviceId !in dataDeviceIds &&
+                device.addedAt?.let { (Clock.System.now() - it) >= SyncSettings.FIRST_SYNC_GRACE_PERIOD } == true
+
+            if (!knownTooOld && !unknownAndNotSyncing) return@mapNotNull null
+
+            OctiServerIssue.AccountCompatibilityIncompatible(
+                connectorId = identifier,
+                deviceId = device.deviceId,
+                minClientVersion = minClientVersion,
+            )
+        }
     }
 
     private suspend fun buildCurrentDeviceRegistrationIssues(): List<ConnectorIssue> {

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -398,7 +398,7 @@ class OctiServerConnector @AssistedInject constructor(
         val encType = credentials.encryptionKeyset.type
         val isGcmSiv = EncryptionMode.fromTypeString(encType) == EncryptionMode.AES256_GCM_SIV
         val registrationIssues = buildCurrentDeviceRegistrationIssues()
-        val compatibilityIssues = buildAccountCompatibilityIssues(metadata, dataDeviceIds)
+        val encryptionIssues = buildEncryptionCompatibilityIssues(metadata, dataDeviceIds)
 
         val blobIssues = if (!isGcmSiv) {
             listOf(
@@ -420,16 +420,16 @@ class OctiServerConnector @AssistedInject constructor(
             }
         }
 
-        val issues = registrationIssues + compatibilityIssues + blobIssues + commitIssues
+        val issues = registrationIssues + encryptionIssues + blobIssues + commitIssues
         log(TAG) { "computeIssues(): ${issues.size} issues" }
         _state.updateBlocking { copy(issues = issues) }
     }
 
-    private fun buildAccountCompatibilityIssues(
+    private fun buildEncryptionCompatibilityIssues(
         metadata: List<DeviceMetadata>,
         dataDeviceIds: Set<DeviceId>,
     ): List<ConnectorIssue> {
-        val minClientVersion = AccountCompatibility.expectedMinClientVersion(credentials.encryptionKeyset)
+        val minClientVersion = OctiServerEncryptionCompat.expectedMinClientVersion(credentials.encryptionKeyset)
             ?: return emptyList()
         return metadata.mapNotNull { device ->
             if (device.deviceId == syncSettings.deviceId) return@mapNotNull null
@@ -442,7 +442,7 @@ class OctiServerConnector @AssistedInject constructor(
 
             if (!knownTooOld && !unknownAndNotSyncing) return@mapNotNull null
 
-            OctiServerIssue.AccountCompatibilityIncompatible(
+            OctiServerIssue.EncryptionCompatibilityIncompatible(
                 connectorId = identifier,
                 deviceId = device.deviceId,
                 minClientVersion = minClientVersion,

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -400,9 +400,9 @@ class OctiServerConnector @AssistedInject constructor(
         val registrationIssues = buildCurrentDeviceRegistrationIssues()
         val encryptionIssues = buildEncryptionCompatibilityIssues(metadata, dataDeviceIds)
 
-        val blobIssues = if (!isGcmSiv) {
+        val legacyIssues = if (!isGcmSiv) {
             listOf(
-                OctiServerIssue.BlobEncryptionUnsupported(
+                OctiServerIssue.LegacyEncryptionAccount(
                     connectorId = identifier,
                     deviceId = syncSettings.deviceId,
                 )
@@ -420,7 +420,7 @@ class OctiServerConnector @AssistedInject constructor(
             }
         }
 
-        val issues = registrationIssues + encryptionIssues + blobIssues + commitIssues
+        val issues = registrationIssues + encryptionIssues + legacyIssues + commitIssues
         log(TAG) { "computeIssues(): ${issues.size} issues" }
         _state.updateBlocking { copy(issues = issues) }
     }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -400,16 +400,7 @@ class OctiServerConnector @AssistedInject constructor(
         val registrationIssues = buildCurrentDeviceRegistrationIssues()
         val encryptionIssues = buildEncryptionCompatibilityIssues(metadata, dataDeviceIds)
 
-        val legacyIssues = if (!isGcmSiv) {
-            listOf(
-                OctiServerIssue.LegacyEncryptionAccount(
-                    connectorId = identifier,
-                    deviceId = syncSettings.deviceId,
-                )
-            )
-        } else {
-            emptyList()
-        }
+        val legacyIssues = buildLegacyEncryptionIssues(metadata, isGcmSiv)
 
         val commitIssues = buildList<ConnectorIssue> {
             if (_commitServerStorageLow.value) {
@@ -423,6 +414,23 @@ class OctiServerConnector @AssistedInject constructor(
         val issues = registrationIssues + encryptionIssues + legacyIssues + commitIssues
         log(TAG) { "computeIssues(): ${issues.size} issues" }
         _state.updateBlocking { copy(issues = issues) }
+    }
+
+    private fun buildLegacyEncryptionIssues(
+        metadata: List<DeviceMetadata>,
+        isGcmSiv: Boolean,
+    ): List<ConnectorIssue> {
+        if (isGcmSiv) return emptyList()
+        return metadata.mapNotNull { device ->
+            if (!VersionCompat.isAtLeast(device.version, OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION)) {
+                return@mapNotNull null
+            }
+
+            OctiServerIssue.LegacyEncryptionAccount(
+                connectorId = identifier,
+                deviceId = device.deviceId,
+            )
+        }
     }
 
     private fun buildEncryptionCompatibilityIssues(

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionCompat.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionCompat.kt
@@ -3,12 +3,12 @@ package eu.darken.octi.syncs.octiserver.core
 import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 
-object AccountCompatibility {
-    const val MIN_ENCRYPTION_V2_CLIENT_VERSION = "1.0.0"
+object OctiServerEncryptionCompat {
+    const val MIN_GCM_SIV_CLIENT_VERSION = "1.0.0"
 
     fun expectedMinClientVersion(keyset: PayloadEncryption.KeySet): String? =
         when (EncryptionMode.fromTypeString(keyset.type)) {
-            EncryptionMode.AES256_GCM_SIV -> MIN_ENCRYPTION_V2_CLIENT_VERSION
+            EncryptionMode.AES256_GCM_SIV -> MIN_GCM_SIV_CLIENT_VERSION
             EncryptionMode.AES256_SIV,
             null -> null
         }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
@@ -64,10 +64,8 @@ class OctiServerEndpoint @AssistedInject constructor(
         this.credentials = credentials
     }
 
-    suspend fun createNewAccount(
-        useLegacyEncryption: Boolean = false,
-    ): OctiServer.Credentials = withContext(dispatcherProvider.IO) {
-        log(TAG) { "createNewAccount(useLegacyEncryption=$useLegacyEncryption)" }
+    suspend fun createNewAccount(): OctiServer.Credentials = withContext(dispatcherProvider.IO) {
+        log(TAG) { "createNewAccount()" }
         val response = try {
             api.register(deviceID = ourDeviceIdString)
         } catch (e: HttpException) {
@@ -79,7 +77,7 @@ class OctiServerEndpoint @AssistedInject constructor(
             serverAdress = serverAdress,
             accountId = OctiServer.Credentials.AccountId(response.accountID),
             devicePassword = OctiServer.Credentials.DevicePassword(response.password),
-            encryptionKeyset = PayloadEncryption(useLegacyEncryption = useLegacyEncryption).exportKeyset()
+            encryptionKeyset = PayloadEncryption().exportKeyset(),
         )
     }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
@@ -28,15 +28,17 @@ sealed interface OctiServerIssue : ConnectorIssue {
         override val description: CaString = caString { it.getString(R.string.sync_octiserver_blob_encryption_unsupported) }
     }
 
-    data class AccountCompatibilityIncompatible(
+    data class EncryptionCompatibilityIncompatible(
         override val connectorId: ConnectorId,
         override val deviceId: DeviceId,
         val minClientVersion: String,
     ) : OctiServerIssue {
         override val severity: IssueSeverity = IssueSeverity.ERROR
-        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_account_compatibility) }
+        override val label: CaString = caString {
+            it.getString(R.string.sync_octiserver_issues_type_encryption_compatibility)
+        }
         override val description: CaString = caString {
-            it.getString(R.string.sync_octiserver_account_compatibility_incompatible, minClientVersion)
+            it.getString(R.string.sync_octiserver_encryption_compatibility_incompatible, minClientVersion)
         }
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
@@ -19,16 +19,6 @@ sealed interface OctiServerIssue : ConnectorIssue {
         override val description: CaString = caString { it.getString(R.string.sync_octiserver_error_device_not_registered) }
     }
 
-    data class EncryptionIncompatible(
-        override val connectorId: ConnectorId,
-        override val deviceId: DeviceId,
-        val deviceLabel: String?,
-    ) : OctiServerIssue {
-        override val severity: IssueSeverity = IssueSeverity.ERROR
-        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_encryption_error) }
-        override val description: CaString = caString { it.getString(R.string.sync_octiserver_device_encryption_incompatible) }
-    }
-
     data class BlobEncryptionUnsupported(
         override val connectorId: ConnectorId,
         override val deviceId: DeviceId,
@@ -36,5 +26,17 @@ sealed interface OctiServerIssue : ConnectorIssue {
         override val severity: IssueSeverity = IssueSeverity.WARNING
         override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_file_sharing_unavailable) }
         override val description: CaString = caString { it.getString(R.string.sync_octiserver_blob_encryption_unsupported) }
+    }
+
+    data class AccountCompatibilityIncompatible(
+        override val connectorId: ConnectorId,
+        override val deviceId: DeviceId,
+        val minClientVersion: String,
+    ) : OctiServerIssue {
+        override val severity: IssueSeverity = IssueSeverity.ERROR
+        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_account_compatibility) }
+        override val description: CaString = caString {
+            it.getString(R.string.sync_octiserver_account_compatibility_incompatible, minClientVersion)
+        }
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
@@ -19,13 +19,13 @@ sealed interface OctiServerIssue : ConnectorIssue {
         override val description: CaString = caString { it.getString(R.string.sync_octiserver_error_device_not_registered) }
     }
 
-    data class BlobEncryptionUnsupported(
+    data class LegacyEncryptionAccount(
         override val connectorId: ConnectorId,
         override val deviceId: DeviceId,
     ) : OctiServerIssue {
         override val severity: IssueSeverity = IssueSeverity.WARNING
-        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_file_sharing_unavailable) }
-        override val description: CaString = caString { it.getString(R.string.sync_octiserver_blob_encryption_unsupported) }
+        override val label: CaString = caString { it.getString(R.string.sync_octiserver_issues_type_legacy_encryption) }
+        override val description: CaString = caString { it.getString(R.string.sync_octiserver_legacy_encryption_account) }
     }
 
     data class EncryptionCompatibilityIncompatible(

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.syncs.octiserver.ui.add
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,13 +22,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
-import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,15 +41,14 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import eu.darken.octi.common.R as CommonR
-import eu.darken.octi.syncs.octiserver.R as OctiServerR
 import eu.darken.octi.common.BuildConfigWrap
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.WebpageTool
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.syncs.octiserver.R as OctiServerR
 import eu.darken.octi.syncs.octiserver.core.OctiServer
 
 @Composable
@@ -63,7 +62,6 @@ fun AddOctiServerScreenHost(vm: AddOctiServerVM = hiltViewModel()) {
             state = it,
             onNavigateUp = { vm.navUp() },
             onSelectType = { type -> vm.selectType(type) },
-            onToggleLegacyEncryption = { vm.toggleLegacyEncryption() },
             onCreateAccount = { customServer -> vm.createAccount(customServer) },
             onLinkAccount = { vm.linkAccount() },
         )
@@ -75,11 +73,11 @@ fun AddOctiServerScreen(
     state: AddOctiServerVM.State,
     onNavigateUp: () -> Unit,
     onSelectType: (OctiServer.Official?) -> Unit,
-    onToggleLegacyEncryption: () -> Unit,
     onCreateAccount: (String?) -> Unit,
     onLinkAccount: () -> Unit,
 ) {
     var showAboutDialog by remember { mutableStateOf(false) }
+    var showCreateDialog by remember { mutableStateOf(false) }
     var customServerText by rememberSaveable { mutableStateOf("") }
     val context = LocalContext.current
 
@@ -150,40 +148,10 @@ fun AddOctiServerScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Switch(
-                    checked = state.useLegacyEncryption,
-                    onCheckedChange = { onToggleLegacyEncryption() },
-                    enabled = !state.isBusy,
-                )
-                Text(
-                    text = stringResource(OctiServerR.string.sync_octiserver_add_legacy_encryption_label),
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(start = 8.dp),
-                )
-            }
-
-            Text(
-                text = stringResource(OctiServerR.string.sync_octiserver_add_legacy_encryption_hint, "v1.0.0"),
-                style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
-            )
-
             Spacer(modifier = Modifier.height(16.dp))
 
             Button(
-                onClick = {
-                    onCreateAccount(if (state.serverType == null) customServerText else null)
-                },
+                onClick = { showCreateDialog = true },
                 enabled = !state.isBusy,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -224,6 +192,16 @@ fun AddOctiServerScreen(
         }
     }
 
+    if (showCreateDialog) {
+        CreateAccountDialog(
+            onDismiss = { showCreateDialog = false },
+            onConfirm = {
+                showCreateDialog = false
+                onCreateAccount(if (state.serverType == null) customServerText else null)
+            },
+        )
+    }
+
     if (showAboutDialog) {
         AlertDialog(
             onDismissRequest = { showAboutDialog = false },
@@ -244,6 +222,28 @@ fun AddOctiServerScreen(
             },
         )
     }
+}
+
+@Composable
+private fun CreateAccountDialog(
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(OctiServerR.string.sync_octiserver_add_create_account_title)) },
+        text = { Text(text = stringResource(OctiServerR.string.sync_octiserver_add_create_account_desc)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = stringResource(OctiServerR.string.sync_octiserver_add_create_account_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
 }
 
 @Composable
@@ -285,7 +285,6 @@ private fun AddOctiServerScreenPreview() = PreviewWrapper {
         state = AddOctiServerVM.State(serverType = OctiServer.Official.PROD),
         onNavigateUp = {},
         onSelectType = {},
-        onToggleLegacyEncryption = {},
         onCreateAccount = {},
         onLinkAccount = {},
     )
@@ -298,7 +297,6 @@ private fun AddOctiServerScreenCustomPreview() = PreviewWrapper {
         state = AddOctiServerVM.State(serverType = null),
         onNavigateUp = {},
         onSelectType = {},
-        onToggleLegacyEncryption = {},
         onCreateAccount = {},
         onLinkAccount = {},
     )
@@ -311,7 +309,6 @@ private fun AddOctiServerScreenBusyPreview() = PreviewWrapper {
         state = AddOctiServerVM.State(serverType = OctiServer.Official.PROD, isBusy = true),
         onNavigateUp = {},
         onSelectType = {},
-        onToggleLegacyEncryption = {},
         onCreateAccount = {},
         onLinkAccount = {},
     )

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerVM.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerVM.kt
@@ -26,7 +26,6 @@ class AddOctiServerVM @Inject constructor(
 
     data class State(
         val serverType: OctiServer.Official? = OctiServer.Official.PROD,
-        val useLegacyEncryption: Boolean = false,
         val isBusy: Boolean = false,
     )
 
@@ -36,10 +35,6 @@ class AddOctiServerVM @Inject constructor(
     fun selectType(type: OctiServer.Official?) {
         log(TAG) { "selectType(type=$type)" }
         _state.value = _state.value.copy(serverType = type)
-    }
-
-    fun toggleLegacyEncryption() {
-        _state.value = _state.value.copy(useLegacyEncryption = !_state.value.useLegacyEncryption)
     }
 
     private fun parseCustomServer(raw: String): OctiServer.Address {
@@ -64,9 +59,7 @@ class AddOctiServerVM @Inject constructor(
 
             withContext(NonCancellable) {
                 log(TAG) { "Creating account..." }
-                val newCredentials = endpoint.createNewAccount(
-                    useLegacyEncryption = _state.value.useLegacyEncryption,
-                )
+                val newCredentials = endpoint.createNewAccount()
                 log(TAG, INFO) { "New account created: $newCredentials" }
                 kServerAccountRepo.add(newCredentials)
             }

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -23,11 +23,11 @@
     <string name="sync_octiserver_issues_type_device_not_registered">Device no longer linked</string>
     <string name="sync_octiserver_error_device_not_registered">This device is no longer registered on the server. Disconnect and re-link from another device, or create a new account.</string>
     <string name="sync_octiserver_resume_sync_action">Resume synchronization</string>
-    <string name="sync_octiserver_add_legacy_encryption_label">Legacy encryption</string>
-    <string name="sync_octiserver_add_legacy_encryption_hint">New accounts use improved encryption. App versions older than %1$s cannot sync with new-style accounts.</string>
-    <string name="sync_octiserver_device_encryption_incompatible">This device may not support this account\'s encryption. Update the app on this device or recreate the account with legacy encryption.</string>
-    <string name="sync_octiserver_blob_encryption_unsupported">File sharing needs updated encryption. Create a new account on one device without Legacy encryption, then link your other devices to it.</string>
-    <string name="sync_octiserver_issues_type_encryption_error">Encryption error</string>
+    <string name="sync_octiserver_add_create_account_title">Create account?</string>
+    <string name="sync_octiserver_add_create_account_desc">A new encrypted sync account will be created on this server.</string>
+    <string name="sync_octiserver_account_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
+    <string name="sync_octiserver_blob_encryption_unsupported">File sharing needs updated encryption. Create a new account on an updated device, then link your other devices to it.</string>
+    <string name="sync_octiserver_issues_type_account_compatibility">Incompatible account</string>
     <string name="sync_octiserver_issues_type_file_sharing_unavailable">File sharing unavailable</string>
     <string name="sync_octiserver_add_create_account_action">Create account</string>
     <string name="sync_octiserver_add_link_existing_action">Link to existing account</string>

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -26,9 +26,9 @@
     <string name="sync_octiserver_add_create_account_title">Create account?</string>
     <string name="sync_octiserver_add_create_account_desc">A new encrypted sync account will be created on this server.</string>
     <string name="sync_octiserver_encryption_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
-    <string name="sync_octiserver_blob_encryption_unsupported">File sharing needs updated encryption. Create a new account on an updated device, then link your other devices to it.</string>
+    <string name="sync_octiserver_legacy_encryption_account">This account uses legacy encryption. Newer features like file sharing are unavailable. Create a new account on an updated device and re-link your other devices to enable them.</string>
     <string name="sync_octiserver_issues_type_encryption_compatibility">Incompatible encryption</string>
-    <string name="sync_octiserver_issues_type_file_sharing_unavailable">File sharing unavailable</string>
+    <string name="sync_octiserver_issues_type_legacy_encryption">Legacy encryption</string>
     <string name="sync_octiserver_add_create_account_action">Create account</string>
     <string name="sync_octiserver_add_link_existing_action">Link to existing account</string>
     <string name="sync_octiserver_add_select_server_label">Select server</string>

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -26,9 +26,9 @@
     <string name="sync_octiserver_add_create_account_title">Create account?</string>
     <string name="sync_octiserver_add_create_account_desc">A new encrypted sync account will be created on this server.</string>
     <string name="sync_octiserver_encryption_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
-    <string name="sync_octiserver_legacy_encryption_account">This account uses legacy encryption. Newer features like file sharing are unavailable. Create a new account on an updated device and re-link your other devices to enable them.</string>
+    <string name="sync_octiserver_legacy_encryption_account">File sharing is unavailable on this device because this account uses legacy encryption. Create a new account on an updated device and re-link your other devices to use file sharing.</string>
     <string name="sync_octiserver_issues_type_encryption_compatibility">Incompatible encryption</string>
-    <string name="sync_octiserver_issues_type_legacy_encryption">Legacy encryption</string>
+    <string name="sync_octiserver_issues_type_legacy_encryption">File sharing unavailable</string>
     <string name="sync_octiserver_add_create_account_action">Create account</string>
     <string name="sync_octiserver_add_link_existing_action">Link to existing account</string>
     <string name="sync_octiserver_add_select_server_label">Select server</string>

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -25,9 +25,9 @@
     <string name="sync_octiserver_resume_sync_action">Resume synchronization</string>
     <string name="sync_octiserver_add_create_account_title">Create account?</string>
     <string name="sync_octiserver_add_create_account_desc">A new encrypted sync account will be created on this server.</string>
-    <string name="sync_octiserver_account_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
+    <string name="sync_octiserver_encryption_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
     <string name="sync_octiserver_blob_encryption_unsupported">File sharing needs updated encryption. Create a new account on an updated device, then link your other devices to it.</string>
-    <string name="sync_octiserver_issues_type_account_compatibility">Incompatible account</string>
+    <string name="sync_octiserver_issues_type_encryption_compatibility">Incompatible encryption</string>
     <string name="sync_octiserver_issues_type_file_sharing_unavailable">File sharing unavailable</string>
     <string name="sync_octiserver_add_create_account_action">Create account</string>
     <string name="sync_octiserver_add_link_existing_action">Link to existing account</string>


### PR DESCRIPTION
## Summary
- Drops the "Legacy encryption" toggle from the OctiServer add-account screen — new accounts always use the current encryption format.
- Adds a confirmation dialog before account creation so a stray tap doesn't immediately create one.
- Replaces the vague "encryption may not match" warning with a clearer message that names the minimum required app version when a peer device on your account is too old. The check is derived locally from the keyset — no server-side support needed.

## Test plan
- [ ] Open the OctiServer add-account screen — confirm the "Legacy encryption" switch is gone.
- [ ] Tap "Create account" — confirm the dialog appears; cancel leaves no account; confirm creates one.
- [ ] On an account with a peer running an outdated app version (or one that has never synced past the grace period), confirm the new "Update to v1.0.0+" issue surfaces in the sync issues list.
