### PR TITLE
Add sort modes to synced devices list

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/compose/SortModeDialog.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/compose/SortModeDialog.kt
@@ -1,0 +1,83 @@
+package eu.darken.octi.common.compose
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.R
+import eu.darken.octi.common.preferences.EnumPreference
+
+@Composable
+fun <T> SortModeDialog(
+    title: String,
+    currentMode: T,
+    modes: List<T>,
+    onSelect: (T) -> Unit,
+    onDismiss: () -> Unit,
+    reversed: Boolean = false,
+    onReverseChange: ((Boolean) -> Unit)? = null,
+) where T : Enum<T>, T : EnumPreference<T> {
+    val context = LocalContext.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column {
+                modes.forEach { mode ->
+                    Row(
+                        modifier = Modifier
+                            .clickable { onSelect(mode) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        RadioButton(
+                            selected = mode == currentMode,
+                            onClick = { onSelect(mode) },
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = mode.label.get(context))
+                    }
+                }
+
+                if (onReverseChange != null) {
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+                    Row(
+                        modifier = Modifier
+                            .clickable { onReverseChange(!reversed) }
+                            .padding(vertical = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.general_sort_reverse_label),
+                            modifier = Modifier.weight(1f),
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Switch(
+                            checked = reversed,
+                            onCheckedChange = onReverseChange,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(android.R.string.cancel))
+            }
+        },
+    )
+}

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="ui_theme_color_blue_label">Blue</string>
     <string name="ui_theme_color_sunset_label">Sunset</string>
     <string name="device_x_label">Device: %s</string>
+    <string name="general_sort_reverse_label">Reverse order</string>
 
     <!-- Widget theme presets -->
     <string name="widget_theme_material_you">Material You</string>

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.twotone.Sort
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
@@ -24,11 +25,13 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.compose.SortModeDialog
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.DeviceRemovalPolicy
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncDevicesSortMode
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
 
@@ -44,13 +47,31 @@ fun SyncDevicesScreenHost(
     NavigationEventHandler(vm)
 
     val state by vm.state.collectAsState(initial = null)
-    state?.let {
+    var showSortDialog by rememberSaveable { mutableStateOf(false) }
+
+    state?.let { current ->
         SyncDevicesScreen(
-            state = it,
+            state = current,
             initialDeviceId = initialDeviceId,
             onNavigateUp = { vm.navUp() },
             onDeleteDevice = { deviceId -> vm.deleteDevice(deviceId) },
+            onSort = { showSortDialog = true },
         )
+
+        if (showSortDialog) {
+            SortModeDialog(
+                title = stringResource(SyncR.string.sync_devices_sort_label),
+                currentMode = current.sortMode,
+                modes = SyncDevicesSortMode.entries,
+                onSelect = { mode ->
+                    vm.updateSortMode(mode)
+                    showSortDialog = false
+                },
+                onDismiss = { showSortDialog = false },
+                reversed = current.sortReversed,
+                onReverseChange = { vm.updateSortReversed(it) },
+            )
+        }
     }
 }
 
@@ -60,6 +81,7 @@ fun SyncDevicesScreen(
     initialDeviceId: String? = null,
     onNavigateUp: () -> Unit,
     onDeleteDevice: (DeviceId) -> Unit,
+    onSort: () -> Unit,
 ) {
     var selectedDeviceId by rememberSaveable { mutableStateOf<String?>(null) }
     var initialConsumed by rememberSaveable { mutableStateOf(false) }
@@ -89,6 +111,14 @@ fun SyncDevicesScreen(
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSort) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.TwoTone.Sort,
+                            contentDescription = stringResource(SyncR.string.sync_devices_sort_label),
+                        )
                     }
                 },
             )
@@ -121,7 +151,6 @@ fun SyncDevicesScreen(
         )
     }
 }
-
 
 @Preview2
 @Composable
@@ -178,6 +207,7 @@ private fun SyncDevicesScreenPreview() = PreviewWrapper {
         ),
         onNavigateUp = {},
         onDeleteDevice = {},
+        onSort = {},
     )
 }
 
@@ -188,5 +218,6 @@ private fun SyncDevicesScreenEmptyPreview() = PreviewWrapper {
         state = SyncDevicesVM.State(deviceRemovalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE),
         onNavigateUp = {},
         onDeleteDevice = {},
+        onSort = {},
     )
 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesSorting.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesSorting.kt
@@ -1,0 +1,37 @@
+package eu.darken.octi.sync.ui.devices
+
+import eu.darken.octi.sync.core.SyncDevicesSortMode
+import io.github.z4kn4fein.semver.Version
+import kotlin.time.Instant
+
+internal fun parseVersion(s: String?): Version? = s?.let {
+    try {
+        Version.parse(it, strict = false)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+internal val SyncDevicesVM.DeviceItem.versionKey: Version?
+    get() = parseVersion(metaInfo?.octiVersionName ?: serverVersion)
+
+internal fun comparatorFor(
+    mode: SyncDevicesSortMode,
+    reversed: Boolean = false,
+): Comparator<SyncDevicesVM.DeviceItem> {
+    val baseTieBreak = compareBy<SyncDevicesVM.DeviceItem, String>(String.CASE_INSENSITIVE_ORDER) { it.displayLabel }
+        .thenBy { it.deviceId.id }
+    val tieBreak = if (reversed) baseTieBreak.reversed() else baseTieBreak
+    // Time/version primary keys flip direction on reverse; nulls always trail so that "unknown"
+    // values don't surface to the top when the user just wanted to invert the timeline.
+    val instantOrder: Comparator<Instant?> =
+        nullsLast(if (reversed) naturalOrder<Instant>() else reverseOrder<Instant>())
+    val versionOrder: Comparator<Version?> =
+        nullsLast(if (reversed) naturalOrder<Version>() else reverseOrder<Version>())
+    return when (mode) {
+        SyncDevicesSortMode.DATE_ADDED -> compareBy(instantOrder) { it: SyncDevicesVM.DeviceItem -> it.serverAddedAt }.then(tieBreak)
+        SyncDevicesSortMode.LAST_SEEN -> compareBy(instantOrder) { it: SyncDevicesVM.DeviceItem -> it.lastSeen }.then(tieBreak)
+        SyncDevicesSortMode.NAME -> tieBreak
+        SyncDevicesSortMode.APP_VERSION -> compareBy(versionOrder) { it: SyncDevicesVM.DeviceItem -> it.versionKey }.then(tieBreak)
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.sync.ui.devices
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
@@ -21,6 +22,7 @@ import eu.darken.octi.sync.core.DeviceRemovalPolicy
 import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.ConnectorIssueAggregator
+import eu.darken.octi.sync.core.SyncDevicesSortMode
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.sync.core.shortLabel
@@ -100,7 +102,14 @@ class SyncDevicesVM @Inject constructor(
         val deviceRemovalPolicy: DeviceRemovalPolicy? = null,
         val isPaused: Boolean = false,
         val deletingDeviceIds: Set<DeviceId> = emptySet(),
+        val sortMode: SyncDevicesSortMode = SyncDevicesSortMode.DATE_ADDED,
+        val sortReversed: Boolean = false,
     )
+
+    private val sortPrefs = combine(
+        syncSettings.devicesSortMode.flow,
+        syncSettings.devicesSortReversed.flow,
+    ) { mode, reversed -> mode to reversed }
 
     val state = connectorFlow
         .flatMapLatest { connector ->
@@ -146,10 +155,7 @@ class SyncDevicesVM @Inject constructor(
                 val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
                 val displayItems = items.map { item ->
                     item.copy(displayLabel = labelsByDevice[item.deviceId] ?: item.baseLabel)
-                }.sortedWith(
-                    compareBy<SyncDevicesVM.DeviceItem, String>(String.CASE_INSENSITIVE_ORDER) { it.displayLabel }
-                        .thenBy { it.deviceId.id }
-                )
+                }
 
                 val deletingIds = operations
                     .filter { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
@@ -163,11 +169,26 @@ class SyncDevicesVM @Inject constructor(
                 )
             }
         }
+        .combine(sortPrefs) { state, (sortMode, reversed) ->
+            state.copy(
+                items = state.items.sortedWith(comparatorFor(sortMode, reversed)),
+                sortMode = sortMode,
+                sortReversed = reversed,
+            )
+        }
         .asStateFlow()
 
     fun initialize(connectorId: String) {
         if (connectorIdFlow.value != null) return
         connectorIdFlow.value = connectorId
+    }
+
+    fun updateSortMode(mode: SyncDevicesSortMode) = launch {
+        syncSettings.devicesSortMode.value(mode)
+    }
+
+    fun updateSortReversed(reversed: Boolean) = launch {
+        syncSettings.devicesSortReversed.value(reversed)
     }
 
     fun deleteDevice(deviceId: DeviceId) = launch {

--- a/app/src/test/java/eu/darken/octi/sync/ui/devices/SyncDevicesSortingTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/ui/devices/SyncDevicesSortingTest.kt
@@ -1,0 +1,189 @@
+package eu.darken.octi.sync.ui.devices
+
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncDevicesSortMode
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class SyncDevicesSortingTest : BaseTest() {
+
+    private val baseInstant = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private fun item(
+        id: String,
+        label: String = id,
+        addedAt: Instant? = null,
+        lastSeen: Instant? = null,
+        metaVersion: String? = null,
+        serverVersion: String? = null,
+    ) = SyncDevicesVM.DeviceItem(
+        deviceId = DeviceId(id),
+        metaInfo = metaVersion?.let {
+            MetaInfo(
+                deviceLabel = label,
+                deviceId = DeviceId(id),
+                octiVersionName = it,
+                octiGitSha = "sha",
+                deviceManufacturer = "vendor",
+                deviceName = label,
+                deviceType = MetaInfo.DeviceType.PHONE,
+                deviceBootedAt = baseInstant,
+                androidVersionName = "14",
+                androidApiLevel = 34,
+                androidSecurityPatch = null,
+            )
+        },
+        lastSeen = lastSeen,
+        error = null,
+        serverVersion = serverVersion,
+        serverAddedAt = addedAt,
+        serverPlatform = "android",
+        displayLabel = label,
+    )
+
+    @Nested
+    inner class `DATE_ADDED` {
+        @Test
+        fun `descending with nulls last`() {
+            val older = item(id = "a", label = "Alpha", addedAt = baseInstant)
+            val newer = item(id = "b", label = "Bravo", addedAt = baseInstant.plus(1.days))
+            val unknown = item(id = "c", label = "Charlie", addedAt = null)
+
+            val sorted = listOf(older, unknown, newer).sortedWith(comparatorFor(SyncDevicesSortMode.DATE_ADDED))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("b", "a", "c")
+        }
+
+        @Test
+        fun `nulls fall back to alphabetical tie-break`() {
+            val charlie = item(id = "c", label = "Charlie", addedAt = null)
+            val alpha = item(id = "a", label = "Alpha", addedAt = null)
+            val bravo = item(id = "b", label = "Bravo", addedAt = null)
+
+            val sorted = listOf(charlie, bravo, alpha).sortedWith(comparatorFor(SyncDevicesSortMode.DATE_ADDED))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("a", "b", "c")
+        }
+    }
+
+    @Nested
+    inner class `LAST_SEEN` {
+        @Test
+        fun `descending with nulls last`() {
+            val older = item(id = "a", lastSeen = baseInstant)
+            val newer = item(id = "b", lastSeen = baseInstant.plus(1.hours))
+            val unknown = item(id = "c", lastSeen = null)
+
+            val sorted = listOf(older, unknown, newer).sortedWith(comparatorFor(SyncDevicesSortMode.LAST_SEEN))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("b", "a", "c")
+        }
+    }
+
+    @Nested
+    inner class `NAME` {
+        @Test
+        fun `case insensitive ascending then deviceId tie-break`() {
+            val a1 = item(id = "z", label = "alpha")
+            val a2 = item(id = "a", label = "ALPHA")
+            val b = item(id = "m", label = "Bravo")
+
+            val sorted = listOf(b, a1, a2).sortedWith(comparatorFor(SyncDevicesSortMode.NAME))
+
+            // "ALPHA" / "alpha" tie under case-insensitive — deviceId tie-break: "a" < "z"
+            sorted.map { it.deviceId.id } shouldBe listOf("a", "z", "m")
+        }
+    }
+
+    @Nested
+    inner class `reversed` {
+        @Test
+        fun `DATE_ADDED reversed flips primary key but keeps nulls last`() {
+            val older = item(id = "a", label = "Alpha", addedAt = baseInstant)
+            val newer = item(id = "b", label = "Bravo", addedAt = baseInstant.plus(1.days))
+            val unknown = item(id = "c", label = "Charlie", addedAt = null)
+
+            val sorted = listOf(older, unknown, newer).sortedWith(
+                comparatorFor(SyncDevicesSortMode.DATE_ADDED, reversed = true)
+            )
+
+            sorted.map { it.deviceId.id } shouldBe listOf("a", "b", "c")
+        }
+
+        @Test
+        fun `NAME reversed sorts Z to A`() {
+            val a = item(id = "a", label = "Alpha")
+            val b = item(id = "b", label = "Bravo")
+            val c = item(id = "c", label = "Charlie")
+
+            val sorted = listOf(a, b, c).sortedWith(comparatorFor(SyncDevicesSortMode.NAME, reversed = true))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("c", "b", "a")
+        }
+
+        @Test
+        fun `APP_VERSION reversed puts older versions first`() {
+            val older = item(id = "old", metaVersion = "0.9.0")
+            val newer = item(id = "new", metaVersion = "1.0.0")
+            val unknown = item(id = "miss", metaVersion = null)
+
+            val sorted = listOf(newer, older, unknown).sortedWith(
+                comparatorFor(SyncDevicesSortMode.APP_VERSION, reversed = true)
+            )
+
+            sorted.map { it.deviceId.id } shouldBe listOf("old", "new", "miss")
+        }
+    }
+
+    @Nested
+    inner class `APP_VERSION` {
+        @Test
+        fun `0_10_0 sorts above 0_9_0 (semver beats lexical)`() {
+            val older = item(id = "a", metaVersion = "0.9.0")
+            val newer = item(id = "b", metaVersion = "0.10.0")
+
+            val sorted = listOf(older, newer).sortedWith(comparatorFor(SyncDevicesSortMode.APP_VERSION))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("b", "a")
+        }
+
+        @Test
+        fun `stable release sorts above prereleases`() {
+            val rc = item(id = "rc", metaVersion = "1.0.0-rc0")
+            val beta = item(id = "beta", metaVersion = "1.0.0-beta1")
+            val stable = item(id = "stable", metaVersion = "1.0.0")
+
+            val sorted = listOf(beta, rc, stable).sortedWith(comparatorFor(SyncDevicesSortMode.APP_VERSION))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("stable", "rc", "beta")
+        }
+
+        @Test
+        fun `unparseable and null versions sort to bottom`() {
+            val good = item(id = "good", label = "Good", metaVersion = "1.0.0")
+            val unparseable = item(id = "broken", label = "Broken", metaVersion = "not-a-version")
+            val nullVer = item(id = "missing", label = "Missing", metaVersion = null)
+
+            val sorted = listOf(unparseable, nullVer, good).sortedWith(comparatorFor(SyncDevicesSortMode.APP_VERSION))
+
+            sorted.first().deviceId.id shouldBe "good"
+            sorted.drop(1).map { it.deviceId.id }.toSet() shouldBe setOf("broken", "missing")
+        }
+
+        @Test
+        fun `falls back to serverVersion when metaInfo is null`() {
+            val withMeta = item(id = "meta", metaVersion = "1.0.0", serverVersion = "1.0.0")
+            val serverOnly = item(id = "server", metaVersion = null, serverVersion = "2.0.0")
+
+            val sorted = listOf(withMeta, serverOnly).sortedWith(comparatorFor(SyncDevicesSortMode.APP_VERSION))
+
+            sorted.map { it.deviceId.id } shouldBe listOf("server", "meta")
+        }
+    }
+}

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListScreen.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/appslist/AppsListScreen.kt
@@ -14,14 +14,11 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.Sort
 import androidx.compose.material.icons.twotone.Android
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -42,6 +39,7 @@ import coil3.compose.AsyncImage
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.compose.SortModeDialog
 import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
@@ -94,8 +92,10 @@ fun AppsListScreenHost(
     }
 
     if (showSortDialog) {
-        SortDialog(
+        SortModeDialog(
+            title = stringResource(AppsR.string.module_apps_sort_label),
             currentMode = state?.sortMode ?: AppsSortMode.NAME,
+            modes = AppsSortMode.entries,
             onSelect = { mode ->
                 vm.updateSortMode(mode)
                 showSortDialog = false
@@ -194,43 +194,6 @@ private fun AppItem(item: AppsListVM.PkgItem) {
             )
         }
     }
-}
-
-@Composable
-private fun SortDialog(
-    currentMode: AppsSortMode,
-    onSelect: (AppsSortMode) -> Unit,
-    onDismiss: () -> Unit,
-) {
-    val context = LocalContext.current
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(stringResource(AppsR.string.module_apps_sort_label)) },
-        text = {
-            Column {
-                AppsSortMode.entries.forEach { mode ->
-                    Row(
-                        modifier = Modifier
-                            .clickable { onSelect(mode) }
-                            .padding(vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = mode == currentMode,
-                            onClick = { onSelect(mode) },
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = mode.label.get(context))
-                    }
-                }
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(android.R.string.cancel))
-            }
-        },
-    )
 }
 
 @Preview2

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncDevicesSortMode.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncDevicesSortMode.kt
@@ -1,0 +1,17 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.ca.CaString
+import eu.darken.octi.common.ca.toCaString
+import eu.darken.octi.common.preferences.EnumPreference
+import eu.darken.octi.sync.R
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class SyncDevicesSortMode(override val label: CaString) : EnumPreference<SyncDevicesSortMode> {
+    @SerialName("DATE_ADDED") DATE_ADDED(R.string.sync_devices_sort_date_added_label.toCaString()),
+    @SerialName("LAST_SEEN") LAST_SEEN(R.string.sync_devices_sort_last_seen_label.toCaString()),
+    @SerialName("NAME") NAME(R.string.sync_devices_sort_name_label.toCaString()),
+    @SerialName("APP_VERSION") APP_VERSION(R.string.sync_devices_sort_app_version_label.toCaString()),
+    ;
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncSettings.kt
@@ -53,6 +53,15 @@ class SyncSettings @Inject constructor(
 
     val showDashboardCard = dataStore.createValue("sync.dashboard.card.show", true)
 
+    val devicesSortMode = dataStore.createValue(
+        "sync.devices.sort.mode",
+        SyncDevicesSortMode.DATE_ADDED,
+        json,
+        onErrorFallbackToDefault = true,
+    )
+
+    val devicesSortReversed = dataStore.createValue("sync.devices.sort.reversed", false)
+
     private val legacyPausedConnectors = dataStore.createSetValue<ConnectorId>(
         "sync.connectors.paused",
         emptySet(),

--- a/sync-core/src/main/res/values/strings.xml
+++ b/sync-core/src/main/res/values/strings.xml
@@ -42,6 +42,12 @@
     <string name="sync_connector_progress_device_update_queued">Device update queued...</string>
     <string name="sync_synced_devices_label">Synced devices</string>
 
+    <string name="sync_devices_sort_label">Sort</string>
+    <string name="sync_devices_sort_date_added_label">By date added</string>
+    <string name="sync_devices_sort_last_seen_label">By last seen</string>
+    <string name="sync_devices_sort_name_label">By name</string>
+    <string name="sync_devices_sort_app_version_label">By app version</string>
+
     <plurals name="sync_stale_period_days">
         <item quantity="one">%d day</item>
         <item quantity="other">%d days</item>

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -542,6 +542,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     platform = info?.platform,
                     label = info?.label,
                     lastSeen = lastSeen,
+                    addedAt = dir.createdTime?.let { Instant.fromEpochMilliseconds(it.value) },
                 )
             }
         }.awaitAll()


### PR DESCRIPTION
## Summary

- Add a sort menu to the **Synced devices** screen (top-right). Choose between **By date added** (default — newest first), **By last seen**, **By name**, and **By app version**.
- Add a **Reverse order** toggle in the same dialog so each mode can flip direction. Mode and reverse state both persist across app restarts.
- Populate `addedAt` for Google Drive devices from the device folder's `createdTime`, so the new default sort works on GDrive accounts (not only Octi Server).
- Extract the sort dialog into a shared composable (`SortModeDialog`) and migrate the Apps list screen onto it to remove duplication.

## Test plan

- [ ] Open Synced devices on a GDrive connector — devices appear newest-first by default.
- [ ] Open the sort dialog, switch through each of the four modes — list reorders, dialog dismisses on selection.
- [ ] Toggle "Reverse order" on — list flips; dialog stays open until a mode is picked or dismissed.
- [ ] Force-stop and relaunch the app — last selected mode and reverse state are restored.
- [ ] Open the Apps list — sort dialog still works (Name / Install date / Update date) without a reverse toggle.
- [ ] Run `:app:testFossDebugUnitTest --tests "*SyncDevicesSortingTest"` — comparator covers null handling, semver ordering, prerelease ordering, and reversed direction.
