### PR TITLE
Show full device details in sync action sheet

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/compose/DetailRow.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/compose/DetailRow.kt
@@ -44,9 +44,15 @@ fun DetailRow(label: String, value: String) {
 }
 
 @Composable
-fun CopyableDetailRow(label: String, value: String, copyable: Boolean, showMessage: (String) -> Unit) {
+fun CopyableDetailRow(
+    label: String,
+    value: String,
+    copyable: Boolean,
+    showMessage: (String) -> Unit,
+    copiedMessage: String? = null,
+) {
     val context = LocalContext.current
-    val copiedMsg = stringResource(CommonR.string.general_copy_action)
+    val resolvedMsg = copiedMessage ?: stringResource(CommonR.string.general_copy_action)
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -69,8 +75,8 @@ fun CopyableDetailRow(label: String, value: String, copyable: Boolean, showMessa
             IconButton(
                 onClick = {
                     val clipboard = context.getSystemService(ClipboardManager::class.java)
-                    clipboard.setPrimaryClip(ClipData.newPlainText("IP", value))
-                    showMessage(copiedMsg)
+                    clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+                    showMessage(resolvedMsg)
                 },
                 modifier = Modifier.size(28.dp),
             ) {

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceActionsSheet.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.sync.ui.devices
 
+import android.text.format.DateUtils
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,39 +9,44 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Android
 import androidx.compose.material.icons.twotone.DeleteSweep
-import androidx.compose.material.icons.twotone.PhoneAndroid
-import androidx.compose.material.icons.twotone.QuestionMark
-import androidx.compose.material.icons.twotone.Tablet
+import androidx.compose.material.icons.twotone.Error
+import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import android.text.format.DateUtils
 import eu.darken.octi.R
-import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.compose.CopyableDetailRow
+import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceRemovalPolicy
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.common.ca.CaString
+import eu.darken.octi.common.ca.toCaString
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 @Composable
 fun DeviceActionsSheet(
@@ -50,7 +56,9 @@ fun DeviceActionsSheet(
     isDeleting: Boolean,
     onDismiss: () -> Unit,
     onDelete: () -> Unit,
+    showMessage: (String) -> Unit,
 ) {
+    val context = LocalContext.current
     val removeIsRevoke = when (removalPolicy) {
         DeviceRemovalPolicy.REMOVE_LOCAL_ONLY -> false
         DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE -> true
@@ -58,99 +66,125 @@ fun DeviceActionsSheet(
     }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = when (device.metaInfo?.deviceType) {
-                        MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
-                        MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
-                        else -> Icons.TwoTone.QuestionMark
-                    },
-                    contentDescription = null,
-                    modifier = Modifier.size(20.dp),
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = device.displayLabel,
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier.weight(1f),
-                )
-                Column(horizontalAlignment = Alignment.End) {
-                    device.serverVersion?.let { version ->
-                        Text(
-                            text = version,
-                            style = MaterialTheme.typography.labelMedium,
-                        )
-                    }
-                    device.serverPlatform?.let { platform ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                imageVector = when (platform.lowercase()) {
-                                    "android" -> Icons.TwoTone.Android
-                                    else -> Icons.TwoTone.QuestionMark
-                                },
-                                contentDescription = null,
-                                modifier = Modifier.size(12.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(modifier = Modifier.width(4.dp))
-                            Text(
-                                text = platform.replaceFirstChar { it.uppercase() },
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
-
-            Text(
-                text = device.deviceId.id,
-                style = MaterialTheme.typography.labelMedium,
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            DeviceHeader(
+                item = device,
+                titleStyle = MaterialTheme.typography.titleMedium,
             )
 
-            device.lastSeen?.let { lastSeen ->
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(
-                        SyncR.string.sync_device_last_seen_label,
-                        DateUtils.getRelativeTimeSpanString(lastSeen.toEpochMilliseconds()).toString(),
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            device.serverAddedAt?.let { addedAt ->
-                Spacer(modifier = Modifier.height(4.dp))
-                Text(
-                    text = stringResource(
-                        R.string.sync_device_added_at_label,
-                        DateUtils.formatDateTime(
-                            LocalContext.current,
-                            addedAt.toEpochMilliseconds(),
-                            DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
-                        ),
-                    ),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-
-            if (device.issues.isNotEmpty()) {
-                Spacer(modifier = Modifier.height(12.dp))
-                device.issues.forEach { issue ->
-                    val tint = when (issue.severity) {
-                        IssueSeverity.ERROR -> MaterialTheme.colorScheme.error
-                        IssueSeverity.WARNING -> MaterialTheme.colorScheme.tertiary
-                    }
+            device.error?.let { error ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.Top) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Error,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = MaterialTheme.colorScheme.error,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = issue.description.get(LocalContext.current),
+                        text = error.localizedMessage
+                            ?: stringResource(CommonR.string.general_error_label),
                         style = MaterialTheme.typography.bodySmall,
-                        color = tint,
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.weight(1f),
                     )
                 }
             }
 
+            if (device.issues.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            device.issues.forEach { issue ->
+                val tint = when (issue.severity) {
+                    IssueSeverity.ERROR -> MaterialTheme.colorScheme.error
+                    IssueSeverity.WARNING -> MaterialTheme.colorScheme.tertiary
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.Top) {
+                    Icon(
+                        imageVector = when (issue.severity) {
+                            IssueSeverity.ERROR -> Icons.TwoTone.Error
+                            IssueSeverity.WARNING -> Icons.TwoTone.Warning
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = tint,
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = issue.description.get(context).ifBlank { issue.label.get(context) },
+                        style = MaterialTheme.typography.bodySmall,
+                        color = tint,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            device.metaInfo?.let { meta ->
+                DetailRow(
+                    label = stringResource(R.string.sync_device_model_label),
+                    value = meta.deviceName,
+                )
+                DetailRow(
+                    label = stringResource(R.string.sync_device_android_version_label),
+                    value = "${meta.androidVersionName} (API ${meta.androidApiLevel})",
+                )
+                meta.androidSecurityPatch?.takeIf { it.isNotBlank() }?.let { patch ->
+                    DetailRow(
+                        label = stringResource(R.string.sync_device_security_patch_label),
+                        value = patch,
+                    )
+                }
+                DetailRow(
+                    label = stringResource(R.string.sync_device_booted_label),
+                    value = DateUtils.getRelativeTimeSpanString(meta.deviceBootedAt.toEpochMilliseconds()).toString(),
+                )
+            }
+
+            CopyableDetailRow(
+                label = stringResource(R.string.sync_device_id_label),
+                value = device.deviceId.id,
+                copyable = true,
+                showMessage = showMessage,
+                copiedMessage = stringResource(R.string.sync_device_id_copied_toast),
+            )
+
+            device.metaInfo?.let { meta ->
+                DetailRow(
+                    label = stringResource(R.string.sync_device_octi_version_label),
+                    value = "${meta.octiVersionName} (${meta.octiGitSha})",
+                )
+            }
+
+            device.serverAddedAt?.let { addedAt ->
+                DetailRow(
+                    label = stringResource(R.string.sync_device_added_label),
+                    value = DateUtils.formatDateTime(
+                        context,
+                        addedAt.toEpochMilliseconds(),
+                        DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_YEAR or DateUtils.FORMAT_ABBREV_MONTH,
+                    ),
+                )
+            }
+
+            device.lastSeen?.let { lastSeen ->
+                DetailRow(
+                    label = stringResource(R.string.sync_device_last_seen_short_label),
+                    value = DateUtils.getRelativeTimeSpanString(lastSeen.toEpochMilliseconds()).toString(),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            HorizontalDivider()
             Spacer(modifier = Modifier.height(16.dp))
 
             Button(
@@ -196,70 +230,138 @@ fun DeviceActionsSheet(
     }
 }
 
+private val previewDeviceId = DeviceId("device-abc-123")
+private val previewConnectorId = ConnectorId(
+    type = ConnectorType.GDRIVE,
+    subtype = "preview",
+    account = "preview@example.com",
+)
+
+private val previewMeta = MetaInfo(
+    deviceLabel = "Pixel 8",
+    deviceId = previewDeviceId,
+    octiVersionName = "0.14.0",
+    octiGitSha = "abc1234",
+    deviceManufacturer = "Google",
+    deviceName = "Pixel 8",
+    deviceType = MetaInfo.DeviceType.PHONE,
+    deviceBootedAt = Clock.System.now() - (86400 * 5).seconds,
+    androidVersionName = "14",
+    androidApiLevel = 34,
+    androidSecurityPatch = "2024-01-05",
+)
+
+private fun previewDevice(
+    metaInfo: MetaInfo? = previewMeta,
+    error: Exception? = null,
+    issues: List<ConnectorIssue> = emptyList(),
+): SyncDevicesVM.DeviceItem = SyncDevicesVM.DeviceItem(
+    deviceId = previewDeviceId,
+    metaInfo = metaInfo,
+    lastSeen = Clock.System.now(),
+    error = error,
+    serverVersion = "0.14.0",
+    serverAddedAt = Clock.System.now() - (86400 * 30).seconds,
+    serverPlatform = "android",
+    issues = issues,
+)
+
+private fun previewIssue(severity: IssueSeverity, label: String, description: String): ConnectorIssue =
+    object : ConnectorIssue {
+        override val connectorId = previewConnectorId
+        override val deviceId = previewDeviceId
+        override val severity = severity
+        override val label: CaString = label.toCaString()
+        override val description: CaString = description.toCaString()
+    }
+
 @Preview2
 @Composable
 private fun DeviceActionsSheetPreview() = PreviewWrapper {
-    val deviceId = DeviceId("device-abc-123")
     DeviceActionsSheet(
-        device = SyncDevicesVM.DeviceItem(
-            deviceId = deviceId,
-            metaInfo = MetaInfo(
-                deviceLabel = "Pixel 8",
-                deviceId = deviceId,
-                octiVersionName = "0.14.0",
-                octiGitSha = "abc1234",
-                deviceManufacturer = "Google",
-                deviceName = "Pixel 8",
-                deviceType = MetaInfo.DeviceType.PHONE,
-                deviceBootedAt = Clock.System.now(),
-                androidVersionName = "14",
-                androidApiLevel = 34,
-                androidSecurityPatch = "2024-01-05",
-            ),
-            lastSeen = Clock.System.now(),
-            error = null,
-            serverVersion = "0.14.0",
-            serverAddedAt = Clock.System.now() - (86400 * 30).seconds,
-            serverPlatform = "android",
+        device = previewDevice(
+            issues = listOf(previewIssue(IssueSeverity.WARNING, "Stale device", "Device hasn't synced in 14 days")),
         ),
         removalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
         isPaused = false,
         isDeleting = false,
         onDismiss = {},
         onDelete = {},
+        showMessage = {},
     )
 }
 
 @Preview2
 @Composable
 private fun DeviceActionsSheetDeletingPreview() = PreviewWrapper {
-    val deviceId = DeviceId("device-abc-123")
     DeviceActionsSheet(
-        device = SyncDevicesVM.DeviceItem(
-            deviceId = deviceId,
-            metaInfo = MetaInfo(
-                deviceLabel = "Pixel 8",
-                deviceId = deviceId,
-                octiVersionName = "0.14.0",
-                octiGitSha = "abc1234",
-                deviceManufacturer = "Google",
-                deviceName = "Pixel 8",
-                deviceType = MetaInfo.DeviceType.PHONE,
-                deviceBootedAt = Clock.System.now(),
-                androidVersionName = "14",
-                androidApiLevel = 34,
-                androidSecurityPatch = "2024-01-05",
-            ),
-            lastSeen = Clock.System.now(),
-            error = null,
-            serverVersion = "0.14.0",
-            serverAddedAt = Clock.System.now() - (86400 * 30).seconds,
-            serverPlatform = "android",
-        ),
+        device = previewDevice(),
         removalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
         isPaused = false,
         isDeleting = true,
         onDismiss = {},
         onDelete = {},
+        showMessage = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun DeviceActionsSheetErrorPreview() = PreviewWrapper {
+    DeviceActionsSheet(
+        device = previewDevice(
+            metaInfo = null,
+            error = RuntimeException("Failed to deserialize MetaInfo: unknown field 'foo'"),
+        ),
+        removalPolicy = DeviceRemovalPolicy.REMOVE_LOCAL_ONLY,
+        isPaused = false,
+        isDeleting = false,
+        onDismiss = {},
+        onDelete = {},
+        showMessage = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun DeviceActionsSheetNoSecurityPatchPreview() = PreviewWrapper {
+    DeviceActionsSheet(
+        device = previewDevice(
+            metaInfo = previewMeta.copy(androidSecurityPatch = null),
+        ),
+        removalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
+        isPaused = false,
+        isDeleting = false,
+        onDismiss = {},
+        onDelete = {},
+        showMessage = {},
+    )
+}
+
+@androidx.compose.ui.tooling.preview.Preview(widthDp = 720, heightDp = 360, showBackground = true)
+@Composable
+private fun DeviceActionsSheetLandscapePreview() = PreviewWrapper {
+    DeviceActionsSheet(
+        device = previewDevice(),
+        removalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
+        isPaused = false,
+        isDeleting = false,
+        onDismiss = {},
+        onDelete = {},
+        showMessage = {},
+    )
+}
+
+@androidx.compose.ui.tooling.preview.Preview(fontScale = 1.5f, showBackground = true)
+@Composable
+private fun DeviceActionsSheetLargeFontPreview() = PreviewWrapper {
+    DeviceActionsSheet(
+        device = previewDevice(),
+        removalPolicy = DeviceRemovalPolicy.REMOVE_AND_REVOKE_REMOTE,
+        isPaused = false,
+        isDeleting = false,
+        onDismiss = {},
+        onDelete = {},
+        showMessage = {},
     )
 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceHeader.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceHeader.kt
@@ -1,0 +1,96 @@
+package eu.darken.octi.sync.ui.devices
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Android
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.modules.meta.core.MetaInfo
+
+@Composable
+internal fun DeviceHeader(
+    item: SyncDevicesVM.DeviceItem,
+    modifier: Modifier = Modifier,
+    titleStyle: TextStyle = MaterialTheme.typography.titleSmall,
+    iconSize: Dp = 28.dp,
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = when (item.metaInfo?.deviceType) {
+                MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+                MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+                else -> Icons.TwoTone.QuestionMark
+            },
+            contentDescription = null,
+            modifier = Modifier.size(iconSize),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.displayLabel,
+                style = titleStyle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            item.metaInfo?.let { meta ->
+                Text(
+                    text = "${meta.deviceManufacturer} · Android ${meta.androidVersionName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(horizontalAlignment = Alignment.End) {
+            item.serverVersion?.let { version ->
+                Text(
+                    text = version,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            item.serverPlatform?.let { platform ->
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = when (platform.lowercase()) {
+                            "android" -> Icons.TwoTone.Android
+                            else -> Icons.TwoTone.QuestionMark
+                        },
+                        contentDescription = null,
+                        modifier = Modifier.size(10.dp),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                    Text(
+                        text = platform.replaceFirstChar { it.uppercase() },
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceRow.kt
@@ -10,12 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.Android
 import androidx.compose.material.icons.twotone.Error
-import androidx.compose.material.icons.twotone.PhoneAndroid
-import androidx.compose.material.icons.twotone.QuestionMark
 import androidx.compose.material.icons.twotone.Schedule
-import androidx.compose.material.icons.twotone.Tablet
 import androidx.compose.material.icons.twotone.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
@@ -26,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.ca.CaString
 import eu.darken.octi.common.ca.toCaString
@@ -57,67 +52,7 @@ internal fun DeviceRow(
             .padding(horizontal = 16.dp, vertical = 4.dp),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = when (item.metaInfo?.deviceType) {
-                        MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
-                        MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
-                        else -> Icons.TwoTone.QuestionMark
-                    },
-                    contentDescription = null,
-                    modifier = Modifier.size(28.dp),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Column(modifier = Modifier.weight(1f)) {
-                    Text(
-                        text = item.displayLabel,
-                        style = MaterialTheme.typography.titleSmall,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    item.metaInfo?.let { meta ->
-                        Text(
-                            text = "${meta.deviceManufacturer} · Android ${meta.androidVersionName}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.width(8.dp))
-                Column(horizontalAlignment = Alignment.End) {
-                    item.serverVersion?.let { version ->
-                        Text(
-                            text = version,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                    item.serverPlatform?.let { platform ->
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                imageVector = when (platform.lowercase()) {
-                                    "android" -> Icons.TwoTone.Android
-                                    else -> Icons.TwoTone.QuestionMark
-                                },
-                                contentDescription = null,
-                                modifier = Modifier.size(10.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                            Spacer(modifier = Modifier.width(2.dp))
-                            Text(
-                                text = platform.replaceFirstChar { it.uppercase() },
-                                style = MaterialTheme.typography.labelSmall,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            )
-                        }
-                    }
-                }
-            }
+            DeviceHeader(item = item)
 
             item.lastSeen?.let { lastSeen ->
                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/SyncDevicesScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -23,6 +25,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -31,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
 import eu.darken.octi.sync.R as SyncR
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.compose.Preview2
@@ -98,6 +103,9 @@ fun SyncDevicesScreen(
 ) {
     var selectedDeviceId by rememberSaveable { mutableStateOf<String?>(null) }
     var initialConsumed by rememberSaveable { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+    val showMessage: (String) -> Unit = { msg -> scope.launch { snackbarHostState.showSnackbar(msg) } }
 
     LaunchedEffect(initialDeviceId, state.items) {
         if (!initialConsumed && initialDeviceId != null && state.items.isNotEmpty()) {
@@ -125,6 +133,7 @@ fun SyncDevicesScreen(
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {
@@ -200,6 +209,7 @@ fun SyncDevicesScreen(
             // Do NOT null selectedDeviceId here — once the VM's optimistic prune drops the
             // device from state.items, selectedDevice resolves to null and the sheet unmounts.
             onDelete = { onDeleteDevice(device.deviceId) },
+            showMessage = showMessage,
         )
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,14 @@
     <string name="sync_add_help_desc">A synchronization service is required for information exchange between Octi installs.\n\nDevices can only see each other if they have a common sync service!</string>
 
     <string name="sync_device_id_label">Device ID</string>
+    <string name="sync_device_id_copied_toast">Device ID copied</string>
+    <string name="sync_device_model_label">Model</string>
+    <string name="sync_device_android_version_label">Android version</string>
+    <string name="sync_device_security_patch_label">Security patch</string>
+    <string name="sync_device_booted_label">Booted</string>
+    <string name="sync_device_octi_version_label">Octi version</string>
+    <string name="sync_device_added_label">Added</string>
+    <string name="sync_device_last_seen_short_label">Last seen</string>
 
     <plurals name="general_devices_count_label">
         <item quantity="one">%d device</item>


### PR DESCRIPTION
## Summary

- Restructure the device action sheet to mirror the row's header style and surface every available `MetaInfo` field as labeled rows: model, Android version + API level, security patch, last boot, Octi version with git SHA, added date, last seen.
- Device ID gets a copy button — UUIDs are useless to read but useful to share for support.
- Extract a shared `DeviceHeader` composable used by both `DeviceRow` and the sheet so the row → sheet transition stays visually consistent.
- `CopyableDetailRow` gains an optional `copiedMessage` parameter for caller-specific snackbar text, and now uses the row's label as the clipboard label instead of a hardcoded `"IP"`.

## Test plan

- [x] `./gradlew :app:assembleFossDebug` — passes
- [x] `./gradlew :app:lintFossDebug` — passes
- [x] Live on Pixel 7a emulator: open Sync → Synced devices → tap a device. Header matches the row, all eight metadata rows render with real values, copy button works, Remove button intact, sheet scrolls on overflow.
