### PR TITLE
Show device name and type in module bottom sheets

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/compose/BottomSheetHeader.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/compose/BottomSheetHeader.kt
@@ -1,0 +1,71 @@
+package eu.darken.octi.common.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Info
+import androidx.compose.material.icons.twotone.PhoneAndroid
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import java.util.Locale
+
+@Composable
+fun BottomSheetHeader(
+    icon: ImageVector,
+    title: String,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = deviceIcon,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.size(14.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = deviceLabel.uppercase(Locale.ROOT),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+    }
+}
+
+@Preview2
+@Composable
+private fun BottomSheetHeaderPreview() = PreviewWrapper {
+    BottomSheetHeader(
+        icon = Icons.TwoTone.Info,
+        title = "Power module",
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
+    )
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -131,6 +131,7 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.sync.core.shortLabel
 import eu.darken.octi.sync.core.SyncConnector.EventMode
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncOrchestrator
@@ -643,31 +644,59 @@ fun DashboardScreen(
     }
 
     // Detail sheets
+    fun deviceHeaderFor(deviceId: DeviceId): Pair<ImageVector, String> {
+        val device = state.devices.find { it.deviceId == deviceId }
+        val icon = when {
+            device == null -> Icons.TwoTone.QuestionMark
+            device.isCurrentDevice -> Icons.TwoTone.Home
+            device.isDegraded -> Icons.TwoTone.Warning
+            else -> when (device.meta?.data?.deviceType) {
+                MetaInfo.DeviceType.PHONE -> Icons.TwoTone.PhoneAndroid
+                MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
+                else -> Icons.TwoTone.QuestionMark
+            }
+        }
+        val label = device?.displayLabel ?: deviceId.shortLabel
+        return icon to label
+    }
+
     showPowerDetail?.let { item ->
+        val (icon, label) = deviceHeaderFor(item.data.deviceId)
         PowerDetailSheet(
             info = item.data.data,
+            deviceLabel = label,
+            deviceIcon = icon,
             onDismiss = { showPowerDetail = null },
         )
     }
 
     showWifiDetail?.let { item ->
+        val (icon, label) = deviceHeaderFor(item.data.deviceId)
         WifiDetailSheet(
             info = item.data.data,
+            deviceLabel = label,
+            deviceIcon = icon,
             onDismiss = { showWifiDetail = null },
         )
     }
 
     showConnectivityDetail?.let { item ->
+        val (icon, label) = deviceHeaderFor(item.data.deviceId)
         ConnectivityDetailSheet(
             info = item.data.data,
+            deviceLabel = label,
+            deviceIcon = icon,
             onDismiss = { showConnectivityDetail = null },
             showMessage = showMessage,
         )
     }
 
     showClipboardDetail?.let { item ->
+        val (icon, label) = deviceHeaderFor(item.data.deviceId)
         ClipboardDetailSheet(
             info = item.data.data,
+            deviceLabel = label,
+            deviceIcon = icon,
             onDismiss = { showClipboardDetail = null },
             onCopy = onCopyClipboard,
             showMessage = showMessage,
@@ -675,8 +704,11 @@ fun DashboardScreen(
     }
 
     showMetaDetail?.let { item ->
+        val (icon, label) = deviceHeaderFor(item.data.deviceId)
         MetaDetailSheet(
             info = item.data.data,
+            deviceLabel = label,
+            deviceIcon = icon,
             lastUpdated = item.data.modifiedAt,
             onDismiss = { showMetaDetail = null },
             showMessage = showMessage,

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/dashboard/ClipboardDetailSheet.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/dashboard/ClipboardDetailSheet.kt
@@ -1,18 +1,15 @@
 package eu.darken.octi.modules.clipboard.ui.dashboard
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.ContentPaste
-import androidx.compose.material3.Icon
+import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -20,8 +17,10 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.compose.BottomSheetHeader
 import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -32,37 +31,34 @@ import okio.ByteString.Companion.encodeUtf8
 @Composable
 fun ClipboardDetailSheet(
     info: ClipboardInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     onDismiss: () -> Unit,
     onCopy: (ClipboardInfo) -> Unit,
     showMessage: (String) -> Unit,
 ) {
     val copiedMsg = stringResource(ClipboardR.string.module_clipboard_copied_octi_to_os)
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        ClipboardDetailContent(info, copiedMsg, onCopy, showMessage)
+        ClipboardDetailContent(info, deviceLabel, deviceIcon, copiedMsg, onCopy, showMessage)
     }
 }
 
 @Composable
 private fun ClipboardDetailContent(
     info: ClipboardInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     copiedMsg: String = "Copied",
     onCopy: (ClipboardInfo) -> Unit = {},
     showMessage: (String) -> Unit = {},
 ) {
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.TwoTone.ContentPaste,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(ClipboardR.string.module_clipboard_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
+        BottomSheetHeader(
+            icon = Icons.TwoTone.ContentPaste,
+            title = stringResource(ClipboardR.string.module_clipboard_label),
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+        )
         DetailRow(
             label = stringResource(ClipboardR.string.module_clipboard_detail_type_label),
             value = when (info.type) {
@@ -109,5 +105,7 @@ private fun ClipboardDetailContentPreview() = PreviewWrapper {
             type = ClipboardInfo.Type.SIMPLE_TEXT,
             data = "Hello clipboard content!".encodeUtf8(),
         ),
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
     )
 }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/dashboard/ConnectivityDetailSheet.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/dashboard/ConnectivityDetailSheet.kt
@@ -1,21 +1,18 @@
 package eu.darken.octi.modules.connectivity.ui.dashboard
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.compose.BottomSheetHeader
 import eu.darken.octi.common.compose.CopyableDetailRow
 import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
@@ -27,36 +24,33 @@ import eu.darken.octi.modules.connectivity.ui.icon
 @Composable
 fun ConnectivityDetailSheet(
     info: ConnectivityInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     onDismiss: () -> Unit,
     showMessage: (String) -> Unit,
 ) {
     val unknownLocal = stringResource(ConnectivityR.string.module_connectivity_unknown_local_ip_label)
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        ConnectivityDetailContent(info, unknownLocal, showMessage)
+        ConnectivityDetailContent(info, deviceLabel, deviceIcon, unknownLocal, showMessage)
     }
 }
 
 @Composable
 private fun ConnectivityDetailContent(
     info: ConnectivityInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     unknownLocal: String = "Unknown",
     showMessage: (String) -> Unit = {},
 ) {
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = info.connectionType.icon,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(ConnectivityR.string.module_connectivity_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
+        BottomSheetHeader(
+            icon = info.connectionType.icon,
+            title = stringResource(ConnectivityR.string.module_connectivity_label),
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+        )
         DetailRow(
             label = stringResource(ConnectivityR.string.module_connectivity_detail_connection_type_label),
             value = when (info.connectionType) {
@@ -108,5 +102,7 @@ private fun ConnectivityDetailContentPreview() = PreviewWrapper {
             gatewayIp = "192.168.1.1",
             dnsServers = listOf("8.8.8.8", "8.8.4.4"),
         ),
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
     )
 }

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaDetailSheet.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/dashboard/MetaDetailSheet.kt
@@ -2,24 +2,20 @@ package eu.darken.octi.modules.meta.ui.dashboard
 
 import android.text.format.DateUtils
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Info
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.clampToNow
+import eu.darken.octi.common.compose.BottomSheetHeader
 import eu.darken.octi.common.compose.CopyableDetailRow
 import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
@@ -36,18 +32,28 @@ import kotlin.time.Instant
 @Composable
 fun MetaDetailSheet(
     info: MetaInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     lastUpdated: Instant?,
     onDismiss: () -> Unit,
     showMessage: (String) -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        MetaDetailContent(info = info, lastUpdated = lastUpdated, showMessage = showMessage)
+        MetaDetailContent(
+            info = info,
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+            lastUpdated = lastUpdated,
+            showMessage = showMessage,
+        )
     }
 }
 
 @Composable
 private fun MetaDetailContent(
     info: MetaInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     lastUpdated: Instant?,
     showMessage: (String) -> Unit = {},
 ) {
@@ -58,26 +64,13 @@ private fun MetaDetailContent(
     }
 
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = Icons.TwoTone.Info,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(MetaR.string.module_meta_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
+        BottomSheetHeader(
+            icon = Icons.TwoTone.Info,
+            title = stringResource(MetaR.string.module_meta_label),
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+        )
 
-        info.deviceLabel?.let { label ->
-            DetailRow(
-                label = stringResource(MetaR.string.module_meta_detail_label_label),
-                value = label,
-            )
-        }
         DetailRow(
             label = stringResource(MetaR.string.module_meta_detail_manufacturer_label),
             value = info.deviceManufacturer,
@@ -161,6 +154,8 @@ private fun previewInfo(
 private fun MetaDetailContentFullPreview() = PreviewWrapper {
     MetaDetailContent(
         info = previewInfo(),
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
         lastUpdated = Clock.System.now() - 5.minutes,
     )
 }
@@ -174,6 +169,8 @@ private fun MetaDetailContentMinimalPreview() = PreviewWrapper {
             androidSecurityPatch = null,
             octiGitSha = "",
         ),
+        deviceLabel = "Pixel 8 Pro",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
         lastUpdated = null,
     )
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/dashboard/PowerDetailSheet.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/dashboard/PowerDetailSheet.kt
@@ -2,25 +2,22 @@ package eu.darken.octi.modules.power.ui.dashboard
 
 import android.os.BatteryManager
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.TemperatureFormatter
+import eu.darken.octi.common.compose.BottomSheetHeader
 import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -34,6 +31,8 @@ import eu.darken.octi.modules.power.ui.PowerEstimationFormatter
 @Composable
 fun PowerDetailSheet(
     info: PowerInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     onDismiss: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -41,30 +40,25 @@ fun PowerDetailSheet(
     val estimationFormatter = remember { PowerEstimationFormatter(context) }
 
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        PowerDetailContent(info, temperatureFormatter, estimationFormatter)
+        PowerDetailContent(info, deviceLabel, deviceIcon, temperatureFormatter, estimationFormatter)
     }
 }
 
 @Composable
 private fun PowerDetailContent(
     info: PowerInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     temperatureFormatter: TemperatureFormatter = TemperatureFormatter(LocalContext.current),
     estimationFormatter: PowerEstimationFormatter = PowerEstimationFormatter(LocalContext.current),
 ) {
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = info.batteryIcon,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(PowerR.string.module_power_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
+        BottomSheetHeader(
+            icon = info.batteryIcon,
+            title = stringResource(PowerR.string.module_power_label),
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+        )
         DetailRow(
             label = stringResource(PowerR.string.module_power_detail_level_label),
             value = "${(info.battery.percent * 100).toInt()}%",
@@ -129,5 +123,7 @@ private fun PowerDetailContentPreview() = PreviewWrapper {
             battery = PowerInfo.Battery(level = 82, scale = 100, health = 2, temp = 31.2f),
             chargeIO = ChargeIO(null, null, null, null, null),
         ),
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
     )
 }

--- a/modules-wifi/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/WifiDetailSheet.kt
+++ b/modules-wifi/src/main/java/eu/darken/octi/modules/wifi/ui/dashboard/WifiDetailSheet.kt
@@ -1,22 +1,19 @@
 package eu.darken.octi.modules.wifi.ui.dashboard
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.compose.BottomSheetHeader
 import eu.darken.octi.common.compose.DetailRow
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -27,29 +24,28 @@ import eu.darken.octi.modules.wifi.ui.receptIcon
 @Composable
 fun WifiDetailSheet(
     info: WifiInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
     onDismiss: () -> Unit,
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
-        WifiDetailContent(info)
+        WifiDetailContent(info, deviceLabel, deviceIcon)
     }
 }
 
 @Composable
-private fun WifiDetailContent(info: WifiInfo) {
+private fun WifiDetailContent(
+    info: WifiInfo,
+    deviceLabel: String,
+    deviceIcon: ImageVector,
+) {
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = info.receptIcon,
-                contentDescription = null,
-                modifier = Modifier.size(24.dp),
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(WifiR.string.module_wifi_label),
-                style = MaterialTheme.typography.titleLarge,
-            )
-        }
-        Spacer(modifier = Modifier.height(16.dp))
+        BottomSheetHeader(
+            icon = info.receptIcon,
+            title = stringResource(WifiR.string.module_wifi_label),
+            deviceLabel = deviceLabel,
+            deviceIcon = deviceIcon,
+        )
         DetailRow(
             label = stringResource(WifiR.string.module_wifi_detail_ssid_label),
             value = info.currentWifi?.ssid
@@ -88,5 +84,7 @@ private fun WifiDetailContentPreview() = PreviewWrapper {
                 freqType = WifiInfo.Wifi.Type.FIVE_GHZ,
             ),
         ),
+        deviceLabel = "Living Room Pixel",
+        deviceIcon = Icons.TwoTone.PhoneAndroid,
     )
 }


### PR DESCRIPTION
## Summary
- Module bottom sheets (Power, Wi-Fi, Connectivity, Clipboard, Meta) now display the source device's name and a small device-type icon as an overline above the title — so taps from the battery widget (and dashboard tile) clearly indicate which device's data is being shown.
- Adds a shared `BottomSheetHeader` composable in `app-common` that renders the overline + icon + title, replacing the previously duplicated header pattern in each sheet.
- The device icon mirrors the dashboard device card mapping: `Home` for the current device, `Warning` for degraded, `PhoneAndroid`/`Tablet`/`QuestionMark` based on `MetaInfo.deviceType`.
- Removes the now-redundant inline device-label row from the Meta detail sheet.

## Test plan
- [x] `./gradlew assembleFossDebug` passes
- [x] Verified on emulator: tap Power and Wi-Fi tiles → overline shows uppercase device name with appropriate device-type icon
- [x] Widget deeplink path benefits automatically (Power, Connectivity, Clipboard widgets) since it routes through the same per-sheet state vars
