### PR TITLE
Fix Octi Server sync encryption error on older Android

### DIFF
--- a/app/src/main/java/eu/darken/octi/App.kt
+++ b/app/src/main/java/eu/darken/octi/App.kt
@@ -24,6 +24,7 @@ import eu.darken.octi.module.core.ModuleManager
 import eu.darken.octi.modules.files.core.BlobMaintenance
 import eu.darken.octi.modules.files.core.IncomingFileNotifier
 import eu.darken.octi.sync.core.SyncOrchestrator
+import eu.darken.octi.sync.core.encryption.CryptoCapabilities
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -47,6 +48,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var releaseManager: ReleaseManager
     @Inject lateinit var blobMaintenance: BlobMaintenance
     @Inject lateinit var incomingFileNotifier: IncomingFileNotifier
+    @Inject lateinit var cryptoCapabilities: CryptoCapabilities
 
     override fun onCreate() {
         super.onCreate()
@@ -61,6 +63,11 @@ open class App : Application(), Configuration.Provider {
             .launchIn(appScope)
 
         log(TAG, INFO) { BuildConfigWrap.VERSION_DESCRIPTION }
+
+        // Eagerly resolve crypto capabilities so the JCE provider install + Tink registration
+        // (which run in PayloadEncryption.companion init) finish before any sync component
+        // touches crypto. Reading the property is enough to trigger the underlying class load.
+        log(TAG) { "gcmSivAvailable=${cryptoCapabilities.gcmSivAvailable}" }
 
         bugReporter.setup(this)
 

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -39,4 +39,8 @@ object Versions {
     object Desugar {
         const val core = "2.1.5"
     }
+
+    object Conscrypt {
+        const val core = "2.5.2"
+    }
 }

--- a/sync-core/build.gradle.kts
+++ b/sync-core/build.gradle.kts
@@ -53,5 +53,6 @@ dependencies {
 
     implementation("androidx.security:security-crypto-ktx:1.1.0")
     implementation("com.google.crypto.tink:tink-android:1.16.0")
+    implementation("org.conscrypt:conscrypt-android:${Versions.Conscrypt.core}")
     testImplementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
 }

--- a/sync-core/proguard-rules.pro
+++ b/sync-core/proguard-rules.pro
@@ -19,3 +19,14 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Conscrypt — bundled to provide AES/GCM-SIV/NoPadding on Android API ≤ 29 where
+# the system Conscrypt lacks it. The provider registers algorithms via reflection
+# on Service class names, and JNI binds native methods by name, so both must
+# survive R8 minification.
+-keep class org.conscrypt.** { *; }
+-keep interface org.conscrypt.** { *; }
+-keepclasseswithmembernames class org.conscrypt.** {
+    native <methods>;
+}
+-dontwarn org.conscrypt.**

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoCapabilities.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoCapabilities.kt
@@ -1,0 +1,34 @@
+package eu.darken.octi.sync.core.encryption
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Runtime-detected crypto features. Currently exposes whether AES-GCM-SIV is usable
+ * end-to-end on this device — see [PayloadEncryption.gcmSivAvailable] for the underlying
+ * detection. Exists so callers like account creation can be exercised in tests with both
+ * `gcmSivAvailable=true` and `gcmSivAvailable=false` without touching JCE provider state.
+ */
+interface CryptoCapabilities {
+    val gcmSivAvailable: Boolean
+}
+
+@Singleton
+class RealCryptoCapabilities @Inject constructor() : CryptoCapabilities {
+    override val gcmSivAvailable: Boolean
+        // Reading the static forces [PayloadEncryption] class load (and thus its companion
+        // init: JCE provider install + Tink registration + RFC 8452 postcondition) on first
+        // access. App.onCreate injects this singleton early so the warmup is deterministic.
+        get() = PayloadEncryption.gcmSivAvailable
+}
+
+@InstallIn(SingletonComponent::class)
+@Module
+abstract class CryptoCapabilitiesModule {
+    @Binds
+    abstract fun bindCryptoCapabilities(impl: RealCryptoCapabilities): CryptoCapabilities
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
@@ -11,7 +11,10 @@ import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AesGcmSivKeyManager
 import com.google.crypto.tink.daead.DeterministicAeadConfig
 import com.google.crypto.tink.streamingaead.StreamingAeadConfig
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.serialization.ByteStringParcelizer
@@ -24,7 +27,7 @@ import okio.ByteString
 import okio.ByteString.Companion.toByteString
 
 
-class PayloadEncryption constructor(
+class PayloadEncryption(
     private val keySet: KeySet? = null,
     private val useLegacyEncryption: Boolean = false,
 ) {
@@ -90,26 +93,136 @@ class PayloadEncryption constructor(
     companion object {
         private val TAG = logTag("Sync", "Crypto", "Payload")
 
+        // RFC 8452 Appendix C.1 vector 1: AES-128-GCM-SIV, key=0x01||..., nonce=0x03||...,
+        // empty plaintext+AAD → tag dc20e2d83f25705bb49e439eca56de25. Used to distinguish
+        // working AES-GCM-SIV from a provider that silently returns AES-GCM under the same
+        // transformation name (observed on Android API ≤ 29 system Conscrypt).
+        private val GCM_SIV_RFC8452_KEY = ByteArray(16).also { it[0] = 1 }
+        private val GCM_SIV_RFC8452_NONCE = ByteArray(12).also { it[0] = 3 }
+        private val GCM_SIV_RFC8452_EXPECTED = byteArrayOf(
+            0xDC.toByte(), 0x20.toByte(), 0xE2.toByte(), 0xD8.toByte(),
+            0x3F.toByte(), 0x25.toByte(), 0x70.toByte(), 0x5B.toByte(),
+            0xB4.toByte(), 0x9E.toByte(), 0x43.toByte(), 0x9E.toByte(),
+            0xCA.toByte(), 0x56.toByte(), 0xDE.toByte(), 0x25.toByte(),
+        )
+
+        // Tink's EngineFactory.AndroidPolicy resolves Cipher providers by *name* in this
+        // exact order before falling through to default JCE lookup. Either being broken
+        // (or returning a wrong-algorithm cipher under "AES/GCM-SIV/NoPadding") would
+        // poison Tink's primitive construction.
+        private val TINK_PREFERRED_PROVIDER_NAMES = listOf("GmsCore_OpenSSL", "AndroidOpenSSL")
+
+        /**
+         * True when [PayloadEncryption] can produce and decrypt AES-GCM-SIV ciphertext on
+         * this device. Set during companion init by [verifyTinkAesGcmSivWorks] after
+         * provider install + Tink registration. Callers (e.g. account creation) should fall
+         * back to [EncryptionMode.AES256_SIV] when this is `false` to avoid producing a
+         * keyset that can never be used.
+         */
+        @Volatile
+        var gcmSivAvailable: Boolean = false
+            private set
+
         init {
-            // Register BouncyCastle for AES-GCM-SIV support in JVM unit tests.
-            // On Android (Dalvik/ART), the platform provider already handles it — skip
-            // to avoid overriding Conscrypt at JCA position 1.
             val vmName = System.getProperty("java.vm.name") ?: ""
             val isAndroidRuntime = vmName.contains("Dalvik", ignoreCase = true)
-            if (!isAndroidRuntime) {
-                try {
-                    val bcClass = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
-                    val provider = bcClass.getDeclaredConstructor().newInstance() as java.security.Provider
-                    java.security.Security.insertProviderAt(provider, 1)
-                } catch (_: ClassNotFoundException) {
-                    // BouncyCastle not on classpath
-                }
+
+            // Feature-detect whether the platform JCE serves a *working* AES/GCM-SIV/NoPadding.
+            // The naive Cipher.getInstance probe is insufficient: on API ≤ 29 the system
+            // Conscrypt accepts the transformation string but returns AES-GCM (Tink later
+            // rejects this via its internal test-vector check, surfacing as "AES GCM SIV
+            // cipher is not available or is invalid"). We run the same RFC 8452 vector here
+            // up-front so the install gate is correct.
+            if (!platformHasWorkingGcmSiv()) {
+                if (isAndroidRuntime) installBundledConscrypt() else installBouncyCastle()
             }
+
             DeterministicAeadConfig.register()
             AeadConfig.register()
             AesGcmSivKeyManager.register(true)
             StreamingAeadConfig.register()
             log(TAG) { "DeterministicAeadConfig + AeadConfig + AesGcmSiv + StreamingAead registered" }
+
+            // Postcondition runs the actual Tink AEAD path (not just JCE Cipher lookup) so
+            // it covers Tink's named-provider resolution exactly. Result is exposed via
+            // [gcmSivAvailable] for new-keyset gating.
+            gcmSivAvailable = verifyTinkAesGcmSivWorks()
+            if (gcmSivAvailable) {
+                log(TAG) { "Tink AES-GCM-SIV round-trip verified" }
+            } else {
+                log(TAG, ERROR) { "Tink AES-GCM-SIV round-trip FAILED — new accounts will fall back to legacy SIV" }
+            }
+        }
+
+        internal fun platformHasWorkingGcmSiv(): Boolean = try {
+            val cipher = javax.crypto.Cipher.getInstance("AES/GCM-SIV/NoPadding")
+            cipher.init(
+                javax.crypto.Cipher.ENCRYPT_MODE,
+                javax.crypto.spec.SecretKeySpec(GCM_SIV_RFC8452_KEY, "AES"),
+                javax.crypto.spec.GCMParameterSpec(128, GCM_SIV_RFC8452_NONCE),
+            )
+            cipher.doFinal(ByteArray(0)).contentEquals(GCM_SIV_RFC8452_EXPECTED)
+        } catch (_: Throwable) {
+            false
+        }
+
+        // Mirrors Tink's EngineFactory.AndroidPolicy lookup order so we can detect
+        // "GmsCore_OpenSSL is broken even though AndroidOpenSSL is healthy" — Tink would
+        // hit the broken provider first.
+        private fun verifyTinkAesGcmSivWorks(): Boolean = try {
+            val testKeyset = KeysetHandle.generateNew(AesGcmSivKeyManager.aes256GcmSivTemplate())
+            val aead = testKeyset.getPrimitive(Aead::class.java)
+            val ciphertext = aead.encrypt("octi-init-probe".toByteArray(), null)
+            aead.decrypt(ciphertext, null).contentEquals("octi-init-probe".toByteArray())
+        } catch (_: Throwable) {
+            false
+        }
+
+        private fun installBundledConscrypt() {
+            // Tink's EngineFactory.AndroidPolicy looks up Cipher providers by *name* in
+            // [TINK_PREFERRED_PROVIDER_NAMES] order before falling through to default JCE
+            // lookup. Installing only at name "Conscrypt" leaves a broken system provider
+            // in place, so Tink would still pick up the platform cipher. We replace each
+            // preferred name with our bundled Conscrypt — `removeProvider` is a no-op when
+            // the name is absent, so this is safe regardless of the device's existing
+            // provider set.
+            try {
+                val conscryptClass = Class.forName("org.conscrypt.Conscrypt")
+                val newProvider = conscryptClass.getMethod("newProvider", String::class.java)
+                for (name in TINK_PREFERRED_PROVIDER_NAMES) {
+                    val provider = newProvider.invoke(null, name) as java.security.Provider
+                    java.security.Security.removeProvider(name)
+                    java.security.Security.insertProviderAt(provider, 1)
+                }
+                log(TAG) { "Installed bundled Conscrypt as ${TINK_PREFERRED_PROVIDER_NAMES.joinToString("+")} (Android API ${android.os.Build.VERSION.SDK_INT})" }
+            } catch (e: java.lang.reflect.InvocationTargetException) {
+                // Unwrap to surface the real failure — most commonly UnsatisfiedLinkError
+                // or ExceptionInInitializerError from Conscrypt's native-lib bootstrap.
+                val cause = e.targetException ?: e
+                log(TAG, ERROR) { "Conscrypt provider init failed (${cause.javaClass.simpleName}): ${cause.asLog()}" }
+            } catch (e: ClassNotFoundException) {
+                log(TAG, WARN) { "Conscrypt class not found at runtime: ${e.message}" }
+            } catch (e: ReflectiveOperationException) {
+                log(TAG, ERROR) { "Failed to instantiate Conscrypt provider: ${e.asLog()}" }
+            } catch (e: LinkageError) {
+                log(TAG, ERROR) { "Conscrypt native lib missing or incompatible: ${e.asLog()}" }
+            } catch (e: SecurityException) {
+                log(TAG, ERROR) { "SecurityManager denied Conscrypt registration: ${e.asLog()}" }
+            }
+        }
+
+        private fun installBouncyCastle() {
+            // JVM unit tests rely on BouncyCastle for AES-GCM-SIV. The Android runtime
+            // never takes this branch — it uses Conscrypt above.
+            try {
+                val bcClass = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
+                val provider = bcClass.getDeclaredConstructor().newInstance() as java.security.Provider
+                java.security.Security.insertProviderAt(provider, 1)
+            } catch (_: ClassNotFoundException) {
+                // BouncyCastle not on classpath
+            } catch (e: ReflectiveOperationException) {
+                log(TAG, ERROR) { "Failed to instantiate BouncyCastle provider: ${e.asLog()}" }
+            }
         }
     }
 }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionTest.kt
@@ -134,4 +134,20 @@ class PayloadEncryptionTest : BaseTest() {
         val crypti = PayloadEncryption(useLegacyEncryption = true)
         crypti.exportKeyset().type shouldBe EncryptionMode.AES256_SIV.typeString
     }
+
+    @Test
+    fun `RFC 8452 vector probe returns true after BouncyCastle is installed`() {
+        // BouncyCastle is on testImplementation and PayloadEncryption.companion.init has
+        // already installed it as a JCE provider by the time any test runs (instantiating
+        // any PayloadEncryption above triggers class load). Locks the RFC 8452 constants
+        // against accidental edits.
+        PayloadEncryption()  // ensure class init has fired
+        PayloadEncryption.platformHasWorkingGcmSiv() shouldBe true
+    }
+
+    @Test
+    fun `gcmSivAvailable is true on JVM (BouncyCastle)`() {
+        PayloadEncryption()  // ensure class init has fired
+        PayloadEncryption.gcmSivAvailable shouldBe true
+    }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
@@ -15,6 +15,7 @@ import eu.darken.octi.common.serialization.RetrofitJson
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.encryption.CryptoCapabilities
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -37,6 +38,7 @@ class OctiServerEndpoint @AssistedInject constructor(
     @RetrofitJson private val retrofitJson: Json,
     private val basicAuthInterceptor: BasicAuthInterceptor,
     private val deviceHeaderInterceptor: DeviceHeaderInterceptor,
+    private val cryptoCapabilities: CryptoCapabilities,
 ) {
 
     private val httpClient by lazy {
@@ -72,12 +74,20 @@ class OctiServerEndpoint @AssistedInject constructor(
             throw OctiServerHttpException(e)
         }
 
+        // Fall back to legacy SIV when the device can't actually do AES-GCM-SIV. Producing
+        // a GCM-SIV keyset on a broken device would create an account whose ciphertext can
+        // never be decrypted on this device — see PayloadEncryption.gcmSivAvailable.
+        val canDoGcmSiv = cryptoCapabilities.gcmSivAvailable
+        if (!canDoGcmSiv) {
+            log(TAG, WARN) { "createNewAccount: AES-GCM-SIV unavailable on this device, falling back to legacy SIV encryption" }
+        }
+
         OctiServer.Credentials(
             createdAt = Clock.System.now(),
             serverAdress = serverAdress,
             accountId = OctiServer.Credentials.AccountId(response.accountID),
             devicePassword = OctiServer.Credentials.DevicePassword(response.password),
-            encryptionKeyset = PayloadEncryption().exportKeyset(),
+            encryptionKeyset = PayloadEncryption(useLegacyEncryption = !canDoGcmSiv).exportKeyset(),
         )
     }
 

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
@@ -1,11 +1,10 @@
 package eu.darken.octi.syncs.octiserver.core
 
-import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.encryption.CryptoCapabilities
+import eu.darken.octi.sync.core.encryption.EncryptionMode
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.json.Json
@@ -13,7 +12,6 @@ import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okio.ByteString.Companion.encodeUtf8
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -22,18 +20,17 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 
 /**
- * Verifies the on-the-wire shape of [OctiServerEndpoint.writeModule] — specifically that the
- * `device-id` query param carries the *target* device passed by the caller, not the caller's
- * own id (the historical hardcoded value before the deviceId-plumbing fix). A call-site grep
- * cannot catch a regression that hardcodes the target inside the wrapper body — this does.
+ * Verifies the AES-GCM-SIV ↔ legacy-SIV fall-back in [OctiServerEndpoint.createNewAccount].
+ * Required because creating a GCM-SIV keyset on a device whose JCE can't actually do
+ * AES-GCM-SIV would produce an account whose ciphertext can never be decrypted on this
+ * device. See d4rken-org/octi#285 and [eu.darken.octi.sync.core.encryption.PayloadEncryption].
  */
-class OctiServerEndpointWriteModuleTest : BaseTest() {
+class OctiServerEndpointCreateAccountTest : BaseTest() {
 
     private lateinit var server: MockWebServer
     private val syncSettings: SyncSettings = mockk()
     private val basicAuthInterceptor = BasicAuthInterceptor()
     private val deviceHeaderInterceptor: DeviceHeaderInterceptor = mockk()
-    private val cryptoCapabilities: CryptoCapabilities = mockk(relaxed = true)
 
     private val retrofitJson = Json {
         ignoreUnknownKeys = true
@@ -46,8 +43,6 @@ class OctiServerEndpointWriteModuleTest : BaseTest() {
         server = MockWebServer()
         server.start()
         every { syncSettings.deviceId } returns DeviceId("caller-uuid")
-        // Pass-through — DeviceHeaderInterceptor reads android.os.Build which is unavailable
-        // here; we don't care about its headers for this test.
         every { deviceHeaderInterceptor.intercept(any()) } answers {
             val chain = firstArg<Interceptor.Chain>()
             chain.proceed(chain.request())
@@ -59,7 +54,7 @@ class OctiServerEndpointWriteModuleTest : BaseTest() {
         server.shutdown()
     }
 
-    private fun newEndpoint(): OctiServerEndpoint {
+    private fun newEndpoint(cryptoCapabilities: CryptoCapabilities): OctiServerEndpoint {
         val url = server.url("/")
         val address = OctiServer.Address(
             domain = url.host,
@@ -78,35 +73,35 @@ class OctiServerEndpointWriteModuleTest : BaseTest() {
         )
     }
 
-    @Test
-    fun `writeModule sends device-id query param with target id, X-Device-ID header with caller id`() = runTest2 {
-        server.enqueue(MockResponse().setResponseCode(200))
-
-        newEndpoint().writeModule(
-            deviceId = DeviceId("target-uuid"),
-            moduleId = ModuleId("eu.darken.octi.module.test"),
-            payload = "hello".encodeUtf8(),
+    private fun enqueueRegisterResponse() {
+        server.enqueue(
+            MockResponse().setResponseCode(201).setBody(
+                """{"account":"acc-id-001","password":"pw"}"""
+            )
         )
-
-        val recorded = server.takeRequest()
-        recorded.method shouldBe "POST"
-        recorded.path shouldContain "/v1/module/eu.darken.octi.module.test"
-        recorded.path shouldContain "device-id=target-uuid"
-        recorded.getHeader("X-Device-ID") shouldBe "caller-uuid"
     }
 
     @Test
-    fun `writeModule when target equals caller still sends both fields verbatim`() = runTest2 {
-        server.enqueue(MockResponse().setResponseCode(200))
+    fun `createNewAccount produces GCM-SIV keyset when gcmSivAvailable=true`() = runTest2 {
+        enqueueRegisterResponse()
 
-        newEndpoint().writeModule(
-            deviceId = DeviceId("caller-uuid"),
-            moduleId = ModuleId("eu.darken.octi.module.test"),
-            payload = "hello".encodeUtf8(),
-        )
+        val endpoint = newEndpoint(cryptoCapabilities = object : CryptoCapabilities {
+            override val gcmSivAvailable: Boolean = true
+        })
 
-        val recorded = server.takeRequest()
-        recorded.path shouldContain "device-id=caller-uuid"
-        recorded.getHeader("X-Device-ID") shouldBe "caller-uuid"
+        val credentials = endpoint.createNewAccount()
+        credentials.encryptionKeyset.type shouldBe EncryptionMode.AES256_GCM_SIV.typeString
+    }
+
+    @Test
+    fun `createNewAccount falls back to legacy SIV keyset when gcmSivAvailable=false`() = runTest2 {
+        enqueueRegisterResponse()
+
+        val endpoint = newEndpoint(cryptoCapabilities = object : CryptoCapabilities {
+            override val gcmSivAvailable: Boolean = false
+        })
+
+        val credentials = endpoint.createNewAccount()
+        credentials.encryptionKeyset.type shouldBe EncryptionMode.AES256_SIV.typeString
     }
 }

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
@@ -4,6 +4,7 @@ import eu.darken.octi.common.serialization.SerializationModule
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.encryption.CryptoCapabilities
 import eu.darken.octi.syncs.octiserver.core.BasicAuthInterceptor
 import eu.darken.octi.syncs.octiserver.core.DeviceHeaderInterceptor
 import eu.darken.octi.syncs.octiserver.core.OctiServer
@@ -99,6 +100,9 @@ class CrossVersionLegacyServerTest : BaseTest() {
             retrofitJson = SerializationModule().retrofitJson(),
             basicAuthInterceptor = BasicAuthInterceptor(),
             deviceHeaderInterceptor = deviceHeaderInterceptor,
+            cryptoCapabilities = object : CryptoCapabilities {
+                override val gcmSivAvailable: Boolean = true
+            },
         )
     }
 


### PR DESCRIPTION
## Summary

- Bundles `org.conscrypt:conscrypt-android` and installs it under the JCE provider names Tink looks up first, so AES-GCM-SIV becomes available on Android versions where the system Conscrypt either lacks it or silently substitutes AES-GCM (observed on a Huawei running Android 10 — the reporter — and on a Pixel 2 / Android 9 in validation).
- Gates the install on an end-to-end RFC 8452 test vector instead of a naive `Cipher.getInstance` probe — the latter is fooled by providers that silently return AES-GCM under the GCM-SIV transformation name.
- Adds an injectable `CryptoCapabilities` boundary. `OctiServerEndpoint.createNewAccount` falls back to legacy `AES256_SIV` when GCM-SIV is unusable, preventing accounts whose ciphertext could never be decrypted on this device.
- `App.onCreate` resolves `CryptoCapabilities` eagerly so the JCE provider state and Tink registration finish before any sync component touches crypto.

## Validation

- 13 unit tests pass (`PayloadEncryptionTest`: 11 with 2 new for the RFC 8452 vector lock and `gcmSivAvailable` flag; `OctiServerEndpointCreateAccountTest`: 2 new asserting GCM-SIV vs SIV fall-back via a fake `CryptoCapabilities`).
- R8-minified `assembleFossBeta` builds clean (~16.5 MB APK).
- Pixel 2 / Android 9 (API 28) — fresh Octi Server account creation + synchronize round-trip both succeed (was the broken path; verified with two runs and an existing-keyset re-decrypt path).
- Emulator API 31 — feature-detect gate correctly skips the bundled-Conscrypt install, no regression.

## Note on APK size

Adds the `conscrypt-android` AAR (native libs across `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64`). Single foss APK ships all ABIs (no ABI splits configured), so APK size grew accordingly. gplay AAB delivers per-ABI at install time.

Closes #285
