### PR TITLE
CI: Skip release bump-only workflow runs

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -3,6 +3,9 @@ name: Code tests & eval
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - VERSION
+      - version.properties
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - VERSION
+      - version.properties
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- skip main-branch CI when a release bump only changes `VERSION` and `version.properties`
- skip Gradle wrapper validation for the same bump-only main pushes
- keep PR triggers unchanged

## Validation
- `git diff --check`
- parsed edited workflow YAML files with Ruby `YAML.load_file`