### PR TITLE
Migrate Hilt plugin to plugins block syntax

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.common"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.android.compose.screenshot") version "0.0.1-alpha13"
+    id("com.google.dagger.hilt.android")
 }
-apply(plugin = "dagger.hilt.android.plugin")
 
 
 val commitHashProvider = providers.of(CommitHashValueSource::class) {}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,3 @@
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath("com.android.tools.build:gradle:${Versions.Gradle.buildTools}")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.Kotlin.core}")
-        classpath("com.google.dagger:hilt-android-gradle-plugin:${Versions.Dagger.core}")
-        classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.AndroidX.Navigation.core}")
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
     implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:2.3.6")
     implementation("org.jetbrains.kotlin:compose-compiler-gradle-plugin:2.3.10")
     implementation("org.jetbrains.kotlin:kotlin-serialization:2.3.10")
+    // Keep version aligned with Versions.Dagger.core
+    implementation("com.google.dagger:hilt-android-gradle-plugin:2.59.2")
     implementation("com.squareup:javapoet:1.13.0")
     implementation("com.android.tools:common:31.13.2")
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,8 +1,4 @@
 object Versions {
-    object Gradle {
-        const val buildTools = "9.0.0"
-    }
-
     object Kotlin {
         const val core = "2.3.10"
         const val coroutines = "1.10.2"

--- a/module-core/build.gradle.kts
+++ b/module-core/build.gradle.kts
@@ -3,9 +3,8 @@ plugins {
     id("kotlin-parcelize")
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.module"

--- a/modules-apps/build.gradle.kts
+++ b/modules-apps/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.apps"

--- a/modules-clipboard/build.gradle.kts
+++ b/modules-clipboard/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.clipboard"

--- a/modules-connectivity/build.gradle.kts
+++ b/modules-connectivity/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.connectivity"

--- a/modules-files/build.gradle.kts
+++ b/modules-files/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.files"

--- a/modules-meta/build.gradle.kts
+++ b/modules-meta/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.meta"

--- a/modules-power/build.gradle.kts
+++ b/modules-power/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.power"

--- a/modules-wifi/build.gradle.kts
+++ b/modules-wifi/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.modules.wifi"

--- a/sync-core/build.gradle.kts
+++ b/sync-core/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.sync"

--- a/syncs-gdrive/build.gradle.kts
+++ b/syncs-gdrive/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.syncs.gdrive"

--- a/syncs-octiserver/build.gradle.kts
+++ b/syncs-octiserver/build.gradle.kts
@@ -4,9 +4,8 @@ plugins {
     id("com.google.devtools.ksp")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.dagger.hilt.android")
 }
-
-apply(plugin = "dagger.hilt.android.plugin")
 
 android {
     namespace = "eu.darken.octi.syncs.octiserver"


### PR DESCRIPTION
## Summary

- Replace `apply(plugin = "dagger.hilt.android.plugin")` with `id("com.google.dagger.hilt.android")` in the `plugins {}` block of all 13 module build files. Placed last so the prior "Hilt applies after every other plugin" ordering is preserved.
- Move Hilt's gradle plugin classpath from the root `buildscript {}` block into `buildSrc/build.gradle.kts` as an `implementation` dep, mirroring how KSP and `kotlin-serialization` are already wired.
- Delete the entire root `buildscript {}` block: AGP and KGP entries were duplicates of `buildSrc`, `navigation-safe-args-gradle-plugin` had no consumer (no `safeargs`/`navArgs`/`Directions` usage anywhere).
- Drop the now-unused `Versions.Gradle.buildTools` constant (was `9.0.0`; the effective AGP runtime was already `9.0.1` from `buildSrc`, since module plugin resolution goes through `buildSrc`'s classpath — the constant was dead and version-mismatched with reality).

Resolves the Gradle warning *"The 'apply' plugin syntax is older and not recommended"*.

## Test plan

- [x] `./gradlew :app:assembleFossDebug --warning-mode=all` — passes; deprecation warning gone.
- [x] `./gradlew :app:assembleGplayDebug` — passes.
- [x] `./gradlew :app:testFossDebugUnitTest :app:testGplayDebugUnitTest` — passes.
- [x] `./gradlew testDebugUnitTest` — all library modules pass.
- [x] `rg 'apply\(plugin\s*=' --glob '*.gradle.kts'` — zero matches.
- [ ] CI: full assemble + test matrix.

## Notes

- `:app:assembleFossDebugAndroidTest` currently fails on a pre-existing broken dependency (`androidx.test:rules:1.6.2` returns 404 from Google Maven; declared at `buildSrc/src/main/java/Dependencies.kt:184`). Unrelated to this PR — worth bumping to `1.7.0` separately.
- The Hilt plugin version is now duplicated: `Versions.Dagger.core` (used for `hilt-android`/`hilt-compiler` runtime deps) and a hardcoded `2.59.2` in `buildSrc/build.gradle.kts` (the plugin classpath). A `// Keep version aligned with Versions.Dagger.core` comment is added next to the `buildSrc` declaration. Same compromise already accepted for KGP.
