### PR TITLE
Fix NavigationController crash from onNewIntent before Compose attaches

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/MainActivity.kt
@@ -70,6 +70,7 @@ class MainActivity : Activity2() {
                                     autoAction = Nav.Main.FileShareList.AutoAction.INCOMING_SHARE,
                                     incomingShareToken = event.token,
                                 ),
+                                popUpTo = Nav.Main.Dashboard,
                             )
                         }
                         MainActivityVM.IncomingShareEvent.Unsupported ->
@@ -77,6 +78,15 @@ class MainActivity : Activity2() {
                         MainActivityVM.IncomingShareEvent.ModuleDisabled ->
                             Toast.makeText(this@MainActivity, FilesR.string.module_files_share_module_disabled, Toast.LENGTH_LONG).show()
                     }
+                }
+            }
+
+            // Pop back to Dashboard for accepted widget / file-share-notification deeplinks. Done
+            // here (Compose) instead of in onNewIntent because onNewIntent can fire before the
+            // back stack is registered with NavigationController (race observed on Android 16 Beta).
+            LaunchedEffect(Unit) {
+                vm.deeplinkAccepted.collect {
+                    navCtrl.popTo(Nav.Main.Dashboard)
                 }
             }
 
@@ -116,12 +126,9 @@ class MainActivity : Activity2() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         setIntent(intent)
-        val handled = vm.handleDeeplinkIntent(intent)
-        if (handled) {
-            // Force nav back to Dashboard so the deeplink observer picks it up. If Dashboard
-            // is not on the back stack (e.g. mid-onboarding), popTo no-ops and we leave nav alone.
-            navCtrl.popTo(Nav.Main.Dashboard)
-        }
+        // Pure parsing — emits VM events. Pop-to-Dashboard is handled inside setContent so it
+        // can never run before the back stack is registered with NavigationController.
+        vm.handleDeeplinkIntent(intent)
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/octi/main/ui/MainActivityVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/MainActivityVM.kt
@@ -67,6 +67,19 @@ class MainActivityVM @Inject constructor(
      */
     val incomingShareEvents = SingleEventFlow<IncomingShareEvent>()
 
+    /**
+     * Fires after a successful widget or file-share-notification deeplink is parsed. The activity
+     * collects this from inside the Compose tree and pops back to Dashboard so the Dashboard-level
+     * observers can consume the buffered event. System-share intents are NOT signalled here —
+     * those navigate directly via [incomingShareEvents] using popUpTo, so a separate pop step is
+     * unnecessary (and would race with the goTo).
+     *
+     * Done via a Compose-side collector instead of calling navCtrl directly from onNewIntent, to
+     * avoid the race where onNewIntent fires before the Compose lambda has registered the back
+     * stack with NavigationController (observed crash on Android 16 Beta).
+     */
+    val deeplinkAccepted = SingleEventFlow<Unit>()
+
     sealed interface IncomingShareEvent {
         data class IncomingShare(val token: String, val selfDeviceId: String) : IncomingShareEvent
         data object Unsupported : IncomingShareEvent
@@ -94,6 +107,7 @@ class MainActivityVM @Inject constructor(
             }
             log(_tag, INFO) { "File-share deeplink accepted: device=${parsed.deviceId}" }
             fileShareDeeplinkEvents.tryEmit(parsed)
+            deeplinkAccepted.tryEmit(Unit)
             return true
         }
 
@@ -104,6 +118,7 @@ class MainActivityVM @Inject constructor(
         }
         log(_tag, INFO) { "Widget deeplink accepted: device=${widget.deviceId} module=${widget.moduleType}" }
         deeplinkEvents.tryEmit(widget)
+        deeplinkAccepted.tryEmit(Unit)
         return true
     }
 

--- a/app/src/test/java/eu/darken/octi/main/ui/MainActivityVMTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/MainActivityVMTest.kt
@@ -5,6 +5,8 @@ import android.content.Intent
 import android.net.Uri
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.common.navigation.FileShareDeeplink
+import eu.darken.octi.common.navigation.WidgetDeeplink
 import eu.darken.octi.common.theming.ThemeColor
 import eu.darken.octi.common.theming.ThemeMode
 import eu.darken.octi.common.theming.ThemeState
@@ -23,6 +25,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
@@ -191,5 +194,75 @@ class MainActivityVMTest : BaseTest() {
         val event = vm.incomingShareEvents.first()
         event.shouldBeInstanceOf<MainActivityVM.IncomingShareEvent.IncomingShare>()
         event.selfDeviceId shouldBe "self-device"
+    }
+
+    @Test
+    fun `widget deeplink emits deeplinkAccepted`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns WidgetDeeplink.ACTION
+            every { getStringExtra(WidgetDeeplink.EXTRA_DEVICE_ID) } returns "device-1"
+            every { getStringExtra(WidgetDeeplink.EXTRA_MODULE_TYPE) } returns "POWER"
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe true
+        vm.deeplinkAccepted.first() shouldBe Unit
+    }
+
+    @Test
+    fun `file-share deeplink emits deeplinkAccepted`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns FileShareDeeplink.ACTION
+            every { getStringExtra(FileShareDeeplink.EXTRA_DEVICE_ID) } returns "device-1"
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe true
+        vm.deeplinkAccepted.first() shouldBe Unit
+    }
+
+    @Test
+    fun `system-share intent does NOT emit deeplinkAccepted`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns Intent.ACTION_SEND
+            every { getParcelableExtra<Uri>(Intent.EXTRA_STREAM) } returns fakeUri("content", "a")
+            every { clipData } returns null
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe true
+        withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
+    }
+
+    @Test
+    fun `unrecognized intent does NOT emit deeplinkAccepted`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns "android.intent.action.MAIN"
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe false
+        withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
+    }
+
+    @Test
+    fun `widget deeplink dropped when onboarding not done does NOT emit deeplinkAccepted`() = runTest2 {
+        every { onboardingDone.flow } returns flowOf(false)
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns WidgetDeeplink.ACTION
+            every { getStringExtra(WidgetDeeplink.EXTRA_DEVICE_ID) } returns "device-1"
+            every { getStringExtra(WidgetDeeplink.EXTRA_MODULE_TYPE) } returns "POWER"
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe false
+        withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
+    }
+
+    @Test
+    fun `file-share deeplink dropped when onboarding not done does NOT emit deeplinkAccepted`() = runTest2 {
+        every { onboardingDone.flow } returns flowOf(false)
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns FileShareDeeplink.ACTION
+            every { getStringExtra(FileShareDeeplink.EXTRA_DEVICE_ID) } returns "device-1"
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe false
+        withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
     }
 }


### PR DESCRIPTION
## Summary

Fixes a Google Play crash report on Samsung Galaxy S24 Ultra running Android 16 Beta (SDK 36):

```
Caused by java.lang.IllegalStateException:
  at eu.darken.octi.common.navigation.NavigationController.getBackStack (NavigationController.kt:15)
  at eu.darken.octi.common.navigation.NavigationController.popTo (NavigationController.kt:61)
  at eu.darken.octi.main.ui.MainActivity.onNewIntent (MainActivity.kt:123)
  at android.app.ActivityThread.deliverNewIntents
  at android.app.ActivityThread.performResumeActivity
```

## Root cause

`NavigationController._backStack` is registered via `setup(backStack)` from inside the `setContent { }` Compose lambda — asynchronous, frame-scheduled. `MainActivity.onNewIntent` runs synchronously and the stack trace shows it firing inside `performResumeActivity → deliverNewIntents`. There is a window during activity recreation (config change, dark-mode flip) or singleTask warm intent delivery where `onNewIntent` runs before the Compose lambda has executed. `_backStack` is still `null`, and `popTo(Nav.Main.Dashboard)` throws.

## Fix

Move the `popTo(Dashboard)` step out of `onNewIntent` and into a Compose-level `LaunchedEffect`. `onNewIntent` becomes a pure intent-parsing entry point that emits VM events; the navigation work happens once Compose has attached, where the back stack is guaranteed initialized.

- Add `MainActivityVM.deeplinkAccepted: SingleEventFlow<Unit>` — fired after a successful widget or file-share-notification deeplink parse (not for system-share intents)
- `MainActivity.onNewIntent` now just calls `vm.handleDeeplinkIntent(intent)` and returns
- New `LaunchedEffect` inside `setContent { }` collects `deeplinkAccepted` → `navCtrl.popTo(Nav.Main.Dashboard)`
- `incomingShareEvents` collector switched to `goTo(FileShareList, popUpTo = Dashboard)` (single atomic call) so it does not race with the parallel `popTo` collector
- `NavigationController` is unchanged — strict `error()` getter stays, contract not weakened

This matches the canonical pattern already used in `permission-pilot` (intent → VM event → Compose-level `LaunchedEffect` → `navCtrl.*`).

## Test plan

- [x] `./gradlew :app:testFossDebugUnitTest` passes (6 new VM tests covering `deeplinkAccepted` across widget / file-share / system-share / unrecognized / not-onboarded cases)
- [x] `./gradlew assembleFossDebug` compiles cleanly
- [ ] Manual: open Octi to Dashboard → navigate to Settings → share a file from another app via system share sheet → confirm back stack lands at `[Dashboard, FileShareList]`
- [ ] Manual: open Octi to Dashboard → navigate to Settings → tap a widget on the home screen → confirm back stack lands at `[Dashboard]` and the module detail sheet opens
- [ ] Manual: with onboarding incomplete, repeat both — confirm we stay on Welcome and no nav happens