### PR TITLE
Fix widgets missing from cover-screen pickers

### DIFF
--- a/modules-clipboard/src/main/res/xml/clipboard_widget_info.xml
+++ b/modules-clipboard/src/main/res/xml/clipboard_widget_info.xml
@@ -12,6 +12,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:configure="eu.darken.octi.modules.clipboard.ui.widget.ClipboardWidgetConfigActivity"
-    android:widgetFeatures="reconfigurable"
+    android:widgetFeatures="reconfigurable|configuration_optional"
     android:radius="16dp"
     tools:targetApi="s" />

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetProviderInfoTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetProviderInfoTest.kt
@@ -1,0 +1,24 @@
+package eu.darken.octi.modules.clipboard.ui.widget
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+class ClipboardWidgetProviderInfoTest : BaseTest() {
+
+    @Test
+    fun `widgetFeatures includes configuration_optional`() {
+        val xml = File("src/main/res/xml/clipboard_widget_info.xml").readText()
+        val features = WIDGET_FEATURES_REGEX.find(xml)
+            ?.groupValues?.get(1)
+            ?.split("|")
+            ?.map { it.trim() }
+            ?.toSet()
+        (features?.contains("configuration_optional") ?: false) shouldBe true
+    }
+
+    companion object {
+        private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+    }
+}

--- a/modules-connectivity/src/main/res/xml/network_widget_info.xml
+++ b/modules-connectivity/src/main/res/xml/network_widget_info.xml
@@ -12,6 +12,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:configure="eu.darken.octi.modules.connectivity.ui.widget.NetworkWidgetConfigActivity"
-    android:widgetFeatures="reconfigurable"
+    android:widgetFeatures="reconfigurable|configuration_optional"
     android:radius="16dp"
     tools:targetApi="s" />

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetProviderInfoTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetProviderInfoTest.kt
@@ -1,0 +1,24 @@
+package eu.darken.octi.modules.connectivity.ui.widget
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+class NetworkWidgetProviderInfoTest : BaseTest() {
+
+    @Test
+    fun `widgetFeatures includes configuration_optional`() {
+        val xml = File("src/main/res/xml/network_widget_info.xml").readText()
+        val features = WIDGET_FEATURES_REGEX.find(xml)
+            ?.groupValues?.get(1)
+            ?.split("|")
+            ?.map { it.trim() }
+            ?.toSet()
+        (features?.contains("configuration_optional") ?: false) shouldBe true
+    }
+
+    companion object {
+        private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+    }
+}

--- a/modules-power/src/main/res/xml/battery_widget_info.xml
+++ b/modules-power/src/main/res/xml/battery_widget_info.xml
@@ -12,6 +12,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetCategory="home_screen"
     android:configure="eu.darken.octi.modules.power.ui.widget.BatteryWidgetConfigActivity"
-    android:widgetFeatures="reconfigurable"
+    android:widgetFeatures="reconfigurable|configuration_optional"
     android:radius="16dp"
     tools:targetApi="s" />

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProviderInfoTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProviderInfoTest.kt
@@ -1,0 +1,24 @@
+package eu.darken.octi.modules.power.ui.widget
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+class BatteryWidgetProviderInfoTest : BaseTest() {
+
+    @Test
+    fun `widgetFeatures includes configuration_optional`() {
+        val xml = File("src/main/res/xml/battery_widget_info.xml").readText()
+        val features = WIDGET_FEATURES_REGEX.find(xml)
+            ?.groupValues?.get(1)
+            ?.split("|")
+            ?.map { it.trim() }
+            ?.toSet()
+        (features?.contains("configuration_optional") ?: false) shouldBe true
+    }
+
+    companion object {
+        private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+    }
+}


### PR DESCRIPTION
## Summary

- On `1.0.0-beta1`, Octi widgets stopped appearing in the cover-screen widget picker on devices like the Motorola Razr Ultra 2025. They still showed and worked on the inner screen.
- Root cause: commit c7ee4e29 dropped `configuration_optional` from `widgetFeatures` on the battery widget, and the same flag was missing on the new clipboard and network widgets. Without it, Android treats the configure activity as mandatory on placement, and constrained widget hosts (cover-screen launchers, etc.) hide such providers from their pickers.
- Restored `reconfigurable|configuration_optional` on all three widget provider XMLs. Defaults render correctly on first paint (Material You theme, all devices); long-press → Reconfigure still opens the customization screen.
- Added one regression test per module asserting the flag is present, so this can't silently regress again.

## Trade-off

The original change forced everyone through the configure screen on placement to surface the new color customization. After this fix, users on standard launchers get the widget with Material You defaults and must long-press to customize — the standard Android idiom and the prior behavior.

Closes #265
