### PR TITLE
Limit free-tier file sharing to 1 file per device

### DIFF
--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileSharePolicy.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileSharePolicy.kt
@@ -1,0 +1,5 @@
+package eu.darken.octi.modules.files.core
+
+object FileSharePolicy {
+    const val FREE_TIER_OWN_FILE_LIMIT = 1
+}

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListScreen.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListScreen.kt
@@ -33,10 +33,12 @@ import androidx.compose.material.icons.twotone.ArrowUpward
 import androidx.compose.material.icons.twotone.Check
 import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material.icons.twotone.Delete
+import androidx.compose.material.icons.twotone.Home
 import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.PieChart
 import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.SaveAlt
+import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -52,6 +54,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -63,6 +66,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -112,36 +116,6 @@ fun FileShareListScreenHost(
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
-    LaunchedEffect(vm.uiEvents) {
-        vm.uiEvents.collect { event ->
-            when (event) {
-                is FileShareListVM.UiEvent.ShowMessage ->
-                    snackbarHostState.showSnackbar(context.getString(event.messageRes))
-                is FileShareListVM.UiEvent.ShowMessageWithSize ->
-                    snackbarHostState.showSnackbar(
-                        context.getString(event.messageRes, Formatter.formatFileSize(context, event.bytes))
-                    )
-                is FileShareListVM.UiEvent.OpenFile -> {
-                    val viewIntent = Intent(Intent.ACTION_VIEW).apply {
-                        setDataAndType(event.uri, event.mimeType.ifBlank { "application/octet-stream" })
-                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                        clipData = ClipData.newRawUri(null, event.uri)
-                    }
-                    try {
-                        context.startActivity(
-                            Intent.createChooser(viewIntent, context.getString(R.string.module_files_open_chooser))
-                        )
-                    } catch (_: ActivityNotFoundException) {
-                        snackbarHostState.showSnackbar(context.getString(R.string.module_files_open_no_app))
-                    } catch (e: SecurityException) {
-                        log(TAG, ERROR) { "open dispatch failed: ${e.asLog()}" }
-                        snackbarHostState.showSnackbar(context.getString(R.string.module_files_open_failed))
-                    }
-                }
-            }
-        }
-    }
-
     val state by vm.state.collectAsState(initial = null)
 
     // Cross-rotation flags for the dashboard-tile auto-action flow. Once the SAF picker is
@@ -190,12 +164,59 @@ fun FileShareListScreenHost(
         }
     }
 
+    LaunchedEffect(vm.uiEvents) {
+        vm.uiEvents.collect { event ->
+            when (event) {
+                is FileShareListVM.UiEvent.ShowMessage ->
+                    snackbarHostState.showSnackbar(context.getString(event.messageRes))
+                is FileShareListVM.UiEvent.ShowMessageWithSize ->
+                    snackbarHostState.showSnackbar(
+                        context.getString(event.messageRes, Formatter.formatFileSize(context, event.bytes))
+                    )
+                is FileShareListVM.UiEvent.OpenFile -> {
+                    val viewIntent = Intent(Intent.ACTION_VIEW).apply {
+                        setDataAndType(event.uri, event.mimeType.ifBlank { "application/octet-stream" })
+                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        clipData = ClipData.newRawUri(null, event.uri)
+                    }
+                    try {
+                        context.startActivity(
+                            Intent.createChooser(viewIntent, context.getString(R.string.module_files_open_chooser))
+                        )
+                    } catch (_: ActivityNotFoundException) {
+                        snackbarHostState.showSnackbar(context.getString(R.string.module_files_open_no_app))
+                    } catch (e: SecurityException) {
+                        log(TAG, ERROR) { "open dispatch failed: ${e.asLog()}" }
+                        snackbarHostState.showSnackbar(context.getString(R.string.module_files_open_failed))
+                    }
+                }
+                is FileShareListVM.UiEvent.LaunchPicker -> {
+                    if (event.auto) autoLaunched = true
+                    openDocLauncher.launch(arrayOf("*/*"))
+                }
+                is FileShareListVM.UiEvent.AtLimit -> {
+                    // No transient feedback — the in-list banner already communicates the state
+                    // and the FAB is rendered as disabled. We only need the side effect for the
+                    // auto-flow: mark complete so LaunchedEffect(autoAction) doesn't re-fire on
+                    // recomposition (rotation) and replay the gated click.
+                    if (event.auto) autoFiringComplete = true
+                }
+                is FileShareListVM.UiEvent.AtLimitDroppedExtras ->
+                    snackbarHostState.showSnackbar(
+                        context.getString(R.string.module_files_free_limit_dropped_extras, event.droppedCount)
+                    )
+            }
+        }
+    }
+
     LaunchedEffect(autoAction) {
         if (autoAction == null || autoLaunched || autoFiringComplete) return@LaunchedEffect
         when (autoAction) {
             Nav.Main.FileShareList.AutoAction.UPLOAD -> {
-                autoLaunched = true
-                openDocLauncher.launch(arrayOf("*/*"))
+                // Pre-action gate via VM. On pass: emits LaunchPicker(auto=true) → uiEvents
+                // collector sets autoLaunched + launches picker. On fail: emits AtLimit(auto=true)
+                // → collector sets autoFiringComplete + shows snackbar, picker never opens.
+                vm.onShareClick(auto = true)
             }
             Nav.Main.FileShareList.AutoAction.INCOMING_SHARE -> {
                 autoLaunched = true
@@ -238,7 +259,8 @@ fun FileShareListScreenHost(
             state = current,
             snackbarHostState = snackbarHostState,
             onNavigateUp = { vm.navUp() },
-            onShareClick = { openDocLauncher.launch(arrayOf("*/*")) },
+            onShareClick = { vm.onShareClick() },
+            onUpgradeClick = { vm.navToUpgrade() },
             onRowClick = { item -> vm.onRowClick(item) },
             onRowSecondaryClick = { item ->
                 if (item.isOwn) vm.onDeleteFile(item)
@@ -271,6 +293,7 @@ fun FileShareListScreen(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigateUp: () -> Unit = {},
     onShareClick: () -> Unit = {},
+    onUpgradeClick: () -> Unit = {},
     onRowClick: (FileShareListVM.FileItem) -> Unit = {},
     onRowSecondaryClick: (FileShareListVM.FileItem) -> Unit = {},
     onRetryClick: (FileShareListVM.FileItem) -> Unit = {},
@@ -307,7 +330,11 @@ fun FileShareListScreen(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             if (state.isSharingAvailable) {
-                FloatingActionButton(onClick = onShareClick) {
+                val disabled = state.freeLimitReached
+                FloatingActionButton(
+                    onClick = { if (!disabled) onShareClick() },
+                    modifier = if (disabled) Modifier.alpha(0.5f) else Modifier,
+                ) {
                     Icon(Icons.TwoTone.Add, contentDescription = stringResource(R.string.module_files_share_action))
                 }
             }
@@ -328,6 +355,7 @@ fun FileShareListScreen(
             val collidingOctiSubtypes = collidingOctiSubtypesFor(state.quotaItems)
             if (state.files.isEmpty() && state.activeUpload == null) {
                 Column(modifier = Modifier.fillMaxSize()) {
+                    if (state.freeLimitReached) FreeLimitBanner(onUpgradeClick = onUpgradeClick)
                     if (showUsageHint) UsageHintCard(onDismiss = onDismissHint)
                     if (lowQuotaItems.isNotEmpty()) {
                         QuotaWarningBanner(
@@ -367,6 +395,7 @@ fun FileShareListScreen(
                 }
             } else {
                 LazyColumn(modifier = Modifier.fillMaxSize()) {
+                    if (state.freeLimitReached) item { FreeLimitBanner(onUpgradeClick = onUpgradeClick) }
                     if (showUsageHint) item { UsageHintCard(onDismiss = onDismissHint) }
                     if (lowQuotaItems.isNotEmpty()) {
                         item {
@@ -453,15 +482,27 @@ private fun DevicesChipRow(
                     selected = selected,
                     onClick = { onToggleFilter(opt.deviceId) },
                     label = { Text(opt.label) },
-                    leadingIcon = if (selected) {
-                        {
-                            Icon(
-                                Icons.TwoTone.Check,
-                                contentDescription = null,
-                                modifier = Modifier.size(16.dp),
-                            )
+                    leadingIcon = when {
+                        opt.isOwn -> {
+                            {
+                                Icon(
+                                    Icons.TwoTone.Home,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
                         }
-                    } else null,
+                        selected -> {
+                            {
+                                Icon(
+                                    Icons.TwoTone.Check,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                        }
+                        else -> null
+                    },
                 )
             }
         }
@@ -530,6 +571,37 @@ private fun SortMenu(
                         }
                     } else null,
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FreeLimitBanner(onUpgradeClick: () -> Unit) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(start = 12.dp, top = 8.dp, bottom = 8.dp, end = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Stars,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = stringResource(R.string.module_files_free_limit_reached_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+            )
+            TextButton(onClick = onUpgradeClick) {
+                Text(stringResource(R.string.module_files_free_limit_action_upgrade))
             }
         }
     }

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
@@ -7,19 +7,24 @@ import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.SingleEventFlow
 import eu.darken.octi.common.flow.shareLatest
 import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleManager
 import eu.darken.octi.modules.files.FileShareModule
 import eu.darken.octi.modules.files.R
 import eu.darken.octi.modules.files.core.FileKey
+import eu.darken.octi.modules.files.core.FileSharePolicy
 import eu.darken.octi.modules.files.core.FileShareInfo
 import eu.darken.octi.modules.files.core.FileShareRepo
 import eu.darken.octi.modules.files.core.FileShareService
@@ -62,6 +67,7 @@ class FileShareListVM @Inject constructor(
     private val fileShareSettings: FileShareSettings,
     private val syncManager: SyncManager,
     private val incomingShareInbox: IncomingShareInbox,
+    private val upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider) {
 
     data class State(
@@ -76,6 +82,7 @@ class FileShareListVM @Inject constructor(
         val isUsageHintDismissed: Boolean = false,
         val isSyncingNow: Boolean = false,
         val sheetTargetKey: FileKey? = null,
+        val freeLimitReached: Boolean = false,
     ) {
         val sheetTarget: FileItem? get() = files.firstOrNull { it.key == sheetTargetKey }
     }
@@ -129,6 +136,9 @@ class FileShareListVM @Inject constructor(
         data class ShowMessage(@StringRes val messageRes: Int) : UiEvent
         data class ShowMessageWithSize(@StringRes val messageRes: Int, val bytes: Long) : UiEvent
         data class OpenFile(val uri: Uri, val mimeType: String) : UiEvent
+        data class LaunchPicker(val auto: Boolean) : UiEvent
+        data class AtLimit(val auto: Boolean = false) : UiEvent
+        data class AtLimitDroppedExtras(val droppedCount: Int) : UiEvent
     }
 
     val uiEvents = SingleEventFlow<UiEvent>()
@@ -145,6 +155,7 @@ class FileShareListVM @Inject constructor(
         val repoState: BaseModuleRepo.State<FileShareInfo>,
         val moduleEnabled: Boolean,
         val byDevice: ModuleManager.ByDevice,
+        val isPro: Boolean,
     )
 
     private data class TransferSnapshot(
@@ -173,7 +184,8 @@ class FileShareListVM @Inject constructor(
             fileShareRepo.state,
             fileShareRepo.isEnabled,
             moduleManager.byDevice,
-        ) { state, enabled, byDevice -> RepoSnapshot(state, enabled, byDevice) },
+            upgradeRepo.upgradeInfo,
+        ) { state, enabled, byDevice, upgrade -> RepoSnapshot(state, enabled, byDevice, upgrade.isPro) },
         combine(
             fileShareService.transfers,
             blobManager.retryStatus,
@@ -287,6 +299,10 @@ class FileShareListVM @Inject constructor(
             .firstOrNull { it.direction == FileShareService.Transfer.Direction.UPLOAD }
             ?.let { ActiveUpload(blobKey = it.blobKey, fileName = it.fileName, progress = it.progress) }
 
+        val ownActiveCount = repo.repoState.self?.data?.files
+            ?.count { now <= it.expiresAt } ?: 0
+        val freeLimitReached = !repo.isPro && ownActiveCount >= FileSharePolicy.FREE_TIER_OWN_FILE_LIMIT
+
         return State(
             files = sortedItems,
             availableDevices = availableDevices,
@@ -299,6 +315,7 @@ class FileShareListVM @Inject constructor(
             isUsageHintDismissed = settings.isUsageHintDismissed,
             isSyncingNow = isSyncingNow,
             sheetTargetKey = ui.sheetTarget,
+            freeLimitReached = freeLimitReached,
         )
     }
 
@@ -340,20 +357,46 @@ class FileShareListVM @Inject constructor(
             .sortedBy { it.label }
     }
 
-    /** Idempotent — only seeds the initial filter once on cold open. Later filter edits win. */
-    fun initialize(initialDeviceFilter: String?) {
-        if (initialDeviceFilter.isNullOrBlank()) return
-        if (_filters.value.isNotEmpty()) return
-        _filters.value = setOf(DeviceId(initialDeviceFilter))
+    /**
+     * No-op kept for the screen LaunchedEffect's lifecycle hook. The route's `deviceId` param is
+     * still used by auto-actions (e.g. DOWNLOAD_LATEST matches against it directly) — only the
+     * filter pre-seed was removed: the list now always opens unfiltered ("all devices"), so the
+     * user lands on the same view regardless of which tile they tapped.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    fun initialize(initialDeviceFilter: String?) = Unit
+
+    /**
+     * Pre-action gate for the share entry points (manual FAB tap and the dashboard auto-action).
+     * Avoids opening the SAF picker when we'd just refuse the upload afterwards.
+     */
+    fun onShareClick(auto: Boolean = false) = launch {
+        if (!canUpload()) {
+            uiEvents.tryEmit(UiEvent.AtLimit(auto = auto))
+            return@launch
+        }
+        uiEvents.tryEmit(UiEvent.LaunchPicker(auto = auto))
+    }
+
+    fun navToUpgrade() {
+        navTo(Nav.Main.Upgrade())
     }
 
     /**
      * Fire-and-forget share — used by the dashboard tile auto-action so the upload survives the
      * subsequent `navUp()`. Snackbar feedback is intentionally dropped (the user is back on the
      * dashboard); transfer progress remains observable through `FileShareService.transfers`.
+     *
+     * Defensive guard: this runs on `appScope` without a screen visible, so the gate sits at the
+     * entry point (`onShareClick(auto = true)` → `LaunchPicker` → picker → here). If reached
+     * without a prior gate, log and exit instead of producing a free upload.
      */
     fun enqueueShareFile(uri: Uri) {
         appScope.launch(dispatcherProvider.IO) {
+            if (!canUpload()) {
+                log(TAG, WARN) { "enqueueShareFile: blocked by free-tier limit" }
+                return@launch
+            }
             runCatching { fileShareService.shareFile(uri) }
                 .onFailure { log(TAG, ERROR) { "enqueueShareFile failed: ${it.asLog()}" } }
         }
@@ -370,31 +413,38 @@ class FileShareListVM @Inject constructor(
     }
 
     /**
-     * Run on [appScope] so an in-flight share survives the user navigating away from the file
-     * list — multi-MB uploads routinely outlive a screen visit. UI feedback via [uiEvents] is
-     * best-effort: while the screen is alive the snackbar fires; afterwards the buffered events
-     * are simply not collected, which is acceptable.
+     * Pro-check on VM scope first (so [navTo] / [uiEvents] fire while the screen is alive), then
+     * the actual upload runs on [appScope] so an in-flight share survives the user navigating
+     * away from the file list — multi-MB uploads routinely outlive a screen visit. UI feedback
+     * via [uiEvents] is best-effort: while the screen is alive the snackbar fires; afterwards
+     * the buffered events are simply not collected, which is acceptable.
      */
-    fun onShareFile(uri: Uri) = launch(appScope) {
-        when (val result = fileShareService.shareFile(uri)) {
-            is FileShareService.ShareResult.Success ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_success))
-            is FileShareService.ShareResult.PartialMirror ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_partial))
-            is FileShareService.ShareResult.AllConnectorsFailed ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_failed))
-            is FileShareService.ShareResult.FileTooLarge ->
-                uiEvents.tryEmit(UiEvent.ShowMessageWithSize(R.string.module_files_upload_too_large, result.maxBytes))
-            is FileShareService.ShareResult.NoEligibleConnectors ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_no_connectors))
-            is FileShareService.ShareResult.Cancelled ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_cancelled))
-            is FileShareService.ShareResult.ServerStorageLow ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_server_storage_low))
-            is FileShareService.ShareResult.AccountQuotaFull ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_account_quota_full))
-            is FileShareService.ShareResult.LocalStorageLow ->
-                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_local_storage_low))
+    fun onShareFile(uri: Uri) = launch {
+        if (!canUpload()) {
+            uiEvents.tryEmit(UiEvent.AtLimit())
+            return@launch
+        }
+        appScope.launch(dispatcherProvider.IO) {
+            when (val result = fileShareService.shareFile(uri)) {
+                is FileShareService.ShareResult.Success ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_success))
+                is FileShareService.ShareResult.PartialMirror ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_partial))
+                is FileShareService.ShareResult.AllConnectorsFailed ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_failed))
+                is FileShareService.ShareResult.FileTooLarge ->
+                    uiEvents.tryEmit(UiEvent.ShowMessageWithSize(R.string.module_files_upload_too_large, result.maxBytes))
+                is FileShareService.ShareResult.NoEligibleConnectors ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_no_connectors))
+                is FileShareService.ShareResult.Cancelled ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_cancelled))
+                is FileShareService.ShareResult.ServerStorageLow ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_server_storage_low))
+                is FileShareService.ShareResult.AccountQuotaFull ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_account_quota_full))
+                is FileShareService.ShareResult.LocalStorageLow ->
+                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_local_storage_low))
+            }
         }
     }
 
@@ -415,12 +465,28 @@ class FileShareListVM @Inject constructor(
     }
 
     /**
-     * Run on [appScope] so the multi-share survives screen lifecycle. Each `shareFile` call
+     * Pro-check on VM scope first; for free users, slice the batch to the remaining free-tier
+     * slots and emit [UiEvent.AtLimitDroppedExtras] for the dropped tail. The actual upload then
+     * runs on [appScope] so the multi-share survives screen lifecycle. Each `shareFile` call
      * suspends until completion before the next starts.
      */
-    fun onShareFilesSequential(uris: List<Uri>) {
+    fun onShareFilesSequential(uris: List<Uri>) = launch {
+        if (uris.isEmpty()) return@launch
+        val isPro = upgradeRepo.isPro()
+        val remaining = if (isPro) {
+            uris.size
+        } else {
+            (FileSharePolicy.FREE_TIER_OWN_FILE_LIMIT - ownFileCount()).coerceAtLeast(0)
+        }
+        if (remaining == 0) {
+            uiEvents.tryEmit(UiEvent.AtLimit())
+            return@launch
+        }
+        val toUpload = uris.take(remaining)
+        val dropped = uris.size - toUpload.size
+        if (dropped > 0) uiEvents.tryEmit(UiEvent.AtLimitDroppedExtras(dropped))
         appScope.launch(dispatcherProvider.IO) {
-            for (uri in uris) {
+            for (uri in toUpload) {
                 runCatching { fileShareService.shareFile(uri) }
                     .onFailure { log(TAG, ERROR) { "onShareFilesSequential(uri=$uri) failed: ${it.asLog()}" } }
             }
@@ -549,6 +615,15 @@ class FileShareListVM @Inject constructor(
     fun onSheetDismiss() {
         _sheetTarget.value = null
     }
+
+    private suspend fun ownFileCount(): Int {
+        val now = Clock.System.now()
+        return fileShareRepo.state.first().self?.data?.files
+            ?.count { it.expiresAt > now } ?: 0
+    }
+
+    private suspend fun canUpload(): Boolean =
+        upgradeRepo.isPro() || ownFileCount() < FileSharePolicy.FREE_TIER_OWN_FILE_LIMIT
 
     companion object {
         private val TAG = logTag("Module", "Files", "List", "VM")

--- a/modules-files/src/main/res/values/strings.xml
+++ b/modules-files/src/main/res/values/strings.xml
@@ -83,4 +83,7 @@
     <string name="module_files_sheet_dismiss_action">Close</string>
     <string name="module_files_share_unsupported">This share isn\'t a file</string>
     <string name="module_files_share_module_disabled">File sharing is disabled</string>
+    <string name="module_files_free_limit_reached_message">Free version is limited to 1 shared file at a time. Delete it to share another, or upgrade for unlimited (within your storage quota).</string>
+    <string name="module_files_free_limit_action_upgrade">Upgrade</string>
+    <string name="module_files_free_limit_dropped_extras">%1$d additional file(s) skipped — free limit is 1.</string>
 </resources>

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.files.ui.list
 
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleManager
@@ -155,7 +156,20 @@ class FileShareListVMTest : BaseTest() {
 
     private val incomingShareInbox = IncomingShareInbox()
 
-    private fun makeVM() = FileShareListVM(
+    // Existing tests assume unrestricted uploads — default to Pro so the free-tier gate
+    // doesn't accidentally drop files. Free-tier tests build their own fake upgradeRepo.
+    private fun fakeUpgradeRepo(isPro: Boolean): UpgradeRepo {
+        val info = object : UpgradeRepo.Info {
+            override val type = UpgradeRepo.Type.FOSS
+            override val isPro = isPro
+            override val upgradedAt: kotlin.time.Instant? = null
+        }
+        return mockk<UpgradeRepo>(relaxed = true).apply {
+            every { upgradeInfo } returns flowOf(info)
+        }
+    }
+
+    private fun makeVM(upgradeRepo: UpgradeRepo = fakeUpgradeRepo(isPro = true)) = FileShareListVM(
         dispatcherProvider = dispatcherProvider,
         appScope = CoroutineScope(SupervisorJob()),
         fileShareRepo = fileShareRepo,
@@ -167,6 +181,7 @@ class FileShareListVMTest : BaseTest() {
         fileShareSettings = fileShareSettings,
         syncManager = syncManager,
         incomingShareInbox = incomingShareInbox,
+        upgradeRepo = upgradeRepo,
     )
 
     @Test
@@ -209,18 +224,21 @@ class FileShareListVMTest : BaseTest() {
     }
 
     @Test
-    fun `initialize seeds activeFilters with the deviceId once`() = runTest2 {
+    fun `initialize does not seed activeFilters - list opens unfiltered regardless of route deviceId`() = runTest2 {
+        // Previously, opening the list from a peer's dashboard tile pre-filtered to that peer.
+        // That made the screen feel inconsistent depending on entry point. Now `initialize` is
+        // a no-op for filters and the list always opens with all devices visible.
         setupBaseMocks(
             selfFiles = listOf(makeFile(name = "mine.txt", blobKey = "blob-mine")),
             otherFiles = mapOf(remoteDevice to listOf(makeFile(name = "theirs.txt", blobKey = "blob-theirs"))),
         )
 
         val vm = makeVM()
-        vm.initialize(remoteDevice.id)
+        vm.initialize(remoteDevice.id) // would have pre-seeded the filter under the old behavior
 
         val state = vm.state.first()
-        state.activeFilters shouldBe setOf(remoteDevice)
-        state.files.map { it.sharedFile.name } shouldBe listOf("theirs.txt")
+        state.activeFilters shouldBe emptySet()
+        state.files.map { it.sharedFile.name }.toSet() shouldBe setOf("mine.txt", "theirs.txt")
     }
 
     @Test
@@ -265,9 +283,12 @@ class FileShareListVMTest : BaseTest() {
             labels = mapOf(selfDevice to "Self", remoteDevice to "Remote", third to "Third"),
         )
         val vm = makeVM()
-        vm.initialize(remoteDevice.id) // start with only remoteDevice selected
-
+        vm.initialize(null)
+        // Bring filter down to {remote} via the public API (initialize no longer seeds filters).
+        vm.onToggleFilter(selfDevice) // empty → {remote, third}
+        vm.onToggleFilter(third)      // → {remote}
         vm.state.first().activeFilters shouldBe setOf(remoteDevice)
+
         // Tapping the only selected chip should empty the filter (= back to all-selected).
         vm.onToggleFilter(remoteDevice)
         vm.state.first().activeFilters shouldBe emptySet()
@@ -285,28 +306,16 @@ class FileShareListVMTest : BaseTest() {
             labels = mapOf(selfDevice to "Self", remoteDevice to "Remote", third to "Third"),
         )
         val vm = makeVM()
-        vm.initialize(remoteDevice.id) // start with {remote}
-        vm.onToggleFilter(selfDevice)  // → {remote, self}
+        vm.initialize(null)
+        // Reach {remote} via toggles.
+        vm.onToggleFilter(selfDevice)
+        vm.onToggleFilter(third)
+        vm.state.first().activeFilters shouldBe setOf(remoteDevice)
+
+        vm.onToggleFilter(selfDevice) // → {remote, self}
         vm.state.first().activeFilters shouldBe setOf(remoteDevice, selfDevice)
-        vm.onToggleFilter(third)       // → {remote, self, third} == all → canonicalize to empty
+        vm.onToggleFilter(third)      // → {remote, self, third} == all → canonicalize to empty
         vm.state.first().activeFilters shouldBe emptySet()
-    }
-
-    @Test
-    fun `stale filters are pruned to currently available devices`() = runTest2 {
-        val ghost = DeviceId("ghost") // not in availableDevices
-        setupBaseMocks(
-            selfFiles = listOf(makeFile(blobKey = "self-1")),
-            otherFiles = mapOf(remoteDevice to listOf(makeFile(blobKey = "remote-1"))),
-        )
-        val vm = makeVM()
-        vm.initialize(ghost.id)
-
-        // Filter set holds 'ghost' which is not in availableDevices — buildState should prune
-        // to empty so the user doesn't end up with a ghost filter that hides every row.
-        val state = vm.state.first()
-        state.activeFilters shouldBe emptySet()
-        state.files.size shouldBe 2
     }
 
     @Test
@@ -582,5 +591,195 @@ class FileShareListVMTest : BaseTest() {
         // Token consumed: a second consume must be a no-op (no extra shareFile call).
         vm.consumeIncomingShare(token)
         coVerify(exactly = 1) { fileShareService.shareFile(uri) }
+    }
+
+    @Test
+    fun `free user with 0 own files - onShareClick emits LaunchPicker`() = runTest2 {
+        setupBaseMocks()
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.onShareClick(auto = false)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.LaunchPicker>()
+        event.auto shouldBe false
+    }
+
+    @Test
+    fun `free user with 1 own file - onShareClick emits AtLimit`() = runTest2 {
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "self-1")))
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.onShareClick(auto = true)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.AtLimit>()
+        event.auto shouldBe true
+    }
+
+    @Test
+    fun `free user with 1 own file - onShareFile emits AtLimit and skips upload`() = runTest2 {
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "self-1")))
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+        val uri = mockk<android.net.Uri>(relaxed = true)
+
+        vm.onShareFile(uri)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.AtLimit>()
+        coVerify(exactly = 0) { fileShareService.shareFile(any()) }
+    }
+
+    @Test
+    fun `free user batch with 0 own files - first uploads and rest dropped`() = runTest2 {
+        setupBaseMocks()
+        val uriA = mockk<android.net.Uri>(relaxed = true)
+        val uriB = mockk<android.net.Uri>(relaxed = true)
+        val uriC = mockk<android.net.Uri>(relaxed = true)
+        coEvery { fileShareService.shareFile(any()) } returns FileShareService.ShareResult.Success
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+        vm.onShareFilesSequential(listOf(uriA, uriB, uriC))
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.AtLimitDroppedExtras>()
+        event.droppedCount shouldBe 2
+        coVerify(timeout = 1_000, exactly = 1) { fileShareService.shareFile(uriA) }
+        coVerify(exactly = 0) { fileShareService.shareFile(uriB) }
+        coVerify(exactly = 0) { fileShareService.shareFile(uriC) }
+    }
+
+    @Test
+    fun `free user batch with 1 own file - all dropped`() = runTest2 {
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "self-1")))
+        val uri = mockk<android.net.Uri>(relaxed = true)
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+        vm.onShareFilesSequential(listOf(uri))
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.AtLimit>()
+        coVerify(exactly = 0) { fileShareService.shareFile(any()) }
+    }
+
+    @Test
+    fun `free user consumeIncomingShare always drains the inbox even when at limit`() = runTest2 {
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "self-1")))
+        val uri = mockk<android.net.Uri>(relaxed = true)
+        val token = incomingShareInbox.enqueue(listOf(uri))
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+        vm.consumeIncomingShare(token)
+
+        // Token must be drained (a re-consume returns null and is a no-op).
+        incomingShareInbox.drain(token) shouldBe null
+        coVerify(exactly = 0) { fileShareService.shareFile(any()) }
+    }
+
+    @Test
+    fun `free user onRetryFile works regardless of own-file count`() = runTest2 {
+        val ownFile = makeFile(blobKey = "stuck", availableOn = setOf("missing"))
+        setupBaseMocks(selfFiles = listOf(ownFile))
+        coEvery { fileShareService.retryMirror(any()) } returns Unit
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+        val item = vm.state.first().files.single()
+        vm.onRetryFile(item)
+
+        coVerify(timeout = 1_000, exactly = 1) { fileShareService.retryMirror("stuck") }
+    }
+
+    @Test
+    fun `pro user - onShareClick emits LaunchPicker even with many own files`() = runTest2 {
+        setupBaseMocks(
+            selfFiles = listOf(
+                makeFile(blobKey = "a"),
+                makeFile(blobKey = "b"),
+                makeFile(blobKey = "c"),
+            )
+        )
+        val vm = makeVM(fakeUpgradeRepo(isPro = true))
+        vm.initialize(null)
+
+        vm.onShareClick(auto = false)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.LaunchPicker>()
+    }
+
+    @Test
+    fun `lapsed pro with N grandfathered files - upload still blocked`() = runTest2 {
+        // User was Pro and uploaded 5 files, now lapsed to Free. The count is the gate, not the
+        // Pro flag — those existing files block new uploads until they expire or are deleted.
+        setupBaseMocks(
+            selfFiles = listOf(
+                makeFile(blobKey = "a"),
+                makeFile(blobKey = "b"),
+                makeFile(blobKey = "c"),
+                makeFile(blobKey = "d"),
+                makeFile(blobKey = "e"),
+            )
+        )
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.onShareClick(auto = false)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.AtLimit>()
+    }
+
+    @Test
+    fun `state freeLimitReached is true for free user with 1 own file`() = runTest2 {
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "self-1")))
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.state.first().freeLimitReached shouldBe true
+    }
+
+    @Test
+    fun `state freeLimitReached is false for free user with 0 own files`() = runTest2 {
+        setupBaseMocks()
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.state.first().freeLimitReached shouldBe false
+    }
+
+    @Test
+    fun `state freeLimitReached is false for pro user even with many own files`() = runTest2 {
+        setupBaseMocks(
+            selfFiles = listOf(
+                makeFile(blobKey = "a"),
+                makeFile(blobKey = "b"),
+                makeFile(blobKey = "c"),
+            )
+        )
+        val vm = makeVM(fakeUpgradeRepo(isPro = true))
+        vm.initialize(null)
+
+        vm.state.first().freeLimitReached shouldBe false
+    }
+
+    @Test
+    fun `expired own files do not count toward the free-tier limit`() = runTest2 {
+        // User has 1 expired own file (24h ago) — should NOT block a new upload, since expired
+        // files no longer occupy a connector slot.
+        setupBaseMocks(selfFiles = listOf(makeFile(blobKey = "old", expiresAt = now - 1.hours)))
+        val vm = makeVM(fakeUpgradeRepo(isPro = false))
+        vm.initialize(null)
+
+        vm.onShareClick(auto = false)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.LaunchPicker>()
     }
 }


### PR DESCRIPTION
## Summary

- Free users get **1 active shared file at a time per device**; Pro is unrestricted.
- At-limit, the file share list shows an inline banner (with an Upgrade action) and the FAB is rendered disabled. Tapping the dimmed FAB is a no-op.
- Pro users who lapse to free keep their existing shared files until natural 24h expiry — only *new* uploads are blocked.
- Manual mirror retry (`onRetryFile`) and background mirror retry (`BlobMaintenance`) stay free for already-started uploads — lapsed Pro users aren't punished for in-flight work.
- Side fix: the list now opens unfiltered regardless of which dashboard tile was tapped (it was pre-filtering to the tapped device).
- Side fix: the own-device filter chip now carries a home icon for clarity.

## Files

- `modules-files/.../core/FileSharePolicy.kt` (new) — `FREE_TIER_OWN_FILE_LIMIT = 1`.
- `FileShareListVM.kt` — `UpgradeRepo` injected, `State.freeLimitReached`, gated upload entry points (`onShareClick`, `onShareFile`, `enqueueShareFile`, `onShareFilesSequential`); `onRetryFile` left untouched per policy.
- `FileShareListScreen.kt` — inline `FreeLimitBanner` (Outlined card, stars icon, Upgrade text button); FAB alpha-dimmed and no-op at limit; consolidated `uiEvents` collector after launcher creation.
- `strings.xml` — banner message + Upgrade action + dropped-extras count.
- `FileShareListVMTest.kt` — added free-tier coverage (0/1/lapsed-Pro/expired-files paths, batch slicing, share-intent always drains, retry stays free, state-level `freeLimitReached` assertions).

## Test plan

- [x] `./gradlew :modules-files:testDebugUnitTest` — passes.
- [x] `./gradlew :app:assembleFossDebug` and `:app:assembleGplayDebug` — both pass.
- [x] Smoke-tested on `octi-1` emulator (FOSS, non-Pro):
  - Below limit → FAB at full opacity → picker opens → upload succeeds.
  - At limit → banner visible (verbatim text matches resource) → FAB dimmed, tap is no-op → Upgrade button navigates to the FOSS sponsors screen.
  - After delete → banner disappears, FAB returns to full opacity, picker opens.
- [x] Verified the cross-device-delete assumption empirically (peer file row offers only Save/Open, no Delete) before settling on the "1 per device" policy.