### PR TITLE
Enable live foreground sync for free users

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -14,7 +14,6 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.combine
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.network.NetworkStateProvider
-import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.DeviceId
 import kotlinx.coroutines.CancellationException
@@ -48,7 +47,6 @@ class ForegroundSyncControl @Inject constructor(
     private val syncManager: SyncManager,
     private val syncExecutor: SyncExecutor,
     private val syncSettings: SyncSettings,
-    private val upgradeRepo: UpgradeRepo,
     private val networkStateProvider: NetworkStateProvider,
 ) {
 
@@ -79,8 +77,9 @@ class ForegroundSyncControl @Inject constructor(
                 backgroundDebounceJob = scope.launch {
                     log(TAG) { "Process backgrounded, debouncing $BACKGROUND_DEBOUNCE..." }
                     delay(BACKGROUND_DEBOUNCE)
+                    lastBackgroundedAt = Clock.System.now()
                     isForeground.value = false
-                    log(TAG) { "Background debounce elapsed, isForeground=false" }
+                    log(TAG) { "Background debounce elapsed, isForeground=false, lastBackgroundedAt=$lastBackgroundedAt" }
                 }
             }
         })
@@ -88,14 +87,12 @@ class ForegroundSyncControl @Inject constructor(
         combine(
             isForeground,
             syncSettings.foregroundSyncEnabled.flow,
-            upgradeRepo.upgradeInfo,
             syncSettings.backgroundSyncOnMobile.flow,
             networkStateProvider.networkState,
-        ) { foreground, enabled, info, syncOnMobile, networkState ->
-            val isPro = info.isPro
+        ) { foreground, enabled, syncOnMobile, networkState ->
             val networkOk = syncOnMobile || !networkState.isMeteredConnection
-            val isActive = foreground && enabled && isPro && networkOk
-            log(TAG) { "combine: foreground=$foreground, enabled=$enabled, isPro=$isPro, networkOk=$networkOk -> isActive=$isActive" }
+            val isActive = computeForegroundSyncActive(foreground, enabled, networkOk)
+            log(TAG) { "combine: foreground=$foreground, enabled=$enabled, networkOk=$networkOk -> isActive=$isActive" }
             isActive
         }
             .distinctUntilChanged()
@@ -242,7 +239,9 @@ class ForegroundSyncControl @Inject constructor(
 
     private fun onBackground() {
         log(TAG, INFO) { "onBackground()" }
-        lastBackgroundedAt = Clock.System.now()
+        // lastBackgroundedAt is set from the lifecycle onStop debounce path,
+        // not here, so transient isActive=false transitions (network/setting flips)
+        // don't trigger spurious catch-up syncs on the next isActive=true.
 
         // Stop collecting events — cancels upstream WebSocket/polling via WhileSubscribed
         eventCollectorJob?.cancel()
@@ -257,3 +256,9 @@ class ForegroundSyncControl @Inject constructor(
         private val TAG = logTag("Sync", "Foreground", "Control")
     }
 }
+
+internal fun computeForegroundSyncActive(
+    foreground: Boolean,
+    syncEnabled: Boolean,
+    networkOk: Boolean,
+): Boolean = foreground && syncEnabled && networkOk

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
@@ -152,30 +152,13 @@ fun SyncSettingsScreen(
                 SettingsCategoryHeader(text = stringResource(R.string.sync_setting_category_foreground_label))
             }
             item {
-                if (state.isPro) {
-                    SettingsSwitchItem(
-                        icon = Icons.TwoTone.Visibility,
-                        title = stringResource(R.string.sync_setting_foreground_enable_title),
-                        subtitle = stringResource(R.string.sync_setting_foreground_enable_desc),
-                        checked = state.foregroundSyncEnabled,
-                        onCheckedChange = onForegroundSyncEnabledChanged,
-                    )
-                } else {
-                    SettingsBaseItem(
-                        icon = Icons.TwoTone.Visibility,
-                        title = stringResource(R.string.sync_setting_foreground_enable_title),
-                        subtitle = stringResource(R.string.sync_setting_foreground_enable_desc),
-                        onClick = { onForegroundSyncEnabledChanged(true) },
-                        trailingContent = {
-                            Icon(
-                                imageVector = Icons.TwoTone.Stars,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(start = 16.dp),
-                            )
-                        },
-                    )
-                }
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Visibility,
+                    title = stringResource(R.string.sync_setting_foreground_enable_title),
+                    subtitle = stringResource(R.string.sync_setting_foreground_enable_desc),
+                    checked = state.foregroundSyncEnabled,
+                    onCheckedChange = onForegroundSyncEnabledChanged,
+                )
             }
             // Background sync section
             item {

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsVM.kt
@@ -86,7 +86,6 @@ class SyncSettingsVM @Inject constructor(
     }
 
     fun setForegroundSyncEnabled(enabled: Boolean) = launch {
-        if (!requirePro()) return@launch
         syncSettings.foregroundSyncEnabled.value(enabled)
     }
 

--- a/app/src/test/java/eu/darken/octi/sync/core/ForegroundSyncControlTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/core/ForegroundSyncControlTest.kt
@@ -1,0 +1,42 @@
+package eu.darken.octi.sync.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ForegroundSyncControlTest : BaseTest() {
+
+    @Nested
+    inner class `computeForegroundSyncActive predicate` {
+
+        @Test
+        fun `active only when all three inputs are true`() {
+            computeForegroundSyncActive(foreground = true, syncEnabled = true, networkOk = true) shouldBe true
+        }
+
+        @Test
+        fun `inactive when any input is false`() {
+            computeForegroundSyncActive(foreground = false, syncEnabled = true, networkOk = true) shouldBe false
+            computeForegroundSyncActive(foreground = true, syncEnabled = false, networkOk = true) shouldBe false
+            computeForegroundSyncActive(foreground = true, syncEnabled = true, networkOk = false) shouldBe false
+        }
+
+        @Test
+        fun `inactive for all-false combinations`() {
+            computeForegroundSyncActive(foreground = false, syncEnabled = false, networkOk = false) shouldBe false
+            computeForegroundSyncActive(foreground = true, syncEnabled = false, networkOk = false) shouldBe false
+            computeForegroundSyncActive(foreground = false, syncEnabled = true, networkOk = false) shouldBe false
+            computeForegroundSyncActive(foreground = false, syncEnabled = false, networkOk = true) shouldBe false
+        }
+
+        // Regression guard: the predicate must not depend on Pro status. Re-introducing an
+        // isPro parameter would break this compile, since the call sites in production code
+        // (and these tests) only pass the three inputs above.
+        @Test
+        fun `pro status is not part of the predicate signature`() {
+            val expected: (Boolean, Boolean, Boolean) -> Boolean = ::computeForegroundSyncActive
+            expected(true, true, true) shouldBe true
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Free users now get the same instant foreground sync as Pro users: Octi Server WebSocket-driven event sync, GDrive 2-minute foreground polling, and catch-up sync on resume.
- The previous Pro gate on `ForegroundSyncControl` produced a "feels laggy" first impression — free users only refreshed data on manual interaction.
- Charging-interval sync (custom intervals while plugged in) **remains** Pro.
- The "Foreground sync" toggle in Sync Settings is now visible to all users (default ON, kept as an escape hatch for battery/privacy/debugging).

## Bug fix bundled

`lastBackgroundedAt` is now set only from the lifecycle `onStop` debounce path, not from every `isActive=false` transition. This prevents spurious catch-up syncs when the activation predicate flips false for non-lifecycle reasons (mobile-data setting toggled off, network type change, etc.). Pro users get this fix as a side benefit.

## Test plan

- Unit test added: `ForegroundSyncControlTest` covers the activation-predicate truth table and includes a regression guard against re-introducing an `isPro` parameter.
- `./gradlew :app:assembleFossDebug :app:assembleGplayDebug` — pass.
- `./gradlew :app:testFossDebugUnitTest :app:testGplayDebugUnitTest` — pass.
- Manual on-device verification (still pending): foreground sync row appears as Switch for free users on both FOSS and GPlay debug builds; live updates flow on Octi Server and GDrive backends; charging row remains Pro-gated; `lastBackgroundedAt` fix verified by toggling "Mobile network" while foregrounded and confirming no catch-up sync.
