### PR TITLE
Hide legacy encryption warning when modern connector reaches device

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -47,6 +47,7 @@ import eu.darken.octi.sync.core.ConnectorIssueAggregator
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.SyncExecutor
 import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.SyncOrchestrator
@@ -280,12 +281,34 @@ class DashboardVM @Inject constructor(
         ) : SyncStatus
     }
 
+    /**
+     * Devices known to at least one blob-capable connector. Drives the
+     * legacy-encryption-warning suppression in [filteredIssues]: when device D
+     * is registered with a modern (blob-capable) connector, the legacy account
+     * is no longer the gate for file-sharing-with-D, so the per-device warning
+     * row that claims otherwise gets dropped.
+     */
+    private val blobReachableDevices: Flow<Set<DeviceId>> = kotlinx.coroutines.flow.combine(
+        syncManager.connectors,
+        syncManager.states,
+        storageStatusManager.configuredConnectorIds,
+    ) { connectors, states, configuredIds ->
+        val pairs = connectors.zip(states.toList()).map { (c, s) -> c.identifier to s }
+        blobReachableDeviceIds(pairs, configuredIds)
+    }
+
     private val filteredIssues: Flow<List<ConnectorIssue>> = kotlinx.coroutines.flow.combine(
         issueAggregator.issues,
         fileShareRepo.isEnabled,
-    ) { issues, fileShareEnabled ->
-        if (fileShareEnabled) issues
-        else issues.filterNot { it is OctiServerIssue.LegacyEncryptionAccount }
+        syncSettings.pausedConnectorIds,
+        blobReachableDevices,
+    ) { issues, fileShareEnabled, pausedIds, blobReachable ->
+        projectDashboardIssues(
+            allIssues = issues,
+            fileShareEnabled = fileShareEnabled,
+            pausedIds = pausedIds,
+            blobReachableDeviceIds = blobReachable,
+        )
     }
 
     // NOTE: must be declared before `state` (which references it via `deviceItems()`).
@@ -318,13 +341,10 @@ class DashboardVM @Inject constructor(
         updateService.availableUpdate.onStart { emit(null) },
         generalSettings.dashboardConfig.flow,
         filteredIssues,
-        syncSettings.pausedConnectorIds,
-    ) { now, networkState, isSyncSetupDismissed, deviceItems, missingPermissions, syncStatus, upgradeInfo, update, uiConfig, allIssues, pausedIds ->
+    ) { now, networkState, isSyncSetupDismissed, deviceItems, missingPermissions, syncStatus, upgradeInfo, update, uiConfig, issues ->
 
         val connectorCount = syncManager.allConnectors.first().size
         val showSyncSetup = !isSyncSetupDismissed && connectorCount == 0
-
-        val issues = filterDashboardIssues(allIssues, pausedIds)
 
         val filteredPermissions = missingPermissions
             .filterNot { WIFI_PERMISSIONS.contains(it) }
@@ -707,12 +727,47 @@ class DashboardVM @Inject constructor(
                 .sortedWith(compareBy({ if (it.severity == IssueSeverity.ERROR) 0 else 1 }, { it::class.simpleName }))
         }
 
-        internal fun filterDashboardIssues(
+        /**
+         * Single dashboard-issue projection. Folds three rules:
+         * - file-share globally disabled → drop `LegacyEncryptionAccount`
+         * - device reachable via at least one blob-capable connector → drop
+         *   `LegacyEncryptionAccount` for that device (the warning text claims
+         *   "file sharing unavailable on this device", but the modern connector
+         *   makes it available; only the legacy account is the limitation, and
+         *   that account already surfaces its own issue under Sync Services)
+         * - connector paused → drop its issues, EXCEPT
+         *   `CurrentDeviceNotRegistered`, which is the auth-issue pause itself
+         *   and must remain visible to drive recovery
+         */
+        internal fun projectDashboardIssues(
             allIssues: List<ConnectorIssue>,
+            fileShareEnabled: Boolean,
             pausedIds: Set<ConnectorId>,
-        ): List<ConnectorIssue> = allIssues.filter {
-            it.connectorId !in pausedIds || it is OctiServerIssue.CurrentDeviceNotRegistered
-        }
+            blobReachableDeviceIds: Set<DeviceId>,
+        ): List<ConnectorIssue> = allIssues
+            .filterNot { !fileShareEnabled && it is OctiServerIssue.LegacyEncryptionAccount }
+            .filterNot {
+                it is OctiServerIssue.LegacyEncryptionAccount &&
+                    it.deviceId in blobReachableDeviceIds
+            }
+            .filter {
+                it.connectorId !in pausedIds || it is OctiServerIssue.CurrentDeviceNotRegistered
+            }
+
+        /**
+         * Devices known to at least one blob-capable connector, by intersecting
+         * each connector's `deviceMetadata` with `blobCapableConnectorIds`. Used
+         * by the dashboard projection to suppress the legacy-encryption warning
+         * when a modern connector covers the same device.
+         */
+        internal fun blobReachableDeviceIds(
+            connectorsAndStates: List<Pair<ConnectorId, SyncConnectorState>>,
+            blobCapableConnectorIds: Set<ConnectorId>,
+        ): Set<DeviceId> = connectorsAndStates
+            .asSequence()
+            .filter { (id, _) -> id in blobCapableConnectorIds }
+            .flatMap { (_, state) -> state.deviceMetadata.asSequence().map { it.deviceId } }
+            .toSet()
 
         private val INFO_ORDER = listOf(
             PowerInfo::class,

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
@@ -8,9 +8,12 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.syncs.octiserver.core.OctiServerIssue
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -32,6 +35,20 @@ class DeviceInfoBuilderTest : BaseTest() {
         subtype = "test",
         account = "test-account",
     )
+
+    /** Second connector to model the legacy + modern dual-account setup. */
+    private val modernConnectorId = ConnectorId(
+        type = ConnectorType.OCTISERVER,
+        subtype = "test",
+        account = "modern-account",
+    )
+
+    private fun fakeState(devices: List<DeviceId>): SyncConnectorState = object : SyncConnectorState {
+        override val lastActionAt: Instant? = null
+        override val lastError: Exception? = null
+        override val deviceMetadata: List<DeviceMetadata> = devices.map { DeviceMetadata(deviceId = it) }
+        override val isAvailable: Boolean = true
+    }
 
     private fun metaInfo(deviceId: DeviceId = currentDeviceId) = MetaInfo(
         deviceLabel = null,
@@ -146,12 +163,187 @@ class DeviceInfoBuilderTest : BaseTest() {
                 deviceId = currentDeviceId,
             )
 
-            val result = DashboardVM.filterDashboardIssues(
+            val result = DashboardVM.projectDashboardIssues(
                 allIssues = listOf(hiddenIssue, visibleIssue),
+                fileShareEnabled = true,
                 pausedIds = setOf(connectorId),
+                blobReachableDeviceIds = emptySet(),
             )
 
             result shouldBe listOf(visibleIssue)
+        }
+    }
+
+    @Nested
+    inner class `blob-reachable computation` {
+        @Test
+        fun `empty input yields empty set`() {
+            DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = emptyList(),
+                blobCapableConnectorIds = emptySet(),
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `connector outside the blob-capable set contributes no devices`() {
+            // Legacy connector is present in connectorsAndStates but excluded from
+            // blobCapableConnectorIds — its devices must NOT appear, otherwise the
+            // legacy account itself would suppress its own legacy warning.
+            val state = fakeState(listOf(currentDeviceId, remoteDeviceId))
+
+            DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = listOf(connectorId to state),
+                blobCapableConnectorIds = emptySet(),
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `blob-capable connector contributes its deviceMetadata`() {
+            val state = fakeState(listOf(currentDeviceId, remoteDeviceId))
+
+            DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = listOf(modernConnectorId to state),
+                blobCapableConnectorIds = setOf(modernConnectorId),
+            ) shouldContainExactlyInAnyOrder setOf(currentDeviceId, remoteDeviceId)
+        }
+
+        @Test
+        fun `two blob-capable connectors with overlapping devices are unioned and deduped`() {
+            val secondModern = ConnectorId(ConnectorType.OCTISERVER, "test", "modern-2")
+            val a = fakeState(listOf(currentDeviceId, remoteDeviceId))
+            val b = fakeState(listOf(remoteDeviceId, DeviceId("third")))
+
+            val ids = DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = listOf(modernConnectorId to a, secondModern to b),
+                blobCapableConnectorIds = setOf(modernConnectorId, secondModern),
+            )
+
+            ids shouldContainExactlyInAnyOrder setOf(currentDeviceId, remoteDeviceId, DeviceId("third"))
+        }
+
+        @Test
+        fun `blob-capable connector with empty metadata contributes nothing`() {
+            val empty = fakeState(emptyList())
+
+            DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = listOf(modernConnectorId to empty),
+                blobCapableConnectorIds = setOf(modernConnectorId),
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `mixed legacy and modern - only modern's devices are reachable`() {
+            // Models the user's bug scenario: same device appears via both connectors.
+            // Only modern's contribution counts toward the reachable set.
+            val legacyState = fakeState(listOf(currentDeviceId, remoteDeviceId))
+            val modernState = fakeState(listOf(currentDeviceId, remoteDeviceId))
+
+            val ids = DashboardVM.blobReachableDeviceIds(
+                connectorsAndStates = listOf(connectorId to legacyState, modernConnectorId to modernState),
+                blobCapableConnectorIds = setOf(modernConnectorId),
+            )
+
+            ids shouldContainExactlyInAnyOrder setOf(currentDeviceId, remoteDeviceId)
+        }
+    }
+
+    @Nested
+    inner class `legacy encryption filtering` {
+        private val legacyForRemote = OctiServerIssue.LegacyEncryptionAccount(
+            connectorId = connectorId,
+            deviceId = remoteDeviceId,
+        )
+        private val legacyForCurrent = OctiServerIssue.LegacyEncryptionAccount(
+            connectorId = connectorId,
+            deviceId = currentDeviceId,
+        )
+
+        @Test
+        fun `legacy warning is dropped for a device covered by a blob-capable connector`() {
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(legacyForRemote),
+                fileShareEnabled = true,
+                pausedIds = emptySet(),
+                blobReachableDeviceIds = setOf(remoteDeviceId),
+            )
+
+            result.shouldBeEmpty()
+        }
+
+        @Test
+        fun `legacy warning is kept when the device has no blob-capable coverage`() {
+            // Only-legacy setup: no modern connectors registered, so blobReachable is empty.
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(legacyForRemote),
+                fileShareEnabled = true,
+                pausedIds = emptySet(),
+                blobReachableDeviceIds = emptySet(),
+            )
+
+            result shouldBe listOf(legacyForRemote)
+        }
+
+        @Test
+        fun `paused-but-blob-capable modern connector still suppresses the legacy warning`() {
+            // Per the chosen behavior: capability-based, not runtime-availability-based.
+            // A modern connector that has previously seen D and is currently paused
+            // should still keep the legacy warning suppressed for D — pause produces
+            // its own dashboard issues, so the user is not silenced.
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(legacyForRemote),
+                fileShareEnabled = true,
+                pausedIds = setOf(modernConnectorId),
+                blobReachableDeviceIds = setOf(remoteDeviceId),
+            )
+
+            result.shouldBeEmpty()
+        }
+
+        @Test
+        fun `legacy warning for the current device is dropped when modern covers self`() {
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(legacyForCurrent),
+                fileShareEnabled = true,
+                pausedIds = emptySet(),
+                blobReachableDeviceIds = setOf(currentDeviceId),
+            )
+
+            result.shouldBeEmpty()
+        }
+
+        @Test
+        fun `non-legacy issue with the same deviceId passes through even when blob-reachable`() {
+            // Use EncryptionCompatibilityIncompatible (not CurrentDeviceNotRegistered, which
+            // has its own paused-but-shown special case that would muddle this assertion).
+            val incompat = OctiServerIssue.EncryptionCompatibilityIncompatible(
+                connectorId = connectorId,
+                deviceId = remoteDeviceId,
+                minClientVersion = "1.2.3",
+            )
+
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(incompat, legacyForRemote),
+                fileShareEnabled = true,
+                pausedIds = emptySet(),
+                blobReachableDeviceIds = setOf(remoteDeviceId),
+            )
+
+            // Legacy gets dropped, but the compatibility issue must remain.
+            result shouldBe listOf(incompat)
+        }
+
+        @Test
+        fun `file-share globally disabled drops legacy warnings regardless of reachability`() {
+            // Existing behavior preserved: when the file-share module is off entirely,
+            // legacy warnings are noise and get dropped before reachability is even checked.
+            val result = DashboardVM.projectDashboardIssues(
+                allIssues = listOf(legacyForRemote),
+                fileShareEnabled = false,
+                pausedIds = emptySet(),
+                blobReachableDeviceIds = emptySet(),
+            )
+
+            result.shouldBeEmpty()
         }
     }
 


### PR DESCRIPTION
## Summary
- On the dashboard, the per-device "File sharing unavailable" warning now only shows when no blob-capable connector covers that device. Previously, devices reachable via both a legacy and a modern Octi Server account showed the warning alongside a working File Sharing tile, which was contradictory.
- Consolidates the dashboard's issue-projection rules (file-share-disabled, blob-reachable-legacy, paused-with-CurrentDeviceNotRegistered) into one `projectDashboardIssues` helper, plus a `blobReachableDeviceIds` helper computed from each connector's `deviceMetadata` intersected with the blob-capable connector set.
- The underlying legacy issue stays in `issueAggregator.issues`, so the per-account view under Sync Services still surfaces it on the legacy account.

## Test plan
- [x] `./gradlew :app:testFossDebugUnitTest` passes (new nested groups: blob-reachable computation, legacy encryption filtering)
- [x] octi-3 + octi-4 with legacy + modern dual-connector setup: "File sharing unavailable" row gone from device card; "1 file(s) shared" tile still functional; warnings chip drops from 3 to 1
- [x] Remaining warning is the genuine legacy entry for Pixel 8 (covered by legacy account only, not modern — correct behavior)
- [x] Sync Services view still surfaces the legacy issue for the legacy account itself
