### PR TITLE
Fix GDrive sync not showing device data after restart

### DIFF
--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -340,11 +340,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     }
 
     private suspend fun GDriveEnvironment.readAppDataIndex(): AppDataIndex {
-        val root = GDriveFile().apply {
-            id = APPDATAFOLDER
-            name = APPDATAFOLDER
-            mimeType = MIME_FOLDER
-        }
+        val root = appDataRoot
         val files = listAppDataFiles()
         val childrenByParent = buildMap<String, MutableList<GDriveFile>> {
             files.forEach { file ->
@@ -355,6 +351,46 @@ class GDriveAppDataConnector @AssistedInject constructor(
         }
         log(TAG, VERBOSE) { "readAppDataIndex(): ${files.size} files" }
         return AppDataIndex(root = root, childrenByParent = childrenByParent)
+    }
+
+    private suspend fun updateDeviceMetadataFromData(data: SyncRead) {
+        val fallbackMetadata = data.devices.map { device ->
+            DeviceMetadata(
+                deviceId = device.deviceId,
+                lastSeen = device.modules.maxOfOrNull { it.modifiedAt },
+            )
+        }
+        if (fallbackMetadata.isEmpty()) return
+
+        _state.updateBlocking {
+            val current = deviceMetadata.associateBy { it.deviceId }.toMutableMap()
+            var changed = false
+            fallbackMetadata.forEach { fallback ->
+                val existing = current[fallback.deviceId]
+                val existingLastSeen = existing?.lastSeen
+                val fallbackLastSeen = fallback.lastSeen
+                when {
+                    existing == null -> {
+                        current[fallback.deviceId] = fallback
+                        changed = true
+                    }
+
+                    fallbackLastSeen != null && (existingLastSeen == null || fallbackLastSeen > existingLastSeen) -> {
+                        current[fallback.deviceId] = existing.copy(lastSeen = fallbackLastSeen)
+                        changed = true
+                    }
+                }
+            }
+            if (changed) copy(deviceMetadata = current.values.toList()) else this
+        }
+    }
+
+    private suspend fun hasMissingDeviceMetadata(): Boolean {
+        val dataDeviceIds = _data.value?.devices.orEmpty().map { it.deviceId }.toSet()
+        if (dataDeviceIds.isEmpty()) return false
+
+        val metadataDeviceIds = _state.value().deviceMetadata.map { it.deviceId }.toSet()
+        return !metadataDeviceIds.containsAll(dataDeviceIds)
     }
 
     private suspend fun GDriveEnvironment.readDrive(
@@ -716,6 +752,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
             }
         }
 
+        var initialReadFailed: Exception? = null
+
         try {
             runDriveAction("sync-sync") {
                 var wroteData = false
@@ -746,6 +784,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     }
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "handleSync(): Failed to read/stats: ${e.asLog()}" }
+                    if (_data.value == null) initialReadFailed = e
                 }
                 log(TAG, VERBOSE) { "handleSync(...): readData finished (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
             }
@@ -755,6 +794,9 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 log(TAG, VERBOSE) { "handleSync(): Sync done, releasing (took ${start.elapsedNow().inWholeMilliseconds}ms)" }
             }
         }
+
+        // runDriveAction clears lastError on success; override when initial hydration failed
+        initialReadFailed?.let { _state.updateBlocking { copy(lastError = it) } }
     }
 
     private suspend fun GDriveEnvironment.refreshDeviceMetadataSafely(source: String) {
@@ -771,26 +813,34 @@ class GDriveAppDataConnector @AssistedInject constructor(
         val existing = _data.value
         if (existing == null) {
             log(TAG) { "handleSync(): First sync, forcing full read despite filters" }
-            _data.value = readDrive(refreshDeviceMetadata = options.stats)
+            val newData = readDrive(refreshDeviceMetadata = options.stats)
+            _data.value = newData
+            updateDeviceMetadataFromData(newData)
             val startToken = drive.changes().getStartPageToken()
                 .setSupportsAllDrives(false)
                 .execute().startPageToken
             syncToken.value(startToken)
         } else {
             val newData = readTargeted(options, refreshStats = options.stats)
-            _data.value = mergeData(existing, newData, options.moduleFilter)
+            val mergedData = mergeData(existing, newData, options.moduleFilter)
+            _data.value = mergedData
+            updateDeviceMetadataFromData(mergedData)
         }
     }
 
     private suspend fun GDriveEnvironment.handleFullRead(options: SyncOptions, wroteData: Boolean) {
         when (val result = checkSyncChanges()) {
             is SyncChangeResult.HasChanges -> {
-                _data.value = readDrive(refreshDeviceMetadata = options.stats)
+                val newData = readDrive(refreshDeviceMetadata = options.stats)
+                _data.value = newData
+                updateDeviceMetadataFromData(newData)
                 syncToken.value(result.newToken)
             }
 
             is SyncChangeResult.ForceFullSync -> {
-                _data.value = readDrive(refreshDeviceMetadata = options.stats)
+                val newData = readDrive(refreshDeviceMetadata = options.stats)
+                _data.value = newData
+                updateDeviceMetadataFromData(newData)
                 val startToken = drive.changes().getStartPageToken()
                     .setSupportsAllDrives(false)
                     .execute().startPageToken
@@ -798,9 +848,18 @@ class GDriveAppDataConnector @AssistedInject constructor(
             }
 
             is SyncChangeResult.NoChanges -> {
-                log(TAG) { "handleSync(): No changes detected, skipping readDrive()" }
-                if (wroteData && options.stats) {
+                if (_data.value == null) {
+                    log(TAG) { "handleSync(): No cached data, forcing initial read" }
+                    val newData = readDrive(refreshDeviceMetadata = options.stats)
+                    _data.value = newData
+                    updateDeviceMetadataFromData(newData)
+                } else if (options.stats && hasMissingDeviceMetadata()) {
+                    log(TAG) { "handleSync(): No changes but device metadata is incomplete, refreshing" }
+                    refreshDeviceMetadataSafely("metadata-missing")
+                } else if (wroteData && options.stats) {
                     refreshDeviceMetadataSafely("post-write")
+                } else {
+                    log(TAG) { "handleSync(): No changes detected, skipping readDrive()" }
                 }
             }
         }

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -324,6 +324,41 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 .value()
             token.shouldNotBeBlank()
         }
+
+        @Test
+        fun `restart with valid token still reads drive when data is uninitialized`() = runTest {
+            val connector = createConnector()
+
+            // Pre-populate sync token, simulating a previous session that left a valid token
+            syncSettings.dataStore
+                .createValue("gdrive.sync_token.test-account", null as String?)
+                .value("pre-existing-token")
+
+            setupEmptyDriveRead()
+            setupNoChanges("pre-existing-token")
+
+            // First sync after restart: _data is null but NoChanges — should still do full read
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            // Data must be non-null even though the change guard said "no changes"
+            connector.data.first().shouldNotBeNull()
+
+            // Second sync: data already loaded, still no changes — optimization must kick in
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            setupNoChanges("pre-existing-token")
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            verify(exactly = 0) { mockFiles.get(any()) }
+            verify(exactly = 0) { mockFiles.list() }
+        }
     }
 
     @Nested
@@ -435,9 +470,10 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             payload: String = "power-data",
             deviceId: DeviceId = deviceA,
             includeDeviceInfo: Boolean = false,
+            appDataRootId: String = "appDataFolder",
         ) {
             val rootFile = GDriveFile().apply {
-                id = "appDataFolder"
+                id = appDataRootId
                 name = "appDataFolder"
                 mimeType = "application/vnd.google-apps.folder"
             }
@@ -445,7 +481,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 id = "devices-dir-id"
                 name = "devices"
                 mimeType = "application/vnd.google-apps.folder"
-                parents = listOf("appDataFolder")
+                parents = listOf(appDataRootId)
             }
             val deviceADir = GDriveFile().apply {
                 id = "device-a-dir-id"
@@ -547,15 +583,19 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         }
 
         @Test
-        fun `full read uses one appData metadata listing`() = runTest {
+        fun `full read indexes devices under resolved appData root id`() = runTest {
             val connector = createConnector()
             setupStartPageToken("start-token")
-            setupDriveWithPowerModule("indexed", includeDeviceInfo = true)
+            setupDriveWithPowerModule(
+                payload = "indexed",
+                includeDeviceInfo = true,
+                appDataRootId = "resolved-appdata-root-id",
+            )
 
             connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
 
             verify(exactly = 1) { mockFilesList.execute() }
-            verify(exactly = 0) { mockFiles.get("appDataFolder") }
+            verify(exactly = 1) { mockFiles.get("appDataFolder") }
             val data = connector.data.first()
             data.shouldNotBeNull()
             data.devices.single().modules.single().payload.utf8() shouldBe "indexed"
@@ -616,6 +656,10 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
                 .modules
                 .first { it.moduleId == power }
             module.payload.utf8() shouldBe "updated"
+
+            val metadata = connector.state.first().deviceMetadata.single()
+            metadata.deviceId shouldBe deviceA
+            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(2000L)
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Fix device directory lookup silently failing: `readAppDataIndex()` hardcoded `"appDataFolder"` as the root ID, but the Drive API resolves it to a real UUID — so children indexed under the real parent ID were never found, producing "No device data dir found" and no module data from other devices
- Force a full Drive read on the first sync after restart even when the change token reports no changes — previously `_data` stayed null until something actually changed on Drive, causing a long delay before other devices appeared
- Add fallback device metadata derivation from module timestamps so device entries are populated even when an explicit metadata refresh was not requested
