### PR TITLE
Reduce Google Drive sync API call volume

### DIFF
--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -43,9 +43,9 @@ import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.SyncWriteContainer
 import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.APPDATAFOLDER
+import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.MIME_FOLDER
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
@@ -154,6 +154,9 @@ class GDriveAppDataConnector @AssistedInject constructor(
     private val parentCache = mutableMapOf<String, String>()
     private val fileIdCache = ConcurrentHashMap<Pair<DeviceId, ModuleId>, String>()
     private val fileIdReverseCache = ConcurrentHashMap<String, Pair<DeviceId, ModuleId>>()
+    private val rootChildCache = ConcurrentHashMap<String, String>()
+    private val deviceDirCache = ConcurrentHashMap<DeviceId, String>()
+    private val deviceInfoFileIdCache = ConcurrentHashMap<DeviceId, String>()
 
     @Volatile private var lastWrittenDeviceInfo: GDriveDeviceInfo? = null
     private val _syncEventMode = MutableStateFlow(EventMode.NONE)
@@ -255,8 +258,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
             if (e.statusCode == 410) {
                 log(TAG, WARN) { "checkForChanges(): Token invalidated, resetting" }
-                parentCache.clear()
-                clearFileIdCache()
+                clearPathCaches()
                 pollToken.value(null)
             } else {
                 log(TAG, ERROR) { "checkForChanges(): API error: ${e.message}" }
@@ -269,7 +271,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     private suspend fun handleReset(): Unit = withContext(NonCancellable) {
         log(TAG, INFO) { "handleReset()" }
-        clearFileIdCache()
+        clearPathCaches()
         runDriveAction("reset-data") {
             appDataRoot.child(DEVICE_DATA_DIR_NAME)
                 ?.listFiles()
@@ -296,7 +298,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 ?.deleteAll()
             if (deviceId == syncSettings.deviceId) {
                 log(TAG, WARN) { "We just deleted ourselves, this connector is dead now" }
-                clearFileIdCache()
+                clearPathCaches()
                 _state.updateBlocking { copy(isDead = true) }
             }
         }
@@ -312,28 +314,89 @@ class GDriveAppDataConnector @AssistedInject constructor(
         }
     }
 
+    private data class AppDataIndex(
+        val root: GDriveFile,
+        val childrenByParent: Map<String, List<GDriveFile>>,
+    ) {
+        fun children(parent: GDriveFile): List<GDriveFile> = childrenByParent[parent.id].orEmpty()
+
+        fun rootChild(name: String): GDriveFile? {
+            val rootChildren = childrenByParent[root.id].orEmpty() + childrenByParent[APPDATAFOLDER].orEmpty()
+            return rootChildren
+                .distinctBy { it.id }
+                .singleChild(name)
+        }
+
+        fun child(parent: GDriveFile, name: String): GDriveFile? = children(parent).singleChild(name)
+
+        private fun Collection<GDriveFile>.singleChild(name: String): GDriveFile? {
+            val matches = filter { it.name == name }
+            return when {
+                matches.size > 1 -> throw IllegalStateException("Multiple files with the same name: $name")
+                matches.isEmpty() -> null
+                else -> matches.single()
+            }
+        }
+    }
+
+    private suspend fun GDriveEnvironment.readAppDataIndex(): AppDataIndex {
+        val root = GDriveFile().apply {
+            id = APPDATAFOLDER
+            name = APPDATAFOLDER
+            mimeType = MIME_FOLDER
+        }
+        val files = listAppDataFiles()
+        val childrenByParent = buildMap<String, MutableList<GDriveFile>> {
+            files.forEach { file ->
+                file.parents.orEmpty().forEach { parentId ->
+                    getOrPut(parentId) { mutableListOf() }.add(file)
+                }
+            }
+        }
+        log(TAG, VERBOSE) { "readAppDataIndex(): ${files.size} files" }
+        return AppDataIndex(root = root, childrenByParent = childrenByParent)
+    }
+
     private suspend fun GDriveEnvironment.readDrive(
         moduleFilter: Set<ModuleId>? = null,
         deviceFilter: Set<DeviceId>? = null,
+        refreshDeviceMetadata: Boolean = false,
     ): GDriveData {
-        log(TAG, DEBUG) { "readDrive(moduleFilter=$moduleFilter, deviceFilter=$deviceFilter): Starting..." }
+        log(TAG, DEBUG) {
+            "readDrive(moduleFilter=$moduleFilter, deviceFilter=$deviceFilter, refreshDeviceMetadata=$refreshDeviceMetadata): Starting..."
+        }
         val start = TimeSource.Monotonic.markNow()
+        val index = readAppDataIndex()
 
-        val deviceDataDir = appDataRoot.child(DEVICE_DATA_DIR_NAME)
+        val deviceDataDir = index.rootChild(DEVICE_DATA_DIR_NAME)
         log(TAG, VERBOSE) { "readDrive(): userDir=$deviceDataDir" }
 
         if (deviceDataDir?.isDirectory != true) {
             log(TAG, WARN) { "No device data dir found ($deviceDataDir)" }
+            if (refreshDeviceMetadata) {
+                _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+            }
             return GDriveData(
                 connectorId = identifier,
                 devices = emptySet(),
             )
         }
+        rootChildCache[DEVICE_DATA_DIR_NAME] = deviceDataDir.id
 
-        val allDeviceDirs = deviceDataDir.listFiles().filter {
+        val allDeviceDirs = index.children(deviceDataDir).filter {
             val isDir = it.isDirectory
             if (!isDir) log(TAG, WARN) { "Unexpected file in userDir: $it" }
             isDir
+        }
+        allDeviceDirs.forEach { dir ->
+            val deviceId = DeviceId(dir.name)
+            deviceDirCache[deviceId] = dir.id
+            parentCache[dir.id] = dir.name
+        }
+
+        if (refreshDeviceMetadata) {
+            // Stats are updated before payload downloads so a module read failure does not freeze metadata.
+            _state.updateBlocking { copy(deviceMetadata = readDeviceMetadata(index, allDeviceDirs)) }
         }
 
         val validDeviceDirs = if (deviceFilter != null) {
@@ -344,53 +407,99 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
         val targetModules = moduleFilter?.let { supportedModuleIds.intersect(it) } ?: supportedModuleIds
 
-        val deviceFetchJobs = validDeviceDirs.map { deviceDir ->
-            scope.async(dispatcherProvider.IO) deviceFetch@{
-                log(TAG, DEBUG) { "readDrive(): Reading module data for device: $deviceDir" }
-                val moduleDirs = deviceDir.listFiles().filter { targetModules.contains(ModuleId(it.name)) }
-                val moduleFetchJobs = moduleDirs.map { moduleFile ->
-                    scope.async(dispatcherProvider.IO) moduleFetch@{
-                        log(TAG, VERBOSE) { "readDrive(): Reading ${moduleFile.name} for ${deviceDir.name}" }
-                        val payload = moduleFile.readData()
+        val devices = coroutineScope {
+            validDeviceDirs.map { deviceDir ->
+                async(dispatcherProvider.IO) deviceFetch@{
+                    log(TAG, DEBUG) { "readDrive(): Reading module data for device: $deviceDir" }
+                    val deviceId = DeviceId(deviceDir.name)
+                    val moduleFiles = index.children(deviceDir).filter { targetModules.contains(ModuleId(it.name)) }
+                    val moduleFetchJobs = moduleFiles.map { moduleFile ->
+                        async(dispatcherProvider.IO) moduleFetch@{
+                            log(TAG, VERBOSE) { "readDrive(): Reading ${moduleFile.name} for ${deviceDir.name}" }
+                            val payload = moduleFile.readData()
 
-                        if (payload == null) {
-                            log(TAG, WARN) { "readDrive(): Module file is empty: ${moduleFile.name}" }
-                            return@moduleFetch null
+                            if (payload == null) {
+                                log(TAG, WARN) { "readDrive(): Module file is empty: ${moduleFile.name}" }
+                                return@moduleFetch null
+                            }
+
+                            val moduleId = ModuleId(moduleFile.name)
+                            cacheModuleFileId(deviceId, moduleId, moduleFile.id)
+
+                            GDriveModuleData(
+                                connectorId = identifier,
+                                deviceId = deviceId,
+                                moduleId = moduleId,
+                                modifiedAt = Instant.fromEpochMilliseconds(moduleFile.modifiedTime.value),
+                                payload = payload,
+                            ).also { log(TAG, VERBOSE) { "readDrive(): Got module data: $it" } }
                         }
-
-                        val deviceId = DeviceId(deviceDir.name)
-                        val moduleId = ModuleId(moduleFile.name)
-                        val cacheKey = deviceId to moduleId
-                        fileIdCache[cacheKey] = moduleFile.id
-                        fileIdReverseCache[moduleFile.id] = cacheKey
-
-                        GDriveModuleData(
-                            connectorId = identifier,
-                            deviceId = deviceId,
-                            moduleId = moduleId,
-                            modifiedAt = Instant.fromEpochMilliseconds(moduleFile.modifiedTime.value),
-                            payload = payload,
-                        ).also { log(TAG, VERBOSE) { "readDrive(): Got module data: $it" } }
                     }
+
+                    val moduleData = moduleFetchJobs.awaitAll().filterNotNull()
+                    log(TAG, DEBUG) { "readDrive(): Finished ${deviceDir.name}" }
+
+                    GDriveDeviceData(
+                        deviceId = deviceId,
+                        modules = moduleData,
+                    )
                 }
-
-                val moduleData = moduleFetchJobs.awaitAll().filterNotNull()
-                log(TAG, DEBUG) { "readDrive(): Finished ${deviceDir.name}" }
-
-                GDriveDeviceData(
-                    deviceId = DeviceId(deviceDir.name),
-                    modules = moduleData,
-                )
-            }
+            }.awaitAll()
         }
-
-        val devices = deviceFetchJobs.awaitAll()
         log(TAG) { "readDrive() took ${start.elapsedNow().inWholeMilliseconds}ms" }
 
         return GDriveData(
             connectorId = identifier,
             devices = devices,
         )
+    }
+
+    private suspend fun GDriveEnvironment.refreshDeviceMetadata() {
+        val index = readAppDataIndex()
+        val deviceDataDir = index.rootChild(DEVICE_DATA_DIR_NAME)
+        if (deviceDataDir?.isDirectory != true) {
+            _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+            return
+        }
+        rootChildCache[DEVICE_DATA_DIR_NAME] = deviceDataDir.id
+        val deviceDirs = index.children(deviceDataDir).filter { it.isDirectory }
+        deviceDirs.forEach { dir ->
+            val deviceId = DeviceId(dir.name)
+            deviceDirCache[deviceId] = dir.id
+            parentCache[dir.id] = dir.name
+        }
+        _state.updateBlocking { copy(deviceMetadata = readDeviceMetadata(index, deviceDirs)) }
+    }
+
+    private suspend fun GDriveEnvironment.readDeviceMetadata(
+        index: AppDataIndex,
+        deviceDirs: List<GDriveFile>,
+    ): List<DeviceMetadata> = coroutineScope {
+        deviceDirs.map { dir ->
+            async(dispatcherProvider.IO) {
+                val deviceId = DeviceId(id = dir.name)
+                val info = try {
+                    index.child(dir, DEVICE_INFO_FILE)?.also {
+                        deviceInfoFileIdCache[deviceId] = it.id
+                    }?.readData()?.let {
+                        json.decodeFromString<GDriveDeviceInfo>(it.utf8())
+                    }
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "readDeviceMetadata(): Failed to read $DEVICE_INFO_FILE for ${dir.name}: ${e.message}" }
+                    null
+                }
+                val lastSeen = index.children(dir)
+                    .filter { it.name != DEVICE_INFO_FILE && !it.isDirectory }
+                    .maxOfOrNull { Instant.fromEpochMilliseconds(it.modifiedTime.value) }
+                DeviceMetadata(
+                    deviceId = deviceId,
+                    version = info?.version,
+                    platform = info?.platform,
+                    label = info?.label,
+                    lastSeen = lastSeen,
+                )
+            }
+        }.awaitAll()
     }
 
     private suspend fun GDriveEnvironment.readDriveByFileIds(
@@ -483,7 +592,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
             if (e.statusCode == 410) {
                 log(TAG, WARN) { "checkSyncChanges(): Token invalidated, resetting" }
-                clearFileIdCache()
+                clearPathCaches()
                 syncToken.value(null)
             }
             SyncChangeResult.ForceFullSync
@@ -527,18 +636,39 @@ class GDriveAppDataConnector @AssistedInject constructor(
         fileIdReverseCache.clear()
     }
 
+    private fun clearPathCaches() {
+        parentCache.clear()
+        clearFileIdCache()
+        rootChildCache.clear()
+        deviceDirCache.clear()
+        deviceInfoFileIdCache.clear()
+    }
+
+    private fun cacheModuleFileId(deviceId: DeviceId, moduleId: ModuleId, fileId: String) {
+        val cacheKey = deviceId to moduleId
+        fileIdCache[cacheKey] = fileId
+        fileIdReverseCache[fileId] = cacheKey
+    }
+
     private fun evictFileIdCache(deviceId: DeviceId) {
         fileIdCache.keys.filter { it.first == deviceId }.forEach { key ->
             fileIdCache.remove(key)?.let { fileIdReverseCache.remove(it) }
         }
+        deviceDirCache.remove(deviceId)
+        deviceInfoFileIdCache.remove(deviceId)
     }
 
     private suspend fun GDriveEnvironment.readTargeted(
         options: SyncOptions,
-        existing: SyncRead,
+        refreshStats: Boolean = false,
     ): GDriveData {
         val mFilter = options.moduleFilter
         val dFilter = options.deviceFilter
+
+        if (refreshStats) {
+            log(TAG) { "readTargeted(): Stats requested, using indexed read to avoid a second appData listing" }
+            return readDrive(mFilter, dFilter, refreshDeviceMetadata = true)
+        }
 
         if (mFilter != null && dFilter != null) {
             val targetModules = mFilter.intersect(supportedModuleIds)
@@ -561,7 +691,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
             }
         }
 
-        return readDrive(mFilter, dFilter)
+        return readDrive(mFilter, dFilter, refreshStats)
     }
 
     private val syncLock = Mutex()
@@ -588,117 +718,90 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
         try {
             runDriveAction("sync-sync") {
-                val jobs = mutableSetOf<Deferred<*>>()
-
-
-                scope.async(dispatcherProvider.IO) {
-                    if (!options.stats) return@async
-
-                    try {
-                        val deviceDirs = appDataRoot.child(DEVICE_DATA_DIR_NAME)
-                            ?.listFiles()
-                            ?.filter { it.isDirectory }
-                            ?: emptyList()
-
-                        val metadata = deviceDirs.map { dir ->
-                            val deviceId = DeviceId(id = dir.name)
-                            val info = try {
-                                dir.child(DEVICE_INFO_FILE)?.readData()?.let {
-                                    json.decodeFromString<GDriveDeviceInfo>(it.utf8())
-                                }
-                            } catch (e: Exception) {
-                                log(TAG, WARN) { "handleSync(): Failed to read $DEVICE_INFO_FILE for ${dir.name}: ${e.message}" }
-                                null
-                            }
-                            val lastSeen = dir.listFiles()
-                                .filter { it.name != DEVICE_INFO_FILE && !it.isDirectory }
-                                .maxOfOrNull { Instant.fromEpochMilliseconds(it.modifiedTime.value) }
-                            DeviceMetadata(
-                                deviceId = deviceId,
-                                version = info?.version,
-                                platform = info?.platform,
-                                label = info?.label,
-                                lastSeen = lastSeen,
-                            )
-                        }
-
-                        _state.updateBlocking { copy(deviceMetadata = metadata) }
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "handleSync(): Failed to list of known devices: ${e.asLog()}" }
-                    }
-                    log(TAG, VERBOSE) { "handleSync(...): devices finished (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
-                }.run { jobs.add(this) }
-
-
-
+                var wroteData = false
                 if (options.writeData && options.writePayload.isNotEmpty()) {
                     log(TAG) { "handleSync(): Writing ${options.writePayload.size} cached modules (batched)" }
                     writeDrive(SyncWriteContainer(
                         deviceId = syncSettings.deviceId,
                         modules = options.writePayload.map { it.module },
                     ))
+                    wroteData = true
                     // writeDrive returned without throwing — record hashes for all written modules
                     options.writePayload.forEach { mw ->
                         syncState.setHash(identifier, mw.module.moduleId, mw.expectedHash)
                     }
                 }
 
+                try {
+                    val isTargeted = options.moduleFilter != null || options.deviceFilter != null
 
-                scope.async(dispatcherProvider.IO) {
-                    if (!options.readData) return@async
-
-                    try {
-                        val isTargeted = options.moduleFilter != null || options.deviceFilter != null
-
+                    if (options.readData) {
                         if (isTargeted) {
-                            val existing = _data.value
-                            if (existing == null) {
-                                log(TAG) { "handleSync(): First sync, forcing full read despite filters" }
-                                _data.value = readDrive()
-                                val startToken = drive.changes().getStartPageToken()
-                                    .setSupportsAllDrives(false)
-                                    .execute().startPageToken
-                                syncToken.value(startToken)
-                            } else {
-                                val newData = readTargeted(options, existing)
-                                _data.value = mergeData(existing, newData, options.moduleFilter)
-                            }
+                            handleTargetedRead(options)
                         } else {
-                            when (val result = checkSyncChanges()) {
-                                is SyncChangeResult.HasChanges -> {
-                                    _data.value = readDrive()
-                                    syncToken.value(result.newToken)
-                                }
-
-                                is SyncChangeResult.ForceFullSync -> {
-                                    _data.value = readDrive()
-                                    val startToken = drive.changes().getStartPageToken()
-                                        .setSupportsAllDrives(false)
-                                        .execute().startPageToken
-                                    syncToken.value(startToken)
-                                }
-
-                                is SyncChangeResult.NoChanges -> {
-                                    log(TAG) { "handleSync(): No changes detected, skipping readDrive()" }
-                                }
-                            }
+                            handleFullRead(options, wroteData)
                         }
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "handleSync(): Failed to read: ${e.asLog()}" }
+                    } else if (options.stats) {
+                        refreshDeviceMetadataSafely("stats-only")
                     }
-                    log(TAG, VERBOSE) { "handleSync(...): readData finished (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
-                }.run { jobs.add(this) }
-
-
-                log(TAG) { "handleSync(...): Waiting for jobs to finish..." }
-                jobs.awaitAll()
-                log(TAG) { "handleSync(...): ... jobs finished." }
-
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "handleSync(): Failed to read/stats: ${e.asLog()}" }
+                }
+                log(TAG, VERBOSE) { "handleSync(...): readData finished (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
             }
         } finally {
             syncLock.withLock {
                 isSyncing = false
                 log(TAG, VERBOSE) { "handleSync(): Sync done, releasing (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
+            }
+        }
+    }
+
+    private suspend fun GDriveEnvironment.refreshDeviceMetadataSafely(source: String) {
+        try {
+            refreshDeviceMetadata()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "refreshDeviceMetadataSafely($source): Failed: ${e.asLog()}" }
+        }
+    }
+
+    private suspend fun GDriveEnvironment.handleTargetedRead(options: SyncOptions) {
+        val existing = _data.value
+        if (existing == null) {
+            log(TAG) { "handleSync(): First sync, forcing full read despite filters" }
+            _data.value = readDrive(refreshDeviceMetadata = options.stats)
+            val startToken = drive.changes().getStartPageToken()
+                .setSupportsAllDrives(false)
+                .execute().startPageToken
+            syncToken.value(startToken)
+        } else {
+            val newData = readTargeted(options, refreshStats = options.stats)
+            _data.value = mergeData(existing, newData, options.moduleFilter)
+        }
+    }
+
+    private suspend fun GDriveEnvironment.handleFullRead(options: SyncOptions, wroteData: Boolean) {
+        when (val result = checkSyncChanges()) {
+            is SyncChangeResult.HasChanges -> {
+                _data.value = readDrive(refreshDeviceMetadata = options.stats)
+                syncToken.value(result.newToken)
+            }
+
+            is SyncChangeResult.ForceFullSync -> {
+                _data.value = readDrive(refreshDeviceMetadata = options.stats)
+                val startToken = drive.changes().getStartPageToken()
+                    .setSupportsAllDrives(false)
+                    .execute().startPageToken
+                syncToken.value(startToken)
+            }
+
+            is SyncChangeResult.NoChanges -> {
+                log(TAG) { "handleSync(): No changes detected, skipping readDrive()" }
+                if (wroteData && options.stats) {
+                    refreshDeviceMetadataSafely("post-write")
+                }
             }
         }
     }
@@ -712,18 +815,29 @@ class GDriveAppDataConnector @AssistedInject constructor(
             return@withContext
         }
 
-        val userDir = appDataRoot.child(DEVICE_DATA_DIR_NAME)
-            ?.also { if (!it.isDirectory) throw IllegalStateException("devices is not a directory: $it") }
+        val userDir = rootChildCache[DEVICE_DATA_DIR_NAME]?.let { cachedDriveFolder(it, DEVICE_DATA_DIR_NAME) }
             ?: run {
-                appDataRoot.createDir(folderName = DEVICE_DATA_DIR_NAME).also {
-                    log(TAG, INFO) { "write(): Created devices dir $it" }
-                }
+                val root = appDataRoot
+                root.child(DEVICE_DATA_DIR_NAME)
+                    ?.also { if (!it.isDirectory) throw IllegalStateException("devices is not a directory: $it") }
+                    ?.also { rootChildCache[DEVICE_DATA_DIR_NAME] = it.id }
+                    ?: root.createDir(folderName = DEVICE_DATA_DIR_NAME).also {
+                        rootChildCache[DEVICE_DATA_DIR_NAME] = it.id
+                        log(TAG, INFO) { "write(): Created devices dir $it" }
+                    }
             }
 
         val deviceIdRaw = data.deviceId.id
-        val deviceDir = userDir.child(deviceIdRaw) ?: userDir.createDir(deviceIdRaw).also {
-            log(TAG) { "writeDrive(): Created device dir $it" }
-        }
+        val deviceDir = deviceDirCache[data.deviceId]?.let { cachedDriveFolder(it, deviceIdRaw) }
+            ?: userDir.child(deviceIdRaw)?.also {
+                deviceDirCache[data.deviceId] = it.id
+                parentCache[it.id] = it.name
+            }
+            ?: userDir.createDir(deviceIdRaw).also {
+                deviceDirCache[data.deviceId] = it.id
+                parentCache[it.id] = it.name
+                log(TAG) { "writeDrive(): Created device dir $it" }
+            }
 
         val writeSemaphore = Semaphore(3)
         coroutineScope {
@@ -731,10 +845,23 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 async {
                     writeSemaphore.withPermit {
                         log(TAG, VERBOSE) { "writeDrive(): Writing module $module" }
+                        val cacheKey = data.deviceId to module.moduleId
+                        fileIdCache[cacheKey]?.let { cachedId ->
+                            try {
+                                cachedDriveFile(cachedId, module.moduleId.id).writeData(module.payload)
+                                return@withPermit
+                            } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+                                if (e.statusCode != 404) throw e
+                                fileIdCache.remove(cacheKey)
+                                fileIdReverseCache.remove(cachedId)
+                                log(TAG, WARN) { "writeDrive(): Cached module file missing, falling back: ${module.moduleId}" }
+                            }
+                        }
                         val moduleFile = deviceDir.child(module.moduleId.id)
                             ?: deviceDir.createFile(module.moduleId.id).also {
                                 log(TAG, VERBOSE) { "writeDrive(): Created module file $it" }
                             }
+                        cacheModuleFileId(data.deviceId, module.moduleId, moduleFile.id)
                         moduleFile.writeData(module.payload)
                     }
                 }
@@ -744,16 +871,34 @@ class GDriveAppDataConnector @AssistedInject constructor(
         // Write device info metadata only when changed
         try {
             val deviceInfo = GDriveDeviceInfo(
-                version = BuildConfigWrap.VERSION_NAME,
+                version = deviceInfoVersionName(),
                 platform = "android",
                 label = syncSettings.deviceLabel.value(),
             )
             if (deviceInfo != lastWrittenDeviceInfo) {
                 val infoPayload = json.encodeToString(deviceInfo).encodeToByteArray().toByteString()
-                val infoFile = deviceDir.child(DEVICE_INFO_FILE) ?: deviceDir.createFile(DEVICE_INFO_FILE).also {
-                    log(TAG, VERBOSE) { "writeDrive(): Created device info file $it" }
+                var infoWritten = false
+                val cachedInfoFile = deviceInfoFileIdCache[data.deviceId]?.let { cachedId ->
+                    try {
+                        cachedDriveFile(cachedId, DEVICE_INFO_FILE).also {
+                            it.writeData(infoPayload)
+                            infoWritten = true
+                        }
+                    } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+                        if (e.statusCode != 404) throw e
+                        deviceInfoFileIdCache.remove(data.deviceId)
+                        log(TAG, WARN) { "writeDrive(): Cached device info file missing, falling back" }
+                        null
+                    }
                 }
-                infoFile.writeData(infoPayload)
+                val infoFile = cachedInfoFile ?: (deviceDir.child(DEVICE_INFO_FILE) ?: deviceDir.createFile(DEVICE_INFO_FILE).also {
+                    log(TAG, VERBOSE) { "writeDrive(): Created device info file $it" }
+                }).also {
+                    deviceInfoFileIdCache[data.deviceId] = it.id
+                }
+                if (!infoWritten) {
+                    infoFile.writeData(infoPayload)
+                }
                 lastWrittenDeviceInfo = deviceInfo
             } else {
                 log(TAG, VERBOSE) { "writeDrive(): Device info unchanged, skipping" }
@@ -763,6 +908,27 @@ class GDriveAppDataConnector @AssistedInject constructor(
         }
 
         log(TAG, VERBOSE) { "writeDrive(): Done" }
+    }
+
+    private fun cachedDriveFile(fileId: String, name: String): GDriveFile = GDriveFile().apply {
+        id = fileId
+        this.name = name
+    }
+
+    private fun cachedDriveFolder(fileId: String, name: String): GDriveFile = cachedDriveFile(fileId, name).apply {
+        mimeType = MIME_FOLDER
+    }
+
+    private fun deviceInfoVersionName(): String? {
+        return try {
+            BuildConfigWrap.VERSION_NAME
+        } catch (e: ExceptionInInitializerError) {
+            log(TAG, WARN) { "deviceInfoVersionName(): Failed to read build version: ${e.message}" }
+            null
+        } catch (e: NoClassDefFoundError) {
+            log(TAG, WARN) { "deviceInfoVersionName(): Failed to read build version: ${e.message}" }
+            null
+        }
     }
 
     /**

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveBlobStore.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveBlobStore.kt
@@ -16,9 +16,11 @@ import eu.darken.octi.sync.core.blob.BlobStore
 import eu.darken.octi.sync.core.blob.CountingSink
 import eu.darken.octi.sync.core.blob.CountingSource
 import eu.darken.octi.sync.core.blob.StorageStatusProvider
+import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.MIME_FOLDER
 import okio.Sink
 import okio.Source
 import okio.buffer
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Instant
 
 /**
@@ -39,6 +41,19 @@ class GDriveBlobStore(
     override val storageStatus: StorageStatusProvider,
 ) : BlobStore {
 
+    private data class BlobFileKey(
+        val deviceId: DeviceId,
+        val moduleId: ModuleId,
+        val remoteRef: RemoteBlobRef,
+    )
+
+    @Volatile private var blobStoreDirId: String? = null
+    // Blob-store caches are intentionally local to this store. Connector token resets do not
+    // invalidate Drive file IDs; stale entries self-heal through the 404 fallback paths below.
+    private val blobDeviceDirCache = ConcurrentHashMap<DeviceId, String>()
+    private val blobModuleDirCache = ConcurrentHashMap<Pair<DeviceId, ModuleId>, String>()
+    private val blobFileIdCache = ConcurrentHashMap<BlobFileKey, String>()
+
     override suspend fun put(
         deviceId: DeviceId,
         moduleId: ModuleId,
@@ -56,10 +71,7 @@ class GDriveBlobStore(
             source
         }
         connector.withDrive {
-            val blobStoreDir = appDataRoot.child(BLOB_STORE_DIR) ?: appDataRoot.createDir(BLOB_STORE_DIR)
-            val deviceDir = blobStoreDir.child(deviceId.id) ?: blobStoreDir.createDir(deviceId.id)
-            val moduleDir = deviceDir.child(moduleId.id) ?: deviceDir.createDir(moduleId.id)
-            val target = moduleDir.child(key.id) ?: moduleDir.createFile(key.id)
+            val target = resolveBlobFileForWrite(deviceId, moduleId, key)
 
             progressingSource.buffer().inputStream().use { input ->
                 target.writeStreamed(
@@ -85,7 +97,7 @@ class GDriveBlobStore(
         // [key] is unused — GDrive stores unencrypted blobs so no AAD is needed.
         return connector.withDrive {
             val file = findBlobFile(deviceId, moduleId, remoteRef) ?: throw BlobNotFoundException(remoteRef.value)
-            val metadata = file.fetchBlobMetadata().toBlobMetadata(remoteRef)
+            val metadata = fetchBlobMetadataIfNeeded(file).toBlobMetadata(remoteRef)
             val progressingSink: Sink = if (onProgress != null) {
                 CountingSink(sink) { written ->
                     onProgress(BlobProgress(bytesTransferred = written, bytesTotal = expectedPlaintextSize))
@@ -103,25 +115,60 @@ class GDriveBlobStore(
     override suspend fun getMetadata(deviceId: DeviceId, moduleId: ModuleId, remoteRef: RemoteBlobRef): BlobMetadata? {
         return connector.withDrive {
             val file = findBlobFile(deviceId, moduleId, remoteRef) ?: return@withDrive null
-            file.fetchBlobMetadata().toBlobMetadata(remoteRef)
+            fetchBlobMetadataIfNeeded(file).toBlobMetadata(remoteRef)
         }
     }
 
     override suspend fun delete(deviceId: DeviceId, moduleId: ModuleId, remoteRef: RemoteBlobRef) {
         log(TAG, VERBOSE) { "delete(ref=${remoteRef.value})" }
         connector.withDrive {
+            val cacheKey = BlobFileKey(deviceId, moduleId, remoteRef)
+            blobFileIdCache[cacheKey]?.let { cachedId ->
+                try {
+                    cachedDriveFile(cachedId, remoteRef.value).deleteAll()
+                    blobFileIdCache.remove(cacheKey)
+                    return@withDrive
+                } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+                    if (e.statusCode != 404) throw e
+                    blobFileIdCache.remove(cacheKey)
+                }
+            }
             val file = findBlobFile(deviceId, moduleId, remoteRef) ?: return@withDrive
             file.deleteAll()
+            blobFileIdCache.remove(cacheKey)
         }
     }
 
     override suspend fun list(deviceId: DeviceId, moduleId: ModuleId): Set<RemoteBlobRef> {
         return connector.withDrive {
-            val moduleDir = appDataRoot.child(BLOB_STORE_DIR)
-                ?.child(deviceId.id)
-                ?.child(moduleId.id)
-                ?: return@withDrive emptySet()
-            moduleDir.listFiles().map { RemoteBlobRef(it.name) }.toSet()
+            val moduleDir = resolveBlobModuleDir(deviceId, moduleId, create = false) ?: return@withDrive emptySet()
+            moduleDir.listFiles().map { file ->
+                RemoteBlobRef(file.name).also { blobFileIdCache[BlobFileKey(deviceId, moduleId, it)] = file.id }
+            }.toSet()
+        }
+    }
+
+    private suspend fun GDriveEnvironment.resolveBlobFileForWrite(
+        deviceId: DeviceId,
+        moduleId: ModuleId,
+        key: BlobKey,
+    ): com.google.api.services.drive.model.File {
+        val moduleDir = resolveBlobModuleDir(deviceId, moduleId, create = true)
+            ?: throw IllegalStateException("Failed to resolve blob module dir for $deviceId/$moduleId")
+        val remoteRef = RemoteBlobRef(key.id)
+        val cacheKey = BlobFileKey(deviceId, moduleId, remoteRef)
+        blobFileIdCache[cacheKey]?.let { cachedId ->
+            try {
+                val cached = getFileMetadata(cachedId, BLOB_FILE_FIELDS)
+                if (cached.name == key.id) return cached
+                blobFileIdCache.remove(cacheKey)
+            } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+                if (e.statusCode != 404) throw e
+                blobFileIdCache.remove(cacheKey)
+            }
+        }
+        return (moduleDir.child(key.id) ?: moduleDir.createFile(key.id)).also {
+            blobFileIdCache[cacheKey] = it.id
         }
     }
 
@@ -130,14 +177,81 @@ class GDriveBlobStore(
         moduleId: ModuleId,
         remoteRef: RemoteBlobRef,
     ): com.google.api.services.drive.model.File? {
-        return appDataRoot.child(BLOB_STORE_DIR)
-            ?.child(deviceId.id)
-            ?.child(moduleId.id)
-            ?.child(remoteRef.value)
+        val cacheKey = BlobFileKey(deviceId, moduleId, remoteRef)
+        blobFileIdCache[cacheKey]?.let { cachedId ->
+            try {
+                val cached = getFileMetadata(cachedId, BLOB_FILE_FIELDS)
+                if (cached.name == remoteRef.value) return cached
+                blobFileIdCache.remove(cacheKey)
+            } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
+                if (e.statusCode != 404) throw e
+                blobFileIdCache.remove(cacheKey)
+            }
+        }
+        val moduleDir = resolveBlobModuleDir(deviceId, moduleId, create = false) ?: return null
+        return moduleDir.child(remoteRef.value)?.also {
+            blobFileIdCache[cacheKey] = it.id
+        }
+    }
+
+    private suspend fun GDriveEnvironment.resolveBlobModuleDir(
+        deviceId: DeviceId,
+        moduleId: ModuleId,
+        create: Boolean,
+    ): com.google.api.services.drive.model.File? {
+        val cacheKey = deviceId to moduleId
+        blobModuleDirCache[cacheKey]?.let { return cachedDriveFolder(it, moduleId.id) }
+
+        val deviceDir = resolveBlobDeviceDir(deviceId, create) ?: return null
+        return (deviceDir.child(moduleId.id) ?: if (create) deviceDir.createDir(moduleId.id) else null)?.also {
+            blobModuleDirCache[cacheKey] = it.id
+        }
+    }
+
+    private suspend fun GDriveEnvironment.resolveBlobDeviceDir(
+        deviceId: DeviceId,
+        create: Boolean,
+    ): com.google.api.services.drive.model.File? {
+        blobDeviceDirCache[deviceId]?.let { return cachedDriveFolder(it, deviceId.id) }
+
+        val blobStoreDir = resolveBlobStoreDir(create) ?: return null
+        return (blobStoreDir.child(deviceId.id) ?: if (create) blobStoreDir.createDir(deviceId.id) else null)?.also {
+            blobDeviceDirCache[deviceId] = it.id
+        }
+    }
+
+    private suspend fun GDriveEnvironment.resolveBlobStoreDir(
+        create: Boolean,
+    ): com.google.api.services.drive.model.File? {
+        blobStoreDirId?.let { return cachedDriveFolder(it, BLOB_STORE_DIR) }
+
+        val root = appDataRoot
+        return (root.child(BLOB_STORE_DIR) ?: if (create) root.createDir(BLOB_STORE_DIR) else null)?.also {
+            blobStoreDirId = it.id
+        }
+    }
+
+    private fun cachedDriveFile(fileId: String, name: String): com.google.api.services.drive.model.File {
+        return com.google.api.services.drive.model.File().apply {
+            id = fileId
+            this.name = name
+        }
+    }
+
+    private fun cachedDriveFolder(fileId: String, name: String): com.google.api.services.drive.model.File {
+        return cachedDriveFile(fileId, name).apply {
+            mimeType = MIME_FOLDER
+        }
+    }
+
+    private suspend fun GDriveEnvironment.fetchBlobMetadataIfNeeded(
+        file: com.google.api.services.drive.model.File,
+    ): com.google.api.services.drive.model.File {
+        return if (file.createdTime != null) file else file.fetchBlobMetadata()
     }
 
     private fun com.google.api.services.drive.model.File.toBlobMetadata(remoteRef: RemoteBlobRef): BlobMetadata {
-        val sizeBytes = size?.toLong() ?: throw IllegalStateException("Missing size for blob ${remoteRef.value}")
+        val sizeBytes = getSize() ?: throw IllegalStateException("Missing size for blob ${remoteRef.value}")
         val createdTimeValue = createdTime?.value ?: throw IllegalStateException("Missing createdTime for blob ${remoteRef.value}")
         // Checksum is intentionally empty — see class doc. Receivers verify against
         // SharedFile.checksum from the synced module document instead.
@@ -151,5 +265,6 @@ class GDriveBlobStore(
     companion object {
         private val TAG = logTag("Sync", "GDrive", "BlobStore")
         private const val BLOB_STORE_DIR = "blob-store"
+        private const val BLOB_FILE_FIELDS = "id,name,mimeType,parents,createdTime,modifiedTime,size"
     }
 }

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveEnvironment.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveEnvironment.kt
@@ -16,19 +16,29 @@ interface GDriveEnvironment {
     val drive: Drive
 
     val GDriveEnvironment.appDataRoot: GDriveFile
-        get() = drive.files().get(APPDATAFOLDER).execute()
+        get() = drive.files().get(APPDATAFOLDER)
+            .setFields("id,name,mimeType")
+            .execute()
 
     val GDriveFile.isDirectory: Boolean
         get() = mimeType == MIME_FOLDER
 
     suspend fun GDriveFile.listFiles(): Collection<GDriveFile> {
-        return drive.files()
-            .list().apply {
-                spaces = APPDATAFOLDER
-                q = " '${id}' in parents "
-                fields = "files(id,name,mimeType,createdTime,modifiedTime,size)"
-            }
-            .execute().files
+        val files = mutableListOf<GDriveFile>()
+        var pageToken: String? = null
+        do {
+            val result = drive.files()
+                .list().apply {
+                    spaces = APPDATAFOLDER
+                    q = " '${id}' in parents "
+                    fields = FILE_LIST_FIELDS
+                    this.pageToken = pageToken
+                }
+                .execute()
+            files += result.files ?: emptyList()
+            pageToken = result.nextPageToken
+        } while (pageToken != null)
+        return files
     }
 
     suspend fun GDriveFile.child(name: String): GDriveFile? {
@@ -36,9 +46,9 @@ interface GDriveEnvironment {
             .list().apply {
                 spaces = APPDATAFOLDER
                 q = " '${id}' in parents and name = '$name' "
-                fields = "files(id,name,mimeType,createdTime,modifiedTime,size)"
+                fields = "files($FILE_FIELDS)"
             }
-            .execute().files
+            .execute().files.orEmpty()
             .let {
                 when {
                     it.size > 1 -> throw IllegalStateException("Multiple folders with the same name.")
@@ -55,7 +65,9 @@ interface GDriveEnvironment {
             mimeType = MIME_FOLDER
             parents = listOf(this@createDir.id)
         }
-        return drive.files().create(metaData).execute()
+        return drive.files().create(metaData)
+            .setFields(FILE_FIELDS)
+            .execute()
     }
 
     suspend fun GDriveFile.createFile(fileName: String): GDriveFile {
@@ -65,7 +77,9 @@ interface GDriveEnvironment {
             parents = listOf(this@createFile.id)
             modifiedTime = DateTime(Clock.System.now().toEpochMilliseconds())
         }
-        return drive.files().create(metaData).execute()
+        return drive.files().create(metaData)
+            .setFields(FILE_FIELDS)
+            .execute()
     }
 
     suspend fun GDriveFile.writeData(toWrite: ByteString) {
@@ -76,9 +90,27 @@ interface GDriveEnvironment {
             mimeType = "application/octet-stream"
             modifiedTime = DateTime(Clock.System.now().toEpochMilliseconds())
         }
-        drive.files().update(id, writeMetaData, payload).execute().also {
-            log(TAG, VERBOSE) { "writeData($name): done: $it" }
-        }
+        drive.files().update(id, writeMetaData, payload)
+            .setFields(FILE_FIELDS)
+            .execute()
+            .also {
+                log(TAG, VERBOSE) { "writeData($name): done: $it" }
+            }
+    }
+
+    suspend fun listAppDataFiles(): List<GDriveFile> {
+        val files = mutableListOf<GDriveFile>()
+        var pageToken: String? = null
+        do {
+            val result = drive.files().list().apply {
+                spaces = APPDATAFOLDER
+                fields = FILE_LIST_FIELDS
+                this.pageToken = pageToken
+            }.execute()
+            files += result.files ?: emptyList()
+            pageToken = result.nextPageToken
+        } while (pageToken != null)
+        return files
     }
 
     suspend fun getFileMetadata(
@@ -128,7 +160,9 @@ interface GDriveEnvironment {
                 this.properties = properties
             }
         }
-        drive.files().update(id, metadata, content).execute()
+        drive.files().update(id, metadata, content)
+            .setFields(FILE_FIELDS)
+            .execute()
     }
 
     suspend fun GDriveFile.readStreamedTo(output: java.io.OutputStream) {
@@ -142,7 +176,9 @@ interface GDriveEnvironment {
 
     companion object {
         internal const val APPDATAFOLDER = "appDataFolder"
-        private const val MIME_FOLDER = "application/vnd.google-apps.folder"
+        internal const val MIME_FOLDER = "application/vnd.google-apps.folder"
+        private const val FILE_FIELDS = "id,name,mimeType,parents,createdTime,modifiedTime,size"
+        private const val FILE_LIST_FIELDS = "nextPageToken,files($FILE_FIELDS)"
         internal val TAG = logTag("Sync", "GDrive", "Connector", "Env")
     }
 }

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -12,11 +12,16 @@ import eu.darken.octi.common.datastore.createValue
 import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.BlobKey
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorSyncState
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.SyncWrite
+import eu.darken.octi.sync.core.blob.BlobMetadata
+import eu.darken.octi.sync.core.blob.StorageStatusProvider
 import eu.darken.octi.sync.core.execute
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
@@ -33,6 +38,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import okio.Buffer
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -94,6 +100,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             produceFile = { File(tempDir, "test_sync_${System.nanoTime()}.preferences_pb") },
         )
         every { syncSettings.dataStore } returns testDataStore
+        every { syncSettings.deviceLabel } returns testDataStore.createValue("sync.device.self.label", null as String?)
         every { syncSettings.deviceId } returns DeviceId("test-device")
         // Processor's pause guard reads syncSettings.isPaused() on every command —
         // supply an empty flow so guardPauseIfNeeded doesn't NoSuchElementException on flow.first().
@@ -160,7 +167,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
     private fun setupEmptyDriveRead() {
         // appDataRoot returns a file with no "devices" child
         val rootFile = GDriveFile().apply {
-            id = "root-id"
+            id = "appDataFolder"
             name = "appDataFolder"
             mimeType = "application/vnd.google-apps.folder"
         }
@@ -189,6 +196,32 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
 
             // changes.list was called for the second sync's checkSyncChanges
             verify(atLeast = 1) { mockChangesList.execute() }
+        }
+
+        @Test
+        fun `periodic sync with stats skips Drive file reads when no changes`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupEmptyDriveRead()
+
+            // First sync initializes syncToken and performs the initial read.
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            setupNoChanges("token-2")
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            verify(exactly = 1) { mockChangesList.execute() }
+            verify(exactly = 0) { mockFiles.get(any()) }
+            verify(exactly = 0) { mockFiles.list() }
         }
 
         @Test
@@ -398,9 +431,13 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         private val deviceA = DeviceId("device-a")
         private val powerFileId = "power-file-id-123"
 
-        private fun setupDriveWithPowerModule(payload: String = "power-data") {
+        private fun setupDriveWithPowerModule(
+            payload: String = "power-data",
+            deviceId: DeviceId = deviceA,
+            includeDeviceInfo: Boolean = false,
+        ) {
             val rootFile = GDriveFile().apply {
-                id = "root-id"
+                id = "appDataFolder"
                 name = "appDataFolder"
                 mimeType = "application/vnd.google-apps.folder"
             }
@@ -408,20 +445,31 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 id = "devices-dir-id"
                 name = "devices"
                 mimeType = "application/vnd.google-apps.folder"
+                parents = listOf("appDataFolder")
             }
             val deviceADir = GDriveFile().apply {
                 id = "device-a-dir-id"
-                name = "device-a"
+                name = deviceId.id
                 mimeType = "application/vnd.google-apps.folder"
+                parents = listOf("devices-dir-id")
             }
             val powerFile = GDriveFile().apply {
                 id = powerFileId
                 name = power.id
                 mimeType = "application/octet-stream"
+                parents = listOf("device-a-dir-id")
                 modifiedTime = DateTime(1000L)
+            }
+            val deviceInfoFile = GDriveFile().apply {
+                id = "device-info-file-id"
+                name = "_device.json"
+                mimeType = "application/octet-stream"
+                parents = listOf("device-a-dir-id")
+                modifiedTime = DateTime(1500L)
             }
 
             val rootGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
                 every { it.execute() } returns rootFile
             }
             val moduleGet = mockk<Drive.Files.Get>(relaxed = true).also {
@@ -431,25 +479,93 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                     firstArg<java.io.OutputStream>().write(payload.toByteArray())
                 }
             }
+            val deviceInfoGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns deviceInfoFile
+                every { it.executeMediaAndDownloadTo(any()) } answers {
+                    firstArg<java.io.OutputStream>().write("""{"version":"1","platform":"android","label":"Device A"}""".toByteArray())
+                }
+            }
 
             every { mockFiles.get(any()) } answers {
                 when (firstArg<String>()) {
                     "appDataFolder" -> rootGet
                     powerFileId -> moduleGet
+                    "device-info-file-id" -> deviceInfoGet
                     else -> mockk(relaxed = true)
                 }
             }
 
-            var listCallIdx = 0
-            every { mockFilesList.execute() } answers {
-                listCallIdx++
-                when (listCallIdx) {
-                    1 -> FileList().apply { files = listOf(devicesDir) }
-                    2 -> FileList().apply { files = listOf(deviceADir) }
-                    3 -> FileList().apply { files = listOf(powerFile) }
-                    else -> FileList().apply { files = emptyList() }
+            every { mockFilesList.execute() } returns FileList().apply {
+                files = buildList {
+                    add(devicesDir)
+                    add(deviceADir)
+                    add(powerFile)
+                    if (includeDeviceInfo) add(deviceInfoFile)
                 }
             }
+        }
+
+        private fun moduleWrite(payloadText: String): SyncOptions.ModuleWrite {
+            val module = object : SyncWrite.Device.Module {
+                override val moduleId: ModuleId = power
+                override val payload = payloadText.encodeUtf8()
+            }
+            return SyncOptions.ModuleWrite(module = module, expectedHash = "hash-$payloadText")
+        }
+
+        private fun googleJsonException(statusCode: Int) =
+            mockk<com.google.api.client.googleapis.json.GoogleJsonResponseException>(relaxed = true).also {
+                every { it.statusCode } returns statusCode
+            }
+
+        private fun setupUpdateCapture(
+            updateIds: MutableList<String>,
+            staleIds: Set<String> = emptySet(),
+        ) {
+            every {
+                mockFiles.update(
+                    any<String>(),
+                    any<GDriveFile>(),
+                    any<com.google.api.client.http.AbstractInputStreamContent>(),
+                )
+            } answers {
+                val fileId = firstArg<String>()
+                updateIds += fileId
+                mockk<Drive.Files.Update>(relaxed = true).also {
+                    every { it.setFields(any<String>()) } returns it
+                    if (fileId in staleIds) {
+                        every { it.execute() } throws googleJsonException(404)
+                    } else {
+                        every { it.execute() } returns GDriveFile().apply {
+                            id = fileId
+                            name = "updated"
+                        }
+                    }
+                }
+            }
+        }
+
+        @Test
+        fun `full read uses one appData metadata listing`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("indexed", includeDeviceInfo = true)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            verify(exactly = 1) { mockFilesList.execute() }
+            verify(exactly = 0) { mockFiles.get("appDataFolder") }
+            val data = connector.data.first()
+            data.shouldNotBeNull()
+            data.devices.single().modules.single().payload.utf8() shouldBe "indexed"
+
+            val metadata = connector.state.first().deviceMetadata.single()
+            metadata.deviceId shouldBe deviceA
+            metadata.version shouldBe "1"
+            metadata.platform shouldBe "android"
+            metadata.label shouldBe "Device A"
+            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(1000L)
         }
 
         @Test
@@ -608,6 +724,290 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 .modules
                 .first { it.moduleId == power }
             module.payload.utf8() shouldBe "fallback-after-mismatch"
+        }
+
+        @Test
+        fun `write uses warm file and directory id caches without traversal`() = runTest {
+            val currentDevice = DeviceId("test-device")
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("original", deviceId = currentDevice, includeDeviceInfo = true)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            val updateIds = mutableListOf<String>()
+            setupUpdateCapture(updateIds)
+
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = false,
+                    writeData = true,
+                    writePayload = listOf(moduleWrite("written")),
+                ),
+            )
+
+            updateIds.contains(powerFileId) shouldBe true
+            updateIds.contains("device-info-file-id") shouldBe true
+            verify(exactly = 0) { mockFiles.get(any()) }
+            verify(exactly = 0) { mockFiles.list() }
+            verify(exactly = 0) { mockFiles.create(any<GDriveFile>()) }
+        }
+
+        @Test
+        fun `write falls back to path lookup when warm module id is stale`() = runTest {
+            val currentDevice = DeviceId("test-device")
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("original", deviceId = currentDevice, includeDeviceInfo = true)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            val freshPowerFile = GDriveFile().apply {
+                id = "fresh-power-file-id"
+                name = power.id
+                mimeType = "application/octet-stream"
+                parents = listOf("device-a-dir-id")
+                modifiedTime = DateTime(2000L)
+            }
+            every { mockFiles.list() } returns mockFilesList
+            every { mockFilesList.execute() } returns FileList().apply {
+                files = listOf(freshPowerFile)
+            }
+            val updateIds = mutableListOf<String>()
+            setupUpdateCapture(updateIds, staleIds = setOf(powerFileId))
+
+            connector.sync(
+                SyncOptions(
+                    stats = false,
+                    readData = false,
+                    writeData = true,
+                    writePayload = listOf(moduleWrite("written")),
+                ),
+            )
+
+            updateIds.contains(powerFileId) shouldBe true
+            updateIds.contains("fresh-power-file-id") shouldBe true
+            verify(exactly = 0) { mockFiles.get(any()) }
+            verify(exactly = 1) { mockFiles.list() }
+            verify(exactly = 0) { mockFiles.create(any<GDriveFile>()) }
+        }
+    }
+
+    @Nested
+    inner class `blob store cache` {
+
+        private val blobDevice = DeviceId("blob-device")
+        private val blobKey = BlobKey("blob-1")
+        private val remoteRef = RemoteBlobRef("blob-1")
+        private val blobFileId = "blob-file-id"
+
+        private fun createBlobStore(connector: GDriveAppDataConnector): GDriveBlobStore {
+            return GDriveBlobStore(
+                connector = connector,
+                connectorId = connector.identifier,
+                storageStatus = mockk<StorageStatusProvider>(relaxed = true),
+            )
+        }
+
+        private fun googleJsonException(statusCode: Int) =
+            mockk<com.google.api.client.googleapis.json.GoogleJsonResponseException>(relaxed = true).also {
+                every { it.statusCode } returns statusCode
+            }
+
+        private fun blobFile(
+            id: String = blobFileId,
+            name: String = remoteRef.value,
+            size: Long = 4L,
+            createdAt: Long = 1000L,
+        ) = GDriveFile().apply {
+            this.id = id
+            this.name = name
+            mimeType = "application/octet-stream"
+            parents = listOf("blob-module-dir-id")
+            setSize(size)
+            createdTime = DateTime(createdAt)
+            modifiedTime = DateTime(createdAt)
+        }
+
+        private fun setupBlobTreeListing(blobFile: GDriveFile = blobFile()) {
+            val rootFile = GDriveFile().apply {
+                id = "appDataFolder"
+                name = "appDataFolder"
+                mimeType = "application/vnd.google-apps.folder"
+            }
+            val blobStoreDir = GDriveFile().apply {
+                id = "blob-store-dir-id"
+                name = "blob-store"
+                mimeType = "application/vnd.google-apps.folder"
+                parents = listOf("appDataFolder")
+            }
+            val deviceDir = GDriveFile().apply {
+                id = "blob-device-dir-id"
+                name = blobDevice.id
+                mimeType = "application/vnd.google-apps.folder"
+                parents = listOf("blob-store-dir-id")
+            }
+            val moduleDir = GDriveFile().apply {
+                id = "blob-module-dir-id"
+                name = power.id
+                mimeType = "application/vnd.google-apps.folder"
+                parents = listOf("blob-device-dir-id")
+            }
+            val rootGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns rootFile
+            }
+            every { mockFiles.get("appDataFolder") } returns rootGet
+
+            var listCall = 0
+            every { mockFiles.list() } returns mockFilesList
+            every { mockFilesList.execute() } answers {
+                listCall++
+                FileList().apply {
+                    files = when (listCall) {
+                        1 -> listOf(blobStoreDir)
+                        2 -> listOf(deviceDir)
+                        3 -> listOf(moduleDir)
+                        else -> listOf(blobFile)
+                    }
+                }
+            }
+        }
+
+        private fun setupBlobGet(
+            id: String,
+            file: GDriveFile,
+            payload: String,
+            metadataThrows404: Boolean = false,
+        ) {
+            val get = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                if (metadataThrows404) {
+                    every { it.execute() } throws googleJsonException(404)
+                } else {
+                    every { it.execute() } returns file
+                }
+                every { it.executeMediaAndDownloadTo(any()) } answers {
+                    firstArg<java.io.OutputStream>().write(payload.toByteArray())
+                }
+            }
+            every { mockFiles.get(id) } returns get
+        }
+
+        private fun setupBlobDelete(deletedIds: MutableList<String>) {
+            every { mockFiles.delete(any()) } answers {
+                val fileId = firstArg<String>()
+                deletedIds += fileId
+                mockk<Drive.Files.Delete>(relaxed = true).also {
+                    every { it.execute() } returns null
+                }
+            }
+        }
+
+        @Test
+        fun `warm blob cache get and delete avoid path traversal`() = runTest {
+            val connector = createConnector()
+            val store = createBlobStore(connector)
+            val file = blobFile()
+            setupBlobTreeListing(file)
+
+            store.list(blobDevice, power) shouldBe setOf(remoteRef)
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            setupBlobGet(blobFileId, file, payload = "data")
+            val sink = Buffer()
+
+            val metadata = store.get(
+                deviceId = blobDevice,
+                moduleId = power,
+                key = blobKey,
+                remoteRef = remoteRef,
+                sink = sink,
+                expectedPlaintextSize = 4L,
+            )
+
+            metadata.size shouldBe 4L
+            sink.readUtf8() shouldBe "data"
+            verify(exactly = 0) { mockFiles.list() }
+
+            io.mockk.clearMocks(
+                mockFiles,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            val deletedIds = mutableListOf<String>()
+            setupBlobDelete(deletedIds)
+
+            store.delete(blobDevice, power, remoteRef)
+
+            deletedIds shouldBe listOf(blobFileId)
+            verify(exactly = 0) { mockFiles.get(any()) }
+            verify(exactly = 0) { mockFiles.list() }
+        }
+
+        @Test
+        fun `blob get falls back to path lookup when cached file id is stale`() = runTest {
+            val connector = createConnector()
+            val store = createBlobStore(connector)
+            val staleFile = blobFile()
+            setupBlobTreeListing(staleFile)
+
+            store.list(blobDevice, power) shouldBe setOf(remoteRef)
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            val freshFile = blobFile(id = "fresh-blob-file-id", createdAt = 2000L)
+            setupBlobGet(blobFileId, staleFile, payload = "stale", metadataThrows404 = true)
+            setupBlobGet("fresh-blob-file-id", freshFile, payload = "fresh")
+            every { mockFiles.list() } returns mockFilesList
+            every { mockFilesList.execute() } returns FileList().apply {
+                files = listOf(freshFile)
+            }
+            val sink = Buffer()
+
+            val metadata = store.get(
+                deviceId = blobDevice,
+                moduleId = power,
+                key = blobKey,
+                remoteRef = remoteRef,
+                sink = sink,
+                expectedPlaintextSize = 5L,
+            )
+
+            metadata.createdAt shouldBe kotlin.time.Instant.fromEpochMilliseconds(2000L)
+            sink.readUtf8() shouldBe "fresh"
+            verify(exactly = 1) { mockFiles.list() }
         }
     }
 }


### PR DESCRIPTION
## Summary

Optimizes the Google Drive sync connector to drastically cut Drive API request volume — both per-sync and during idle foreground polling.

- **Single paginated `appData` metadata index** replaces the old per-folder `child()`/`listFiles()` walk. One `files.list` call rebuilds the whole tree locally; module payloads and `_device.json` are then fetched only when needed.
- **Stats refresh folded into the same indexed read** — no second walk of `devices/`. `lastSeen` is derived from indexed module metadata.
- **Idle foreground polling** now collapses to a single `changes.list` every two minutes when nothing has changed: no `files.get`, no `files.list`.
- **Warm ID caches for writes**: module file IDs, device dirs, the `devices/` root child, the device-info file, and blob-store dirs/files are cached after first traversal. Subsequent writes/gets/deletes hit Drive directly by ID with a 404 fallback to the path lookup that refreshes the cache.
- **Minimal field projections** (`setFields`) on every `get`/`list`/`create`/`update` to keep response payloads small.
- **Pagination added to `GDriveFile.listFiles()`** (latent bug fix — the old code silently truncated past the default Drive page size).

`pollToken` and `syncToken` are kept separate; no Drive webhook/channel registration; no schema or `RemoteBlobRef` format changes.

## Test plan

- [ ] `./gradlew :syncs-gdrive:testFossDebugUnitTest` passes
- [ ] Existing tests (410-token-reset, pagination, targeted-sync, direct-file-id) still pass
- [ ] New tests cover: indexed full read (single `list` + populated device metadata), warm write-cache hit (no traversal), stale write-cache 404 fallback, warm blob get/delete (no traversal), stale blob get fallback
- [ ] Smoke on octi-1/octi-2: sync once, observe 4-minute idle window — only `changes.list` calls every 2 minutes, no `files.list` or `files.get` between them
