### PR TITLE
Show a consistent 'Pro' badge across all gated settings

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/settings/SettingsBaseItem.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/settings/SettingsBaseItem.kt
@@ -3,9 +3,11 @@ package eu.darken.octi.common.settings
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material3.Icon
@@ -14,10 +16,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.compose.Preview2
@@ -34,7 +38,7 @@ fun SettingsBaseItem(
     iconSize: Dp = 24.dp,
     subtitle: String? = null,
     enabled: Boolean = true,
-    onDisabledClick: (() -> Unit)? = null,
+    requiresUpgrade: Boolean = false,
     onLongClick: (() -> Unit)? = null,
     trailingContent: @Composable (() -> Unit)? = null,
 ) {
@@ -42,8 +46,8 @@ fun SettingsBaseItem(
         modifier = modifier
             .fillMaxWidth()
             .combinedClickable(
-                enabled = enabled || onDisabledClick != null,
-                onClick = if (enabled) onClick else onDisabledClick ?: onClick,
+                enabled = enabled,
+                onClick = onClick,
                 onLongClick = onLongClick,
             )
             .padding(horizontal = 16.dp, vertical = 16.dp),
@@ -78,12 +82,21 @@ fun SettingsBaseItem(
                 .weight(1f)
                 .padding(start = if (hasIcon) 16.dp else 0.dp),
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Normal,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Normal,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = contentAlpha),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (requiresUpgrade) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    UpgradeBadge(modifier = Modifier.alpha(contentAlpha))
+                }
+            }
             if (subtitle != null) {
                 Text(
                     text = subtitle,
@@ -106,5 +119,30 @@ private fun SettingsBaseItemPreview() = PreviewWrapper {
         subtitle = "Monitor mode, scanner, notifications",
         icon = Icons.TwoTone.Settings,
         onClick = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun SettingsBaseItemUpgradePreview() = PreviewWrapper {
+    SettingsBaseItem(
+        title = "General Settings",
+        subtitle = "Monitor mode, scanner, notifications",
+        icon = Icons.TwoTone.Settings,
+        onClick = {},
+        requiresUpgrade = true,
+    )
+}
+
+@Preview2
+@Composable
+private fun SettingsBaseItemUpgradeDisabledPreview() = PreviewWrapper {
+    SettingsBaseItem(
+        title = "General Settings",
+        subtitle = "Monitor mode, scanner, notifications",
+        icon = Icons.TwoTone.Settings,
+        onClick = {},
+        enabled = false,
+        requiresUpgrade = true,
     )
 }

--- a/app-common/src/main/java/eu/darken/octi/common/settings/SettingsListPreferenceItem.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/settings/SettingsListPreferenceItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,21 +39,29 @@ fun <T> SettingsListPreferenceItem(
     modifier: Modifier = Modifier,
     subtitle: String? = null,
     enabled: Boolean = true,
-    onDisabledClick: (() -> Unit)? = null,
+    requiresUpgrade: Boolean = false,
+    onUpgradeClick: (() -> Unit)? = null,
 ) {
     var showDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(requiresUpgrade) {
+        if (requiresUpgrade) showDialog = false
+    }
 
     SettingsBaseItem(
         icon = icon,
         title = title,
         subtitle = subtitle ?: entryLabel(selectedEntry),
-        onClick = { if (enabled) showDialog = true },
+        onClick = when {
+            requiresUpgrade -> onUpgradeClick ?: {}
+            else -> { { showDialog = true } }
+        },
         modifier = modifier,
         enabled = enabled,
-        onDisabledClick = onDisabledClick,
+        requiresUpgrade = requiresUpgrade,
     )
 
-    if (showDialog) {
+    if (showDialog && !requiresUpgrade) {
         AlertDialog(
             onDismissRequest = { showDialog = false },
             title = { Text(text = title) },
@@ -106,5 +115,20 @@ private fun SettingsListPreferenceItemPreview() = PreviewWrapper {
         selectedEntry = "Automatic",
         onEntrySelected = {},
         entryLabel = { it },
+    )
+}
+
+@Preview2
+@Composable
+private fun SettingsListPreferenceItemUpgradePreview() = PreviewWrapper {
+    SettingsListPreferenceItem(
+        icon = Icons.TwoTone.Tune,
+        title = "Mode",
+        entries = listOf("Manual", "Automatic", "Always"),
+        selectedEntry = "Automatic",
+        onEntrySelected = {},
+        entryLabel = { it },
+        requiresUpgrade = true,
+        onUpgradeClick = {},
     )
 }

--- a/app-common/src/main/java/eu/darken/octi/common/settings/SettingsSwitchItem.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/settings/SettingsSwitchItem.kt
@@ -20,7 +20,7 @@ fun SettingsSwitchItem(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    onDisabledClick: (() -> Unit)? = null,
+    requiresUpgrade: Boolean = false,
 ) {
     SettingsBaseItem(
         icon = icon,
@@ -29,11 +29,11 @@ fun SettingsSwitchItem(
         modifier = modifier,
         subtitle = subtitle,
         enabled = enabled,
-        onDisabledClick = onDisabledClick,
+        requiresUpgrade = requiresUpgrade,
         trailingContent = {
             Switch(
                 checked = checked,
-                onCheckedChange = onCheckedChange,
+                onCheckedChange = if (requiresUpgrade) null else onCheckedChange,
                 enabled = enabled,
                 modifier = Modifier.padding(start = 16.dp),
             )
@@ -62,5 +62,18 @@ private fun SettingsSwitchItemOffPreview() = PreviewWrapper {
         subtitle = "Display connection notifications",
         checked = false,
         onCheckedChange = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun SettingsSwitchItemUpgradePreview() = PreviewWrapper {
+    SettingsSwitchItem(
+        icon = Icons.TwoTone.Notifications,
+        title = "Show notifications",
+        subtitle = "Display connection notifications",
+        checked = false,
+        onCheckedChange = {},
+        requiresUpgrade = true,
     )
 }

--- a/app-common/src/main/java/eu/darken/octi/common/settings/UpgradeBadge.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/settings/UpgradeBadge.kt
@@ -1,0 +1,47 @@
+package eu.darken.octi.common.settings
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.R
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+
+@Composable
+fun UpgradeBadge(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.TwoTone.Stars,
+            contentDescription = stringResource(R.string.general_upgrade_required_label),
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(modifier = Modifier.width(2.dp))
+        Text(
+            text = stringResource(R.string.upgrade_badge_label),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.primary,
+            maxLines = 1,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeBadgePreview() = PreviewWrapper {
+    UpgradeBadge()
+}

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="general_reset_action">Reset</string>
     <string name="general_disconnect_action">Disconnect</string>
     <string name="general_upgrade_action">Upgrade</string>
+    <string name="general_upgrade_required_label">Requires upgrade</string>
+    <string name="upgrade_badge_label" translatable="false">Pro</string>
     <string name="general_update_action">Update</string>
     <string name="general_donate_action">Donate</string>
     <string name="general_check_action">Check</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name_upgraded">Octi FOSS</string>
 
+    <string name="upgrade_badge_label" translatable="false">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requires Octi Pro</string>
 
     <string name="upgrades_dashcard_title">Get Octi Pro</string>

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -105,8 +105,8 @@ fun GeneralSettingsScreen(
                     selectedEntry = state.themeMode,
                     onEntrySelected = onThemeModeSelected,
                     entryLabel = { it.label.get(context) },
-                    enabled = state.isPro,
-                    onDisabledClick = onUpgrade,
+                    requiresUpgrade = !state.isPro,
+                    onUpgradeClick = onUpgrade,
                 )
             }
             item {
@@ -117,12 +117,12 @@ fun GeneralSettingsScreen(
                     selectedEntry = state.themeStyle,
                     onEntrySelected = onThemeStyleSelected,
                     entryLabel = { it.label.get(context) },
-                    enabled = state.isPro,
-                    onDisabledClick = onUpgrade,
+                    requiresUpgrade = !state.isPro,
+                    onUpgradeClick = onUpgrade,
                 )
             }
             item {
-                val isColorPickerEnabled = state.isPro &&
+                val isColorPickerApplicable =
                     !(state.themeStyle == ThemeStyle.MATERIAL_YOU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
                 SettingsListPreferenceItem(
                     icon = Icons.TwoTone.Palette,
@@ -131,8 +131,9 @@ fun GeneralSettingsScreen(
                     selectedEntry = state.themeColor,
                     onEntrySelected = onThemeColorSelected,
                     entryLabel = { it.label.get(context) },
-                    enabled = isColorPickerEnabled,
-                    onDisabledClick = onUpgrade,
+                    enabled = isColorPickerApplicable,
+                    requiresUpgrade = !state.isPro,
+                    onUpgradeClick = onUpgrade,
                 )
             }
         }
@@ -145,6 +146,27 @@ private fun GeneralSettingsScreenPreview() = PreviewWrapper {
     GeneralSettingsScreen(
         state = GeneralSettingsVM.State(
             isPro = true,
+            isUpdateCheckSupported = true,
+            isUpdateCheckEnabled = true,
+            themeMode = ThemeMode.SYSTEM,
+            themeStyle = ThemeStyle.DEFAULT,
+            themeColor = ThemeColor.GREEN,
+        ),
+        onNavigateUp = {},
+        onThemeModeSelected = {},
+        onThemeStyleSelected = {},
+        onThemeColorSelected = {},
+        onUpdateCheckChanged = {},
+        onUpgrade = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun GeneralSettingsScreenNonProPreview() = PreviewWrapper {
+    GeneralSettingsScreen(
+        state = GeneralSettingsVM.State(
+            isPro = false,
             isUpdateCheckSupported = true,
             isUpdateCheckEnabled = true,
             themeMode = ThemeMode.SYSTEM,

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/general/GeneralSettingsVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/general/GeneralSettingsVM.kt
@@ -10,6 +10,7 @@ import eu.darken.octi.common.theming.ThemeStyle
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.main.core.GeneralSettings
 import eu.darken.octi.main.core.updater.UpdateChecker
 import kotlinx.coroutines.flow.combine
@@ -20,7 +21,7 @@ import javax.inject.Inject
 class GeneralSettingsVM @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val generalSettings: GeneralSettings,
-    upgradeRepo: UpgradeRepo,
+    private val upgradeRepo: UpgradeRepo,
     private val updateChecker: UpdateChecker,
 ) : ViewModel4(dispatcherProvider) {
 
@@ -54,14 +55,17 @@ class GeneralSettingsVM @Inject constructor(
     }.asStateFlow()
 
     fun setThemeMode(mode: ThemeMode) = launch {
+        if (!requirePro()) return@launch
         generalSettings.themeMode.value(mode)
     }
 
     fun setThemeStyle(style: ThemeStyle) = launch {
+        if (!requirePro()) return@launch
         generalSettings.themeStyle.value(style)
     }
 
     fun setThemeColor(color: ThemeColor) = launch {
+        if (!requirePro()) return@launch
         generalSettings.themeColor.value(color)
     }
 
@@ -69,6 +73,12 @@ class GeneralSettingsVM @Inject constructor(
 
     fun setUpdateCheckEnabled(enabled: Boolean) = launch {
         generalSettings.isUpdateCheckEnabled.value(enabled)
+    }
+
+    private suspend fun requirePro(): Boolean {
+        if (upgradeRepo.isPro()) return true
+        navTo(Nav.Main.Upgrade())
+        return false
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/octi/module/ui/settings/ModuleSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/module/ui/settings/ModuleSettingsScreen.kt
@@ -9,12 +9,10 @@ import androidx.compose.material.icons.twotone.BatteryFull
 import androidx.compose.material.icons.automirrored.twotone.InsertDriveFile
 import androidx.compose.material.icons.twotone.ContentPaste
 import androidx.compose.material.icons.twotone.Public
-import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Store
 import androidx.compose.material.icons.twotone.Wifi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -22,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.octi.R
 import eu.darken.octi.modules.apps.R as AppsR
@@ -36,7 +33,6 @@ import eu.darken.octi.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
-import eu.darken.octi.common.settings.SettingsBaseItem
 import eu.darken.octi.common.settings.SettingsCategoryHeader
 import eu.darken.octi.common.settings.SettingsSwitchItem
 
@@ -55,7 +51,6 @@ fun ModuleSettingsScreenHost(vm: ModuleSettingsVM = hiltViewModel()) {
             onWifiEnabledChanged = { enabled -> vm.setWifiEnabled(enabled) },
             onAppsEnabledChanged = { enabled -> vm.setAppsEnabled(enabled) },
             onAppsInstallerEnabledChanged = { enabled -> vm.setAppsInstallerEnabled(enabled) },
-            onUpgrade = { vm.goUpgrade() },
             onClipboardEnabledChanged = { enabled -> vm.setClipboardEnabled(enabled) },
             onFilesEnabledChanged = { enabled -> vm.setFilesEnabled(enabled) },
         )
@@ -71,7 +66,6 @@ fun ModuleSettingsScreen(
     onWifiEnabledChanged: (Boolean) -> Unit,
     onAppsEnabledChanged: (Boolean) -> Unit,
     onAppsInstallerEnabledChanged: (Boolean) -> Unit,
-    onUpgrade: () -> Unit,
     onClipboardEnabledChanged: (Boolean) -> Unit,
     onFilesEnabledChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -139,31 +133,15 @@ fun ModuleSettingsScreen(
                 )
             }
             item {
-                if (state.isPro) {
-                    SettingsSwitchItem(
-                        icon = Icons.TwoTone.Store,
-                        title = stringResource(AppsR.string.module_apps_installer_label),
-                        subtitle = stringResource(AppsR.string.module_apps_installer_desc),
-                        checked = state.isAppsInstallerEnabled,
-                        onCheckedChange = onAppsInstallerEnabledChanged,
-                        enabled = state.isAppsEnabled,
-                    )
-                } else {
-                    SettingsBaseItem(
-                        icon = Icons.TwoTone.Store,
-                        title = stringResource(AppsR.string.module_apps_installer_label),
-                        subtitle = stringResource(AppsR.string.module_apps_installer_desc),
-                        onClick = onUpgrade,
-                        trailingContent = {
-                            Icon(
-                                imageVector = Icons.TwoTone.Stars,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(start = 16.dp),
-                            )
-                        },
-                    )
-                }
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.Store,
+                    title = stringResource(AppsR.string.module_apps_installer_label),
+                    subtitle = stringResource(AppsR.string.module_apps_installer_desc),
+                    checked = state.isAppsInstallerEnabled,
+                    onCheckedChange = onAppsInstallerEnabledChanged,
+                    enabled = state.isAppsEnabled,
+                    requiresUpgrade = !state.isPro,
+                )
             }
             item {
                 SettingsCategoryHeader(text = stringResource(R.string.modules_category_misc_label))
@@ -210,7 +188,31 @@ private fun ModuleSettingsScreenPreview() = PreviewWrapper {
         onWifiEnabledChanged = {},
         onAppsEnabledChanged = {},
         onAppsInstallerEnabledChanged = {},
-        onUpgrade = {},
+        onClipboardEnabledChanged = {},
+        onFilesEnabledChanged = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun ModuleSettingsScreenNonProPreview() = PreviewWrapper {
+    ModuleSettingsScreen(
+        state = ModuleSettingsVM.State(
+            isPro = false,
+            isPowerEnabled = true,
+            isConnectivityEnabled = true,
+            isWifiEnabled = true,
+            isAppsEnabled = true,
+            isAppsInstallerEnabled = false,
+            isClipboardEnabled = true,
+            isFilesEnabled = true,
+        ),
+        onNavigateUp = {},
+        onPowerEnabledChanged = {},
+        onConnectivityEnabledChanged = {},
+        onWifiEnabledChanged = {},
+        onAppsEnabledChanged = {},
+        onAppsInstallerEnabledChanged = {},
         onClipboardEnabledChanged = {},
         onFilesEnabledChanged = {},
     )

--- a/app/src/main/java/eu/darken/octi/module/ui/settings/ModuleSettingsVM.kt
+++ b/app/src/main/java/eu/darken/octi/module/ui/settings/ModuleSettingsVM.kt
@@ -7,6 +7,7 @@ import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.modules.apps.core.AppsSettings
 import eu.darken.octi.modules.clipboard.ClipboardSettings
 import eu.darken.octi.modules.connectivity.core.ConnectivitySettings
@@ -19,7 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class ModuleSettingsVM @Inject constructor(
     dispatcherProvider: DispatcherProvider,
-    upgradeRepo: UpgradeRepo,
+    private val upgradeRepo: UpgradeRepo,
     private val powerSettings: PowerSettings,
     private val connectivitySettings: ConnectivitySettings,
     private val wifiSettings: WifiSettings,
@@ -86,6 +87,7 @@ class ModuleSettingsVM @Inject constructor(
     }
 
     fun setAppsInstallerEnabled(enabled: Boolean) = launch {
+        if (!requirePro()) return@launch
         appsSettings.includeInstaller.value(enabled)
     }
 
@@ -97,7 +99,11 @@ class ModuleSettingsVM @Inject constructor(
         fileShareSettings.isEnabled.value(enabled)
     }
 
-    fun goUpgrade() = navTo(Nav.Main.Upgrade())
+    private suspend fun requirePro(): Boolean {
+        if (upgradeRepo.isPro()) return true
+        navTo(Nav.Main.Upgrade())
+        return false
+    }
 
     companion object {
         private val TAG = logTag("Settings", "Module", "VM")

--- a/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/settings/SyncSettingsScreen.kt
@@ -11,14 +11,12 @@ import androidx.compose.material.icons.automirrored.twotone.Label
 import androidx.compose.material.icons.twotone.BatteryChargingFull
 import androidx.compose.material.icons.twotone.Dashboard
 import androidx.compose.material.icons.twotone.SignalWifi4Bar
-import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material.icons.twotone.Timer
 import androidx.compose.material.icons.twotone.Visibility
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -186,31 +184,15 @@ fun SyncSettingsScreen(
                 )
             }
             item {
-                if (state.isPro) {
-                    SettingsSwitchItem(
-                        icon = Icons.TwoTone.BatteryChargingFull,
-                        title = stringResource(R.string.sync_setting_charging_enable_title),
-                        subtitle = stringResource(R.string.sync_setting_charging_enable_desc),
-                        checked = state.backgroundSyncChargingEnabled,
-                        onCheckedChange = onChargingEnabledChanged,
-                        enabled = state.backgroundSyncEnabled,
-                    )
-                } else {
-                    SettingsBaseItem(
-                        icon = Icons.TwoTone.BatteryChargingFull,
-                        title = stringResource(R.string.sync_setting_charging_enable_title),
-                        subtitle = stringResource(R.string.sync_setting_charging_enable_desc),
-                        onClick = { onChargingEnabledChanged(true) },
-                        trailingContent = {
-                            Icon(
-                                imageVector = Icons.TwoTone.Stars,
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.padding(start = 16.dp),
-                            )
-                        },
-                    )
-                }
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.BatteryChargingFull,
+                    title = stringResource(R.string.sync_setting_charging_enable_title),
+                    subtitle = stringResource(R.string.sync_setting_charging_enable_desc),
+                    checked = state.backgroundSyncChargingEnabled,
+                    onCheckedChange = onChargingEnabledChanged,
+                    enabled = state.backgroundSyncEnabled,
+                    requiresUpgrade = !state.isPro,
+                )
             }
             if (state.backgroundSyncChargingEnabled && state.isPro && state.backgroundSyncEnabled) {
                 item {
@@ -386,6 +368,33 @@ private fun SyncSettingsScreenPreview() = PreviewWrapper {
             backgroundSyncInterval = 60,
             backgroundSyncOnMobile = true,
             isPro = true,
+            backgroundSyncChargingEnabled = false,
+            backgroundSyncChargingInterval = 15,
+            foregroundSyncEnabled = false,
+        ),
+        onNavigateUp = {},
+        onShowDashboardCardChanged = {},
+        onDeviceLabelChanged = {},
+        onBackgroundSyncEnabledChanged = {},
+        onBackgroundSyncIntervalChanged = {},
+        onBackgroundSyncOnMobileChanged = {},
+        onChargingEnabledChanged = {},
+        onChargingIntervalChanged = {},
+        onForegroundSyncEnabledChanged = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun SyncSettingsScreenNonProPreview() = PreviewWrapper {
+    SyncSettingsScreen(
+        state = SyncSettingsVM.State(
+            showDashboardCard = true,
+            deviceLabel = null,
+            backgroundSyncEnabled = true,
+            backgroundSyncInterval = 60,
+            backgroundSyncOnMobile = true,
+            isPro = false,
             backgroundSyncChargingEnabled = false,
             backgroundSyncChargingInterval = 15,
             foregroundSyncEnabled = false,

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.common.flow.replayingShare
 import eu.darken.octi.common.flow.throttleLatest
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.module.core.device
+import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.modules.power.core.PowerInfo
 import eu.darken.octi.modules.power.core.PowerRepo
@@ -22,6 +23,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.sync.Mutex
@@ -30,6 +32,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 @Singleton
 class PowerAlertManager @Inject constructor(
@@ -41,6 +44,7 @@ class PowerAlertManager @Inject constructor(
 ) {
 
     private val mutex = Mutex()
+    private val shownNotifications = mutableSetOf<AlertNotificationKey>()
 
     val alerts: Flow<Collection<PowerAlert<*>>> = combine(
         powerSettings.alertRules.flow,
@@ -56,7 +60,9 @@ class PowerAlertManager @Inject constructor(
 
     init {
         combine(
-            powerRepo.state.throttleLatest(1.seconds),
+            powerRepo.state
+                .throttleLatest(1.seconds)
+                .distinctUntilChangedBy { it.alertRelevantStateKey() },
             powerSettings.alertRules.flow,
         ) { powerStates, alertRules ->
             processAlerts(powerStates, alertRules)
@@ -109,11 +115,12 @@ class PowerAlertManager @Inject constructor(
                                 log(TAG, INFO) { "Rule has triggered" }
                                 val newEvent = PowerAlertRule.Event(rule.id)
                                 powerSettings.alertEvents.update { it + newEvent }
-                                notifications.show(rule, powerState.data, metaState.data)
+                                showNotificationIfNeeded(rule, newEvent, powerState.data, metaState.data)
                             }
 
                             event != null && !isTriggered && isRecovered -> {
                                 log(TAG, INFO) { "Rule is no longer triggered" }
+                                shownNotifications.remove(event.notificationKey)
                                 powerSettings.alertEvents.update { it - event }
                                 notifications.dismiss(rule)
                             }
@@ -123,8 +130,8 @@ class PowerAlertManager @Inject constructor(
                             }
 
                             event != null && event.dismissedAt == null && isTriggered && !isRecovered -> {
-                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed), updating notification" }
-                                notifications.show(rule, powerState.data, metaState.data)
+                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed)" }
+                                showNotificationIfNeeded(rule, event, powerState.data, metaState.data)
                             }
                         }
                     }
@@ -139,11 +146,12 @@ class PowerAlertManager @Inject constructor(
                                 log(TAG, INFO) { "Rule has triggered" }
                                 val newEvent = PowerAlertRule.Event(rule.id)
                                 powerSettings.alertEvents.update { it + newEvent }
-                                notifications.show(rule, powerState.data, metaState.data)
+                                showNotificationIfNeeded(rule, newEvent, powerState.data, metaState.data)
                             }
 
                             event != null && !isTriggered && isRecovered -> {
                                 log(TAG, INFO) { "Rule is no longer triggered" }
+                                shownNotifications.remove(event.notificationKey)
                                 powerSettings.alertEvents.update { it - event }
                                 notifications.dismiss(rule)
                             }
@@ -153,8 +161,8 @@ class PowerAlertManager @Inject constructor(
                             }
 
                             event != null && event.dismissedAt == null && isTriggered && !isRecovered -> {
-                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed), updating notification" }
-                                notifications.show(rule, powerState.data, metaState.data)
+                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed)" }
+                                showNotificationIfNeeded(rule, event, powerState.data, metaState.data)
                             }
                         }
                     }
@@ -162,6 +170,51 @@ class PowerAlertManager @Inject constructor(
             }
         }
     }
+
+    private suspend fun showNotificationIfNeeded(
+        rule: PowerAlertRule,
+        event: PowerAlertRule.Event,
+        power: PowerInfo,
+        meta: MetaInfo,
+    ) {
+        val key = event.notificationKey
+        if (key in shownNotifications) {
+            log(TAG, VERBOSE) { "Notification already shown for $key" }
+            return
+        }
+
+        notifications.show(rule, power, meta)
+        shownNotifications += key
+    }
+
+    private val PowerAlertRule.Event.notificationKey: AlertNotificationKey
+        get() = AlertNotificationKey(
+            alertId = id,
+            triggeredAt = triggeredAt,
+        )
+
+    private fun ModuleRepo.State<PowerInfo>.alertRelevantStateKey(): Set<AlertRelevantPowerState> = all
+        .map {
+            AlertRelevantPowerState(
+                deviceId = it.deviceId,
+                isCharging = it.data.isCharging,
+                batteryLevel = it.data.battery.level,
+                batteryScale = it.data.battery.scale,
+            )
+        }
+        .toSet()
+
+    private data class AlertNotificationKey(
+        val alertId: PowerAlertRuleId,
+        val triggeredAt: Instant,
+    )
+
+    private data class AlertRelevantPowerState(
+        val deviceId: DeviceId,
+        val isCharging: Boolean,
+        val batteryLevel: Int,
+        val batteryScale: Int,
+    )
 
     suspend fun setBatteryLowAlert(deviceId: DeviceId, threshold: Float?): Unit = mutex.withLock {
         log(TAG) { "setBatteryLowAlert($deviceId,$threshold)" }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
-import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.hasApiLevel
@@ -48,7 +47,7 @@ class PowerAlertNotifications @Inject constructor(
 
         val openPi: PendingIntent = PendingIntent.getActivity(
             context,
-            0,
+            alert.pendingIntentRequestCode,
             context.packageManager.getLaunchIntentForPackage(context.packageName)!!.apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 putExtra(ARG_ALERT_ID, alert.id)
@@ -59,7 +58,7 @@ class PowerAlertNotifications @Inject constructor(
 
         val deletePi = PendingIntent.getBroadcast(
             context,
-            0,
+            alert.pendingIntentRequestCode,
             Intent(context, PowerAlertNotificationReceiver::class.java).apply {
                 action = ACTION_DISMISS
                 putExtra(ARG_ALERT_ID, alert.id)
@@ -74,6 +73,9 @@ class PowerAlertNotifications @Inject constructor(
             val hash = (deviceId.toString() + this::class.java.simpleName).hashCode()
             return NOTIFICATION_ID_RANGE_STATE + (hash.absoluteValue % 101)
         }
+
+    private val PowerAlertRule.pendingIntentRequestCode: Int
+        get() = id.hashCode() and Int.MAX_VALUE
 
     suspend fun show(rule: PowerAlertRule, power: PowerInfo, meta: MetaInfo) {
         log(TAG) { "show($rule, $meta)" }
@@ -129,8 +131,8 @@ class PowerAlertNotifications @Inject constructor(
     companion object {
         const val ARG_ALERT_ID = "alertId"
         internal const val NOTIFICATION_ID_RANGE_STATE = 1000
-        val ACTION_DISMISS = "${BuildConfigWrap.APPLICATION_ID}.module.power.alert.NOTIFICATION_DISMISSED"
-        private val CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.module.power.alerts"
+        const val ACTION_DISMISS = "eu.darken.octi.module.power.alert.NOTIFICATION_DISMISSED"
+        private const val CHANNEL_ID = "eu.darken.octi.notification.channel.module.power.alerts"
         val TAG = logTag("Module", "Power", "Alert", "Notifications")
     }
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsScreen.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -41,6 +42,7 @@ import eu.darken.octi.common.compose.PreviewWrapper
 import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.common.settings.UpgradeBadge
 import eu.darken.octi.modules.power.core.alert.BatteryHighAlertRule
 import eu.darken.octi.modules.power.core.alert.BatteryLowAlertRule
 import eu.darken.octi.modules.power.core.alert.PowerAlert
@@ -65,6 +67,7 @@ fun PowerAlertsScreenHost(
             onNavigateUp = { vm.navUp() },
             onLowBatteryThreshold = { threshold -> vm.setBatteryLowAlert(threshold) },
             onHighBatteryThreshold = { threshold -> vm.setBatteryHighAlert(threshold) },
+            onUpgrade = { vm.goUpgrade() },
         )
     }
 }
@@ -75,6 +78,7 @@ fun PowerAlertsScreen(
     onNavigateUp: () -> Unit,
     onLowBatteryThreshold: (Float) -> Unit,
     onHighBatteryThreshold: (Float) -> Unit,
+    onUpgrade: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -108,7 +112,9 @@ fun PowerAlertsScreen(
             LowBatteryCard(
                 threshold = state.batteryLowAlert?.rule?.threshold ?: 0f,
                 isActive = state.batteryLowAlert != null,
+                isPro = state.isPro,
                 onThresholdChanged = onLowBatteryThreshold,
+                onUpgrade = onUpgrade,
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -116,7 +122,9 @@ fun PowerAlertsScreen(
             HighBatteryCard(
                 threshold = state.batteryHighAlert?.rule?.threshold ?: 0f,
                 isActive = state.batteryHighAlert != null,
+                isPro = state.isPro,
                 onThresholdChanged = onHighBatteryThreshold,
+                onUpgrade = onUpgrade,
             )
         }
     }
@@ -126,7 +134,9 @@ fun PowerAlertsScreen(
 private fun LowBatteryCard(
     threshold: Float,
     isActive: Boolean,
+    isPro: Boolean,
     onThresholdChanged: (Float) -> Unit,
+    onUpgrade: () -> Unit,
 ) {
     var sliderValue by remember(threshold) { mutableFloatStateOf(threshold) }
 
@@ -140,7 +150,9 @@ private fun LowBatteryCard(
     }
 
     ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isPro, onClick = onUpgrade),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -156,6 +168,10 @@ private fun LowBatteryCard(
                     fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
+                if (!isPro) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    UpgradeBadge()
+                }
             }
 
             Text(
@@ -170,6 +186,7 @@ private fun LowBatteryCard(
                 onValueChangeFinished = { onThresholdChanged(sliderValue) },
                 valueRange = 0f..0.95f,
                 steps = 18,
+                enabled = isPro,
                 modifier = Modifier.padding(top = 8.dp),
             )
 
@@ -186,7 +203,9 @@ private fun LowBatteryCard(
 private fun HighBatteryCard(
     threshold: Float,
     isActive: Boolean,
+    isPro: Boolean,
     onThresholdChanged: (Float) -> Unit,
+    onUpgrade: () -> Unit,
 ) {
     var sliderValue by remember(threshold) { mutableFloatStateOf(threshold) }
 
@@ -200,7 +219,9 @@ private fun HighBatteryCard(
     }
 
     ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isPro, onClick = onUpgrade),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -216,6 +237,10 @@ private fun HighBatteryCard(
                     fontWeight = if (isActive) FontWeight.Bold else FontWeight.Normal,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
                 )
+                if (!isPro) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    UpgradeBadge()
+                }
             }
 
             Text(
@@ -230,6 +255,7 @@ private fun HighBatteryCard(
                 onValueChangeFinished = { onThresholdChanged(sliderValue) },
                 valueRange = 0f..1f,
                 steps = 19,
+                enabled = isPro,
                 modifier = Modifier.padding(top = 8.dp),
             )
 
@@ -249,6 +275,7 @@ private fun PowerAlertsScreenActivePreview() = PreviewWrapper {
     PowerAlertsScreen(
         state = PowerAlertsVM.State(
             deviceLabel = "Pixel 8",
+            isPro = true,
             batteryLowAlert = PowerAlert(
                 rule = BatteryLowAlertRule(deviceId = deviceId, threshold = 0.2f),
                 event = null,
@@ -261,6 +288,7 @@ private fun PowerAlertsScreenActivePreview() = PreviewWrapper {
         onNavigateUp = {},
         onLowBatteryThreshold = {},
         onHighBatteryThreshold = {},
+        onUpgrade = {},
     )
 }
 
@@ -268,9 +296,22 @@ private fun PowerAlertsScreenActivePreview() = PreviewWrapper {
 @Composable
 private fun PowerAlertsScreenDisabledPreview() = PreviewWrapper {
     PowerAlertsScreen(
-        state = PowerAlertsVM.State(deviceLabel = "Pixel 8"),
+        state = PowerAlertsVM.State(deviceLabel = "Pixel 8", isPro = true),
         onNavigateUp = {},
         onLowBatteryThreshold = {},
         onHighBatteryThreshold = {},
+        onUpgrade = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun PowerAlertsScreenNonProPreview() = PreviewWrapper {
+    PowerAlertsScreen(
+        state = PowerAlertsVM.State(deviceLabel = "Pixel 8", isPro = false),
+        onNavigateUp = {},
+        onLowBatteryThreshold = {},
+        onHighBatteryThreshold = {},
+        onUpgrade = {},
     )
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
@@ -40,6 +40,7 @@ class PowerAlertsVM @Inject constructor(
 
     data class State(
         val deviceLabel: String = "",
+        val isPro: Boolean = false,
         val batteryLowAlert: PowerAlert<BatteryLowAlertRule>? = null,
         val batteryHighAlert: PowerAlert<BatteryHighAlertRule>? = null,
     )
@@ -50,7 +51,8 @@ class PowerAlertsVM @Inject constructor(
             combine(
                 alertsManager.alerts.map { alerts -> alerts.filter { it.deviceId == deviceId } },
                 metaRepo.state,
-            ) { alerts, metaState ->
+                upgradeRepo.upgradeInfo,
+            ) { alerts, metaState, upgradeInfo ->
                 val metaData = metaState.all.firstOrNull { it.deviceId == deviceId }
 
                 if (metaData == null) {
@@ -66,12 +68,15 @@ class PowerAlertsVM @Inject constructor(
 
                 State(
                     deviceLabel = metaData.data.deviceLabel ?: metaData.data.deviceName,
+                    isPro = upgradeInfo.isPro,
                     batteryLowAlert = lowAlert,
                     batteryHighAlert = highAlert,
                 )
             }
         }
         .asStateFlow()
+
+    fun goUpgrade() = navTo(Nav.Main.Upgrade())
 
     fun initialize(deviceId: String) {
         log(TAG) { "initialize($deviceId)" }

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertManagerTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertManagerTest.kt
@@ -1,0 +1,198 @@
+package eu.darken.octi.modules.power.core.alert
+
+import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.modules.meta.MetaModule
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.core.MetaRepo
+import eu.darken.octi.modules.power.PowerModule
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.modules.power.core.PowerRepo
+import eu.darken.octi.modules.power.core.PowerSettings
+import eu.darken.octi.sync.core.DeviceId
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class PowerAlertManagerTest : BaseTest() {
+
+    private val powerRepo = mockk<PowerRepo>()
+    private val powerSettings = mockk<PowerSettings>()
+    private val notifications = mockk<PowerAlertNotifications>(relaxed = true)
+    private val metaRepo = mockk<MetaRepo>()
+
+    private val remoteDevice = DeviceId("remote")
+    private val selfDevice = DeviceId("self")
+
+    @Test
+    fun `active alert is notified only once despite repeated power updates`() = runTest2 {
+        val rule = BatteryHighAlertRule(deviceId = remoteDevice, threshold = 0.85f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(
+            setOf(PowerAlertRule.Event(id = rule.id, triggeredAt = Instant.parse("2026-05-02T12:31:07.195Z")))
+        )
+        val powerStates = MutableStateFlow(
+            powerState(remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 94, currentNow = -536190))
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        powerStates.value = powerState(
+            remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 94, currentNow = -100000),
+            self = powerInfo(status = PowerInfo.Status.CHARGING, level = 80, currentNow = 196875),
+        )
+        advanceTimeBy(1_100)
+        powerStates.value = powerState(
+            remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 95, currentNow = -100000),
+            self = powerInfo(status = PowerInfo.Status.CHARGING, level = 80, currentNow = 25781),
+        )
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { notifications.show(rule, any(), any()) }
+    }
+
+    @Test
+    fun `recovered alert can notify again after retriggering`() = runTest2 {
+        val rule = BatteryHighAlertRule(deviceId = remoteDevice, threshold = 0.85f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(emptySet<PowerAlertRule.Event>())
+        val powerStates = MutableStateFlow(
+            powerState(remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 94))
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        powerStates.value = powerState(remote = powerInfo(status = PowerInfo.Status.DISCHARGING, level = 79))
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        powerStates.value = powerState(remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 94))
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { notifications.show(rule, any(), any()) }
+        coVerify(exactly = 1) { notifications.dismiss(rule) }
+    }
+
+    private fun kotlinx.coroutines.test.TestScope.setupManager(
+        rules: StatefulValue<Set<PowerAlertRule>>,
+        events: StatefulValue<Set<PowerAlertRule.Event>>,
+        powerStates: MutableStateFlow<BaseModuleRepo.State<PowerInfo>>,
+    ): PowerAlertManager {
+        every { powerRepo.state } returns powerStates
+        every { metaRepo.state } returns MutableStateFlow(
+            BaseModuleRepo.State(
+                moduleId = MetaModule.MODULE_ID,
+                others = listOf(metaData(remoteDevice)),
+            )
+        )
+        every { powerSettings.alertRules } returns rules.value
+        every { powerSettings.alertEvents } returns events.value
+        coEvery { notifications.show(any(), any(), any()) } just runs
+        coEvery { notifications.dismiss(any()) } just runs
+
+        return PowerAlertManager(
+            appScope = backgroundScope,
+            powerRepo = powerRepo,
+            powerSettings = powerSettings,
+            notifications = notifications,
+            metaRepo = metaRepo,
+        )
+    }
+
+    private fun powerState(
+        remote: PowerInfo,
+        self: PowerInfo = powerInfo(status = PowerInfo.Status.CHARGING, level = 80),
+    ): BaseModuleRepo.State<PowerInfo> = BaseModuleRepo.State(
+        moduleId = PowerModule.MODULE_ID,
+        self = ModuleData(
+            modifiedAt = Clock.System.now(),
+            deviceId = selfDevice,
+            moduleId = PowerModule.MODULE_ID,
+            data = self,
+        ),
+        others = listOf(
+            ModuleData(
+                modifiedAt = Clock.System.now(),
+                deviceId = remoteDevice,
+                moduleId = PowerModule.MODULE_ID,
+                data = remote,
+            )
+        ),
+    )
+
+    private fun powerInfo(
+        status: PowerInfo.Status,
+        level: Int,
+        scale: Int = 100,
+        currentNow: Int? = null,
+    ) = PowerInfo(
+        status = status,
+        battery = PowerInfo.Battery(
+            level = level,
+            scale = scale,
+            health = 2,
+            temp = 33.5f,
+        ),
+        chargeIO = PowerInfo.ChargeIO(
+            currentNow = currentNow,
+            currenAvg = null,
+            fullSince = null,
+            fullAt = null,
+            emptyAt = null,
+        ),
+    )
+
+    private fun metaData(deviceId: DeviceId) = ModuleData(
+        modifiedAt = Clock.System.now(),
+        deviceId = deviceId,
+        moduleId = MetaModule.MODULE_ID,
+        data = MetaInfo(
+            deviceLabel = "Pixel 1",
+            deviceId = deviceId,
+            octiVersionName = "1.0.0-beta1",
+            octiGitSha = "test",
+            deviceManufacturer = "Google",
+            deviceName = "Pixel XL",
+            deviceType = MetaInfo.DeviceType.PHONE,
+            deviceBootedAt = Clock.System.now(),
+            androidVersionName = "10",
+            androidApiLevel = 29,
+            androidSecurityPatch = "2019-10-06",
+        ),
+    )
+
+    private fun <T> statefulValue(initial: T): StatefulValue<T> = StatefulValue(initial)
+
+    private class StatefulValue<T>(initial: T) {
+        val flow = MutableStateFlow(initial)
+        val value = mockk<DataStoreValue<T>> {
+            every { flow } returns this@StatefulValue.flow
+            every { keyName } returns "test"
+            coEvery { update(any()) } coAnswers {
+                val transform = firstArg<(T) -> T?>()
+                val old = this@StatefulValue.flow.value
+                val new = transform(old) ?: old
+                this@StatefulValue.flow.value = new
+                DataStoreValue.Updated(old, new)
+            }
+        }
+    }
+}

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
@@ -8,8 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -34,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
+import eu.darken.octi.common.settings.UpgradeBadge
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
@@ -122,19 +122,14 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
                         text = stringResource(SyncR.string.sync_connector_paused_label),
                         modifier = Modifier.weight(1f),
                     )
-                    if (isPro) {
-                        Switch(
-                            checked = isPaused,
-                            onCheckedChange = null,
-                        )
-                    } else {
-                        M3Icon(
-                            imageVector = Icons.TwoTone.Stars,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(start = 16.dp),
-                        )
+                    if (!isPro) {
+                        UpgradeBadge()
+                        Spacer(modifier = Modifier.width(8.dp))
                     }
+                    Switch(
+                        checked = isPaused,
+                        onCheckedChange = null,
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
@@ -7,13 +7,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
-import androidx.compose.material3.Icon as M3Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
@@ -33,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
+import eu.darken.octi.common.settings.UpgradeBadge
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
@@ -139,19 +138,14 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                         text = stringResource(SyncR.string.sync_connector_paused_label),
                         modifier = Modifier.weight(1f),
                     )
-                    if (canTogglePause) {
-                        Switch(
-                            checked = isPaused,
-                            onCheckedChange = null,
-                        )
-                    } else {
-                        M3Icon(
-                            imageVector = Icons.TwoTone.Stars,
-                            contentDescription = null,
-                            tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(start = 16.dp),
-                        )
+                    if (!canTogglePause) {
+                        UpgradeBadge()
+                        Spacer(modifier = Modifier.width(8.dp))
                     }
+                    Switch(
+                        checked = isPaused,
+                        onCheckedChange = null,
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Summary

### Unified Pro-gating UI

- All Pro-gated settings rows now share a single consistent UI: a star + "Pro" badge ("FOSS" on the FOSS flavor) appended to the row title, with the real Switch / list-preference selector still visible at full opacity. Tapping the row navigates to the upgrade screen.
- Replaces the two prior inconsistent patterns (dim-with-`onDisabledClick` on theme settings; star-icon-replaces-toggle on charging sync, apps installer, and connector pause toggles).
- Battery alert thresholds in Power Alerts now show the badge on each card title and disable the slider when not Pro — fixes the bad UX where dragging the slider triggered an unexpected upgrade-screen pop-up.
- Adds VM-level `requirePro()` guards to settings VMs that previously wrote directly to DataStore without checking Pro status (theme settings, apps installer, power alerts) — UI gating is a UX optimisation, the VM guard is the security boundary.

### Power alert notification dedup

- An active battery alert no longer re-notifies on every power update — notifications are keyed by triggered-alert id+timestamp and only shown once per trigger. Previously, the system spammed the same notification every time the battery level/charging state changed while the alert was active.
- Per-alert `PendingIntent` request codes so dismissing one alert's notification doesn't collapse with another's.
- Adds `PowerAlertManagerTest` covering "active alert notified only once" and "recovered alert can re-notify after re-triggering".

## Test plan

- [x] `./gradlew assembleFossDebug assembleGplayDebug`
- [x] `./gradlew testFossDebugUnitTest testGplayDebugUnitTest`
- [x] gplay (non-Pro): theme rows, charging sync, apps installer all show "Pro" badge at full opacity; tap → Upgrade.
- [x] FOSS (clean install, non-Pro): same rows show "FOSS" badge; tap → Upgrade.
