### PR TITLE
Disambiguate duplicate device labels

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -54,6 +54,8 @@ import eu.darken.octi.sync.core.SyncOrchestrator
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.blob.BlobManager
 import eu.darken.octi.sync.core.blob.StorageStatusManager
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
+import eu.darken.octi.sync.core.shortLabel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -200,9 +202,10 @@ class DashboardVM @Inject constructor(
         val degradedPlatform: String? = null,
         val degradedVersion: String? = null,
         val degradedLastSeen: Instant? = null,
+        val displayLabel: String = meta?.data?.labelOrFallback ?: degradedLabel ?: deviceId.shortLabel,
     ) {
-        val displayLabel: String
-            get() = meta?.data?.labelOrFallback ?: degradedLabel ?: deviceId.id.take(8)
+        val baseLabel: String
+            get() = meta?.data?.labelOrFallback ?: degradedLabel ?: deviceId.shortLabel
     }
 
     sealed interface ModuleItem {
@@ -694,10 +697,17 @@ class DashboardVM @Inject constructor(
                 }
         }
 
-        (normalItems + degradedItems)
-            .sortedBy { it.displayLabel.lowercase() }
-            .sortedByDescending { it.deviceId == syncSettings.deviceId }
-            .sortedBy { it.isDegraded }
+        val items = normalItems + degradedItems
+        val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
+
+        items
+            .map { item -> item.copy(displayLabel = labelsByDevice[item.deviceId] ?: item.baseLabel) }
+            .sortedWith(
+                compareBy<DashboardVM.DeviceItem> { it.isDegraded }
+                    .thenByDescending { it.deviceId == syncSettings.deviceId }
+                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it.displayLabel }
+                    .thenBy { it.deviceId.id }
+            )
     }
 
     private val ModuleData<out Any>.orderPrio: Int

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
@@ -71,7 +71,7 @@ fun DeviceActionsSheet(
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    text = device.metaInfo?.labelOrFallback ?: "?",
+                    text = device.displayLabel,
                     style = MaterialTheme.typography.titleMedium,
                     modifier = Modifier.weight(1f),
                 )

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
@@ -71,7 +71,7 @@ internal fun DeviceRow(
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
-                        text = item.metaInfo?.labelOrFallback ?: item.serverLabel ?: item.deviceId.id.take(8),
+                        text = item.displayLabel,
                         style = MaterialTheme.typography.titleSmall,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -22,6 +22,8 @@ import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.ConnectorIssueAggregator
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
+import eu.darken.octi.sync.core.shortLabel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
@@ -87,7 +89,11 @@ class SyncDevicesVM @Inject constructor(
         val serverPlatform: String?,
         val serverLabel: String? = null,
         val issues: List<ConnectorIssue> = emptyList(),
-    )
+        val displayLabel: String = metaInfo?.labelOrFallback ?: serverLabel ?: deviceId.shortLabel,
+    ) {
+        val baseLabel: String
+            get() = metaInfo?.labelOrFallback ?: serverLabel ?: deviceId.shortLabel
+    }
 
     data class State(
         val items: List<DeviceItem> = emptyList(),
@@ -135,14 +141,22 @@ class SyncDevicesVM @Inject constructor(
                         serverLabel = deviceMeta.label,
                         issues = allIssues.filter { it.connectorId == connectorId && it.deviceId == deviceId },
                     )
-                }.sortedBy { (it.metaInfo?.labelOrFallback ?: it.serverLabel ?: it.deviceId.id).lowercase() }
+                }
+
+                val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
+                val displayItems = items.map { item ->
+                    item.copy(displayLabel = labelsByDevice[item.deviceId] ?: item.baseLabel)
+                }.sortedWith(
+                    compareBy<SyncDevicesVM.DeviceItem, String>(String.CASE_INSENSITIVE_ORDER) { it.displayLabel }
+                        .thenBy { it.deviceId.id }
+                )
 
                 val deletingIds = operations
                     .filter { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
                     .mapNotNullTo(mutableSetOf()) { (it.command as? ConnectorCommand.DeleteDevice)?.deviceId }
 
                 State(
-                    items = items,
+                    items = displayItems,
                     deviceRemovalPolicy = connector.capabilities.deviceRemovalPolicy,
                     isPaused = pausedIds.contains(connectorId),
                     deletingDeviceIds = deletingIds,

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListVM.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListVM.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.SingleEventFlow
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.apps.core.AppsRepo
@@ -81,8 +82,12 @@ class AppsListVM @Inject constructor(
                         }
                     }
 
+                val labelsByDevice = disambiguateDeviceLabels(
+                    metaState.all.associate { it.deviceId to it.data.labelOrFallback }
+                )
+
                 State(
-                    deviceLabel = metaData.data.deviceLabel ?: metaData.data.deviceName,
+                    deviceLabel = labelsByDevice[deviceId] ?: metaData.data.labelOrFallback,
                     items = items,
                     sortMode = sortMode,
                 )

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
@@ -58,6 +58,8 @@ import eu.darken.octi.modules.clipboard.ClipboardRepo
 import eu.darken.octi.modules.clipboard.R
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.meta.core.MetaRepo
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -121,7 +123,16 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
             }
                 .orEmpty()
                 .distinctBy { it.id }
-                .sortedBy { it.label.lowercase() }
+                .let { devices ->
+                    val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
+                    devices.map { device ->
+                        device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label)
+                    }
+                }
+                .sortedWith(
+                    compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+                        .thenBy { it.id }
+                )
 
             setContent {
                 val themeState by themeSettings.themeState.collectAsState(ThemeState())

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -42,6 +42,7 @@ import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.clipboard.ClipboardInfo
 import eu.darken.octi.modules.clipboard.R
 import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.common.R as CommonR
 
 internal object ClipboardWidgetSizing {
@@ -203,7 +204,7 @@ private fun buildDeviceRows(
     val clipboardAll = clipboardState.all as? Collection<ModuleData<ClipboardInfo>>
         ?: return emptyList()
 
-    return clipboardAll
+    val pairs = clipboardAll
         .asSequence()
         .filter { it.deviceId.id != selfDeviceId }
         .filter { allowedDeviceIds.isNullOrEmpty() || it.deviceId.id in allowedDeviceIds }
@@ -211,12 +212,22 @@ private fun buildDeviceRows(
             val metaData = metaAll.firstOrNull { it.deviceId == clipData.deviceId }
             metaData?.let { clipData to it }
         }
-        .sortedBy { (_, metaData) -> metaData.data.labelOrFallback.lowercase() }
+        .toList()
+    val labelsByDevice = disambiguateDeviceLabels(pairs.associate { (_, metaData) ->
+        metaData.deviceId to metaData.data.labelOrFallback
+    })
+
+    return pairs
+        .sortedWith(
+            compareBy<Pair<ModuleData<ClipboardInfo>, ModuleData<MetaInfo>>, String>(String.CASE_INSENSITIVE_ORDER) {
+                labelsByDevice[it.second.deviceId] ?: it.second.data.labelOrFallback
+            }.thenBy { it.second.deviceId.id }
+        )
         .take(maxRows)
         .map { (clipData, metaData) ->
             val preview = clipData.data.toWidgetPreview()
             ClipboardDeviceRow(
-                deviceName = metaData.data.labelOrFallback,
+                deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
                     metaData.modifiedAt.toEpochMilliseconds(),
                     System.currentTimeMillis(),

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
@@ -55,6 +55,8 @@ import eu.darken.octi.modules.connectivity.R
 import eu.darken.octi.modules.connectivity.core.ConnectivityRepo
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.meta.core.MetaRepo
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -114,7 +116,16 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
             }
                 .orEmpty()
                 .distinctBy { it.id }
-                .sortedBy { it.label.lowercase() }
+                .let { devices ->
+                    val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
+                    devices.map { device ->
+                        device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label)
+                    }
+                }
+                .sortedWith(
+                    compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+                        .thenBy { it.id }
+                )
 
             setContent {
                 val themeState by themeSettings.themeState.collectAsState(ThemeState())

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -35,9 +35,12 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.connectivity.R
 import eu.darken.octi.modules.connectivity.core.ConnectivityInfo
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.common.R as CommonR
 
 internal object NetworkWidgetSizing {
@@ -170,12 +173,12 @@ private fun buildDeviceTiles(
     if (metaState == null || connectivityState == null) return emptyList()
     if (maxRows <= 0) return emptyList()
 
-    val metaAll = metaState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.meta.core.MetaInfo>>
+    val metaAll = metaState.all as? Collection<ModuleData<MetaInfo>>
         ?: return emptyList()
-    val connectivityAll = connectivityState.all as? Collection<eu.darken.octi.module.core.ModuleData<ConnectivityInfo>>
+    val connectivityAll = connectivityState.all as? Collection<ModuleData<ConnectivityInfo>>
         ?: return emptyList()
 
-    return connectivityAll
+    val pairs = connectivityAll
         .mapNotNull { connData ->
             val metaData = metaAll.firstOrNull { it.deviceId == connData.deviceId }
             metaData?.let { connData to it }
@@ -184,12 +187,21 @@ private fun buildDeviceTiles(
             if (allowedDeviceIds.isNullOrEmpty()) pairs
             else pairs.filter { (connData, _) -> connData.deviceId.id in allowedDeviceIds }
         }
-        .sortedBy { (_, metaData) -> metaData.data.labelOrFallback.lowercase() }
+    val labelsByDevice = disambiguateDeviceLabels(pairs.associate { (_, metaData) ->
+        metaData.deviceId to metaData.data.labelOrFallback
+    })
+
+    return pairs
+        .sortedWith(
+            compareBy<Pair<ModuleData<ConnectivityInfo>, ModuleData<MetaInfo>>, String>(String.CASE_INSENSITIVE_ORDER) {
+                labelsByDevice[it.second.deviceId] ?: it.second.data.labelOrFallback
+            }.thenBy { it.second.deviceId.id }
+        )
         .take(maxRows)
         .map { (connData, metaData) ->
             NetworkDeviceTile(
                 deviceId = connData.deviceId.id,
-                deviceName = metaData.data.labelOrFallback,
+                deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
                     metaData.modifiedAt.toEpochMilliseconds(),
                     System.currentTimeMillis(),

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/IncomingFileNotifier.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/IncomingFileNotifier.kt
@@ -24,6 +24,8 @@ import eu.darken.octi.module.core.ModuleManager
 import eu.darken.octi.modules.files.R
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
+import eu.darken.octi.sync.core.shortLabel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
@@ -111,6 +113,9 @@ class IncomingFileNotifier @Inject constructor(
                     .filter { now <= it.retainUntil }
                     .map { it.targetDeviceId to it.blobKey }
                     .toSet()
+                val labelsByDevice = disambiguateDeviceLabels(snap.byDevice.devices.mapValues { (deviceId, moduleDatas) ->
+                    moduleDatas.firstNotNullOfOrNull { it.data as? MetaInfo }?.labelOrFallback ?: deviceId.shortLabel
+                })
 
                 for (moduleData in snap.state.others) {
                     val deviceId = moduleData.deviceId
@@ -178,10 +183,7 @@ class IncomingFileNotifier @Inject constructor(
                         continue
                     }
 
-                    val deviceLabel = snap.byDevice.devices[deviceId]
-                        ?.firstNotNullOfOrNull { it.data as? MetaInfo }
-                        ?.labelOrFallback
-                        ?: deviceId.id.take(8)
+                    val deviceLabel = labelsByDevice[deviceId] ?: deviceId.shortLabel
 
                     for (blobKey in added) {
                         val sharedFile = moduleData.data.files.find { it.blobKey == blobKey } ?: continue

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
@@ -44,6 +44,8 @@ import eu.darken.octi.sync.core.blob.BlobProgress
 import eu.darken.octi.sync.core.blob.RetryStatus
 import eu.darken.octi.sync.core.blob.StorageStatus
 import eu.darken.octi.sync.core.blob.StorageStatusManager
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
+import eu.darken.octi.sync.core.shortLabel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -252,19 +254,24 @@ class FileShareListVM @Inject constructor(
             repo.repoState.others.forEach { add(it.deviceId to it.data) }
         }
 
-        val labelByDevice: Map<DeviceId, String> = deviceData
-            .associate { (id, _) -> id to deviceLabelFor(id, repo.byDevice) }
+        val labelByDevice: Map<DeviceId, String> = disambiguateDeviceLabels(
+            deviceData.associate { (id, _) -> id to deviceLabelFor(id, repo.byDevice) }
+        )
 
         val availableDevices = deviceData
             .map { (id, _) ->
                 DeviceOption(
                     deviceId = id,
-                    label = labelByDevice[id] ?: id.id.take(8),
+                    label = labelByDevice[id] ?: id.shortLabel,
                     isOwn = id == ownDeviceId,
                 )
             }
             .distinctBy { it.deviceId }
-            .sortedWith(compareByDescending<DeviceOption> { it.isOwn }.thenBy { it.label })
+            .sortedWith(
+                compareByDescending<DeviceOption> { it.isOwn }
+                    .thenBy(String.CASE_INSENSITIVE_ORDER) { it.label }
+                    .thenBy { it.deviceId.id }
+            )
 
         val now = Clock.System.now()
         val deleteRequestedKeys = activeDeleteRequestKeys(deviceData, now)
@@ -274,7 +281,7 @@ class FileShareListVM @Inject constructor(
 
         val items: List<FileItem> = deviceData.flatMap { (ownerId, info) ->
             if (!filterIsEmpty && ownerId !in effectiveFilters) return@flatMap emptyList()
-            val ownerLabel = labelByDevice[ownerId] ?: ownerId.id.take(8)
+            val ownerLabel = labelByDevice[ownerId] ?: ownerId.shortLabel
             val isOwn = ownerId == ownDeviceId
             info.files
                 .filter { now <= it.expiresAt }
@@ -368,7 +375,7 @@ class FileShareListVM @Inject constructor(
     private fun deviceLabelFor(deviceId: DeviceId, byDevice: ModuleManager.ByDevice): String {
         val meta = byDevice.devices[deviceId]
             ?.firstOrNull { it.data is MetaInfo } as? ModuleData<MetaInfo>
-        return meta?.data?.labelOrFallback ?: deviceId.id.take(8)
+        return meta?.data?.labelOrFallback ?: deviceId.shortLabel
     }
 
     private fun buildMissingConnectors(

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/alerts/PowerAlertsVM.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.isPro
 import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.modules.power.core.alert.BatteryHighAlertRule
 import eu.darken.octi.modules.power.core.alert.BatteryLowAlertRule
 import eu.darken.octi.modules.power.core.alert.PowerAlert
@@ -66,8 +67,12 @@ class PowerAlertsVM @Inject constructor(
                 @Suppress("UNCHECKED_CAST")
                 val highAlert = alerts.find { it.rule is BatteryHighAlertRule } as PowerAlert<BatteryHighAlertRule>?
 
+                val labelsByDevice = disambiguateDeviceLabels(
+                    metaState.all.associate { it.deviceId to it.data.labelOrFallback }
+                )
+
                 State(
-                    deviceLabel = metaData.data.deviceLabel ?: metaData.data.deviceName,
+                    deviceLabel = labelsByDevice[deviceId] ?: metaData.data.labelOrFallback,
                     isPro = upgradeInfo.isPro,
                     batteryLowAlert = lowAlert,
                     batteryHighAlert = highAlert,

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetConfigActivity.kt
@@ -57,6 +57,8 @@ import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.meta.core.MetaRepo
 import eu.darken.octi.modules.power.R
 import eu.darken.octi.modules.power.core.PowerRepo
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -109,7 +111,16 @@ class BatteryWidgetConfigActivity : androidx.activity.ComponentActivity() {
             }
                 .orEmpty()
                 .distinctBy { it.id }
-                .sortedBy { it.label.lowercase() }
+                .let { devices ->
+                    val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
+                    devices.map { device ->
+                        device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label)
+                    }
+                }
+                .sortedWith(
+                    compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+                        .thenBy { it.id }
+                )
 
             setContent {
                 val themeState by themeSettings.themeState.collectAsState(ThemeState())

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -34,9 +34,13 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import eu.darken.octi.common.navigation.WidgetDeeplink
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
+import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.modules.power.R
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.sync.core.disambiguateDeviceLabels
 
 private object BatteryWidgetSizing {
     /** 8dp outer padding × 2 sides + 4dp spacer between bar and percent text + 44dp percent text width. */
@@ -136,10 +140,10 @@ private fun buildDeviceRows(
     if (metaState == null || powerState == null) return emptyList()
     if (maxRows <= 0) return emptyList()
 
-    val metaAll = metaState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.meta.core.MetaInfo>> ?: return emptyList()
-    val powerAll = powerState.all as? Collection<eu.darken.octi.module.core.ModuleData<eu.darken.octi.modules.power.core.PowerInfo>> ?: return emptyList()
+    val metaAll = metaState.all as? Collection<ModuleData<MetaInfo>> ?: return emptyList()
+    val powerAll = powerState.all as? Collection<ModuleData<PowerInfo>> ?: return emptyList()
 
-    return powerAll
+    val pairs = powerAll
         .mapNotNull { powerData ->
             val metaData = metaAll.firstOrNull { it.deviceId == powerData.deviceId }
             metaData?.let { powerData to it }
@@ -148,12 +152,21 @@ private fun buildDeviceRows(
             if (allowedDeviceIds.isNullOrEmpty()) pairs
             else pairs.filter { (powerData, _) -> powerData.deviceId.id in allowedDeviceIds }
         }
-        .sortedBy { (_, metaData) -> metaData.data.labelOrFallback.lowercase() }
+    val labelsByDevice = disambiguateDeviceLabels(pairs.associate { (_, metaData) ->
+        metaData.deviceId to metaData.data.labelOrFallback
+    })
+
+    return pairs
+        .sortedWith(
+            compareBy<Pair<ModuleData<PowerInfo>, ModuleData<MetaInfo>>, String>(String.CASE_INSENSITIVE_ORDER) {
+                labelsByDevice[it.second.deviceId] ?: it.second.data.labelOrFallback
+            }.thenBy { it.second.deviceId.id }
+        )
         .take(maxRows)
         .map { (powerData, metaData) ->
             BatteryDeviceRow(
                 deviceId = powerData.deviceId.id,
-                deviceName = metaData.data.labelOrFallback,
+                deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
                     metaData.modifiedAt.toEpochMilliseconds(),
                     System.currentTimeMillis(),

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceLabelExtensions.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceLabelExtensions.kt
@@ -1,0 +1,22 @@
+package eu.darken.octi.sync.core
+
+private const val DEVICE_LABEL_ID_CHARS = 8
+
+val DeviceId.shortLabel: String
+    get() = id.take(DEVICE_LABEL_ID_CHARS)
+
+fun disambiguateDeviceLabels(labelsByDevice: Map<DeviceId, String>): Map<DeviceId, String> {
+    val collisionCounts = labelsByDevice.values
+        .groupingBy { it.normalizedDeviceLabel() }
+        .eachCount()
+
+    return labelsByDevice.mapValues { (deviceId, label) ->
+        if ((collisionCounts[label.normalizedDeviceLabel()] ?: 0) > 1) {
+            "$label (${deviceId.shortLabel})"
+        } else {
+            label
+        }
+    }
+}
+
+private fun String.normalizedDeviceLabel(): String = trim().lowercase()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/DeviceLabelExtensionsTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/DeviceLabelExtensionsTest.kt
@@ -1,0 +1,45 @@
+package eu.darken.octi.sync.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DeviceLabelExtensionsTest : BaseTest() {
+
+    @Test
+    fun `short label uses first eight characters`() {
+        DeviceId("12345678-90ab-cdef").shortLabel shouldBe "12345678"
+    }
+
+    @Test
+    fun `unique labels are unchanged`() {
+        val alpha = DeviceId("aaaaaaaa-0000-0000-0000-000000000000")
+        val beta = DeviceId("bbbbbbbb-0000-0000-0000-000000000000")
+
+        disambiguateDeviceLabels(
+            mapOf(
+                alpha to "Pixel",
+                beta to "Tablet",
+            )
+        ) shouldBe mapOf(
+            alpha to "Pixel",
+            beta to "Tablet",
+        )
+    }
+
+    @Test
+    fun `duplicate labels get stable device id suffixes`() {
+        val alpha = DeviceId("aaaaaaaa-0000-0000-0000-000000000000")
+        val beta = DeviceId("bbbbbbbb-0000-0000-0000-000000000000")
+
+        disambiguateDeviceLabels(
+            mapOf(
+                alpha to "Pixel",
+                beta to "pixel",
+            )
+        ) shouldBe mapOf(
+            alpha to "Pixel (aaaaaaaa)",
+            beta to "pixel (bbbbbbbb)",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared helper that appends the first 8 device ID characters only when labels collide.
- Use the disambiguated label across dashboard, synced-device management, file sharing, detail headers, notifications, and widget device lists/config screens.
- Add deterministic device ID tie-breakers for label-based sorting.

## Tests
- `./gradlew :sync-core:testDebugUnitTest :modules-apps:testDebugUnitTest :modules-clipboard:testDebugUnitTest :modules-connectivity:testDebugUnitTest :modules-files:testDebugUnitTest :modules-power:testDebugUnitTest :app:testFossDebugUnitTest --continue`