### PR TITLE
Add device metadata tile to dashboard

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -119,7 +119,9 @@ import eu.darken.octi.modules.apps.core.AppsInfo
 import eu.darken.octi.modules.clipboard.ClipboardInfo
 import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardDetailSheet
 import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityDetailSheet
+import eu.darken.octi.modules.meta.MetaModule
 import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.ui.dashboard.MetaDetailSheet
 import eu.darken.octi.modules.power.core.PowerInfo
 import eu.darken.octi.modules.power.core.PowerInfo.ChargeIO
 import eu.darken.octi.modules.power.core.PowerInfo.Status
@@ -392,6 +394,7 @@ fun DashboardScreen(
     var showWifiDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Wifi?>(null) }
     var showConnectivityDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Connectivity?>(null) }
     var showClipboardDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Clipboard?>(null) }
+    var showMetaDetail by remember { mutableStateOf<DashboardVM.ModuleItem.Meta?>(null) }
     var showIssuesSheetSeverity by remember { mutableStateOf<IssueSeverity?>(null) }
     var showReliabilitySheet by remember { mutableStateOf(false) }
 
@@ -411,7 +414,8 @@ fun DashboardScreen(
             is DashboardVM.ModuleItem.Clipboard -> showClipboardDetail = target
             is DashboardVM.ModuleItem.Wifi,
             is DashboardVM.ModuleItem.Apps,
-            is DashboardVM.ModuleItem.FileShare -> {
+            is DashboardVM.ModuleItem.FileShare,
+            is DashboardVM.ModuleItem.Meta -> {
                 // Not reachable from widgets today; no-op.
             }
         }
@@ -564,6 +568,7 @@ fun DashboardScreen(
                     onFileShareClicked = onFileShareClicked,
                     onFileShareUpload = onFileShareUpload,
                     onFileShareDownload = onFileShareDownload,
+                    onMetaClicked = { showMetaDetail = it },
                     showMessage = showMessage,
                     onDoneEditing = { deviceId, config ->
                         onSaveTileLayout(deviceId, config)
@@ -618,6 +623,7 @@ fun DashboardScreen(
                         onFileShareClicked = onFileShareClicked,
                         onFileShareUpload = onFileShareUpload,
                         onFileShareDownload = onFileShareDownload,
+                        onMetaClicked = { showMetaDetail = it },
                         showMessage = showMessage,
                         onDoneEditing = { deviceId, config ->
                             onSaveTileLayout(deviceId, config)
@@ -664,6 +670,15 @@ fun DashboardScreen(
             info = item.data.data,
             onDismiss = { showClipboardDetail = null },
             onCopy = onCopyClipboard,
+            showMessage = showMessage,
+        )
+    }
+
+    showMetaDetail?.let { item ->
+        MetaDetailSheet(
+            info = item.data.data,
+            lastUpdated = item.data.modifiedAt,
+            onDismiss = { showMetaDetail = null },
             showMessage = showMessage,
         )
     }
@@ -1511,6 +1526,7 @@ private fun DashboardDeviceCard(
     onFileShareClicked: (DeviceId) -> Unit,
     onFileShareUpload: (DeviceId) -> Unit,
     onFileShareDownload: (DeviceId) -> Unit,
+    onMetaClicked: (DashboardVM.ModuleItem.Meta) -> Unit,
     showMessage: (String) -> Unit,
 ) {
     val meta = device.meta?.data
@@ -1678,6 +1694,7 @@ private fun DashboardDeviceCard(
                 rows = rows,
                 moduleItems = device.moduleItems,
                 deviceId = device.deviceId,
+                now = device.now,
                 onPowerClicked = onPowerClicked,
                 onPowerAlerts = onPowerAlerts,
                 onWifiClicked = onWifiClicked,
@@ -1692,6 +1709,7 @@ private fun DashboardDeviceCard(
                 onFileShareClicked = onFileShareClicked,
                 onFileShareUpload = onFileShareUpload,
                 onFileShareDownload = onFileShareDownload,
+                onMetaClicked = onMetaClicked,
                 showMessage = showMessage,
             )
         }
@@ -1724,6 +1742,7 @@ private fun DeviceCardOrEditor(
     onFileShareClicked: (DeviceId) -> Unit,
     onFileShareUpload: (DeviceId) -> Unit,
     onFileShareDownload: (DeviceId) -> Unit,
+    onMetaClicked: (DashboardVM.ModuleItem.Meta) -> Unit,
     showMessage: (String) -> Unit,
     onDoneEditing: (String, TileLayoutConfig) -> Unit,
     onCancelEditing: () -> Unit,
@@ -1769,6 +1788,7 @@ private fun DeviceCardOrEditor(
             onFileShareClicked = onFileShareClicked,
             onFileShareUpload = onFileShareUpload,
             onFileShareDownload = onFileShareDownload,
+            onMetaClicked = onMetaClicked,
             showMessage = showMessage,
         )
     }
@@ -1783,6 +1803,7 @@ private fun buildAvailableModuleIds(moduleItems: List<DashboardVM.ModuleItem>): 
             is DashboardVM.ModuleItem.Apps -> "eu.darken.octi.module.core.apps"
             is DashboardVM.ModuleItem.Clipboard -> "eu.darken.octi.module.core.clipboard"
             is DashboardVM.ModuleItem.FileShare -> "eu.darken.octi.module.core.files"
+            is DashboardVM.ModuleItem.Meta -> MetaModule.MODULE_ID.id
         }
     }.toSet()
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -34,6 +34,7 @@ import eu.darken.octi.modules.connectivity.core.ConnectivityInfo
 import eu.darken.octi.modules.files.core.FileShareInfo
 import eu.darken.octi.modules.files.core.FileShareRepo
 import eu.darken.octi.syncs.octiserver.core.OctiServerIssue
+import eu.darken.octi.modules.meta.MetaModule
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.modules.power.core.PowerInfo
 import eu.darken.octi.modules.power.core.alert.BatteryHighAlertRule
@@ -235,6 +236,8 @@ class DashboardVM @Inject constructor(
             val isSharingAvailable: Boolean,
             val configuredConnectorIds: Set<String>,
         ) : ModuleItem
+
+        data class Meta(val data: ModuleData<MetaInfo>) : ModuleItem
     }
 
     data class SyncDetail(
@@ -656,7 +659,7 @@ class DashboardVM @Inject constructor(
                                 null
                             }
                         }
-                    }
+                    } + ModuleItem.Meta(metaModule)
 
                 DeviceItem(
                     now = now,
@@ -796,6 +799,7 @@ class DashboardVM @Inject constructor(
             "eu.darken.octi.module.core.apps",
             "eu.darken.octi.module.core.clipboard",
             "eu.darken.octi.module.core.files",
+            MetaModule.MODULE_ID.id,
         )
         private const val DEVICE_LIMIT = 3
         private val WIFI_PERMISSIONS = setOf(Permission.ACCESS_FINE_LOCATION, Permission.ACCESS_COARSE_LOCATION)

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/ModuleTileGrid.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/ModuleTileGrid.kt
@@ -19,17 +19,21 @@ import eu.darken.octi.modules.clipboard.ui.dashboard.ClipboardModuleTile
 import eu.darken.octi.modules.connectivity.ui.dashboard.ConnectivityModuleTile
 import eu.darken.octi.modules.files.ui.dashboard.FileShareDashState
 import eu.darken.octi.modules.files.ui.dashboard.FileShareModuleTile
+import eu.darken.octi.modules.meta.MetaModule
+import eu.darken.octi.modules.meta.ui.dashboard.MetaModuleTile
 import eu.darken.octi.modules.power.ui.dashboard.PowerDashState
 import eu.darken.octi.modules.power.ui.dashboard.PowerModuleTile
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiDashState
 import eu.darken.octi.modules.wifi.ui.dashboard.WifiModuleTile
 import eu.darken.octi.sync.core.DeviceId
+import kotlin.time.Instant
 
 @Composable
 fun ModuleTileGrid(
     rows: List<TileRow>,
     moduleItems: List<DashboardVM.ModuleItem>,
     deviceId: DeviceId,
+    now: Instant,
     modifier: Modifier = Modifier,
     onPowerClicked: (DashboardVM.ModuleItem.Power) -> Unit,
     onPowerAlerts: (DeviceId) -> Unit,
@@ -45,6 +49,7 @@ fun ModuleTileGrid(
     onFileShareClicked: (DeviceId) -> Unit,
     onFileShareUpload: (DeviceId) -> Unit,
     onFileShareDownload: (DeviceId) -> Unit,
+    onMetaClicked: (DashboardVM.ModuleItem.Meta) -> Unit,
     showMessage: (String) -> Unit,
 ) {
     val moduleMap = buildModuleIdMap(moduleItems)
@@ -78,6 +83,7 @@ fun ModuleTileGrid(
                         modifier = tileModifier,
                         isWide = isHeroRow,
                         deviceId = deviceId,
+                        now = now,
                         onPowerClicked = onPowerClicked,
                         onPowerAlerts = onPowerAlerts,
                         onWifiClicked = onWifiClicked,
@@ -92,6 +98,7 @@ fun ModuleTileGrid(
                         onFileShareClicked = onFileShareClicked,
                         onFileShareUpload = onFileShareUpload,
                         onFileShareDownload = onFileShareDownload,
+                        onMetaClicked = onMetaClicked,
                         showMessage = showMessage,
                     )
                 }
@@ -107,6 +114,7 @@ private fun ModuleTileDispatch(
     modifier: Modifier,
     isWide: Boolean,
     deviceId: DeviceId,
+    now: Instant,
     onPowerClicked: (DashboardVM.ModuleItem.Power) -> Unit,
     onPowerAlerts: (DeviceId) -> Unit,
     onWifiClicked: (DashboardVM.ModuleItem.Wifi) -> Unit,
@@ -121,6 +129,7 @@ private fun ModuleTileDispatch(
     onFileShareClicked: (DeviceId) -> Unit,
     onFileShareUpload: (DeviceId) -> Unit,
     onFileShareDownload: (DeviceId) -> Unit,
+    onMetaClicked: (DashboardVM.ModuleItem.Meta) -> Unit,
     showMessage: (String) -> Unit,
 ) {
     when (val item = moduleMap[moduleId]) {
@@ -191,6 +200,14 @@ private fun ModuleTileDispatch(
             onDownloadClicked = { onFileShareDownload(deviceId) },
         )
 
+        is DashboardVM.ModuleItem.Meta -> MetaModuleTile(
+            info = item.data.data,
+            now = now,
+            modifier = modifier,
+            isWide = isWide,
+            onDetailClicked = { onMetaClicked(item) },
+        )
+
         null -> {} // Module not available for this device
     }
 }
@@ -204,6 +221,7 @@ private fun buildModuleIdMap(moduleItems: List<DashboardVM.ModuleItem>): Map<Str
             is DashboardVM.ModuleItem.Apps -> "eu.darken.octi.module.core.apps"
             is DashboardVM.ModuleItem.Clipboard -> "eu.darken.octi.module.core.clipboard"
             is DashboardVM.ModuleItem.FileShare -> "eu.darken.octi.module.core.files"
+            is DashboardVM.ModuleItem.Meta -> MetaModule.MODULE_ID.id
         }
     }
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/ModuleUiRegistry.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/ModuleUiRegistry.kt
@@ -43,7 +43,7 @@ object ModuleUiRegistry {
         ModuleUiSpec(ClipboardModule.MODULE_ID, Icons.TwoTone.ContentPaste, ClipboardR.string.module_clipboard_label, hasDashboardTile = true),
         ModuleUiSpec(FileShareModule.MODULE_ID, Icons.AutoMirrored.TwoTone.InsertDriveFile, FilesR.string.module_files_label, hasDashboardTile = true),
         ModuleUiSpec(AppsModule.MODULE_ID, Icons.TwoTone.Apps, AppsR.string.module_apps_label, hasDashboardTile = true),
-        ModuleUiSpec(MetaModule.MODULE_ID, Icons.TwoTone.Info, MetaR.string.module_meta_label, hasDashboardTile = false),
+        ModuleUiSpec(MetaModule.MODULE_ID, Icons.TwoTone.Info, MetaR.string.module_meta_label, hasDashboardTile = true),
     )
 
     val orderedIds: List<ModuleId> = entries.map { it.id }

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardConfigSerializationTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardConfigSerializationTest.kt
@@ -41,7 +41,8 @@ class DashboardConfigSerializationTest : BaseTest() {
                         "eu.darken.octi.module.core.connectivity",
                         "eu.darken.octi.module.core.clipboard",
                         "eu.darken.octi.module.core.files",
-                        "eu.darken.octi.module.core.apps"
+                        "eu.darken.octi.module.core.apps",
+                        "eu.darken.octi.module.core.meta"
                     ],
                     "wideModules": ["eu.darken.octi.module.core.power"],
                     "hiddenModules": []

--- a/modules-meta/build.gradle.kts
+++ b/modules-meta/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("kotlin-parcelize")
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 apply(plugin = "dagger.hilt.android.plugin")
@@ -13,6 +14,10 @@ android {
 
     defaultConfig {
         minSdk = ProjectConfig.minSdk
+    }
+
+    buildFeatures {
+        compose = true
     }
 
     setupModuleBuildTypes()
@@ -42,5 +47,6 @@ dependencies {
     addCoroutines()
     addSerialization()
     addIO()
+    addCompose()
     addTesting()
 }

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/MetaUptimeFormatter.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/MetaUptimeFormatter.kt
@@ -1,0 +1,17 @@
+package eu.darken.octi.modules.meta.ui
+
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Instant
+
+fun formatUptime(now: Instant, bootedAt: Instant): String {
+    val raw = now - bootedAt
+    val span = if (raw < ZERO) ZERO else raw
+    return span.toComponents { days, hours, minutes, _, _ ->
+        when {
+            days > 0L -> "${days}d ${hours}h"
+            hours > 0L -> "${hours}h ${minutes}m"
+            minutes > 0L -> "${minutes}m"
+            else -> "<1m"
+        }
+    }
+}

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaDetailSheet.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaDetailSheet.kt
@@ -1,0 +1,179 @@
+package eu.darken.octi.modules.meta.ui.dashboard
+
+import android.text.format.DateUtils
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Info
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.clampToNow
+import eu.darken.octi.common.compose.CopyableDetailRow
+import eu.darken.octi.common.compose.DetailRow
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.modules.meta.R as MetaR
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+@Composable
+fun MetaDetailSheet(
+    info: MetaInfo,
+    lastUpdated: Instant?,
+    onDismiss: () -> Unit,
+    showMessage: (String) -> Unit,
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        MetaDetailContent(info = info, lastUpdated = lastUpdated, showMessage = showMessage)
+    }
+}
+
+@Composable
+private fun MetaDetailContent(
+    info: MetaInfo,
+    lastUpdated: Instant?,
+    showMessage: (String) -> Unit = {},
+) {
+    val deviceTypeLabel = when (info.deviceType) {
+        MetaInfo.DeviceType.PHONE -> stringResource(MetaR.string.module_meta_detail_device_type_phone)
+        MetaInfo.DeviceType.TABLET -> stringResource(MetaR.string.module_meta_detail_device_type_tablet)
+        MetaInfo.DeviceType.UNKNOWN -> stringResource(MetaR.string.module_meta_detail_device_type_unknown)
+    }
+
+    Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.TwoTone.Info,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(MetaR.string.module_meta_label),
+                style = MaterialTheme.typography.titleLarge,
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+
+        info.deviceLabel?.let { label ->
+            DetailRow(
+                label = stringResource(MetaR.string.module_meta_detail_label_label),
+                value = label,
+            )
+        }
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_manufacturer_label),
+            value = info.deviceManufacturer,
+        )
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_model_label),
+            value = info.deviceName,
+        )
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_device_type_label),
+            value = deviceTypeLabel,
+        )
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_android_version_label),
+            value = info.androidVersionName,
+        )
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_api_level_label),
+            value = info.androidApiLevel.toString(),
+        )
+        info.androidSecurityPatch?.let { patch ->
+            DetailRow(
+                label = stringResource(MetaR.string.module_meta_detail_security_patch_label),
+                value = patch,
+            )
+        }
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_booted_label),
+            value = DateUtils
+                .getRelativeTimeSpanString(info.deviceBootedAt.clampToNow().toEpochMilliseconds())
+                .toString(),
+        )
+        DetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_octi_version_label),
+            value = info.octiVersionName,
+        )
+        val gitSha = info.octiGitSha.takeIf { it.isNotBlank() }
+        CopyableDetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_git_sha_label),
+            value = gitSha ?: "—",
+            copyable = gitSha != null,
+            showMessage = showMessage,
+        )
+        CopyableDetailRow(
+            label = stringResource(MetaR.string.module_meta_detail_device_id_label),
+            value = info.deviceId.id,
+            copyable = true,
+            showMessage = showMessage,
+        )
+        lastUpdated?.let { ts ->
+            DetailRow(
+                label = stringResource(MetaR.string.module_meta_detail_last_updated_label),
+                value = DateUtils.getRelativeTimeSpanString(ts.toEpochMilliseconds()).toString(),
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+private fun previewInfo(
+    deviceLabel: String? = "Living Room Pixel",
+    androidSecurityPatch: String? = "2025-04-05",
+    octiGitSha: String = "abc1234def5",
+    bootedAgo: kotlin.time.Duration = 2.days + 4.hours,
+): MetaInfo = MetaInfo(
+    deviceLabel = deviceLabel,
+    deviceId = DeviceId("preview-device-id-1234"),
+    octiVersionName = "1.0.0-rc1",
+    octiGitSha = octiGitSha,
+    deviceManufacturer = "Google",
+    deviceName = "Pixel 8 Pro",
+    deviceType = MetaInfo.DeviceType.PHONE,
+    deviceBootedAt = Clock.System.now() - bootedAgo,
+    androidVersionName = "15",
+    androidApiLevel = 35,
+    androidSecurityPatch = androidSecurityPatch,
+)
+
+@Preview2
+@Composable
+private fun MetaDetailContentFullPreview() = PreviewWrapper {
+    MetaDetailContent(
+        info = previewInfo(),
+        lastUpdated = Clock.System.now() - 5.minutes,
+    )
+}
+
+@Preview2
+@Composable
+private fun MetaDetailContentMinimalPreview() = PreviewWrapper {
+    MetaDetailContent(
+        info = previewInfo(
+            deviceLabel = null,
+            androidSecurityPatch = null,
+            octiGitSha = "",
+        ),
+        lastUpdated = null,
+    )
+}

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaModuleTile.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaModuleTile.kt
@@ -1,0 +1,152 @@
+package eu.darken.octi.modules.meta.ui.dashboard
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material.icons.twotone.QuestionMark
+import androidx.compose.material.icons.twotone.Tablet
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.modules.meta.R as MetaR
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.meta.ui.formatUptime
+import eu.darken.octi.sync.core.DeviceId
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+@Composable
+fun MetaModuleTile(
+    info: MetaInfo,
+    now: Instant,
+    modifier: Modifier = Modifier,
+    isWide: Boolean = false,
+    onDetailClicked: () -> Unit,
+) {
+    val androidLabel = stringResource(MetaR.string.module_meta_android_name_x_label, info.androidVersionName)
+    val uptimeLabel = stringResource(MetaR.string.module_meta_uptime_label, formatUptime(now, info.deviceBootedAt))
+
+    val tileColor = if (isWide) {
+        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.25f)
+    } else {
+        MaterialTheme.colorScheme.surfaceContainerHighest
+    }
+
+    val tileDescription = "${info.deviceName} $androidLabel"
+
+    Surface(
+        onClick = onDetailClicked,
+        modifier = modifier.semantics { contentDescription = tileDescription },
+        shape = RoundedCornerShape(12.dp),
+        color = tileColor,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = when (info.deviceType) {
+                        MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+                        MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+                        MetaInfo.DeviceType.UNKNOWN -> Icons.TwoTone.QuestionMark
+                    },
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = info.deviceName,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+            Text(
+                text = androidLabel,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = uptimeLabel,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+    }
+}
+
+private fun previewInfo(
+    deviceName: String = "Pixel 8 Pro",
+    deviceType: MetaInfo.DeviceType = MetaInfo.DeviceType.PHONE,
+    androidVersionName: String = "15",
+    bootedAgo: kotlin.time.Duration = 2.days + 4.hours,
+): MetaInfo = MetaInfo(
+    deviceLabel = null,
+    deviceId = DeviceId("preview"),
+    octiVersionName = "1.0.0",
+    octiGitSha = "abc1234",
+    deviceManufacturer = "Google",
+    deviceName = deviceName,
+    deviceType = deviceType,
+    deviceBootedAt = Clock.System.now() - bootedAgo,
+    androidVersionName = androidVersionName,
+    androidApiLevel = 35,
+    androidSecurityPatch = "2025-04-05",
+)
+
+@Preview2
+@Composable
+private fun MetaModuleTileHalfPreview() = PreviewWrapper {
+    MetaModuleTile(
+        info = previewInfo(),
+        now = Clock.System.now(),
+        onDetailClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun MetaModuleTileWidePreview() = PreviewWrapper {
+    MetaModuleTile(
+        info = previewInfo(),
+        now = Clock.System.now(),
+        isWide = true,
+        onDetailClicked = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun MetaModuleTileTabletLongNamePreview() = PreviewWrapper {
+    MetaModuleTile(
+        info = previewInfo(
+            deviceName = "Galaxy Tab S9 Ultra Plus 5G Wifi Edition",
+            deviceType = MetaInfo.DeviceType.TABLET,
+            androidVersionName = "14",
+        ),
+        now = Clock.System.now(),
+        onDetailClicked = {},
+    )
+}

--- a/modules-meta/src/main/res/values/strings.xml
+++ b/modules-meta/src/main/res/values/strings.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="module_meta_label">Meta module</string>
-    <string name="module_meta_android_name_x_label">Android %s</string>
+    <string name="module_meta_android_name_x_label">Android %1$s</string>
+    <string name="module_meta_uptime_label">Up %1$s</string>
+    <string name="module_meta_detail_label_label">Label</string>
+    <string name="module_meta_detail_manufacturer_label">Manufacturer</string>
+    <string name="module_meta_detail_model_label">Model</string>
+    <string name="module_meta_detail_device_type_label">Device type</string>
+    <string name="module_meta_detail_device_type_phone">Phone</string>
+    <string name="module_meta_detail_device_type_tablet">Tablet</string>
+    <string name="module_meta_detail_device_type_unknown">Unknown</string>
+    <string name="module_meta_detail_android_version_label">Android version</string>
+    <string name="module_meta_detail_api_level_label">API level</string>
+    <string name="module_meta_detail_security_patch_label">Security patch</string>
+    <string name="module_meta_detail_booted_label">Booted</string>
+    <string name="module_meta_detail_octi_version_label">Octi version</string>
+    <string name="module_meta_detail_git_sha_label">Build commit</string>
+    <string name="module_meta_detail_device_id_label">Device ID</string>
+    <string name="module_meta_detail_last_updated_label">Last updated</string>
 </resources>

--- a/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/MetaUptimeFormatterTest.kt
+++ b/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/MetaUptimeFormatterTest.kt
@@ -1,0 +1,70 @@
+package eu.darken.octi.modules.meta.ui
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+class MetaUptimeFormatterTest : BaseTest() {
+
+    private val now = Instant.fromEpochMilliseconds(1_700_000_000_000)
+
+    @Nested
+    inner class `sub-minute durations` {
+        @Test
+        fun `future boot time renders as less than a minute`() {
+            formatUptime(now, now + 5.minutes) shouldBe "<1m"
+        }
+
+        @Test
+        fun `30 seconds uptime renders as less than a minute`() {
+            formatUptime(now, now - 30.seconds) shouldBe "<1m"
+        }
+    }
+
+    @Nested
+    inner class `minute and hour ranges` {
+        @Test
+        fun `exactly one minute uptime`() {
+            formatUptime(now, now - 1.minutes) shouldBe "1m"
+        }
+
+        @Test
+        fun `47 minutes uptime`() {
+            formatUptime(now, now - 47.minutes) shouldBe "47m"
+        }
+
+        @Test
+        fun `exactly one hour uptime`() {
+            formatUptime(now, now - 1.hours) shouldBe "1h 0m"
+        }
+
+        @Test
+        fun `2 hours 30 minutes uptime`() {
+            formatUptime(now, now - (2.hours + 30.minutes)) shouldBe "2h 30m"
+        }
+    }
+
+    @Nested
+    inner class `day range` {
+        @Test
+        fun `exactly one day uptime`() {
+            formatUptime(now, now - 1.days) shouldBe "1d 0h"
+        }
+
+        @Test
+        fun `5 days 12 hours uptime`() {
+            formatUptime(now, now - (5.days + 12.hours)) shouldBe "5d 12h"
+        }
+
+        @Test
+        fun `365 days uptime does not overflow`() {
+            formatUptime(now, now - 365.days) shouldBe "365d 0h"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New **Meta** tile on each device card on the dashboard showing the device model, Android version, and uptime — surfacing metadata that was already collected and synced but never visible in the UI.
- Tap the tile to open a detail sheet with the full device record: manufacturer, model, device type, Android version + API level, security patch date, boot time, Octi version, build commit and device ID (both copyable), and the meta blob's last sync time (helps spot stale remote devices).
- Visible by default on every device card, last in the tile order. Users can hide or reorder it via the existing tile editor, same as any other module tile.

## Test plan

- [x] `./gradlew :app:assembleFossDebug` — clean compile across all modules
- [x] `./gradlew :modules-meta:testDebugUnitTest` — uptime formatter unit tests pass (covers future-boot clock skew, sub-minute, hour, and day boundaries)
- [x] On-device check: install APK, open dashboard, verify Meta tile renders correctly with device model, Android version, and uptime
- [x] On-device check: tap tile → detail sheet opens with all rows; copy build commit → clipboard receives the SHA
- [x] On-device check: open tile editor → confirm Meta is listed and can be hidden/reordered
