### PR TITLE
Polish sync connector action sheet

### DIFF
--- a/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
@@ -266,6 +266,7 @@ internal fun SyncServicesContent() = PreviewWrapper {
                         connectorId = gdriveId,
                         connector = PreviewConnector(gdriveId, "octi@example.com"),
                         ourState = previewSyncState(lastActionAt = NOW - 5.seconds),
+                        activeOperations = emptyList(),
                         storageStatus = previewStorageStatus(gdriveId, used = 6_000_000, total = 15_000_000_000),
                         otherStates = listOf(previewSyncState(lastActionAt = NOW - 40.seconds)),
                         pauseReason = null,
@@ -276,6 +277,7 @@ internal fun SyncServicesContent() = PreviewWrapper {
                         connectorId = octiServerId,
                         connector = PreviewConnector(octiServerId, "octi.example.com"),
                         ourState = previewSyncState(lastActionAt = NOW - 2.hours),
+                        activeOperations = emptyList(),
                         storageStatus = previewStorageStatus(octiServerId, used = 4_300, total = 50_000_000),
                         otherStates = listOf(previewSyncState(lastActionAt = NOW - 12.minutes)),
                         pauseReason = null,
@@ -683,6 +685,7 @@ private class PreviewContribution(
     override fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
@@ -45,6 +45,7 @@ import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import androidx.compose.ui.graphics.Color
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorOperation
 import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.core.SyncConnector
@@ -191,6 +192,7 @@ private fun previewContribution(
     @Composable override fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorCardState.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorCardState.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.sync.ui.list
 
 import eu.darken.octi.sync.core.ConnectorIssue
+import eu.darken.octi.sync.core.ConnectorOperation
 import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
@@ -14,6 +15,7 @@ import eu.darken.octi.sync.core.blob.StorageStatus
 data class ConnectorCardState(
     val connector: SyncConnector,
     val syncState: SyncConnectorState,
+    val activeOperations: List<ConnectorOperation>,
     val storageStatus: StorageStatus,
     val pauseReason: ConnectorPauseReason?,
     val isPaused: Boolean,

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorOverviewProvider.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/ConnectorOverviewProvider.kt
@@ -52,15 +52,16 @@ class ConnectorOverviewProvider @Inject constructor(
             else combine(connectors.map { c ->
                 combine(c.state, c.operations) { state, ops ->
                     val issues = allIssues.filter { it.connectorId == c.identifier }
-                    val isBusy = ops.any { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
+                    val activeOperations = ops.filter { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
                     val pauseReason = pauseStates.reasonFor(c.identifier)
                     ConnectorCardState(
                         connector = c,
                         syncState = state,
+                        activeOperations = activeOperations,
                         storageStatus = statuses[c.identifier] ?: StorageStatus.Unsupported(c.identifier),
                         pauseReason = pauseReason,
                         isPaused = pauseReason != null,
-                        isBusy = isBusy,
+                        isBusy = activeOperations.isNotEmpty(),
                         issues = issues,
                     )
                 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
@@ -191,6 +191,7 @@ fun SyncListScreen(
         contribution.ActionsSheet(
             connector = item.connector,
             state = item.ourState,
+            activeOperations = item.activeOperations,
             isPaused = item.isPaused,
             pauseReason = item.pauseReason,
             isPro = state.isPro,
@@ -198,7 +199,6 @@ fun SyncListScreen(
             onTogglePause = { onTogglePause(item.connectorId) },
             onForceSync = {
                 onForceSync(item.connectorId)
-                showActionsForId = null
             },
             onViewDevices = {
                 onViewDevices(item.connectorId)
@@ -210,7 +210,6 @@ fun SyncListScreen(
             },
             onReset = {
                 onReset(item.connectorId)
-                showActionsForId = null
             },
             onDisconnect = {
                 onDisconnect(item.connectorId)
@@ -461,6 +460,7 @@ private fun previewConnectorItem(connectorId: ConnectorId): SyncListVM.Connector
         connectorId = connectorId,
         connector = connector,
         ourState = state,
+        activeOperations = emptyList(),
         storageStatus = StorageStatus.Ready(
             connectorId = connectorId,
             snapshot = StorageSnapshot(
@@ -516,6 +516,7 @@ private fun previewContribution(
     override fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListVM.kt
@@ -15,6 +15,7 @@ import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
+import eu.darken.octi.sync.core.ConnectorOperation
 import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
@@ -57,6 +58,7 @@ class SyncListVM @Inject constructor(
         val connectorId: ConnectorId,
         val connector: SyncConnector,
         val ourState: SyncConnectorState,
+        val activeOperations: List<ConnectorOperation>,
         val storageStatus: StorageStatus,
         val otherStates: Collection<SyncConnectorState>,
         val pauseReason: ConnectorPauseReason?,
@@ -104,6 +106,7 @@ class SyncListVM @Inject constructor(
                     connectorId = card.connector.identifier,
                     connector = card.connector,
                     ourState = card.syncState,
+                    activeOperations = card.activeOperations,
                     storageStatus = card.storageStatus,
                     otherStates = cards.filter { it.connector.identifier != card.connector.identifier }
                         .map { it.syncState },

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorActionSheetComponents.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorActionSheetComponents.kt
@@ -1,0 +1,324 @@
+package eu.darken.octi.sync.core
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Cloud
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.navigation.NavigationDestination
+import eu.darken.octi.common.settings.UpgradeBadge
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.R
+import kotlin.time.Clock
+
+fun List<ConnectorOperation>.hasActivePauseToggle(): Boolean = any {
+    it.isActive && (it.command is ConnectorCommand.Pause || it.command == ConnectorCommand.Resume)
+}
+
+@Composable
+fun ConnectorActionSheetHeader(
+    contribution: ConnectorUiContribution,
+    title: String,
+    subtitle: String?,
+    account: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.Top,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Surface(
+            shape = CircleShape,
+            color = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ) {
+            contribution.Icon(
+                modifier = Modifier
+                    .padding(10.dp)
+                    .size(24.dp),
+                tint = MaterialTheme.colorScheme.onSecondaryContainer,
+            )
+        }
+
+        Spacer(modifier = Modifier.width(12.dp))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (!subtitle.isNullOrBlank()) {
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Text(
+                text = stringResource(R.string.sync_connector_account_label),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 10.dp),
+            )
+            Text(
+                text = account.ifBlank { stringResource(CommonR.string.general_na_label) },
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+fun ConnectorOperationProgress(
+    activeOperations: List<ConnectorOperation>,
+    modifier: Modifier = Modifier,
+) {
+    val operation = activeOperations.displayOperation() ?: return
+
+    Surface(
+        shape = MaterialTheme.shapes.small,
+        color = MaterialTheme.colorScheme.primaryContainer,
+        contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Text(
+                text = operation.label(),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+fun ConnectorPauseRow(
+    isPaused: Boolean,
+    showPauseSwitch: Boolean,
+    isInProgress: Boolean,
+    onTogglePause: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(
+                enabled = !isInProgress,
+                onClick = onTogglePause,
+            )
+            .padding(vertical = 8.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.sync_connector_paused_label),
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f),
+        )
+        when {
+            isInProgress -> CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                strokeWidth = 2.dp,
+            )
+            showPauseSwitch -> Switch(
+                checked = isPaused,
+                onCheckedChange = null,
+            )
+            else -> UpgradeBadge(modifier = Modifier.padding(start = 16.dp))
+        }
+    }
+}
+
+private val ConnectorOperation.isActive: Boolean
+    get() = this is ConnectorOperation.Queued || this is ConnectorOperation.Processing
+
+private fun List<ConnectorOperation>.displayOperation(): ConnectorOperation? =
+    firstOrNull { it.isActive && it.command.prioritizeForDisplay } ?: firstOrNull { it.isActive }
+
+private val ConnectorCommand.prioritizeForDisplay: Boolean
+    get() = this is ConnectorCommand.Pause || this == ConnectorCommand.Resume || this == ConnectorCommand.Reset
+
+@Composable
+private fun ConnectorOperation.label(): String {
+    val queued = this is ConnectorOperation.Queued
+    return when (command) {
+        is ConnectorCommand.Sync -> stringResource(
+            if (queued) R.string.sync_connector_progress_sync_queued
+            else R.string.sync_connector_progress_syncing,
+        )
+        is ConnectorCommand.Pause -> stringResource(
+            if (queued) R.string.sync_connector_progress_pause_queued
+            else R.string.sync_connector_progress_pausing,
+        )
+        ConnectorCommand.Resume -> stringResource(
+            if (queued) R.string.sync_connector_progress_resume_queued
+            else R.string.sync_connector_progress_resuming,
+        )
+        ConnectorCommand.Reset -> stringResource(
+            if (queued) R.string.sync_connector_progress_reset_queued
+            else R.string.sync_connector_progress_resetting,
+        )
+        is ConnectorCommand.DeleteDevice -> stringResource(
+            if (queued) R.string.sync_connector_progress_device_update_queued
+            else R.string.sync_connector_progress_device_updating,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ConnectorActionSheetNormalPreview() = PreviewWrapper {
+    PreviewSheetContent(
+        activeOperations = emptyList(),
+        isPaused = false,
+        showPauseSwitch = true,
+    )
+}
+
+@Preview2
+@Composable
+private fun ConnectorActionSheetBusySyncPreview() = PreviewWrapper {
+    PreviewSheetContent(
+        activeOperations = listOf(
+            ConnectorOperation.Processing(
+                id = OperationId.create(),
+                command = ConnectorCommand.Sync(),
+                submittedAt = Clock.System.now(),
+                startedAt = Clock.System.now(),
+            ),
+        ),
+        isPaused = false,
+        showPauseSwitch = true,
+    )
+}
+
+@Preview2
+@Composable
+private fun ConnectorActionSheetPauseQueuedPreview() = PreviewWrapper {
+    PreviewSheetContent(
+        activeOperations = listOf(
+            ConnectorOperation.Queued(
+                id = OperationId.create(),
+                command = ConnectorCommand.Pause(),
+                submittedAt = Clock.System.now(),
+            ),
+        ),
+        isPaused = false,
+        showPauseSwitch = true,
+    )
+}
+
+@Preview2
+@Composable
+private fun ConnectorActionSheetPausedNonProPreview() = PreviewWrapper {
+    PreviewSheetContent(
+        activeOperations = emptyList(),
+        isPaused = true,
+        showPauseSwitch = false,
+    )
+}
+
+@Composable
+private fun PreviewSheetContent(
+    activeOperations: List<ConnectorOperation>,
+    isPaused: Boolean,
+    showPauseSwitch: Boolean,
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        ConnectorActionSheetHeader(
+            contribution = PreviewConnectorContribution,
+            title = "Octi Server",
+            subtitle = "sync.darken.eu",
+            account = "account-1234",
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        ConnectorOperationProgress(activeOperations = activeOperations)
+        if (activeOperations.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+        ConnectorPauseRow(
+            isPaused = isPaused,
+            showPauseSwitch = showPauseSwitch,
+            isInProgress = activeOperations.hasActivePauseToggle(),
+            onTogglePause = {},
+        )
+    }
+}
+
+private object PreviewConnectorContribution : ConnectorUiContribution {
+    override val type: ConnectorType = ConnectorType.OCTISERVER
+    override val displayOrder: Int = 0
+    override val labelRes: Int = R.string.sync_connector_paused_label
+    override val descriptionRes: Int = R.string.sync_connector_paused_label
+
+    @Composable
+    override fun Icon(modifier: Modifier, tint: androidx.compose.ui.graphics.Color) {
+        Icon(
+            imageVector = Icons.TwoTone.Cloud,
+            contentDescription = null,
+            modifier = modifier,
+            tint = tint,
+        )
+    }
+
+    override fun addAccountDestination(): NavigationDestination = object : NavigationDestination {}
+
+    @Composable
+    override fun listCardTitle(connector: SyncConnector): String = "Octi Server"
+
+    @Composable
+    override fun listCardAccountValue(connector: SyncConnector): String = "account-1234"
+
+    @Composable
+    override fun ActionsSheet(
+        connector: SyncConnector,
+        state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
+        isPaused: Boolean,
+        pauseReason: ConnectorPauseReason?,
+        isPro: Boolean,
+        onDismiss: () -> Unit,
+        onTogglePause: () -> Unit,
+        onForceSync: () -> Unit,
+        onViewDevices: () -> Unit,
+        onLinkNewDevice: () -> Unit,
+        onReset: () -> Unit,
+        onDisconnect: () -> Unit,
+    ) = Unit
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
@@ -55,6 +55,7 @@ interface ConnectorUiContribution {
     fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,

--- a/sync-core/src/main/res/values/strings.xml
+++ b/sync-core/src/main/res/values/strings.xml
@@ -29,6 +29,17 @@
     <string name="sync_connector_paused_label">Pause synchronization</string>
     <string name="sync_connector_paused_error_label">Connector paused</string>
     <string name="sync_connector_paused_error_desc">This connector is paused. Resume it to perform this action.</string>
+    <string name="sync_connector_account_label">Account</string>
+    <string name="sync_connector_progress_syncing">Synchronizing...</string>
+    <string name="sync_connector_progress_sync_queued">Synchronization queued...</string>
+    <string name="sync_connector_progress_pausing">Pausing synchronization...</string>
+    <string name="sync_connector_progress_pause_queued">Pause queued...</string>
+    <string name="sync_connector_progress_resuming">Resuming synchronization...</string>
+    <string name="sync_connector_progress_resume_queued">Resume queued...</string>
+    <string name="sync_connector_progress_resetting">Resetting data...</string>
+    <string name="sync_connector_progress_reset_queued">Reset queued...</string>
+    <string name="sync_connector_progress_device_updating">Updating devices...</string>
+    <string name="sync_connector_progress_device_update_queued">Device update queued...</string>
     <string name="sync_synced_devices_label">Synced devices</string>
 
     <plurals name="sync_stale_period_days">

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
@@ -1,14 +1,10 @@
 package eu.darken.octi.syncs.gdrive.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -16,7 +12,6 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon as M3Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -24,7 +19,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
@@ -33,13 +27,17 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
-import eu.darken.octi.common.settings.UpgradeBadge
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorActionSheetHeader
+import eu.darken.octi.sync.core.ConnectorOperation
+import eu.darken.octi.sync.core.ConnectorOperationProgress
 import eu.darken.octi.sync.core.ConnectorPauseReason
+import eu.darken.octi.sync.core.ConnectorPauseRow
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.core.hasActivePauseToggle
 import eu.darken.octi.syncs.gdrive.R
 import eu.darken.octi.syncs.gdrive.core.GDriveAppDataConnector
 import javax.inject.Inject
@@ -80,6 +78,7 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
     override fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
@@ -94,50 +93,41 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
         val gdrive = connector as? GDriveAppDataConnector ?: return
         var showDisconnectConfirmation by remember { mutableStateOf(false) }
         var showResetConfirmation by remember { mutableStateOf(false) }
+        val isBusy = activeOperations.isNotEmpty()
+        val pauseToggleInProgress = activeOperations.hasActivePauseToggle()
 
         ModalBottomSheet(onDismissRequest = onDismiss) {
-            Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                Text(
-                    text = buildString {
-                        append(stringResource(R.string.sync_gdrive_type_label))
-                        append(" (${stringResource(R.string.sync_gdrive_appdata_label)})")
-                    },
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = gdrive.account.email,
-                    style = MaterialTheme.typography.labelMedium,
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 24.dp),
+            ) {
+                ConnectorActionSheetHeader(
+                    contribution = this@GDriveUiContribution,
+                    title = stringResource(R.string.sync_gdrive_type_label),
+                    subtitle = stringResource(R.string.sync_gdrive_appdata_label),
+                    account = gdrive.account.email,
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = onTogglePause)
-                        .padding(vertical = 4.dp),
-                ) {
-                    Text(
-                        text = stringResource(SyncR.string.sync_connector_paused_label),
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (!isPro) {
-                        UpgradeBadge()
-                        Spacer(modifier = Modifier.width(8.dp))
-                    }
-                    Switch(
-                        checked = isPaused,
-                        onCheckedChange = null,
-                    )
+                ConnectorOperationProgress(activeOperations = activeOperations)
+                if (activeOperations.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
                 }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                ConnectorPauseRow(
+                    isPaused = isPaused,
+                    showPauseSwitch = isPro,
+                    isInProgress = pauseToggleInProgress,
+                    onTogglePause = onTogglePause,
+                )
 
                 Button(
                     onClick = onForceSync,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(CommonR.string.general_sync_action))
                 }
@@ -145,7 +135,7 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = onViewDevices,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(SyncR.string.sync_synced_devices_label))
                 }
@@ -153,7 +143,7 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = { showResetConfirmation = true },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(CommonR.string.general_reset_action))
                 }
@@ -167,8 +157,6 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
                 ) {
                     Text(text = stringResource(CommonR.string.general_disconnect_action))
                 }
-
-                Spacer(modifier = Modifier.height(24.dp))
             }
         }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
@@ -1,20 +1,16 @@
 package eu.darken.octi.syncs.octiserver.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -22,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -31,13 +26,17 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationDestination
-import eu.darken.octi.common.settings.UpgradeBadge
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorActionSheetHeader
+import eu.darken.octi.sync.core.ConnectorOperation
+import eu.darken.octi.sync.core.ConnectorOperationProgress
 import eu.darken.octi.sync.core.ConnectorPauseReason
+import eu.darken.octi.sync.core.ConnectorPauseRow
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.core.hasActivePauseToggle
 import eu.darken.octi.syncs.octiserver.R
 import eu.darken.octi.syncs.octiserver.core.OctiServerConnector
 import eu.darken.octi.syncs.octiserver.core.OctiServerIssue
@@ -82,6 +81,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
     override fun ActionsSheet(
         connector: SyncConnector,
         state: SyncConnectorState,
+        activeOperations: List<ConnectorOperation>,
         isPaused: Boolean,
         pauseReason: ConnectorPauseReason?,
         isPro: Boolean,
@@ -99,19 +99,29 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
         val unknownDeviceIssue = state.issues.filterIsInstance<OctiServerIssue.CurrentDeviceNotRegistered>().firstOrNull()
         val context = LocalContext.current
         val canTogglePause = isPro || pauseReason == ConnectorPauseReason.AuthIssue
+        val isBusy = activeOperations.isNotEmpty()
+        val pauseToggleInProgress = activeOperations.hasActivePauseToggle()
 
         ModalBottomSheet(onDismissRequest = onDismiss) {
-            Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                Text(
-                    text = "${stringResource(R.string.sync_octiserver_type_label)} (${octi.serverDisplay()})",
-                    style = MaterialTheme.typography.titleMedium,
-                )
-                Text(
-                    text = octi.credentials.accountId.id,
-                    style = MaterialTheme.typography.labelMedium,
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .padding(bottom = 24.dp),
+            ) {
+                ConnectorActionSheetHeader(
+                    contribution = this@OctiServerUiContribution,
+                    title = stringResource(R.string.sync_octiserver_type_label),
+                    subtitle = octi.serverDisplay(),
+                    account = octi.credentials.accountId.id,
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
+
+                ConnectorOperationProgress(activeOperations = activeOperations)
+                if (activeOperations.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                }
 
                 if (unknownDeviceIssue != null) {
                     Text(
@@ -127,33 +137,18 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                     Spacer(modifier = Modifier.height(12.dp))
                 }
 
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable(onClick = onTogglePause)
-                        .padding(vertical = 4.dp),
-                ) {
-                    Text(
-                        text = stringResource(SyncR.string.sync_connector_paused_label),
-                        modifier = Modifier.weight(1f),
-                    )
-                    if (!canTogglePause) {
-                        UpgradeBadge()
-                        Spacer(modifier = Modifier.width(8.dp))
-                    }
-                    Switch(
-                        checked = isPaused,
-                        onCheckedChange = null,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
+                ConnectorPauseRow(
+                    isPaused = isPaused,
+                    showPauseSwitch = canTogglePause,
+                    isInProgress = pauseToggleInProgress,
+                    onTogglePause = onTogglePause,
+                )
 
                 if (unknownDeviceIssue != null && isPaused) {
                     FilledTonalButton(
                         onClick = onTogglePause,
                         modifier = Modifier.fillMaxWidth(),
+                        enabled = !pauseToggleInProgress,
                     ) {
                         Text(text = stringResource(R.string.sync_octiserver_resume_sync_action))
                     }
@@ -162,7 +157,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 Button(
                     onClick = onForceSync,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(CommonR.string.general_sync_action))
                 }
@@ -170,7 +165,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = onViewDevices,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(SyncR.string.sync_synced_devices_label))
                 }
@@ -178,7 +173,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = onLinkNewDevice,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(R.string.sync_octiserver_link_device_action))
                 }
@@ -186,7 +181,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = { showResetConfirmation = true },
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused,
+                    enabled = !isPaused && !isBusy,
                 ) {
                     Text(text = stringResource(CommonR.string.general_reset_action))
                 }
@@ -200,8 +195,6 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 ) {
                     Text(text = stringResource(CommonR.string.general_disconnect_action))
                 }
-
-                Spacer(modifier = Modifier.height(24.dp))
             }
         }
 


### PR DESCRIPTION
## Summary
- Add active connector operation plumbing to sync connector action sheets
- Introduce shared connector action sheet header, progress, pause-row components, and previews
- Refactor Google Drive and Octi Server action sheets to show type/icon, subtype/server, labeled account, and queued/running action progress
- Keep inline action sheets open for sync/reset progress while preserving navigation/disconnect dismissal behavior

## Tests
- `./gradlew :app:testFossDebugUnitTest --tests eu.darken.octi.sync.core.ConnectorUiContributionRegistryTest :sync-core:testDebugUnitTest --tests eu.darken.octi.sync.core.ConnectorProcessorTest`
- `git diff --check`