### PR TITLE
Show BETA chip in toolbar and fix Support issues link

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1055,7 +1055,11 @@ private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
         upgradeInfo.isPro -> stringResource(R.string.app_name_upgraded)
         else -> appName
     }
-    val showBetaChip = BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.BETA
+    val buildChannelLabel = when (BuildConfigWrap.BUILD_TYPE) {
+        BuildConfigWrap.BuildType.DEV -> "DEV"
+        BuildConfigWrap.BuildType.BETA -> "BETA"
+        BuildConfigWrap.BuildType.RELEASE -> null
+    }
 
     val titleParts = titleText.split(" ").filter { it.isNotEmpty() }
 
@@ -1084,21 +1088,21 @@ private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
             )
         }
 
-        if (showBetaChip) {
-            BetaBuildChip()
+        if (buildChannelLabel != null) {
+            BuildChannelChip(label = buildChannelLabel)
         }
     }
 }
 
 @Composable
-private fun BetaBuildChip() {
+private fun BuildChannelChip(label: String) {
     Surface(
         shape = MaterialTheme.shapes.small,
         color = MaterialTheme.colorScheme.tertiaryContainer,
         contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
     ) {
         Text(
-            text = "BETA",
+            text = label,
             modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
             style = MaterialTheme.typography.labelSmall,
             maxLines = 1,

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1055,20 +1055,54 @@ private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
         upgradeInfo.isPro -> stringResource(R.string.app_name_upgraded)
         else -> appName
     }
+    val showBetaChip = BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.BETA
 
     val titleParts = titleText.split(" ").filter { it.isNotEmpty() }
 
-    if (titleParts.size == 2) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (titleParts.size == 2) {
+            Text(
+                text = buildAnnotatedString {
+                    append("${titleParts[0]} ")
+                    withStyle(SpanStyle(color = colorResource(R.color.colorUpgraded))) {
+                        append(titleParts[1])
+                    }
+                },
+                modifier = Modifier.weight(1f, fill = false),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        } else {
+            Text(
+                text = appName,
+                modifier = Modifier.weight(1f, fill = false),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        if (showBetaChip) {
+            BetaBuildChip()
+        }
+    }
+}
+
+@Composable
+private fun BetaBuildChip() {
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.tertiaryContainer,
+        contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    ) {
         Text(
-            text = buildAnnotatedString {
-                append("${titleParts[0]} ")
-                withStyle(SpanStyle(color = colorResource(R.color.colorUpgraded))) {
-                    append(titleParts[1])
-                }
-            },
+            text = "BETA",
+            modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
         )
-    } else {
-        Text(text = appName)
     }
 }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/support/SupportScreen.kt
@@ -54,12 +54,12 @@ fun SupportScreenHost(vm: SupportVM = hiltViewModel()) {
     }
 
     val state by vm.state.collectAsState(initial = null)
-    state?.let {
+    state?.let { state ->
         SupportScreen(
-            state = it,
+            state = state,
             onNavigateUp = { vm.navUp() },
             onDocumentation = { vm.openUrl("https://github.com/d4rken-org/octi/wiki") },
-            onIssueTracker = { vm.openUrl("https://github.com/d4rken-org/octi") },
+            onIssueTracker = { vm.openUrl("https://github.com/d4rken-org/octi/issues") },
             onDiscord = { vm.openUrl("https://discord.gg/s7V4C6zuVy") },
             onStartDebugLog = { vm.startDebugLog() },
             onStopDebugLog = { vm.stopDebugLog() },


### PR DESCRIPTION
## Summary
- Show a small "BETA" chip next to the app name in the dashboard toolbar when running a beta build, so testers can tell at a glance which build they have installed.
- Fix the Support screen "Issue tracker" link to open the issues page directly instead of the repository root.

## Commits
- Show BETA chip in toolbar for beta builds
- Fix Support screen issue tracker link
