### PR TITLE
Show connector identity and refresh on Synced devices screen

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -48,6 +48,7 @@ import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.IssueSeverity
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.core.disambiguatedAccountLabel
 import eu.darken.octi.sync.core.SyncExecutor
 import eu.darken.octi.sync.core.SyncManager
 import eu.darken.octi.sync.core.SyncOrchestrator
@@ -715,15 +716,16 @@ class DashboardVM @Inject constructor(
 
 
     private fun List<ConnectorDetail>.disambiguateLabels(): List<ConnectorDetail> {
-        val duplicates = groupBy { it.type to it.accountLabel }.filterValues { it.size > 1 }
-        if (duplicates.isEmpty()) return this
+        val peerKeys = map { it.type to it.accountLabel }
         return map { detail ->
-            if (duplicates.containsKey(detail.type to detail.accountLabel)) {
-                val shortId = detail.connectorId.account.take(8)
-                detail.copy(accountLabel = "${detail.accountLabel} ($shortId)")
-            } else {
-                detail
-            }
+            detail.copy(
+                accountLabel = disambiguatedAccountLabel(
+                    type = detail.type,
+                    account = detail.connectorId.account,
+                    accountLabel = detail.accountLabel,
+                    peerKeys = peerKeys,
+                ),
+            )
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
@@ -1,28 +1,38 @@
 package eu.darken.octi.sync.ui.devices
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.twotone.Sort
+import androidx.compose.material.icons.twotone.Refresh
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.octi.sync.R as SyncR
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.compose.SortModeDialog
@@ -31,6 +41,7 @@ import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.sync.core.DeviceRemovalPolicy
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.LocalConnectorContributions
 import eu.darken.octi.sync.core.SyncDevicesSortMode
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
@@ -56,6 +67,7 @@ fun SyncDevicesScreenHost(
             onNavigateUp = { vm.navUp() },
             onDeleteDevice = { deviceId -> vm.deleteDevice(deviceId) },
             onSort = { showSortDialog = true },
+            onRefresh = { vm.refresh() },
         )
 
         if (showSortDialog) {
@@ -82,6 +94,7 @@ fun SyncDevicesScreen(
     onNavigateUp: () -> Unit,
     onDeleteDevice: (DeviceId) -> Unit,
     onSort: () -> Unit,
+    onRefresh: () -> Unit,
 ) {
     var selectedDeviceId by rememberSaveable { mutableStateOf<String?>(null) }
     var initialConsumed by rememberSaveable { mutableStateOf(false) }
@@ -104,16 +117,55 @@ fun SyncDevicesScreen(
 
     val selectedDevice = selectedDeviceId?.let { id -> state.items.find { it.deviceId.id == id } }
 
+    val contribution = state.connectorType?.let { LocalConnectorContributions.current[it] }
+    val subtitleText = contribution?.let { c ->
+        val typeLabel = stringResource(c.labelRes)
+        val account = state.accountLabel?.takeUnless { it.isBlank() }
+        if (account != null) "$typeLabel · $account" else typeLabel
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(text = stringResource(SyncR.string.sync_synced_devices_label)) },
+                title = {
+                    Column {
+                        Text(text = stringResource(SyncR.string.sync_synced_devices_label))
+                        if (subtitleText != null) {
+                            Text(
+                                text = subtitleText,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                },
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
                     }
                 },
                 actions = {
+                    if (!state.isPaused) {
+                        Box(
+                            modifier = Modifier.size(48.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (state.isBusy) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(20.dp),
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                IconButton(onClick = onRefresh) {
+                                    Icon(
+                                        imageVector = Icons.TwoTone.Refresh,
+                                        contentDescription = stringResource(CommonR.string.general_sync_action),
+                                    )
+                                }
+                            }
+                        }
+                    }
                     IconButton(onClick = onSort) {
                         Icon(
                             imageVector = Icons.AutoMirrored.TwoTone.Sort,
@@ -208,6 +260,7 @@ private fun SyncDevicesScreenPreview() = PreviewWrapper {
         onNavigateUp = {},
         onDeleteDevice = {},
         onSort = {},
+        onRefresh = {},
     )
 }
 
@@ -219,5 +272,7 @@ private fun SyncDevicesScreenEmptyPreview() = PreviewWrapper {
         onNavigateUp = {},
         onDeleteDevice = {},
         onSort = {},
+        onRefresh = {},
     )
 }
+

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesVM.kt
@@ -11,6 +11,7 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.replayingShare
+import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.modules.meta.MetaModule
 import eu.darken.octi.modules.meta.core.MetaInfo
@@ -25,6 +26,7 @@ import eu.darken.octi.sync.core.ConnectorIssueAggregator
 import eu.darken.octi.sync.core.SyncDevicesSortMode
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
+import eu.darken.octi.sync.core.disambiguatedAccountLabel
 import eu.darken.octi.sync.core.shortLabel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -104,6 +106,9 @@ class SyncDevicesVM @Inject constructor(
         val deletingDeviceIds: Set<DeviceId> = emptySet(),
         val sortMode: SyncDevicesSortMode = SyncDevicesSortMode.DATE_ADDED,
         val sortReversed: Boolean = false,
+        val connectorType: ConnectorType? = null,
+        val accountLabel: String? = null,
+        val isBusy: Boolean = false,
     )
 
     private val sortPrefs = combine(
@@ -111,64 +116,78 @@ class SyncDevicesVM @Inject constructor(
         syncSettings.devicesSortReversed.flow,
     ) { mode, reversed -> mode to reversed }
 
-    val state = connectorFlow
-        .flatMapLatest { connector ->
-            combine(
-                connector.state.map { it.deviceMetadata },
-                connector.data.map { data ->
-                    data?.devices
-                        ?.flatMap { it.modules }
-                        ?.filter { it.moduleId == MetaModule.MODULE_ID }
-                },
-                connector.operations,
-                issueAggregator.issues,
-                syncSettings.pausedConnectorIds,
-            ) { deviceMetadata, metaDatas, operations, allIssues, pausedIds ->
-                log(TAG) { "Loading devices, ${deviceMetadata.size} metadata, ${allIssues.size} issues" }
+    val state = combine(connectorFlow, manager.allConnectors) { connector, allConnectors ->
+        connector to allConnectors
+    }.flatMapLatest { (connector, allConnectors) ->
+        combine(
+            connector.state.map { it.deviceMetadata },
+            connector.data.map { data ->
+                data?.devices
+                    ?.flatMap { it.modules }
+                    ?.filter { it.moduleId == MetaModule.MODULE_ID }
+            },
+            connector.operations,
+            issueAggregator.issues,
+            syncSettings.pausedConnectorIds,
+        ) { deviceMetadata, metaDatas, operations, allIssues, pausedIds ->
+            log(TAG) { "Loading devices, ${deviceMetadata.size} metadata, ${allIssues.size} issues" }
 
-                val connectorId = connector.identifier
-                val items = deviceMetadata.map { deviceMeta ->
-                    val deviceId = deviceMeta.deviceId
-                    var error: Exception? = null
-                    val metaInfo = metaDatas?.find { it.deviceId == deviceId }?.let {
-                        try {
-                            metaSerializer.deserialize(it.payload)
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Failed to deserialize MetaInfo:\n${e.asLog()}" }
-                            error = e
-                            null
-                        }
+            val connectorId = connector.identifier
+            val items = deviceMetadata.map { deviceMeta ->
+                val deviceId = deviceMeta.deviceId
+                var error: Exception? = null
+                val metaInfo = metaDatas?.find { it.deviceId == deviceId }?.let {
+                    try {
+                        metaSerializer.deserialize(it.payload)
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Failed to deserialize MetaInfo:\n${e.asLog()}" }
+                        error = e
+                        null
                     }
-                    DeviceItem(
-                        deviceId = deviceId,
-                        metaInfo = metaInfo,
-                        lastSeen = deviceMeta.lastSeen,
-                        error = error,
-                        serverVersion = deviceMeta.version,
-                        serverAddedAt = deviceMeta.addedAt,
-                        serverPlatform = deviceMeta.platform,
-                        serverLabel = deviceMeta.label,
-                        issues = allIssues.filter { it.connectorId == connectorId && it.deviceId == deviceId },
-                    )
                 }
-
-                val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
-                val displayItems = items.map { item ->
-                    item.copy(displayLabel = labelsByDevice[item.deviceId] ?: item.baseLabel)
-                }
-
-                val deletingIds = operations
-                    .filter { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing }
-                    .mapNotNullTo(mutableSetOf()) { (it.command as? ConnectorCommand.DeleteDevice)?.deviceId }
-
-                State(
-                    items = displayItems,
-                    deviceRemovalPolicy = connector.capabilities.deviceRemovalPolicy,
-                    isPaused = pausedIds.contains(connectorId),
-                    deletingDeviceIds = deletingIds,
+                DeviceItem(
+                    deviceId = deviceId,
+                    metaInfo = metaInfo,
+                    lastSeen = deviceMeta.lastSeen,
+                    error = error,
+                    serverVersion = deviceMeta.version,
+                    serverAddedAt = deviceMeta.addedAt,
+                    serverPlatform = deviceMeta.platform,
+                    serverLabel = deviceMeta.label,
+                    issues = allIssues.filter { it.connectorId == connectorId && it.deviceId == deviceId },
                 )
             }
+
+            val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
+            val displayItems = items.map { item ->
+                item.copy(displayLabel = labelsByDevice[item.deviceId] ?: item.baseLabel)
+            }
+
+            val activeOperations = operations.filter {
+                it is ConnectorOperation.Queued || it is ConnectorOperation.Processing
+            }
+            val deletingIds = activeOperations
+                .mapNotNullTo(mutableSetOf()) { (it.command as? ConnectorCommand.DeleteDevice)?.deviceId }
+            val isBusy = activeOperations.isNotEmpty()
+
+            val displayedAccountLabel = disambiguatedAccountLabel(
+                type = connectorId.type,
+                account = connectorId.account,
+                accountLabel = connector.accountLabel,
+                peerKeys = allConnectors.map { it.identifier.type to it.accountLabel },
+            )
+
+            State(
+                items = displayItems,
+                deviceRemovalPolicy = connector.capabilities.deviceRemovalPolicy,
+                isPaused = pausedIds.contains(connectorId),
+                deletingDeviceIds = deletingIds,
+                connectorType = connectorId.type,
+                accountLabel = displayedAccountLabel,
+                isBusy = isBusy,
+            )
         }
+    }
         .combine(sortPrefs) { state, (sortMode, reversed) ->
             state.copy(
                 items = state.items.sortedWith(comparatorFor(sortMode, reversed)),
@@ -206,6 +225,20 @@ class SyncDevicesVM @Inject constructor(
         // device from connector state + data, which drops the row from state.items — the UI
         // auto-dismisses the sheet. Failure surfaces via the completions bridge in init.
         connector.submit(ConnectorCommand.DeleteDevice(deviceId))
+    }
+
+    fun refresh() = launch(appScope) {
+        log(TAG, INFO) { "refresh()" }
+        val connector = connectorFlow.first()
+        val syncAlreadyActive = connector.operations.value.any {
+            (it is ConnectorOperation.Queued || it is ConnectorOperation.Processing) &&
+                it.command is ConnectorCommand.Sync
+        }
+        if (syncAlreadyActive) {
+            log(TAG, INFO) { "refresh: Sync already in flight, skipping duplicate" }
+            return@launch
+        }
+        manager.sync(connector.identifier)
     }
 
     companion object {

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorLabelExtensions.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorLabelExtensions.kt
@@ -1,0 +1,22 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.sync.ConnectorType
+
+private const val CONNECTOR_LABEL_ID_CHARS = 8
+
+/**
+ * Returns the account label, suffixed with a short id when (type, accountLabel) clashes with
+ * at least one other entry in [peerKeys]. Used by sync UI surfaces to disambiguate otherwise-
+ * identical connector rows (e.g. two Octi Server accounts on the same domain).
+ *
+ * [peerKeys] should include the target itself; a clash is any count > 1.
+ */
+fun disambiguatedAccountLabel(
+    type: ConnectorType,
+    account: String,
+    accountLabel: String,
+    peerKeys: Iterable<Pair<ConnectorType, String>>,
+): String {
+    val matches = peerKeys.count { it.first == type && it.second == accountLabel }
+    return if (matches > 1) "$accountLabel (${account.take(CONNECTOR_LABEL_ID_CHARS)})" else accountLabel
+}


### PR DESCRIPTION
## Summary

Adds connector context to the Synced devices screen so users with multiple sync backends can tell which one they're managing — and refresh it without leaving the screen.

- Two-line `TopAppBar`: title `Synced devices` + a subtitle showing the connector type and account label, e.g. `Google Drive · me@gmail.com` or `Octi Server · sync.darken.eu`.
- Refresh icon in the toolbar (left of the existing sort icon) that triggers a manual sync. Swaps to a spinner while any operation is in flight on the connector, and is hidden when the connector is paused. Rapid double-taps are debounced via a peek-and-skip guard in the VM.
- When two connectors of the same type share the same `accountLabel` (e.g. two Octi Server accounts on the same server), the subtitle is suffixed with a short ID — same disambiguation rule the dashboard chip already uses.
- Disambiguation logic moved to `sync-core` (`disambiguatedAccountLabel`); the dashboard's previous private extension now delegates to the shared helper.

## Test plan

- [x] `./gradlew :app:assembleFossDebug` passes
- [x] On-device validation (emulator): GDrive subtitle reads `Google Drive · <email>`, Octi Server reads `Octi Server · <domain>`. Refresh icon visible to the left of Sort, swap-to-spinner behavior confirmed (sync completes too fast on a local emulator to capture the spinner in a screenshot, but the icon-disappear → reappear sequence is observable in the element list)
- [ ] Verify two connectors of the same type produce distinct disambiguated subtitles (test environment doesn't currently have this case)
- [ ] Verify large accessibility font scale doesn't clip the two-line title
