### PR TITLE
Cache sync device metadata

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
@@ -71,7 +71,7 @@ internal fun DeviceRow(
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = item.metaInfo?.labelOrFallback ?: item.deviceId.id.take(8),
+                        text = item.metaInfo?.labelOrFallback ?: item.serverLabel ?: item.deviceId.id.take(8),
                         style = MaterialTheme.typography.titleSmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -85,6 +85,7 @@ class SyncDevicesVM @Inject constructor(
         val serverVersion: String?,
         val serverAddedAt: Instant?,
         val serverPlatform: String?,
+        val serverLabel: String? = null,
         val issues: List<ConnectorIssue> = emptyList(),
     )
 
@@ -131,9 +132,10 @@ class SyncDevicesVM @Inject constructor(
                         serverVersion = deviceMeta.version,
                         serverAddedAt = deviceMeta.addedAt,
                         serverPlatform = deviceMeta.platform,
+                        serverLabel = deviceMeta.label,
                         issues = allIssues.filter { it.connectorId == connectorId && it.deviceId == deviceId },
                     )
-                }.sortedBy { it.metaInfo?.labelOrFallback?.lowercase() }
+                }.sortedBy { (it.metaInfo?.labelOrFallback ?: it.serverLabel ?: it.deviceId.id).lowercase() }
 
                 val deletingIds = operations
                     .filter { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
@@ -1,13 +1,25 @@
 package eu.darken.octi.sync.core
 
+import eu.darken.octi.common.serialization.serializer.InstantSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 import kotlin.time.Instant
 
+@Serializable
 data class DeviceMetadata(
+    @SerialName("deviceId")
     val deviceId: DeviceId,
+    @SerialName("version")
     val version: String? = null,
+    @SerialName("platform")
     val platform: String? = null,
+    @SerialName("label")
     val label: String? = null,
+    @Serializable(with = InstantSerializer::class)
+    @SerialName("lastSeen")
     val lastSeen: Instant? = null,
+    @Serializable(with = InstantSerializer::class)
+    @SerialName("addedAt")
     val addedAt: Instant? = null,
 )
 

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -245,6 +245,7 @@ class SyncManager @Inject constructor(
             return@withContext
         }
         getConnectorById<SyncConnector>(identifier).first().execute(ConnectorCommand.Reset)
+        syncCache.removeDeviceMetadata(identifier)
         log(TAG) { "resetData(identifier=$identifier) done" }
     }
 
@@ -266,6 +267,7 @@ class SyncManager @Inject constructor(
             hubs.first().filter { it.owns(identifier) }.forEach {
                 it.remove(identifier)
             }
+            syncCache.removeDeviceMetadata(identifier)
         } catch (e: Exception) {
             log(TAG, ERROR) { "disconnect(...) failed: ${e.asLog()}" }
             throw e

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadata.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadata.kt
@@ -1,0 +1,20 @@
+package eu.darken.octi.sync.core.cache
+
+import eu.darken.octi.common.serialization.serializer.InstantSerializer
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceMetadata
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Instant
+
+@Serializable
+data class CachedConnectorDeviceMetadata(
+    @SerialName("schemaVersion") val schemaVersion: Int = SCHEMA_VERSION,
+    @SerialName("connectorId") val connectorId: ConnectorId,
+    @Serializable(with = InstantSerializer::class) @SerialName("cachedAt") val cachedAt: Instant,
+    @SerialName("devices") val devices: List<DeviceMetadata> = emptyList(),
+) {
+    companion object {
+        const val SCHEMA_VERSION = 1
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/cache/SyncCache.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/cache/SyncCache.kt
@@ -11,14 +11,17 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.hashing.Hash
 import eu.darken.octi.common.hashing.toHash
 import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.SyncRead
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Clock
 
 @Singleton
 class SyncCache @Inject constructor(
@@ -28,6 +31,7 @@ class SyncCache @Inject constructor(
 ) {
     private val cacheLock = Mutex()
     private val cacheDir by lazy { File(context.cacheDir, "sync_caches").also { it.mkdirs() } }
+    private val deviceMetadataCacheDir by lazy { File(cacheDir, "device_metadata").also { it.mkdirs() } }
 
     private suspend inline fun <reified T> guard(crossinline block: () -> T) = withContext(dispatcherProvider.IO) {
         cacheLock.withLock {
@@ -36,6 +40,8 @@ class SyncCache @Inject constructor(
     }
 
     private fun ConnectorId.toCacheFile() = File(cacheDir, "$type-${idString.toHash(Hash.Algo.SHA256)}")
+    private fun ConnectorId.toDeviceMetadataCacheFile() =
+        File(deviceMetadataCacheDir, "$type-${idString.toHash(Hash.Algo.SHA256)}.json")
 
     suspend fun load(id: ConnectorId): SyncRead? = guard {
         log(TAG, VERBOSE) { "load(id=$id)" }
@@ -76,6 +82,81 @@ class SyncCache @Inject constructor(
         }
     }
 
+    suspend fun loadDeviceMetadata(id: ConnectorId): List<DeviceMetadata>? = guard {
+        log(TAG, VERBOSE) { "loadDeviceMetadata(id=$id)" }
+        val cacheFile = id.toDeviceMetadataCacheFile()
+        try {
+            if (!cacheFile.exists()) return@guard null
+
+            val cached = json.decodeFromString<CachedConnectorDeviceMetadata>(cacheFile.readText())
+            if (cached.schemaVersion != CachedConnectorDeviceMetadata.SCHEMA_VERSION) {
+                discardDeviceMetadataCache(cacheFile, "unsupported schema ${cached.schemaVersion}")
+                return@guard null
+            }
+            if (cached.connectorId != id) {
+                discardDeviceMetadataCache(cacheFile, "connector mismatch")
+                return@guard null
+            }
+            cached.devices.also {
+                log(TAG, VERBOSE) { "loadDeviceMetadata(id=$id): ${it.size} devices" }
+            }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to load cached device metadata: ${e.asLog()}" }
+            discardDeviceMetadataCache(cacheFile, "decode failed")
+            null
+        }
+    }
+
+    suspend fun saveDeviceMetadata(id: ConnectorId, devices: List<DeviceMetadata>): Unit = guard {
+        log(TAG, VERBOSE) { "saveDeviceMetadata(id=$id, devices=${devices.size})" }
+        try {
+            val cached = CachedConnectorDeviceMetadata(
+                connectorId = id,
+                cachedAt = Clock.System.now(),
+                devices = devices,
+            )
+            val cacheFile = id.toDeviceMetadataCacheFile()
+            cacheFile.parentFile?.mkdirs()
+            cacheFile.writeTextAtomic(json.encodeToString(cached))
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to cache device metadata: ${e.asLog()}" }
+        }
+    }
+
+    private fun discardDeviceMetadataCache(cacheFile: File, reason: String) {
+        log(TAG, WARN) { "Discarding device metadata cache ($reason): $cacheFile" }
+        if (cacheFile.exists() && !cacheFile.delete()) {
+            log(TAG, WARN) { "Failed to delete invalid device metadata cache: $cacheFile" }
+        }
+    }
+
+    private fun File.writeTextAtomic(text: String) {
+        val parent = parentFile ?: throw IOException("Cache file has no parent: $this")
+        parent.mkdirs()
+        val tmpFile = File(parent, "$name.tmp")
+
+        try {
+            if (tmpFile.exists() && !tmpFile.delete()) {
+                throw IOException("Failed to delete stale temp cache file: $tmpFile")
+            }
+
+            tmpFile.writeText(text)
+
+            if (!tmpFile.renameTo(this)) {
+                if (exists() && !delete()) {
+                    throw IOException("Failed to delete old cache file: $this")
+                }
+                if (!tmpFile.renameTo(this)) {
+                    throw IOException("Failed to rename temp cache file $tmpFile to $this")
+                }
+            }
+        } finally {
+            if (tmpFile.exists() && !tmpFile.delete()) {
+                log(TAG, WARN) { "Failed to delete temp cache file: $tmpFile" }
+            }
+        }
+    }
+
     private fun SyncRead.toCached(mappedDevices: List<CachedSyncRead.Device>) = CachedSyncRead(
         connectorId = connectorId,
         devices = mappedDevices,
@@ -102,6 +183,12 @@ class SyncCache @Inject constructor(
         if (!success) log(TAG, WARN) { "Failed to delete $cacheFile" }
     }
 
+    suspend fun removeDeviceMetadata(id: ConnectorId) = guard {
+        log(TAG) { "removeDeviceMetadata(id=$id)" }
+        val cacheFile = id.toDeviceMetadataCacheFile()
+        val success = cacheFile.delete()
+        if (!success && cacheFile.exists()) log(TAG, WARN) { "Failed to delete $cacheFile" }
+    }
 
     companion object {
         private val TAG = logTag("Sync", "Cache")

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadataSerializationTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadataSerializationTest.kt
@@ -1,0 +1,83 @@
+package eu.darken.octi.sync.core.cache
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+import kotlin.time.Instant
+
+class CachedConnectorDeviceMetadataSerializationTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    private val testConnectorId = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "prod", account = "acc-123")
+    private val testDeviceId = DeviceId(id = "device-abc")
+
+    private val fullCache = CachedConnectorDeviceMetadata(
+        connectorId = testConnectorId,
+        cachedAt = Instant.parse("2026-05-02T10:15:30Z"),
+        devices = listOf(
+            DeviceMetadata(
+                deviceId = testDeviceId,
+                version = "1.2.3",
+                platform = "android",
+                label = "Pixel 8",
+                lastSeen = Instant.parse("2026-05-02T10:14:00Z"),
+                addedAt = Instant.parse("2026-04-01T09:00:00Z"),
+            )
+        ),
+    )
+
+    @Test
+    fun `round-trip serialization`() {
+        val encoded = json.encodeToString(fullCache)
+        val decoded = json.decodeFromString<CachedConnectorDeviceMetadata>(encoded)
+        decoded shouldBe fullCache
+    }
+
+    @Test
+    fun `wire format stability`() {
+        val encoded = json.encodeToString(fullCache)
+        encoded.toComparableJson() shouldBe """
+            {
+                "schemaVersion": 1,
+                "connectorId": {"type": "kserver", "subtype": "prod", "account": "acc-123"},
+                "cachedAt": "2026-05-02T10:15:30Z",
+                "devices": [
+                    {
+                        "deviceId": {"id": "device-abc"},
+                        "version": "1.2.3",
+                        "platform": "android",
+                        "label": "Pixel 8",
+                        "lastSeen": "2026-05-02T10:14:00Z",
+                        "addedAt": "2026-04-01T09:00:00Z"
+                    }
+                ]
+            }
+        """.toComparableJson()
+    }
+
+    @Test
+    fun `forward compatibility - unknown fields are ignored`() {
+        val futureJson = """
+            {
+                "schemaVersion": 1,
+                "connectorId": {"type": "kserver", "subtype": "prod", "account": "acc-123"},
+                "cachedAt": "2026-05-02T10:15:30Z",
+                "devices": [],
+                "futureField": "ignored"
+            }
+        """
+        val decoded = json.decodeFromString<CachedConnectorDeviceMetadata>(futureJson)
+        decoded.devices shouldBe emptyList()
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/cache/SyncCacheTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/cache/SyncCacheTest.kt
@@ -1,0 +1,154 @@
+package eu.darken.octi.sync.core.cache
+
+import android.content.Context
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import kotlin.time.Instant
+
+class SyncCacheTest : BaseTest() {
+
+    @TempDir
+    lateinit var cacheDir: File
+
+    private val context = mockk<Context>()
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+    private val connectorId = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "prod", account = "acc-123")
+
+    private fun newCache(): SyncCache {
+        every { context.cacheDir } returns cacheDir
+        return SyncCache(json, TestDispatcherProvider(), context)
+    }
+
+    private fun metadataFiles(): List<File> = cacheDir
+        .walkTopDown()
+        .filter { it.isFile }
+        .toList()
+
+    private fun cachedMetadataFile(): File = metadataFiles().single()
+
+    @Test
+    fun `device metadata round-trip`() = runTest {
+        val cache = newCache()
+        val metadata = listOf(
+            DeviceMetadata(
+                deviceId = DeviceId("device-abc"),
+                version = "1.2.3",
+                platform = "android",
+                label = "Pixel 8",
+                lastSeen = Instant.parse("2026-05-02T10:14:00Z"),
+                addedAt = Instant.parse("2026-04-01T09:00:00Z"),
+            )
+        )
+
+        cache.saveDeviceMetadata(connectorId, metadata)
+
+        cache.loadDeviceMetadata(connectorId) shouldBe metadata
+        metadataFiles().none { it.name.endsWith(".tmp") } shouldBe true
+    }
+
+    @Test
+    fun `empty device metadata is cached as empty list`() = runTest {
+        val cache = newCache()
+
+        cache.saveDeviceMetadata(connectorId, emptyList())
+
+        cache.loadDeviceMetadata(connectorId) shouldBe emptyList()
+    }
+
+    @Test
+    fun `remove device metadata deletes cached entry`() = runTest {
+        val cache = newCache()
+        cache.saveDeviceMetadata(connectorId, listOf(DeviceMetadata(deviceId = DeviceId("device-abc"))))
+
+        cache.removeDeviceMetadata(connectorId)
+
+        cache.loadDeviceMetadata(connectorId).shouldBeNull()
+    }
+
+    @Test
+    fun `corrupt device metadata cache returns null`() = runTest {
+        val cache = newCache()
+        cache.saveDeviceMetadata(connectorId, listOf(DeviceMetadata(deviceId = DeviceId("device-abc"))))
+        cachedMetadataFile().writeText("not-json")
+
+        cache.loadDeviceMetadata(connectorId).shouldBeNull()
+        metadataFiles() shouldBe emptyList()
+    }
+
+    @Test
+    fun `unsupported device metadata schema returns null and deletes cached entry`() = runTest {
+        val cache = newCache()
+        cache.saveDeviceMetadata(connectorId, listOf(DeviceMetadata(deviceId = DeviceId("device-abc"))))
+        cachedMetadataFile().writeText(
+            """
+                {
+                    "schemaVersion": 999,
+                    "connectorId": {"type": "kserver", "subtype": "prod", "account": "acc-123"},
+                    "cachedAt": "2026-05-02T10:15:30Z",
+                    "devices": []
+                }
+            """.trimIndent()
+        )
+
+        cache.loadDeviceMetadata(connectorId).shouldBeNull()
+        metadataFiles() shouldBe emptyList()
+    }
+
+    @Test
+    fun `connector id mismatch returns null and deletes cached entry`() = runTest {
+        val cache = newCache()
+        cache.saveDeviceMetadata(connectorId, listOf(DeviceMetadata(deviceId = DeviceId("device-abc"))))
+        cachedMetadataFile().writeText(
+            """
+                {
+                    "schemaVersion": 1,
+                    "connectorId": {"type": "kserver", "subtype": "prod", "account": "other-account"},
+                    "cachedAt": "2026-05-02T10:15:30Z",
+                    "devices": []
+                }
+            """.trimIndent()
+        )
+
+        cache.loadDeviceMetadata(connectorId).shouldBeNull()
+        metadataFiles() shouldBe emptyList()
+    }
+
+    @Test
+    fun `missing optional device metadata fields deserialize`() = runTest {
+        val cache = newCache()
+        cache.saveDeviceMetadata(connectorId, emptyList())
+        cachedMetadataFile().writeText(
+            """
+                {
+                    "schemaVersion": 1,
+                    "connectorId": {"type": "kserver", "subtype": "prod", "account": "acc-123"},
+                    "cachedAt": "2026-05-02T10:15:30Z",
+                    "devices": [
+                        {
+                            "deviceId": {"id": "device-minimal"}
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        cache.loadDeviceMetadata(connectorId) shouldBe listOf(DeviceMetadata(deviceId = DeviceId("device-minimal")))
+    }
+}

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -42,6 +42,7 @@ import eu.darken.octi.sync.core.SyncRead
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.SyncWriteContainer
+import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.APPDATAFOLDER
 import eu.darken.octi.syncs.gdrive.core.GDriveEnvironment.Companion.MIME_FOLDER
 import kotlinx.coroutines.CancellationException
@@ -83,6 +84,7 @@ import com.google.api.services.drive.model.File as GDriveFile
 
 class GDriveAppDataConnector @AssistedInject constructor(
     @Assisted account: GoogleAccount,
+    @Assisted private val initialDeviceMetadata: List<DeviceMetadata>,
     @AppScope private val scope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     @ApplicationContext private val context: Context,
@@ -90,6 +92,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     private val supportedModuleIds: Set<@JvmSuppressWildcards ModuleId>,
     private val syncSettings: SyncSettings,
     private val syncState: ConnectorSyncState,
+    private val syncCache: SyncCache,
     private val json: Json,
 ) : GDriveBaseConnector(dispatcherProvider, context, account), SyncConnector {
 
@@ -106,7 +109,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         parentScope = scope + dispatcherProvider.IO,
         loggingTag = TAG,
     ) {
-        State()
+        State(deviceMetadata = initialDeviceMetadata)
     }
 
     override val state: Flow<State> = _state.flow
@@ -281,6 +284,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 }
         }
         syncState.clearConnector(identifier)
+        _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+        syncCache.removeDeviceMetadata(identifier)
     }
 
     private suspend fun handleDeleteDevice(deviceId: DeviceId): Unit = withContext(NonCancellable) {
@@ -303,9 +308,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
             }
         }
         // Eager prune: survives VM teardown and is visible immediately to all observers.
-        _state.updateBlocking {
-            copy(deviceMetadata = deviceMetadata.filterNot { it.deviceId == deviceId })
-        }
+        val prunedMetadata = _state.value().deviceMetadata.filterNot { it.deviceId == deviceId }
+        updateDeviceMetadata(prunedMetadata)
         _data.value = _data.value?.let { read ->
             GDriveData(
                 connectorId = read.connectorId,
@@ -410,7 +414,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         if (deviceDataDir?.isDirectory != true) {
             log(TAG, WARN) { "No device data dir found ($deviceDataDir)" }
             if (refreshDeviceMetadata) {
-                _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+                updateDeviceMetadata(emptyList())
             }
             return GDriveData(
                 connectorId = identifier,
@@ -432,7 +436,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
         if (refreshDeviceMetadata) {
             // Stats are updated before payload downloads so a module read failure does not freeze metadata.
-            _state.updateBlocking { copy(deviceMetadata = readDeviceMetadata(index, allDeviceDirs)) }
+            updateDeviceMetadata(readDeviceMetadata(index, allDeviceDirs))
         }
 
         val validDeviceDirs = if (deviceFilter != null) {
@@ -494,7 +498,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
         val index = readAppDataIndex()
         val deviceDataDir = index.rootChild(DEVICE_DATA_DIR_NAME)
         if (deviceDataDir?.isDirectory != true) {
-            _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+            updateDeviceMetadata(emptyList())
             return
         }
         rootChildCache[DEVICE_DATA_DIR_NAME] = deviceDataDir.id
@@ -504,7 +508,12 @@ class GDriveAppDataConnector @AssistedInject constructor(
             deviceDirCache[deviceId] = dir.id
             parentCache[dir.id] = dir.name
         }
-        _state.updateBlocking { copy(deviceMetadata = readDeviceMetadata(index, deviceDirs)) }
+        updateDeviceMetadata(readDeviceMetadata(index, deviceDirs))
+    }
+
+    private suspend fun updateDeviceMetadata(metadata: List<DeviceMetadata>) {
+        _state.updateBlocking { copy(deviceMetadata = metadata) }
+        syncCache.saveDeviceMetadata(identifier, metadata)
     }
 
     private suspend fun GDriveEnvironment.readDeviceMetadata(
@@ -1044,7 +1053,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(account: GoogleAccount): GDriveAppDataConnector
+        fun create(account: GoogleAccount, initialDeviceMetadata: List<DeviceMetadata>): GDriveAppDataConnector
     }
 
     companion object {

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveHub.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveHub.kt
@@ -11,11 +11,13 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.flow.shareLatest
+import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorHub
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.sync.core.execute
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -26,6 +28,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -38,6 +42,7 @@ class GDriveHub @Inject constructor(
     private val accountRepo: GoogleAccountRepo,
     private val connectorFactory: GDriveAppDataConnector.Factory,
     private val syncSettings: SyncSettings,
+    private val syncCache: SyncCache,
 ) : ConnectorHub {
 
     private data class Live(
@@ -47,6 +52,7 @@ class GDriveHub @Inject constructor(
     )
 
     private val live = ConcurrentHashMap<GoogleAccount.Id, Live>()
+    private val reconcileLock = Mutex()
 
     private val _connectors: Flow<Collection<GDriveAppDataConnector>> = accountRepo.accounts
         .map { accounts -> reconcile(accounts) }
@@ -55,8 +61,7 @@ class GDriveHub @Inject constructor(
 
     override val connectors: Flow<Collection<GDriveAppDataConnector>> = _connectors
 
-    @Synchronized
-    private fun reconcile(accounts: Collection<GoogleAccount>): Collection<GDriveAppDataConnector> {
+    private suspend fun reconcile(accounts: Collection<GoogleAccount>): Collection<GDriveAppDataConnector> = reconcileLock.withLock {
         val currentKeys = accounts.map { it.id }.toSet()
 
         // Remove gone accounts — cancel their processor scope.
@@ -70,19 +75,27 @@ class GDriveHub @Inject constructor(
 
         // Add new accounts — spin up connector + processor on a connector-lifetime scope.
         accounts.forEach { account ->
-            live.computeIfAbsent(account.id) {
+            if (!live.containsKey(account.id)) {
                 log(TAG, INFO) { "Creating connector for $account" }
+                val connectorId = account.toConnectorId()
+                val initialDeviceMetadata = syncCache.loadDeviceMetadata(connectorId).orEmpty()
                 val connectorScope = CoroutineScope(appScope.coroutineContext + SupervisorJob())
-                val connector = connectorFactory.create(account)
+                val connector = connectorFactory.create(account, initialDeviceMetadata)
                 val job = connector.start(connectorScope)
                 // Kick off an initial read-only sync; fire-and-forget via the queue.
                 connector.submit(ConnectorCommand.Sync(SyncOptions(writeData = false)))
-                Live(connector, connectorScope, job)
+                live[account.id] = Live(connector, connectorScope, job)
             }
         }
 
-        return live.values.map { it.connector }
+        return@withLock live.values.map { it.connector }
     }
+
+    private fun GoogleAccount.toConnectorId() = ConnectorId(
+        type = ConnectorType.GDRIVE,
+        subtype = "appdatascope",
+        account = id.id,
+    )
 
     override suspend fun owns(connectorId: ConnectorId): Boolean {
         return _connectors.first().any { it.identifier == connectorId }

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -16,12 +16,14 @@ import eu.darken.octi.sync.core.BlobKey
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorSyncState
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.blob.BlobMetadata
 import eu.darken.octi.sync.core.blob.StorageStatusProvider
+import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.sync.core.execute
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldBeNull
@@ -38,6 +40,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import okio.Buffer
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -94,7 +97,10 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         syncSettings = mockk(relaxed = true)
     }
 
-    private fun TestScope.createConnector(): GDriveAppDataConnector {
+    private fun TestScope.createConnector(
+        initialDeviceMetadata: List<DeviceMetadata> = emptyList(),
+        syncCache: SyncCache? = null,
+    ): GDriveAppDataConnector {
         val testDataStore = PreferenceDataStoreFactory.create(
             scope = this.backgroundScope,
             produceFile = { File(tempDir, "test_sync_${System.nanoTime()}.preferences_pb") },
@@ -107,22 +113,28 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         coEvery { syncSettings.isPaused(any()) } returns false
 
         val testAccount = GoogleAccount(accountId = "test-account", email = "test@example.com")
+        val context = mockk<Context>(relaxed = true)
+        every { context.cacheDir } returns tempDir
+        val json = Json { ignoreUnknownKeys = true }
 
         val mockNetworkState = mockk<NetworkStateProvider>(relaxed = true)
         every { mockNetworkState.networkState } returns flowOf(
             mockk { every { isInternetAvailable } returns true },
         )
+        val cache = syncCache ?: SyncCache(json, testDispatcher, context)
 
         val connector = GDriveAppDataConnector(
             account = testAccount,
+            initialDeviceMetadata = initialDeviceMetadata,
             scope = this.backgroundScope,
             dispatcherProvider = testDispatcher,
-            context = mockk<Context>(relaxed = true),
+            context = context,
             networkStateProvider = mockNetworkState,
             supportedModuleIds = setOf(power, wifi),
             syncSettings = syncSettings,
             syncState = ConnectorSyncState(),
-            json = kotlinx.serialization.json.Json { ignoreUnknownKeys = true },
+            syncCache = cache,
+            json = json,
         )
 
         // Inject mock Drive via reflection, bypassing GDriveBaseConnector's lazy init
@@ -143,6 +155,22 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
      */
     private suspend fun GDriveAppDataConnector.sync(options: SyncOptions) =
         execute(ConnectorCommand.Sync(options))
+
+    @Test
+    fun `starts with initial device metadata`() = runTest {
+        val metadata = listOf(
+            DeviceMetadata(
+                deviceId = DeviceId("cached-device"),
+                version = "1",
+                platform = "android",
+                label = "Cached Device",
+            )
+        )
+
+        val connector = createConnector(initialDeviceMetadata = metadata)
+
+        connector.state.first().deviceMetadata shouldBe metadata
+    }
 
     private fun setupNoChanges(newToken: String = "token-2") {
         every { mockChangesList.execute() } returns ChangeList().apply {
@@ -606,6 +634,23 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             metadata.platform shouldBe "android"
             metadata.label shouldBe "Device A"
             metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(1000L)
+        }
+
+        @Test
+        fun `full read with stats persists device metadata cache`() = runTest {
+            val context = mockk<Context>(relaxed = true)
+            every { context.cacheDir } returns tempDir
+            val syncCache = SyncCache(Json { ignoreUnknownKeys = true }, testDispatcher, context)
+            val connector = createConnector(syncCache = syncCache)
+            setupStartPageToken("start-token")
+            setupDriveWithPowerModule("indexed", includeDeviceInfo = true)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            val cached = syncCache.loadDeviceMetadata(connector.identifier)
+            cached.shouldNotBeNull()
+            cached.single().deviceId shouldBe deviceA
+            cached.single().label shouldBe "Device A"
         }
 
         @Test

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -44,6 +44,7 @@ import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.SyncWriteContainer
 import eu.darken.octi.sync.core.VersionCompat
+import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import kotlinx.coroutines.CancellationException
@@ -82,6 +83,7 @@ import kotlin.time.TimeSource
 @Suppress("BlockingMethodInNonBlockingContext")
 class OctiServerConnector @AssistedInject constructor(
     @Assisted val credentials: OctiServer.Credentials,
+    @Assisted private val initialDeviceMetadata: List<DeviceMetadata>,
     @AppScope private val scope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val endpointFactory: OctiServerEndpoint.Factory,
@@ -89,6 +91,7 @@ class OctiServerConnector @AssistedInject constructor(
     private val networkStateProvider: NetworkStateProvider,
     private val syncSettings: SyncSettings,
     private val syncState: ConnectorSyncState,
+    private val syncCache: SyncCache,
     private val supportedModuleIds: Set<@JvmSuppressWildcards ModuleId>,
     private val baseHttpClient: OkHttpClient,
     private val json: Json,
@@ -124,7 +127,10 @@ class OctiServerConnector @AssistedInject constructor(
         parentScope = scope + dispatcherProvider.IO,
         loggingTag = TAG,
     ) {
-        State(issues = buildCurrentDeviceRegistrationIssues())
+        State(
+            issues = buildCurrentDeviceRegistrationIssues(),
+            deviceMetadata = initialDeviceMetadata,
+        )
     }
 
     override val state: Flow<State> = _state.flow
@@ -250,6 +256,8 @@ class OctiServerConnector @AssistedInject constructor(
             etagCache.clear()
         }
         syncState.clearConnector(identifier)
+        _state.updateBlocking { copy(deviceMetadata = emptyList()) }
+        syncCache.removeDeviceMetadata(identifier)
     }
 
     private suspend fun handleDeleteDevice(deviceId: DeviceId) {
@@ -259,9 +267,8 @@ class OctiServerConnector @AssistedInject constructor(
             etagCache.keys.removeAll { it.first == deviceId }
         }
         // Eager prune: survives VM teardown and is visible immediately to all observers.
-        _state.updateBlocking {
-            copy(deviceMetadata = deviceMetadata.filterNot { it.deviceId == deviceId })
-        }
+        val prunedMetadata = _state.value().deviceMetadata.filterNot { it.deviceId == deviceId }
+        updateDeviceMetadata(prunedMetadata)
         _data.value = _data.value?.let { read ->
             OctiServerData(
                 connectorId = read.connectorId,
@@ -304,7 +311,7 @@ class OctiServerConnector @AssistedInject constructor(
                         addedAt = it.addedAt,
                     )
                 }
-                _state.updateBlocking { copy(deviceMetadata = metadata) }
+                updateDeviceMetadata(metadata)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -356,6 +363,11 @@ class OctiServerConnector @AssistedInject constructor(
         }
 
         computeIssues()
+    }
+
+    private suspend fun updateDeviceMetadata(metadata: List<DeviceMetadata>) {
+        _state.updateBlocking { copy(deviceMetadata = metadata) }
+        syncCache.saveDeviceMetadata(identifier, metadata)
     }
 
     /**
@@ -758,7 +770,7 @@ class OctiServerConnector @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(account: OctiServer.Credentials): OctiServerConnector
+        fun create(account: OctiServer.Credentials, initialDeviceMetadata: List<DeviceMetadata>): OctiServerConnector
     }
 
     companion object {

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerHub.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerHub.kt
@@ -10,12 +10,14 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.flow.shareLatest
+import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorHub
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.sync.core.execute
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -26,6 +28,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -39,6 +43,7 @@ class OctiServerHub @Inject constructor(
     private val connectorFactory: OctiServerConnector.Factory,
     private val endpointFactory: OctiServerEndpoint.Factory,
     private val syncSettings: SyncSettings,
+    private val syncCache: SyncCache,
 ) : ConnectorHub {
 
     private data class Live(
@@ -48,6 +53,7 @@ class OctiServerHub @Inject constructor(
     )
 
     private val live = ConcurrentHashMap<OctiServer.Credentials.AccountId, Live>()
+    private val reconcileLock = Mutex()
 
     private val _connectors: Flow<Collection<SyncConnector>> = accountRepo.accounts
         .map { accounts -> reconcile(accounts) }
@@ -56,8 +62,7 @@ class OctiServerHub @Inject constructor(
 
     override val connectors: Flow<Collection<SyncConnector>> = _connectors
 
-    @Synchronized
-    private fun reconcile(accounts: Collection<OctiServer.Credentials>): Collection<SyncConnector> {
+    private suspend fun reconcile(accounts: Collection<OctiServer.Credentials>): Collection<SyncConnector> = reconcileLock.withLock {
         val currentKeys = accounts.map { it.accountId }.toSet()
 
         val goneKeys = live.keys - currentKeys
@@ -69,18 +74,26 @@ class OctiServerHub @Inject constructor(
         }
 
         accounts.forEach { creds ->
-            live.computeIfAbsent(creds.accountId) {
+            if (!live.containsKey(creds.accountId)) {
                 log(TAG, INFO) { "Creating connector for ${creds.serverAdress.domain}:${creds.accountId.id}" }
+                val connectorId = creds.toConnectorId()
+                val initialDeviceMetadata = syncCache.loadDeviceMetadata(connectorId).orEmpty()
                 val connectorScope = CoroutineScope(appScope.coroutineContext + SupervisorJob())
-                val connector = connectorFactory.create(creds)
+                val connector = connectorFactory.create(creds, initialDeviceMetadata)
                 val job = connector.start(connectorScope)
                 connector.submit(ConnectorCommand.Sync(SyncOptions(writeData = false)))
-                Live(connector, connectorScope, job)
+                live[creds.accountId] = Live(connector, connectorScope, job)
             }
         }
 
-        return live.values.map { it.connector }
+        return@withLock live.values.map { it.connector }
     }
+
+    private fun OctiServer.Credentials.toConnectorId() = ConnectorId(
+        type = ConnectorType.OCTISERVER,
+        subtype = serverAdress.domain,
+        account = accountId.id,
+    )
 
     override suspend fun owns(connectorId: ConnectorId): Boolean {
         return _connectors.first().any { it.identifier == connectorId }


### PR DESCRIPTION
## Summary
- cache per-connector synchronized-device metadata under the existing sync cache directory
- seed GDrive and OctiServer connector state from cached metadata on startup, then refresh from the normal remote sync
- harden metadata cache reads/writes against corrupt JSON, schema changes, connector mismatches, and partial writes
- use cached connector labels as a device-list fallback before module metadata arrives

## Tests
- `./gradlew :sync-core:testDebugUnitTest :syncs-gdrive:testDebugUnitTest :syncs-octiserver:testDebugUnitTest :app:compileFossDebugKotlin`