### PR TITLE
Fix cross-device file deletion and add delete confirmation

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -561,6 +561,14 @@ class DashboardVM @Inject constructor(
     ) { now, byDevice, missingPermissions, activeConnectors, activeStates, alerts, _, fileShare ->
         val statesList = activeStates.toList()
         val statesMap = activeConnectors.zip(statesList).associate { (c, s) -> c.identifier to s }
+        val fileDeleteRequests = byDevice.devices.values
+            .flatMap { moduleDatas ->
+                moduleDatas.mapNotNull { it.data as? FileShareInfo }
+            }
+            .flatMap { it.deleteRequests }
+            .filter { now <= it.retainUntil }
+            .map { it.targetDeviceId to it.blobKey }
+            .toSet()
 
         // Build normal device items from module data
         val normalItems = byDevice.devices
@@ -605,7 +613,15 @@ class DashboardVM @Inject constructor(
                             )
 
                             is FileShareInfo -> ModuleItem.FileShare(
-                                data = moduleData as ModuleData<FileShareInfo>,
+                                data = (moduleData as ModuleData<FileShareInfo>).let { fileData ->
+                                    fileData.copy(
+                                        data = fileData.data.copy(
+                                            files = fileData.data.files.filterNot {
+                                                (deviceId.id to it.blobKey) in fileDeleteRequests
+                                            },
+                                        ),
+                                    )
+                                },
                                 isOurDevice = deviceId == syncSettings.deviceId,
                                 isSharingAvailable = fileShare.isSharingAvailable,
                                 configuredConnectorIds = fileShare.configuredConnectorIds,

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/BlobMaintenance.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/BlobMaintenance.kt
@@ -11,6 +11,7 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.modules.files.FileShareModule
 import eu.darken.octi.sync.core.BlobKey
 import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.blob.BlobCacheDirs
@@ -54,6 +55,7 @@ class BlobMaintenance @Inject constructor(
     private val fileShareSettings: FileShareSettings,
     private val syncSettings: SyncSettings,
     private val blobCacheDirs: BlobCacheDirs,
+    private val publisher: FileSharePublisher,
 ) {
 
     private val stagingDir: File
@@ -85,9 +87,11 @@ class BlobMaintenance @Inject constructor(
     internal suspend fun runOnce() = maintenanceLock.withLock {
         log(TAG) { "runOnce() starting" }
         cleanupStaleTempFiles()
+        consumeRemoteDeleteRequests()
         retryMirrorUploads()
         retryPendingDeletes()
         pruneExpired()
+        pruneOwnDeleteRequests()
         trimBackoff()
         log(TAG) { "runOnce() complete" }
     }
@@ -231,6 +235,82 @@ class BlobMaintenance @Inject constructor(
         storageStatusManager.invalidateAndRefresh(touched)
     }
 
+    private suspend fun consumeRemoteDeleteRequests() {
+        val own = fileShareCache.get(syncSettings.deviceId)?.data ?: return
+        val now = Clock.System.now()
+        val requestedBlobKeys = fileShareCache.cachedDevices()
+            .filter { it != syncSettings.deviceId }
+            .mapNotNull { fileShareCache.get(it)?.data }
+            .flatMap { it.deleteRequests }
+            .filter { it.targetDeviceId == syncSettings.deviceId.id && now <= it.retainUntil }
+            .map { it.blobKey }
+            .toSet()
+        if (requestedBlobKeys.isEmpty()) return
+
+        val configuredById = blobManager.configuredConnectorsByIdString()
+        val touched = mutableSetOf<ConnectorId>()
+        for (file in own.files.filter { it.blobKey in requestedBlobKeys }) {
+            try {
+                touched += deleteOwnFileForRequest(file, configuredById)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "consumeRemoteDeleteRequests(): Failed for ${file.name}: ${e.asLog()}" }
+            }
+        }
+        if (touched.isEmpty()) return
+        storageStatusManager.invalidateAndRefresh(touched)
+        publisher.publishNow()
+    }
+
+    private suspend fun deleteOwnFileForRequest(
+        file: FileShareInfo.SharedFile,
+        configuredById: Map<String, ConnectorId>,
+    ): Set<ConnectorId> {
+        log(TAG) { "deleteOwnFileForRequest(): ${file.name}" }
+        val targets: Map<ConnectorId, RemoteBlobRef> = file.availableOn
+            .mapNotNull { idStr ->
+                val connectorId = configuredById[idStr] ?: return@mapNotNull null
+                val ref = file.connectorRefs[idStr] ?: return@mapNotNull null
+                connectorId to ref
+            }
+            .toMap()
+
+        if (targets.isEmpty()) {
+            val tombstone = PendingDelete(
+                blobKey = file.blobKey,
+                remainingConnectors = file.availableOn,
+                createdAt = Clock.System.now(),
+            )
+            fileShareSettings.pendingDeletes.update { it + (file.blobKey to tombstone) }
+            return emptySet()
+        }
+
+        val successfulDeletes = blobManager.delete(
+            deviceId = syncSettings.deviceId,
+            moduleId = FileShareModule.MODULE_ID,
+            blobKey = BlobKey(file.blobKey),
+            targets = targets,
+        )
+
+        val deletedIds = successfulDeletes.map { it.idString }.toSet()
+        val newAvailableOn = file.availableOn - deletedIds
+        val newConnectorRefs = file.connectorRefs - deletedIds
+        if (newAvailableOn.isEmpty()) {
+            fileShareHandler.removeFile(file.blobKey)
+            fileShareSettings.pendingDeletes.update { it - file.blobKey }
+        } else if (newAvailableOn != file.availableOn) {
+            fileShareHandler.updateLocations(file.blobKey, newAvailableOn, newConnectorRefs)
+            val tombstone = PendingDelete(
+                blobKey = file.blobKey,
+                remainingConnectors = newAvailableOn,
+                createdAt = Clock.System.now(),
+            )
+            fileShareSettings.pendingDeletes.update { it + (file.blobKey to tombstone) }
+        }
+        return successfulDeletes
+    }
+
     private suspend fun pruneExpired() {
         val own = fileShareCache.get(syncSettings.deviceId)?.data ?: return
         val now = Clock.System.now()
@@ -358,11 +438,39 @@ class BlobMaintenance @Inject constructor(
         storageStatusManager.invalidateAndRefresh(touched)
     }
 
+    private suspend fun pruneOwnDeleteRequests() {
+        val own = fileShareCache.get(syncSettings.deviceId)?.data ?: return
+        if (own.deleteRequests.isEmpty()) return
+
+        val now = Clock.System.now()
+        // Pre-fetch target snapshots OUTSIDE the state-update lock — fileShareCache.get is suspend
+        // and must not be called from inside the DynamicStateFlow mutation.
+        val targetSnapshots: Map<String, FileShareInfo?> = own.deleteRequests
+            .map { it.targetDeviceId }
+            .toSet()
+            .associateWith { fileShareCache.get(DeviceId(it))?.data }
+
+        fileShareHandler.mutateDeleteRequests { requests ->
+            requests.filter { request ->
+                if (now > request.retainUntil) return@filter false
+                val targetData = targetSnapshots[request.targetDeviceId]
+                    ?: return@filter true // null = transient cache miss, keep until retainUntil
+                targetData.files.any { it.blobKey == request.blobKey && now <= it.expiresAt }
+            }
+        }
+    }
+
     companion object {
         private val TAG = logTag("Module", "Files", "BlobMaintenance")
         private val STARTUP_DELAY = 60.seconds
         private val MAINTENANCE_INTERVAL = 30.minutes
-        private val STALE_FORGET_DELAY = 24.hours
+        /**
+         * How long after expiry before a stale file is purged from the owner's own list.
+         * Kept aligned with [FileShareService.DELETE_REQUEST_RETENTION] so a delete request
+         * never outlives its target file in the owner's cache — the two 24-hour windows are
+         * intentionally the same.
+         */
+        internal val STALE_FORGET_DELAY = 24.hours
         private val SHORT_TTL = 1.hours
         private val OPEN_CACHE_TTL = 24.hours
     }

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareHandler.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareHandler.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Clock
 
 /**
  * Minimal [ModuleInfoSource] for the files module.
@@ -66,6 +67,36 @@ class FileShareHandler @Inject constructor(
         updateOwn { current ->
             current.copy(files = current.files.filter { it.blobKey != blobKey })
         }
+    }
+
+    suspend fun upsertDeleteRequest(request: FileShareInfo.DeleteRequest) {
+        val now = Clock.System.now()
+        if (now > request.retainUntil) {
+            log(TAG, VERBOSE) {
+                "upsertDeleteRequest(): refusing already-expired request blobKey=${request.blobKey}"
+            }
+            return
+        }
+        log(TAG, VERBOSE) {
+            "upsertDeleteRequest(target=${request.targetDeviceId.take(8)}, blobKey=${request.blobKey})"
+        }
+        updateOwn { current ->
+            current.copy(
+                deleteRequests = current.deleteRequests
+                    .filter { now <= it.retainUntil }
+                    .filterNot { it.targetDeviceId == request.targetDeviceId && it.blobKey == request.blobKey } +
+                    request,
+            )
+        }
+    }
+
+    /** Atomically mutate the delete-request list. The [transform] must be pure and non-suspending;
+     * do not call suspend functions (e.g. cache reads) inside it. */
+    suspend fun mutateDeleteRequests(
+        transform: (List<FileShareInfo.DeleteRequest>) -> List<FileShareInfo.DeleteRequest>,
+    ) {
+        log(TAG, VERBOSE) { "mutateDeleteRequests()" }
+        updateOwn { current -> current.copy(deleteRequests = transform(current.deleteRequests)) }
     }
 
     /**

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareInfo.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareInfo.kt
@@ -9,6 +9,7 @@ import kotlin.time.Instant
 @Serializable
 data class FileShareInfo(
     @SerialName("files") val files: List<SharedFile> = emptyList(),
+    @SerialName("deleteRequests") val deleteRequests: List<DeleteRequest> = emptyList(),
 ) {
     @Serializable
     data class SharedFile(
@@ -31,4 +32,19 @@ data class FileShareInfo(
             require(checksum.isNotBlank()) { "SharedFile.checksum must not be blank (blobKey=$blobKey)" }
         }
     }
+
+    /**
+     * A non-owner's request to have the owner delete a specific blob.
+     * Trust model: all paired devices on the same account are trusted — any peer's DeleteRequest
+     * is honored fleet-wide. [BlobMaintenance] on the owning device consumes this.
+     */
+    @Serializable
+    data class DeleteRequest(
+        @SerialName("targetDeviceId") val targetDeviceId: String,
+        @SerialName("blobKey") val blobKey: String,
+        @Serializable(with = InstantSerializer::class)
+        @SerialName("requestedAt") val requestedAt: Instant,
+        @Serializable(with = InstantSerializer::class)
+        @SerialName("retainUntil") val retainUntil: Instant,
+    )
 }

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileSharePublisher.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileSharePublisher.kt
@@ -1,0 +1,49 @@
+package eu.darken.octi.modules.files.core
+
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.modules.files.FileShareModule
+import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncOptions
+import eu.darken.octi.sync.core.SyncSettings
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Clock
+
+/**
+ * Shared helper that pushes the local file-share state to all configured sync connectors
+ * immediately, bypassing the normal 1-second throttle in [FileShareHandler.info].
+ * Used by both [FileShareService] (after inserting a delete request) and [BlobMaintenance]
+ * (after consuming remote delete requests) so the requester's state is visible to peers
+ * in the same sync cycle rather than waiting for the next maintenance pass.
+ */
+@Singleton
+class FileSharePublisher @Inject constructor(
+    private val syncSettings: SyncSettings,
+    private val fileShareHandler: FileShareHandler,
+    private val fileShareSync: FileShareSync,
+    private val syncManager: SyncManager,
+) {
+
+    suspend fun publishNow() {
+        val selfData = ModuleData(
+            modifiedAt = Clock.System.now(),
+            deviceId = syncSettings.deviceId,
+            moduleId = FileShareModule.MODULE_ID,
+            data = fileShareHandler.currentOwn(),
+        )
+        fileShareSync.sync(selfData)
+        syncManager.sync(
+            SyncOptions(
+                stats = false,
+                readData = false,
+                writeData = true,
+                moduleFilter = setOf(FileShareModule.MODULE_ID),
+            ),
+        )
+    }
+
+    companion object {
+        private val TAG = logTag("Module", "Files", "Publisher")
+    }
+}

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
@@ -60,6 +60,7 @@ import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
 @Singleton
@@ -75,6 +76,7 @@ class FileShareService @Inject constructor(
     private val storageStatusManager: StorageStatusManager,
     private val syncSettings: SyncSettings,
     private val blobCacheDirs: BlobCacheDirs,
+    private val publisher: FileSharePublisher,
 ) {
 
     sealed class ShareResult {
@@ -119,6 +121,7 @@ class FileShareService @Inject constructor(
 
     sealed class DeleteResult {
         data object Deleted : DeleteResult()
+        data object Requested : DeleteResult()
         data object NotFound : DeleteResult()
         data class Partial(val remainingConnectors: Set<String>) : DeleteResult()
     }
@@ -793,6 +796,28 @@ class FileShareService @Inject constructor(
         blobMaintenance.runMirrorUploadsFor(setOf(blobKey))
     }
 
+    suspend fun deleteFile(ownerDeviceId: DeviceId, sharedFile: FileShareInfo.SharedFile): DeleteResult =
+        withContext(dispatcherProvider.IO) {
+            log(TAG, INFO) { "deleteFile(owner=${ownerDeviceId.logLabel}, blobKey=${sharedFile.blobKey})" }
+            if (ownerDeviceId == syncSettings.deviceId) {
+                return@withContext deleteOwnFile(sharedFile.blobKey)
+            }
+
+            val now = Clock.System.now()
+            val request = FileShareInfo.DeleteRequest(
+                targetDeviceId = ownerDeviceId.id,
+                blobKey = sharedFile.blobKey,
+                requestedAt = now,
+                retainUntil = minOf(
+                    maxOf(sharedFile.expiresAt + DELETE_REQUEST_RETENTION, now + DELETE_REQUEST_RETENTION),
+                    now + DELETE_REQUEST_MAX_RETENTION,
+                ),
+            )
+            fileShareHandler.upsertDeleteRequest(request)
+            publisher.publishNow()
+            DeleteResult.Requested
+        }
+
     suspend fun deleteOwnFile(blobKey: String): DeleteResult = withContext(dispatcherProvider.IO) {
         log(TAG, INFO) { "deleteOwnFile(blobKey=$blobKey)" }
         val currentState = fileShareHandler.currentOwn()
@@ -878,5 +903,12 @@ class FileShareService @Inject constructor(
     companion object {
         private val TAG = logTag("Module", "Files", "Service")
         private val DEFAULT_EXPIRY = 48.hours
+        /**
+         * How long a delete request is kept after the file's expiry or now, whichever is later.
+         * Kept aligned with [BlobMaintenance.STALE_FORGET_DELAY] so a request never outlives the
+         * file it targets in the owner's cache.
+         */
+        internal val DELETE_REQUEST_RETENTION = 24.hours
+        private val DELETE_REQUEST_MAX_RETENTION = 7.days
     }
 }

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/IncomingFileNotifier.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/IncomingFileNotifier.kt
@@ -106,12 +106,18 @@ class IncomingFileNotifier @Inject constructor(
                 var dirty = false
                 val now = Clock.System.now()
                 val knownDevices = snap.state.others.map { it.deviceId }.toSet()
+                val deleteRequested = snap.state.all
+                    .flatMap { it.data.deleteRequests }
+                    .filter { now <= it.retainUntil }
+                    .map { it.targetDeviceId to it.blobKey }
+                    .toSet()
 
                 for (moduleData in snap.state.others) {
                     val deviceId = moduleData.deviceId
                     // Filter expired files so an already-expired share doesn't notify after restart.
                     val current = moduleData.data.files
                         .filter { now <= it.expiresAt }
+                        .filter { (deviceId.id to it.blobKey) !in deleteRequested }
                         .map { it.blobKey }
                         .toSet()
                     val previous = seenByDevice[deviceId]

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileDetailBottomSheet.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileDetailBottomSheet.kt
@@ -102,54 +102,62 @@ fun FileDetailBottomSheet(
                     value = item.sharedFile.availableOn.joinToString(", "),
                 )
             }
+            if (item.isDeleteRequested) {
+                DetailRow(
+                    label = stringResource(R.string.module_files_sheet_property_status),
+                    value = stringResource(R.string.module_files_delete_requested_label),
+                )
+            }
 
             Spacer(modifier = Modifier.size(20.dp))
 
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-            ) {
-                val openEnabled = item.canOpenOrSave && !item.isInFlight && !item.isOpenPreparing && !item.isDeleting
-                OutlinedButton(
-                    enabled = openEnabled,
-                    onClick = onOpen,
-                    modifier = Modifier.weight(1f),
+            if (!item.isDeleteRequested) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    if (item.isOpenPreparing) {
-                        CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                    val openEnabled = item.canOpenOrSave && !item.isInFlight && !item.isOpenPreparing && !item.isDeleting
+                    OutlinedButton(
+                        enabled = openEnabled,
+                        onClick = onOpen,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        if (item.isOpenPreparing) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource(R.string.module_files_open_preparing))
+                        } else {
+                            Icon(Icons.AutoMirrored.TwoTone.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource(R.string.module_files_action_open))
+                        }
+                    }
+                    val saveEnabled = item.canOpenOrSave && !item.isInFlight && !item.isDeleting
+                    OutlinedButton(
+                        enabled = saveEnabled,
+                        onClick = onSave,
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Icon(Icons.TwoTone.SaveAlt, contentDescription = null, modifier = Modifier.size(18.dp))
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.module_files_open_preparing))
-                    } else {
-                        Icon(Icons.AutoMirrored.TwoTone.OpenInNew, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.module_files_action_open))
+                        Text(stringResource(R.string.module_files_action_save_as))
                     }
                 }
-                val saveEnabled = item.canOpenOrSave && !item.isInFlight && !item.isDeleting
-                OutlinedButton(
-                    enabled = saveEnabled,
-                    onClick = onSave,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(Icons.TwoTone.SaveAlt, contentDescription = null, modifier = Modifier.size(18.dp))
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(stringResource(R.string.module_files_action_save_as))
-                }
-            }
 
-            if (item.isOwn && !item.isPendingDelete) {
-                Spacer(modifier = Modifier.size(8.dp))
-                OutlinedButton(
-                    enabled = !item.isDeleting,
-                    onClick = onDelete,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (item.isDeleting) {
-                        CircularProgressIndicator(modifier = Modifier.size(16.dp))
-                    } else {
-                        Icon(Icons.TwoTone.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(stringResource(R.string.module_files_delete_action))
+                if (!item.isPendingDelete) {
+                    Spacer(modifier = Modifier.size(8.dp))
+                    OutlinedButton(
+                        enabled = !item.isDeleting,
+                        onClick = onDelete,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (item.isDeleting) {
+                            CircularProgressIndicator(modifier = Modifier.size(16.dp))
+                        } else {
+                            Icon(Icons.TwoTone.Delete, contentDescription = null, modifier = Modifier.size(18.dp))
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource(R.string.module_files_delete_action))
+                        }
                     }
                 }
             }

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListScreen.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.twotone.Refresh
 import androidx.compose.material.icons.twotone.SaveAlt
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Sync
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -254,6 +255,37 @@ fun FileShareListScreenHost(
         createDocLauncher.launch(buildSaveAsIntent(item))
     }
 
+    val deleteConfirmation by vm.deleteConfirmation.collectAsState()
+    deleteConfirmation?.let { confirmation ->
+        AlertDialog(
+            onDismissRequest = { vm.cancelDeleteConfirmation() },
+            title = { Text(stringResource(R.string.module_files_delete_confirm_title)) },
+            text = {
+                Text(
+                    if (confirmation.isOwn) {
+                        stringResource(R.string.module_files_delete_confirm_own, confirmation.sharedFile.name)
+                    } else {
+                        stringResource(
+                            R.string.module_files_delete_confirm_peer,
+                            confirmation.sharedFile.name,
+                            confirmation.ownerLabel,
+                        )
+                    },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { vm.confirmDelete() }) {
+                    Text(stringResource(R.string.module_files_delete_confirm_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { vm.cancelDeleteConfirmation() }) {
+                    Text(stringResource(R.string.module_files_delete_cancel_action))
+                }
+            },
+        )
+    }
+
     state?.let { current ->
         FileShareListScreen(
             state = current,
@@ -263,7 +295,7 @@ fun FileShareListScreenHost(
             onUpgradeClick = { vm.navToUpgrade() },
             onRowClick = { item -> vm.onRowClick(item) },
             onRowSecondaryClick = { item ->
-                if (item.isOwn) vm.onDeleteFile(item)
+                if (item.isOwn) vm.requestDelete(item)
                 else launchManualSave(item)
             },
             onRetryClick = { item -> vm.onRetryFile(item) },
@@ -275,7 +307,7 @@ fun FileShareListScreenHost(
             onSheetDismiss = { vm.onSheetDismiss() },
             onSheetOpen = { item -> vm.onOpenFile(item) },
             onSheetSave = { item -> launchManualSave(item) },
-            onSheetDelete = { item -> vm.onDeleteFile(item) },
+            onSheetDelete = { item -> vm.requestDelete(item) },
         )
     }
 }
@@ -736,7 +768,10 @@ private fun FileItemRow(
                                 DateUtils.MINUTE_IN_MILLIS,
                             )
                         )
-                        if (item.isPendingDelete) {
+                        if (item.isDeleteRequested) {
+                            append(" • ")
+                            append(context.getString(R.string.module_files_delete_requested_label))
+                        } else if (item.isPendingDelete) {
                             append(" • ")
                             append(context.getString(R.string.module_files_pending_delete_label))
                         } else if (!item.canOpenOrSave && !item.isOwn) {
@@ -768,6 +803,7 @@ private fun FileItemRow(
                         CircularProgressIndicator(modifier = Modifier.size(24.dp))
                     }
                 }
+                item.isDeleteRequested -> Unit
                 item.isOwn && item.canRetry -> {
                     IconButton(onClick = onRetryClick) {
                         Icon(

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
@@ -45,14 +45,19 @@ import eu.darken.octi.sync.core.blob.RetryStatus
 import eu.darken.octi.sync.core.blob.StorageStatus
 import eu.darken.octi.sync.core.blob.StorageStatusManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class FileShareListVM @Inject constructor(
@@ -97,6 +102,7 @@ class FileShareListVM @Inject constructor(
         val canOpenOrSave: Boolean,
         val isDeleting: Boolean = false,
         val isPendingDelete: Boolean = false,
+        val isDeleteRequested: Boolean = false,
         val isOpenPreparing: Boolean = false,
         val downloadProgress: BlobProgress? = null,
         val uploadProgress: BlobProgress? = null,
@@ -104,7 +110,7 @@ class FileShareListVM @Inject constructor(
     ) {
         val isInFlight: Boolean get() = downloadProgress != null || uploadProgress != null
         val anyRetrying: Boolean get() = missingConnectors.any { it.status is RetryStatus.RetryingAt }
-        val canRetry: Boolean get() = missingConnectors.any {
+        val canRetry: Boolean get() = !isDeleteRequested && missingConnectors.any {
             it.status is RetryStatus.Stopped ||
                 it.status is RetryStatus.QuotaExceeded ||
                 it.status is RetryStatus.ServerStorageLow
@@ -141,6 +147,14 @@ class FileShareListVM @Inject constructor(
         data class AtLimitDroppedExtras(val droppedCount: Int) : UiEvent
     }
 
+    data class DeleteConfirmation(
+        val key: FileKey,
+        val ownerDeviceId: DeviceId,
+        val sharedFile: FileShareInfo.SharedFile,
+        val isOwn: Boolean,
+        val ownerLabel: String,
+    )
+
     val uiEvents = SingleEventFlow<UiEvent>()
 
     private val _filters = MutableStateFlow<Set<DeviceId>>(emptySet())
@@ -150,6 +164,15 @@ class FileShareListVM @Inject constructor(
     private val _openPreparing = MutableStateFlow<Set<FileKey>>(emptySet())
     private val _sheetTarget = MutableStateFlow<FileKey?>(null)
     private val _isSyncingNow = MutableStateFlow(false)
+    private val _deleteConfirmation = MutableStateFlow<DeleteConfirmation?>(null)
+    val deleteConfirmation: StateFlow<DeleteConfirmation?> = _deleteConfirmation.asStateFlow()
+
+    private val tickerUiRefresh = flow {
+        while (true) {
+            emit(Unit)
+            delay(60.seconds)
+        }
+    }
 
     private data class RepoSnapshot(
         val repoState: BaseModuleRepo.State<FileShareInfo>,
@@ -207,7 +230,7 @@ class FileShareListVM @Inject constructor(
             fileShareSettings.pendingDeletes.flow,
             fileShareSettings.isUsageHintDismissed.flow,
         ) { pendingDeletes, hint -> SettingsSnapshot(pendingDeletes, hint) },
-        _isSyncingNow,
+        combine(_isSyncingNow, tickerUiRefresh) { syncing, _ -> syncing },
     ) { repo, transfer, ui, settings, syncingNow ->
         buildState(repo, transfer, ui, settings, syncingNow)
     }
@@ -244,6 +267,7 @@ class FileShareListVM @Inject constructor(
             .sortedWith(compareByDescending<DeviceOption> { it.isOwn }.thenBy { it.label })
 
         val now = Clock.System.now()
+        val deleteRequestedKeys = activeDeleteRequestKeys(deviceData, now)
         val availableSet = availableDevices.map { it.deviceId }.toSet()
         val effectiveFilters = ui.filters intersect availableSet
         val filterIsEmpty = effectiveFilters.isEmpty()
@@ -256,6 +280,7 @@ class FileShareListVM @Inject constructor(
                 .filter { now <= it.expiresAt }
                 .map { sharedFile ->
                     val key = FileKey.of(ownerId, sharedFile.blobKey)
+                    val isDeleteRequested = key in deleteRequestedKeys
                     val transferEntry = transfer.transfers[sharedFile.blobKey]
                     val download = transferEntry
                         ?.takeIf { it.direction == FileShareService.Transfer.Direction.DOWNLOAD }
@@ -274,9 +299,10 @@ class FileShareListVM @Inject constructor(
                         ownerDeviceId = ownerId,
                         ownerDeviceLabel = ownerLabel,
                         isOwn = isOwn,
-                        canOpenOrSave = candidates.isNotEmpty(),
+                        canOpenOrSave = candidates.isNotEmpty() && !isDeleteRequested,
                         isDeleting = key in ui.deleting,
                         isPendingDelete = sharedFile.blobKey in settings.pendingDeletes,
+                        isDeleteRequested = isDeleteRequested,
                         isOpenPreparing = key in ui.openPreparing,
                         downloadProgress = download,
                         uploadProgress = upload,
@@ -318,6 +344,15 @@ class FileShareListVM @Inject constructor(
             freeLimitReached = freeLimitReached,
         )
     }
+
+    private fun activeDeleteRequestKeys(
+        deviceData: List<Pair<DeviceId, FileShareInfo>>,
+        now: kotlin.time.Instant,
+    ): Set<FileKey> = deviceData
+        .flatMap { (_, info) -> info.deleteRequests }
+        .filter { now <= it.retainUntil }
+        .map { FileKey.of(DeviceId(it.targetDeviceId), it.blobKey) }
+        .toSet()
 
     private fun comparatorFor(by: SortKey, descending: Boolean): Comparator<FileItem> {
         val base: Comparator<FileItem> = when (by) {
@@ -494,6 +529,10 @@ class FileShareListVM @Inject constructor(
     }
 
     fun onSaveFile(item: FileItem, uri: Uri) = launch {
+        if (!item.canOpenOrSave) {
+            uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_save_not_available))
+            return@launch
+        }
         when (val result = fileShareService.saveFile(item.sharedFile, item.ownerDeviceId, uri)) {
             is FileShareService.SaveResult.Success ->
                 uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_save_success))
@@ -513,6 +552,10 @@ class FileShareListVM @Inject constructor(
     }
 
     fun onOpenFile(item: FileItem) = launch {
+        if (!item.canOpenOrSave) {
+            uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_save_not_available))
+            return@launch
+        }
         _openPreparing.update { it + item.key }
         try {
             when (val result = fileShareService.openFile(item.sharedFile, item.ownerDeviceId)) {
@@ -547,19 +590,40 @@ class FileShareListVM @Inject constructor(
         fileShareSettings.isUsageHintDismissed.value(true)
     }
 
-    fun onDeleteFile(item: FileItem) = launch {
-        _deleting.update { it + item.key }
+    fun requestDelete(item: FileItem) {
+        _deleteConfirmation.value = DeleteConfirmation(
+            key = item.key,
+            ownerDeviceId = item.ownerDeviceId,
+            sharedFile = item.sharedFile,
+            isOwn = item.isOwn,
+            ownerLabel = item.ownerDeviceLabel,
+        )
+    }
+
+    fun cancelDeleteConfirmation() {
+        _deleteConfirmation.value = null
+    }
+
+    fun confirmDelete() = launch {
+        val confirmation = _deleteConfirmation.value ?: return@launch
+        _deleteConfirmation.value = null
+        performDelete(confirmation.key, confirmation.ownerDeviceId, confirmation.sharedFile)
+    }
+
+    private suspend fun performDelete(key: FileKey, ownerDeviceId: DeviceId, sharedFile: FileShareInfo.SharedFile) {
+        _deleting.update { it + key }
         try {
-            val result = runCatching { fileShareService.deleteOwnFile(item.sharedFile.blobKey) }
+            val result = runCatching { fileShareService.deleteFile(ownerDeviceId, sharedFile) }
             val message: Int = when (val r = result.getOrNull()) {
                 FileShareService.DeleteResult.Deleted -> R.string.module_files_delete_success
+                FileShareService.DeleteResult.Requested -> R.string.module_files_delete_requested
                 FileShareService.DeleteResult.NotFound -> R.string.module_files_delete_failed
                 is FileShareService.DeleteResult.Partial -> R.string.module_files_delete_partial
                 null -> R.string.module_files_delete_failed
             }
             uiEvents.tryEmit(UiEvent.ShowMessage(message))
         } finally {
-            _deleting.update { it - item.key }
+            _deleting.update { it - key }
         }
     }
 

--- a/modules-files/src/main/res/values/strings.xml
+++ b/modules-files/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="module_files_save_failed">Failed to save file</string>
     <string name="module_files_checksum_mismatch">File integrity check failed</string>
     <string name="module_files_delete_success">File deleted</string>
+    <string name="module_files_delete_requested">Deletion requested</string>
     <string name="module_files_delete_partial">File partially deleted. Cleanup will continue in the background.</string>
     <string name="module_files_delete_failed">Failed to delete file</string>
     <string name="module_files_quota_header">Storage</string>
@@ -74,16 +75,23 @@
     <string name="module_files_open_failed">Failed to open file</string>
     <string name="module_files_open_preparing">Preparing…</string>
     <string name="module_files_pending_delete_label">Cleanup pending…</string>
+    <string name="module_files_delete_requested_label">Deletion requested…</string>
     <string name="module_files_sheet_property_size">Size</string>
     <string name="module_files_sheet_property_type">Type</string>
     <string name="module_files_sheet_property_shared_by">Shared by</string>
     <string name="module_files_sheet_property_shared_at">Shared</string>
     <string name="module_files_sheet_property_expires_at">Expires</string>
     <string name="module_files_sheet_property_available_on">Available on</string>
+    <string name="module_files_sheet_property_status">Status</string>
     <string name="module_files_sheet_dismiss_action">Close</string>
     <string name="module_files_share_unsupported">This share isn\'t a file</string>
     <string name="module_files_share_module_disabled">File sharing is disabled</string>
     <string name="module_files_free_limit_reached_message">Free version is limited to 1 shared file at a time. Delete it to share another, or upgrade for unlimited (within your storage quota).</string>
     <string name="module_files_free_limit_action_upgrade">Upgrade</string>
     <string name="module_files_free_limit_dropped_extras">%1$d additional file(s) skipped — free limit is 1.</string>
+    <string name="module_files_delete_confirm_title">Delete file?</string>
+    <string name="module_files_delete_confirm_own">%1$s will be removed from all your devices.</string>
+    <string name="module_files_delete_confirm_peer">Request %2$s to delete %1$s? It will be removed once they sync.</string>
+    <string name="module_files_delete_confirm_action">Delete</string>
+    <string name="module_files_delete_cancel_action">Cancel</string>
 </resources>

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/BlobMaintenanceTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/BlobMaintenanceTest.kt
@@ -22,6 +22,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -33,6 +34,7 @@ import testhelpers.coroutine.runTest2
 import java.io.File
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 class BlobMaintenanceTest : BaseTest() {
 
@@ -45,6 +47,7 @@ class BlobMaintenanceTest : BaseTest() {
     private val fileShareSettings = mockk<FileShareSettings>()
     private val pendingDeletes = mockk<DataStoreValue<Map<String, PendingDelete>>>()
     private val syncSettings = mockk<SyncSettings>()
+    private val publisher = mockk<FileSharePublisher>(relaxed = true)
 
     @TempDir
     lateinit var tempDir: File
@@ -66,6 +69,7 @@ class BlobMaintenanceTest : BaseTest() {
         every { syncSettings.deviceId } returns selfDeviceId
         every { fileShareSettings.pendingDeletes } returns pendingDeletes
         every { blobManager.trimBackoff(any()) } just runs
+        coEvery { fileShareCache.cachedDevices() } returns setOf(selfDeviceId)
     }
 
     private fun createBlobMaintenance(testScope: kotlinx.coroutines.test.TestScope): BlobMaintenance {
@@ -79,6 +83,7 @@ class BlobMaintenanceTest : BaseTest() {
             fileShareSettings = fileShareSettings,
             syncSettings = syncSettings,
             blobCacheDirs = BlobCacheDirs(context),
+            publisher = publisher,
         )
     }
 
@@ -101,11 +106,26 @@ class BlobMaintenanceTest : BaseTest() {
         connectorRefs = connectorRefs,
     )
 
-    private fun makeModuleData(files: List<FileShareInfo.SharedFile>) = ModuleData(
+    private fun makeModuleData(
+        files: List<FileShareInfo.SharedFile>,
+        deviceId: DeviceId = selfDeviceId,
+        deleteRequests: List<FileShareInfo.DeleteRequest> = emptyList(),
+    ) = ModuleData(
         modifiedAt = Clock.System.now(),
-        deviceId = selfDeviceId,
+        deviceId = deviceId,
         moduleId = FileShareModule.MODULE_ID,
-        data = FileShareInfo(files = files),
+        data = FileShareInfo(files = files, deleteRequests = deleteRequests),
+    )
+
+    private fun makeDeleteRequest(
+        targetDeviceId: DeviceId,
+        blobKey: String,
+        retainUntil: Instant = Clock.System.now() + 2.hours,
+    ) = FileShareInfo.DeleteRequest(
+        targetDeviceId = targetDeviceId.id,
+        blobKey = blobKey,
+        requestedAt = Clock.System.now(),
+        retainUntil = retainUntil,
     )
 
     private fun makeTombstone(blobKey: String, remaining: Set<String> = emptySet()) = PendingDelete(
@@ -113,6 +133,112 @@ class BlobMaintenanceTest : BaseTest() {
         remainingConnectors = remaining,
         createdAt = Clock.System.now(),
     )
+
+    @Nested
+    inner class `remote delete requests` {
+
+        @Test
+        fun `consume request from peer using own device namespace`() = runTest2 {
+            val remoteDeviceId = DeviceId("remote-device")
+            val file = makeFile(
+                blobKey = "requested-blob",
+                availableOn = setOf(connectorA.idString),
+                connectorRefs = mapOf(connectorA.idString to RemoteBlobRef("srv-a")),
+            )
+            val request = makeDeleteRequest(
+                targetDeviceId = selfDeviceId,
+                blobKey = file.blobKey,
+            )
+
+            coEvery { fileShareCache.cachedDevices() } returns setOf(selfDeviceId, remoteDeviceId)
+            coEvery { fileShareCache.get(selfDeviceId) } returns makeModuleData(listOf(file))
+            coEvery {
+                fileShareCache.get(remoteDeviceId)
+            } returns makeModuleData(
+                files = emptyList(),
+                deviceId = remoteDeviceId,
+                deleteRequests = listOf(request),
+            )
+            coEvery { blobManager.configuredConnectorsByIdString() } returns mapOf(connectorA.idString to connectorA)
+            every { pendingDeletes.flow } returns flowOf(emptyMap())
+            coEvery {
+                blobManager.delete(
+                    deviceId = selfDeviceId,
+                    moduleId = FileShareModule.MODULE_ID,
+                    blobKey = BlobKey(file.blobKey),
+                    targets = mapOf(connectorA to RemoteBlobRef("srv-a")),
+                )
+            } returns setOf(connectorA)
+            coEvery { fileShareHandler.removeFile(file.blobKey) } just runs
+            coEvery { pendingDeletes.update(any()) } returns DataStoreValue.Updated(emptyMap(), emptyMap())
+
+            val maintenance = createBlobMaintenance(this)
+            maintenance.runOnce()
+
+            coVerify(exactly = 1) {
+                blobManager.delete(
+                    deviceId = selfDeviceId,
+                    moduleId = FileShareModule.MODULE_ID,
+                    blobKey = BlobKey(file.blobKey),
+                    targets = mapOf(connectorA to RemoteBlobRef("srv-a")),
+                )
+            }
+            coVerify(exactly = 0) {
+                blobManager.delete(
+                    deviceId = remoteDeviceId,
+                    moduleId = any(),
+                    blobKey = any(),
+                    targets = any(),
+                )
+            }
+            coVerify(exactly = 1) { fileShareHandler.removeFile(file.blobKey) }
+        }
+
+        @Test
+        fun `prune own requests after target stops advertising file`() = runTest2 {
+            val remoteDeviceId = DeviceId("remote-device")
+            val offlineDeviceId = DeviceId("offline-device")
+            val stillAdvertised = makeFile(blobKey = "still-advertised")
+            val keepRequest = makeDeleteRequest(
+                targetDeviceId = remoteDeviceId,
+                blobKey = stillAdvertised.blobKey,
+            )
+            val prunedRequest = makeDeleteRequest(
+                targetDeviceId = remoteDeviceId,
+                blobKey = "already-gone",
+            )
+            val offlineRequest = makeDeleteRequest(
+                targetDeviceId = offlineDeviceId,
+                blobKey = "unknown-target",
+            )
+            val expiredRequest = makeDeleteRequest(
+                targetDeviceId = offlineDeviceId,
+                blobKey = "expired-request",
+                retainUntil = Clock.System.now() - 1.hours,
+            )
+
+            coEvery { fileShareCache.get(selfDeviceId) } returns makeModuleData(
+                files = emptyList(),
+                deleteRequests = listOf(keepRequest, prunedRequest, offlineRequest, expiredRequest),
+            )
+            coEvery { fileShareCache.get(remoteDeviceId) } returns makeModuleData(
+                files = listOf(stillAdvertised),
+                deviceId = remoteDeviceId,
+            )
+            coEvery { fileShareCache.get(offlineDeviceId) } returns null
+            coEvery { blobManager.configuredConnectorsByIdString() } returns mapOf(connectorA.idString to connectorA)
+            every { pendingDeletes.flow } returns flowOf(emptyMap())
+            val transformSlot = slot<(List<FileShareInfo.DeleteRequest>) -> List<FileShareInfo.DeleteRequest>>()
+            coEvery { fileShareHandler.mutateDeleteRequests(capture(transformSlot)) } just runs
+
+            val maintenance = createBlobMaintenance(this)
+            maintenance.runOnce()
+
+            coVerify(exactly = 1) { fileShareHandler.mutateDeleteRequests(any()) }
+            val input = listOf(keepRequest, prunedRequest, offlineRequest, expiredRequest)
+            transformSlot.captured(input) shouldBe listOf(keepRequest, offlineRequest)
+        }
+    }
 
     @Nested
     inner class `retryMirrorUploads` {

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareHandlerTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareHandlerTest.kt
@@ -1,0 +1,99 @@
+package eu.darken.octi.modules.files.core
+
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+
+class FileShareHandlerTest : BaseTest() {
+
+    private val syncSettings = mockk<SyncSettings>()
+    private val cache = mockk<FileShareCache>()
+    private val settings = mockk<FileShareSettings>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        every { syncSettings.deviceId } returns DeviceId("self")
+        coEvery { cache.get(any()) } returns null
+    }
+
+    private fun makeHandler(scope: kotlinx.coroutines.CoroutineScope) = FileShareHandler(
+        appScope = scope,
+        settings = settings,
+        cache = cache,
+        syncSettings = syncSettings,
+    )
+
+    private fun makeRequest(
+        targetDeviceId: String = "target",
+        blobKey: String = "blob-1",
+        retainUntil: kotlin.time.Instant = Clock.System.now() + 2.hours,
+    ) = FileShareInfo.DeleteRequest(
+        targetDeviceId = targetDeviceId,
+        blobKey = blobKey,
+        requestedAt = Clock.System.now(),
+        retainUntil = retainUntil,
+    )
+
+    @Nested
+    inner class `upsertDeleteRequest` {
+
+        @Test
+        fun `inserts a new request`() = runTest2 {
+            val handler = makeHandler(backgroundScope)
+            val request = makeRequest(blobKey = "new-blob")
+
+            handler.upsertDeleteRequest(request)
+
+            handler.currentOwn().deleteRequests shouldBe listOf(request)
+        }
+
+        @Test
+        fun `deduplicates on targetDeviceId and blobKey`() = runTest2 {
+            val handler = makeHandler(backgroundScope)
+            val original = makeRequest(blobKey = "dup-blob", retainUntil = Clock.System.now() + 1.hours)
+            val updated = makeRequest(blobKey = "dup-blob", retainUntil = Clock.System.now() + 2.hours)
+
+            handler.upsertDeleteRequest(original)
+            handler.upsertDeleteRequest(updated)
+
+            val requests = handler.currentOwn().deleteRequests
+            requests.size shouldBe 1
+            requests.single().retainUntil shouldBe updated.retainUntil
+        }
+
+        @Test
+        fun `ignores already-expired inserts`() = runTest2 {
+            val handler = makeHandler(backgroundScope)
+            val expired = makeRequest(retainUntil = Clock.System.now() - 1.hours)
+
+            handler.upsertDeleteRequest(expired)
+
+            handler.currentOwn().deleteRequests shouldBe emptyList()
+        }
+
+        @Test
+        fun `drops existing expired entries on insert`() = runTest2 {
+            val handler = makeHandler(backgroundScope)
+            val stale = makeRequest(blobKey = "stale", retainUntil = Clock.System.now() - 1.hours)
+            // Insert stale entry directly via mutateDeleteRequests to bypass the expiry guard
+            handler.mutateDeleteRequests { it + stale }
+
+            val fresh = makeRequest(blobKey = "fresh")
+            handler.upsertDeleteRequest(fresh)
+
+            val requests = handler.currentOwn().deleteRequests
+            requests.size shouldBe 1
+            requests.single().blobKey shouldBe "fresh"
+        }
+    }
+}

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareInfoSerializationTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareInfoSerializationTest.kt
@@ -39,6 +39,14 @@ class FileShareInfoSerializationTest : BaseTest() {
                     ),
                 ),
             ),
+            deleteRequests = listOf(
+                FileShareInfo.DeleteRequest(
+                    targetDeviceId = "device-b",
+                    blobKey = "key-2",
+                    requestedAt = Instant.parse("2026-01-02T00:00:00Z"),
+                    retainUntil = Instant.parse("2026-01-04T00:00:00Z"),
+                ),
+            ),
         )
         val encoded = json.encodeToString(FileShareInfo.serializer(), info)
         encoded.toComparableJson() shouldBe """
@@ -54,6 +62,14 @@ class FileShareInfoSerializationTest : BaseTest() {
                         "expiresAt": "2026-01-03T00:00:00Z",
                         "availableOn": ["server-a", "gdrive-b"],
                         "connectorRefs": {"server-a": "srv-blob-id", "gdrive-b": "key-1"}
+                    }
+                ],
+                "deleteRequests": [
+                    {
+                        "targetDeviceId": "device-b",
+                        "blobKey": "key-2",
+                        "requestedAt": "2026-01-02T00:00:00Z",
+                        "retainUntil": "2026-01-04T00:00:00Z"
                     }
                 ]
             }
@@ -100,6 +116,24 @@ class FileShareInfoSerializationTest : BaseTest() {
         deserialized shouldBe original
         deserialized.files.size shouldBe 2
         deserialized.files[0].availableOn.size shouldBe 2
+    }
+
+    @Test
+    fun `round-trip FileShareInfo with delete requests`() {
+        val now = Clock.System.now()
+        val original = FileShareInfo(
+            deleteRequests = listOf(
+                FileShareInfo.DeleteRequest(
+                    targetDeviceId = "device-b",
+                    blobKey = "blob-1",
+                    requestedAt = now,
+                    retainUntil = now + 24.hours,
+                ),
+            ),
+        )
+        val serialized = json.encodeToString(FileShareInfo.serializer(), original)
+        val deserialized = json.decodeFromString(FileShareInfo.serializer(), serialized)
+        deserialized shouldBe original
     }
 
     @Test

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
@@ -12,6 +12,7 @@ import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.blob.BlobCacheDirs
 import eu.darken.octi.sync.core.blob.BlobFileTooLargeException
@@ -48,6 +49,7 @@ class FileShareServiceTest : BaseTest() {
     private val blobMaintenance = mockk<BlobMaintenance>(relaxed = true)
     private val storageStatusManager = mockk<StorageStatusManager>(relaxed = true)
     private val syncSettings = mockk<SyncSettings>()
+    private val publisher = mockk<FileSharePublisher>(relaxed = true)
     private fun createService() = FileShareService(
         context = context,
         dispatcherProvider = dispatcherProvider,
@@ -60,7 +62,46 @@ class FileShareServiceTest : BaseTest() {
         storageStatusManager = storageStatusManager,
         syncSettings = syncSettings,
         blobCacheDirs = BlobCacheDirs(context),
+        publisher = publisher,
     )
+
+    @Test
+    fun `deleteFile for remote owner records delete request without deleting blobs`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val remoteDeviceId = DeviceId("remote")
+        val file = FileShareInfo.SharedFile(
+            name = "doc.pdf",
+            mimeType = "application/pdf",
+            size = 123,
+            blobKey = "blob-remote",
+            checksum = "abc",
+            sharedAt = Clock.System.now(),
+            expiresAt = Clock.System.now() + 1.hours,
+            availableOn = setOf("connector"),
+            connectorRefs = mapOf("connector" to RemoteBlobRef("ref")),
+        )
+        var capturedRequest: FileShareInfo.DeleteRequest? = null
+
+        every { context.cacheDir } returns cacheDir
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { handler.upsertDeleteRequest(any()) } coAnswers {
+            capturedRequest = firstArg()
+        }
+        coEvery { handler.currentOwn() } answers {
+            FileShareInfo(deleteRequests = listOfNotNull(capturedRequest))
+        }
+
+        val result = createService().deleteFile(remoteDeviceId, file)
+
+        result shouldBe FileShareService.DeleteResult.Requested
+        capturedRequest!!.targetDeviceId shouldBe remoteDeviceId.id
+        capturedRequest!!.blobKey shouldBe file.blobKey
+        coVerify(exactly = 1) { publisher.publishNow() }
+        coVerify(exactly = 0) { blobManager.delete(any(), any(), any(), any()) }
+
+        cacheDir.deleteRecursively()
+    }
 
     @Test
     fun `deleteOwnFile returns deleted when every connector delete succeeds`() = runTest2 {

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/IncomingFileNotifierTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/IncomingFileNotifierTest.kt
@@ -329,6 +329,61 @@ class IncomingFileNotifierTest : BaseTest() {
     }
 
     @Test
+    fun `self DeleteRequest suppresses incoming notification for the targeted blob`() = runTest2 {
+        // Regression for F10: state.all is used (not state.others) so self's own delete requests
+        // suppress incoming-file notifications on this device for the targeted peer's blob.
+        // Without this behavior, a delete request would not suppress the notification.
+        //
+        // Two-emission sequence:
+        //   1. Remote has file "existing" — first emission seeds seenByDevice silently.
+        //   2. Remote adds file "new-targeted", self has DeleteRequest targeting it — must NOT notify.
+        val selfDevice = DeviceId("self-device")
+        val deleteRequest = FileShareInfo.DeleteRequest(
+            targetDeviceId = remoteDevice.id,
+            blobKey = "new-targeted",
+            requestedAt = Clock.System.now(),
+            retainUntil = Clock.System.now() + 2.hours,
+        )
+
+        fun stateWith(
+            remoteFiles: List<FileShareInfo.SharedFile>,
+            selfDeleteRequests: List<FileShareInfo.DeleteRequest> = emptyList(),
+        ) = BaseModuleRepo.State(
+            moduleId = FileShareModule.MODULE_ID,
+            self = ModuleData(
+                modifiedAt = Clock.System.now(),
+                deviceId = selfDevice,
+                moduleId = FileShareModule.MODULE_ID,
+                data = FileShareInfo(deleteRequests = selfDeleteRequests),
+            ),
+            others = listOf(
+                ModuleData(
+                    modifiedAt = Clock.System.now(),
+                    deviceId = remoteDevice,
+                    moduleId = FileShareModule.MODULE_ID,
+                    data = FileShareInfo(files = remoteFiles),
+                )
+            ),
+        )
+
+        val states = MutableStateFlow(stateWith(listOf(makeFile("existing"))))
+        buildNotifier(states).start()
+        advanceUntilIdle()
+        // First emission: silent seed — no notification
+        verify(exactly = 0) { notificationManager.notify(any<Int>(), any()) }
+
+        // Second emission: remote adds a NEW file that self has a delete request for
+        states.value = stateWith(
+            remoteFiles = listOf(makeFile("existing"), makeFile("new-targeted")),
+            selfDeleteRequests = listOf(deleteRequest),
+        )
+        advanceUntilIdle()
+
+        // The delete request must suppress the notification for "new-targeted"
+        verify(exactly = 0) { notificationManager.notify(any<Int>(), any()) }
+    }
+
+    @Test
     fun `device-purge cancels notifications for that device's blobs`() = runTest2 {
         val otherDevice = DeviceId("other-device")
         // Pre-seed: other-device has blobs that already triggered notifications.

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
@@ -112,9 +112,22 @@ class FileShareListVMTest : BaseTest() {
         ),
     )
 
+    private fun makeDeleteRequest(
+        targetDeviceId: DeviceId,
+        blobKey: String,
+        retainUntil: kotlin.time.Instant = now + 24.hours,
+    ) = FileShareInfo.DeleteRequest(
+        targetDeviceId = targetDeviceId.id,
+        blobKey = blobKey,
+        requestedAt = now,
+        retainUntil = retainUntil,
+    )
+
     private fun setupBaseMocks(
         selfFiles: List<FileShareInfo.SharedFile> = emptyList(),
+        selfDeleteRequests: List<FileShareInfo.DeleteRequest> = emptyList(),
         otherFiles: Map<DeviceId, List<FileShareInfo.SharedFile>> = emptyMap(),
+        otherDeleteRequests: Map<DeviceId, List<FileShareInfo.DeleteRequest>> = emptyMap(),
         labels: Map<DeviceId, String> = mapOf(selfDevice to "Self Pixel", remoteDevice to "Remote Pixel"),
         configuredConnectors: Map<ConnectorId, StorageStatus> = mapOf(connector to StorageStatus.Loading(connector, lastKnown = null)),
     ) {
@@ -124,15 +137,26 @@ class FileShareListVMTest : BaseTest() {
                 modifiedAt = now,
                 deviceId = selfDevice,
                 moduleId = FileShareModule.MODULE_ID,
-                data = FileShareInfo(files = selfFiles),
+                data = FileShareInfo(files = selfFiles, deleteRequests = selfDeleteRequests),
+            )
+        } else if (selfDeleteRequests.isNotEmpty()) {
+            ModuleData(
+                modifiedAt = now,
+                deviceId = selfDevice,
+                moduleId = FileShareModule.MODULE_ID,
+                data = FileShareInfo(deleteRequests = selfDeleteRequests),
             )
         } else null
-        val others = otherFiles.map { (devId, files) ->
+        val otherDeviceIds = otherFiles.keys + otherDeleteRequests.keys
+        val others = otherDeviceIds.map { devId ->
             ModuleData(
                 modifiedAt = now,
                 deviceId = devId,
                 moduleId = FileShareModule.MODULE_ID,
-                data = FileShareInfo(files = files),
+                data = FileShareInfo(
+                    files = otherFiles[devId].orEmpty(),
+                    deleteRequests = otherDeleteRequests[devId].orEmpty(),
+                ),
             )
         }
         every { fileShareRepo.state } returns flowOf(
@@ -221,6 +245,34 @@ class FileShareListVMTest : BaseTest() {
         val vm = makeVM()
         vm.initialize(null)
         vm.state.first().files.map { it.sharedFile.name } shouldBe listOf("live.txt")
+    }
+
+    @Test
+    fun `delete requested remote file remains visible but cannot open or save`() = runTest2 {
+        val remoteFile = makeFile(name = "theirs.txt", blobKey = "blob-theirs")
+        setupBaseMocks(
+            otherFiles = mapOf(remoteDevice to listOf(remoteFile)),
+            selfDeleteRequests = listOf(makeDeleteRequest(remoteDevice, remoteFile.blobKey)),
+        )
+
+        val item = makeVM().state.first().files.single()
+
+        item.isDeleteRequested shouldBe true
+        item.canOpenOrSave shouldBe false
+    }
+
+    @Test
+    fun `expired delete request no longer disables remote file`() = runTest2 {
+        val remoteFile = makeFile(name = "theirs.txt", blobKey = "blob-theirs")
+        setupBaseMocks(
+            otherFiles = mapOf(remoteDevice to listOf(remoteFile)),
+            selfDeleteRequests = listOf(makeDeleteRequest(remoteDevice, remoteFile.blobKey, retainUntil = now - 1.hours)),
+        )
+
+        val item = makeVM().state.first().files.single()
+
+        item.isDeleteRequested shouldBe false
+        item.canOpenOrSave shouldBe true
     }
 
     @Test
@@ -466,15 +518,16 @@ class FileShareListVMTest : BaseTest() {
     }
 
     @Test
-    fun `onDeleteFile clears deletingKeys even on exception`() = runTest2 {
+    fun `confirmDelete clears deletingKeys even on exception`() = runTest2 {
         val ownFile = makeFile(blobKey = "del-fail")
         setupBaseMocks(selfFiles = listOf(ownFile))
-        coEvery { fileShareService.deleteOwnFile(any()) } throws RuntimeException("boom")
+        coEvery { fileShareService.deleteFile(any(), any()) } throws RuntimeException("boom")
 
         val vm = makeVM()
         vm.initialize(null)
         val item = vm.state.first().files.single()
-        vm.onDeleteFile(item)
+        vm.requestDelete(item)
+        vm.confirmDelete()
 
         val event = vm.uiEvents.first()
         event.shouldBeInstanceOf<FileShareListVM.UiEvent.ShowMessage>()
@@ -781,5 +834,55 @@ class FileShareListVMTest : BaseTest() {
 
         val event = vm.uiEvents.first()
         event.shouldBeInstanceOf<FileShareListVM.UiEvent.LaunchPicker>()
+    }
+
+    @Test
+    fun `requestDelete populates deleteConfirmation with correct metadata`() = runTest2 {
+        val ownFile = makeFile(blobKey = "confirm-me")
+        setupBaseMocks(selfFiles = listOf(ownFile))
+
+        val vm = makeVM()
+        vm.initialize(null)
+        val item = vm.state.first().files.single()
+        vm.requestDelete(item)
+
+        val confirmation = vm.deleteConfirmation.value
+        confirmation shouldNotBe null
+        confirmation!!.key shouldBe item.key
+        confirmation.isOwn shouldBe true
+        confirmation.sharedFile.blobKey shouldBe "confirm-me"
+        coVerify(exactly = 0) { fileShareService.deleteFile(any(), any()) }
+    }
+
+    @Test
+    fun `cancelDeleteConfirmation clears state without invoking fileShareService`() = runTest2 {
+        val ownFile = makeFile(blobKey = "cancel-me")
+        setupBaseMocks(selfFiles = listOf(ownFile))
+
+        val vm = makeVM()
+        vm.initialize(null)
+        val item = vm.state.first().files.single()
+        vm.requestDelete(item)
+        vm.cancelDeleteConfirmation()
+
+        vm.deleteConfirmation.value shouldBe null
+        coVerify(exactly = 0) { fileShareService.deleteFile(any(), any()) }
+    }
+
+    @Test
+    fun `confirmDelete clears confirmation and calls fileShareService exactly once`() = runTest2 {
+        val ownFile = makeFile(blobKey = "delete-confirmed")
+        setupBaseMocks(selfFiles = listOf(ownFile))
+        coEvery { fileShareService.deleteFile(any(), any()) } returns FileShareService.DeleteResult.Deleted
+
+        val vm = makeVM()
+        vm.initialize(null)
+        val item = vm.state.first().files.single()
+        vm.requestDelete(item)
+        vm.confirmDelete()
+
+        vm.uiEvents.first().shouldBeInstanceOf<FileShareListVM.UiEvent.ShowMessage>()
+        vm.deleteConfirmation.value shouldBe null
+        coVerify(exactly = 1) { fileShareService.deleteFile(selfDevice, ownFile) }
     }
 }


### PR DESCRIPTION
## Summary

- Add delete confirmation dialog for own and peer files — both the row icon and bottom-sheet Delete button now prompt before acting
- Extract `FileSharePublisher` so `BlobMaintenance` can explicitly push own state after consuming remote delete requests, closing a process-death window where blob deletions could go unannounced to peers
- Fix a concurrent-write hazard in `pruneOwnDeleteRequests`: cache reads are pre-fetched outside the `DynamicStateFlow` mutation lock
- Cap delete request `retainUntil` at 7 days; drop already-expired entries on insert
- Add a 60-second UI ticker so "Deletion requested…" labels disappear once `retainUntil` passes without a manual app restart

## Test plan
- [ ] Own file: row icon → cancel → file unchanged
- [ ] Own file: row icon → confirm → file removed
- [ ] Peer file: sheet Delete → dialog shows peer name → confirm → "Deletion requested…" appears on row
- [ ] Unit: `BlobMaintenanceTest`, `FileShareHandlerTest`, `FileShareServiceTest`, `FileShareListVMTest`, `IncomingFileNotifierTest`
