### PR TITLE
Extract CryptoBootstrap from PayloadEncryption

### DIFF
--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoBootstrap.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoBootstrap.kt
@@ -1,0 +1,165 @@
+package eu.darken.octi.sync.core.encryption
+
+import com.google.crypto.tink.Aead
+import com.google.crypto.tink.KeysetHandle
+import com.google.crypto.tink.aead.AeadConfig
+import com.google.crypto.tink.aead.AesGcmSivKeyManager
+import com.google.crypto.tink.daead.DeterministicAeadConfig
+import com.google.crypto.tink.streamingaead.StreamingAeadConfig
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+
+/**
+ * Owns the process-global crypto setup: JCE provider selection, Tink configuration
+ * registration, and runtime AES-GCM-SIV feature detection. Kept separate from
+ * [PayloadEncryption] so the encryption wrapper itself stays a pure Tink-keyset facade.
+ *
+ * Bootstrap fires once when this object is first referenced. Callers who need crypto must
+ * either inject [CryptoCapabilities] (which delegates to [gcmSivAvailable]) or invoke
+ * [ensureInitialized] before relying on Tink registry state. [PayloadEncryption.init]
+ * already does the latter, so direct construction sites are covered.
+ */
+internal object CryptoBootstrap {
+    private val TAG = logTag("Sync", "Crypto", "Bootstrap")
+
+    // RFC 8452 Appendix C.1 vector 1: AES-128-GCM-SIV, key=0x01||..., nonce=0x03||...,
+    // empty plaintext+AAD → tag dc20e2d83f25705bb49e439eca56de25. Used to distinguish
+    // working AES-GCM-SIV from a provider that silently returns AES-GCM under the same
+    // transformation name (observed on Android API ≤ 29 system Conscrypt).
+    private val GCM_SIV_RFC8452_KEY = ByteArray(16).also { it[0] = 1 }
+    private val GCM_SIV_RFC8452_NONCE = ByteArray(12).also { it[0] = 3 }
+    private val GCM_SIV_RFC8452_EXPECTED = byteArrayOf(
+        0xDC.toByte(), 0x20.toByte(), 0xE2.toByte(), 0xD8.toByte(),
+        0x3F.toByte(), 0x25.toByte(), 0x70.toByte(), 0x5B.toByte(),
+        0xB4.toByte(), 0x9E.toByte(), 0x43.toByte(), 0x9E.toByte(),
+        0xCA.toByte(), 0x56.toByte(), 0xDE.toByte(), 0x25.toByte(),
+    )
+
+    // Tink's EngineFactory.AndroidPolicy resolves Cipher providers by *name* in this
+    // exact order before falling through to default JCE lookup. Either being broken
+    // (or returning a wrong-algorithm cipher under "AES/GCM-SIV/NoPadding") would
+    // poison Tink's primitive construction.
+    private val TINK_PREFERRED_PROVIDER_NAMES = listOf("GmsCore_OpenSSL", "AndroidOpenSSL")
+
+    /**
+     * True when this device can produce and decrypt AES-GCM-SIV ciphertext end-to-end via
+     * Tink. Set during this object's [init] block by [verifyTinkAesGcmSivWorks] after
+     * provider install + Tink registration. Callers (e.g. account creation) should fall
+     * back to [EncryptionMode.AES256_SIV] when this is `false` to avoid producing a keyset
+     * that can never be used.
+     */
+    val gcmSivAvailable: Boolean
+
+    init {
+        val vmName = System.getProperty("java.vm.name") ?: ""
+        val isAndroidRuntime = vmName.contains("Dalvik", ignoreCase = true)
+
+        // Feature-detect whether the platform JCE serves a *working* AES/GCM-SIV/NoPadding.
+        // The naive Cipher.getInstance probe is insufficient: on API ≤ 29 the system
+        // Conscrypt accepts the transformation string but returns AES-GCM (Tink later
+        // rejects this via its internal test-vector check, surfacing as "AES GCM SIV
+        // cipher is not available or is invalid"). We run the same RFC 8452 vector here
+        // up-front so the install gate is correct.
+        if (!platformHasWorkingGcmSiv()) {
+            if (isAndroidRuntime) installBundledConscrypt() else installBouncyCastle()
+        }
+
+        DeterministicAeadConfig.register()
+        AeadConfig.register()
+        AesGcmSivKeyManager.register(true)
+        StreamingAeadConfig.register()
+        log(TAG) { "DeterministicAeadConfig + AeadConfig + AesGcmSiv + StreamingAead registered" }
+
+        // Postcondition runs the actual Tink AEAD path (not just JCE Cipher lookup) so
+        // it covers Tink's named-provider resolution exactly. Result is exposed via
+        // [gcmSivAvailable] for new-keyset gating.
+        gcmSivAvailable = verifyTinkAesGcmSivWorks()
+        if (gcmSivAvailable) {
+            log(TAG) { "Tink AES-GCM-SIV round-trip verified" }
+        } else {
+            log(TAG, ERROR) { "Tink AES-GCM-SIV round-trip FAILED — new accounts will fall back to legacy SIV" }
+        }
+    }
+
+    /**
+     * No-op call whose only purpose is to force this object's class load (and thus its
+     * [init] block). Use from sites that need bootstrap to have run before they touch
+     * Tink, but that don't otherwise read [gcmSivAvailable]. Naming the side effect makes
+     * it auditable; a property read for the same purpose would be too subtle.
+     */
+    fun ensureInitialized() = Unit
+
+    internal fun platformHasWorkingGcmSiv(): Boolean = try {
+        val cipher = javax.crypto.Cipher.getInstance("AES/GCM-SIV/NoPadding")
+        cipher.init(
+            javax.crypto.Cipher.ENCRYPT_MODE,
+            javax.crypto.spec.SecretKeySpec(GCM_SIV_RFC8452_KEY, "AES"),
+            javax.crypto.spec.GCMParameterSpec(128, GCM_SIV_RFC8452_NONCE),
+        )
+        cipher.doFinal(ByteArray(0)).contentEquals(GCM_SIV_RFC8452_EXPECTED)
+    } catch (_: Throwable) {
+        false
+    }
+
+    // Mirrors Tink's EngineFactory.AndroidPolicy lookup order so we can detect
+    // "GmsCore_OpenSSL is broken even though AndroidOpenSSL is healthy" — Tink would
+    // hit the broken provider first.
+    private fun verifyTinkAesGcmSivWorks(): Boolean = try {
+        val testKeyset = KeysetHandle.generateNew(AesGcmSivKeyManager.aes256GcmSivTemplate())
+        val aead = testKeyset.getPrimitive(Aead::class.java)
+        val ciphertext = aead.encrypt("octi-init-probe".toByteArray(), null)
+        aead.decrypt(ciphertext, null).contentEquals("octi-init-probe".toByteArray())
+    } catch (_: Throwable) {
+        false
+    }
+
+    private fun installBundledConscrypt() {
+        // Tink's EngineFactory.AndroidPolicy looks up Cipher providers by *name* in
+        // [TINK_PREFERRED_PROVIDER_NAMES] order before falling through to default JCE
+        // lookup. Installing only at name "Conscrypt" leaves a broken system provider
+        // in place, so Tink would still pick up the platform cipher. We replace each
+        // preferred name with our bundled Conscrypt — `removeProvider` is a no-op when
+        // the name is absent, so this is safe regardless of the device's existing
+        // provider set.
+        try {
+            val conscryptClass = Class.forName("org.conscrypt.Conscrypt")
+            val newProvider = conscryptClass.getMethod("newProvider", String::class.java)
+            for (name in TINK_PREFERRED_PROVIDER_NAMES) {
+                val provider = newProvider.invoke(null, name) as java.security.Provider
+                java.security.Security.removeProvider(name)
+                java.security.Security.insertProviderAt(provider, 1)
+            }
+            log(TAG) { "Installed bundled Conscrypt as ${TINK_PREFERRED_PROVIDER_NAMES.joinToString("+")} (Android API ${android.os.Build.VERSION.SDK_INT})" }
+        } catch (e: java.lang.reflect.InvocationTargetException) {
+            // Unwrap to surface the real failure — most commonly UnsatisfiedLinkError
+            // or ExceptionInInitializerError from Conscrypt's native-lib bootstrap.
+            val cause = e.targetException ?: e
+            log(TAG, ERROR) { "Conscrypt provider init failed (${cause.javaClass.simpleName}): ${cause.asLog()}" }
+        } catch (e: ClassNotFoundException) {
+            log(TAG, WARN) { "Conscrypt class not found at runtime: ${e.message}" }
+        } catch (e: ReflectiveOperationException) {
+            log(TAG, ERROR) { "Failed to instantiate Conscrypt provider: ${e.asLog()}" }
+        } catch (e: LinkageError) {
+            log(TAG, ERROR) { "Conscrypt native lib missing or incompatible: ${e.asLog()}" }
+        } catch (e: SecurityException) {
+            log(TAG, ERROR) { "SecurityManager denied Conscrypt registration: ${e.asLog()}" }
+        }
+    }
+
+    private fun installBouncyCastle() {
+        // JVM unit tests rely on BouncyCastle for AES-GCM-SIV. The Android runtime
+        // never takes this branch — it uses Conscrypt above.
+        try {
+            val bcClass = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
+            val provider = bcClass.getDeclaredConstructor().newInstance() as java.security.Provider
+            java.security.Security.insertProviderAt(provider, 1)
+        } catch (_: ClassNotFoundException) {
+            // BouncyCastle not on classpath
+        } catch (e: ReflectiveOperationException) {
+            log(TAG, ERROR) { "Failed to instantiate BouncyCastle provider: ${e.asLog()}" }
+        }
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoCapabilities.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoCapabilities.kt
@@ -20,10 +20,11 @@ interface CryptoCapabilities {
 @Singleton
 class RealCryptoCapabilities @Inject constructor() : CryptoCapabilities {
     override val gcmSivAvailable: Boolean
-        // Reading the static forces [PayloadEncryption] class load (and thus its companion
-        // init: JCE provider install + Tink registration + RFC 8452 postcondition) on first
-        // access. App.onCreate injects this singleton early so the warmup is deterministic.
-        get() = PayloadEncryption.gcmSivAvailable
+        // Reading the property forces [CryptoBootstrap] class load (and thus its init
+        // block: JCE provider install + Tink registration + RFC 8452 postcondition) on
+        // first access. App.onCreate injects this singleton early so the warmup is
+        // deterministic.
+        get() = CryptoBootstrap.gcmSivAvailable
 }
 
 @InstallIn(SingletonComponent::class)

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
@@ -7,14 +7,8 @@ import com.google.crypto.tink.InsecureSecretKeyAccess
 import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.KeysetHandle
 import com.google.crypto.tink.TinkProtoKeysetFormat
-import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.aead.AesGcmSivKeyManager
-import com.google.crypto.tink.daead.DeterministicAeadConfig
-import com.google.crypto.tink.streamingaead.StreamingAeadConfig
-import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
-import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
-import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.serialization.ByteStringParcelizer
@@ -31,6 +25,15 @@ class PayloadEncryption(
     private val keySet: KeySet? = null,
     private val useLegacyEncryption: Boolean = false,
 ) {
+
+    init {
+        // Process-global JCE provider install + Tink configuration registration must
+        // happen before any keysetHandle / primitive call. CryptoBootstrap owns that;
+        // calling ensureInitialized forces its class load on first construction so direct
+        // instantiation sites (tests, OctiServerConnector, etc.) are covered without
+        // relying on App.onCreate having run first.
+        CryptoBootstrap.ensureInitialized()
+    }
 
     private val keysetHandle by lazy {
         keySet?.let {
@@ -92,137 +95,5 @@ class PayloadEncryption(
 
     companion object {
         private val TAG = logTag("Sync", "Crypto", "Payload")
-
-        // RFC 8452 Appendix C.1 vector 1: AES-128-GCM-SIV, key=0x01||..., nonce=0x03||...,
-        // empty plaintext+AAD → tag dc20e2d83f25705bb49e439eca56de25. Used to distinguish
-        // working AES-GCM-SIV from a provider that silently returns AES-GCM under the same
-        // transformation name (observed on Android API ≤ 29 system Conscrypt).
-        private val GCM_SIV_RFC8452_KEY = ByteArray(16).also { it[0] = 1 }
-        private val GCM_SIV_RFC8452_NONCE = ByteArray(12).also { it[0] = 3 }
-        private val GCM_SIV_RFC8452_EXPECTED = byteArrayOf(
-            0xDC.toByte(), 0x20.toByte(), 0xE2.toByte(), 0xD8.toByte(),
-            0x3F.toByte(), 0x25.toByte(), 0x70.toByte(), 0x5B.toByte(),
-            0xB4.toByte(), 0x9E.toByte(), 0x43.toByte(), 0x9E.toByte(),
-            0xCA.toByte(), 0x56.toByte(), 0xDE.toByte(), 0x25.toByte(),
-        )
-
-        // Tink's EngineFactory.AndroidPolicy resolves Cipher providers by *name* in this
-        // exact order before falling through to default JCE lookup. Either being broken
-        // (or returning a wrong-algorithm cipher under "AES/GCM-SIV/NoPadding") would
-        // poison Tink's primitive construction.
-        private val TINK_PREFERRED_PROVIDER_NAMES = listOf("GmsCore_OpenSSL", "AndroidOpenSSL")
-
-        /**
-         * True when [PayloadEncryption] can produce and decrypt AES-GCM-SIV ciphertext on
-         * this device. Set during companion init by [verifyTinkAesGcmSivWorks] after
-         * provider install + Tink registration. Callers (e.g. account creation) should fall
-         * back to [EncryptionMode.AES256_SIV] when this is `false` to avoid producing a
-         * keyset that can never be used.
-         */
-        @Volatile
-        var gcmSivAvailable: Boolean = false
-            private set
-
-        init {
-            val vmName = System.getProperty("java.vm.name") ?: ""
-            val isAndroidRuntime = vmName.contains("Dalvik", ignoreCase = true)
-
-            // Feature-detect whether the platform JCE serves a *working* AES/GCM-SIV/NoPadding.
-            // The naive Cipher.getInstance probe is insufficient: on API ≤ 29 the system
-            // Conscrypt accepts the transformation string but returns AES-GCM (Tink later
-            // rejects this via its internal test-vector check, surfacing as "AES GCM SIV
-            // cipher is not available or is invalid"). We run the same RFC 8452 vector here
-            // up-front so the install gate is correct.
-            if (!platformHasWorkingGcmSiv()) {
-                if (isAndroidRuntime) installBundledConscrypt() else installBouncyCastle()
-            }
-
-            DeterministicAeadConfig.register()
-            AeadConfig.register()
-            AesGcmSivKeyManager.register(true)
-            StreamingAeadConfig.register()
-            log(TAG) { "DeterministicAeadConfig + AeadConfig + AesGcmSiv + StreamingAead registered" }
-
-            // Postcondition runs the actual Tink AEAD path (not just JCE Cipher lookup) so
-            // it covers Tink's named-provider resolution exactly. Result is exposed via
-            // [gcmSivAvailable] for new-keyset gating.
-            gcmSivAvailable = verifyTinkAesGcmSivWorks()
-            if (gcmSivAvailable) {
-                log(TAG) { "Tink AES-GCM-SIV round-trip verified" }
-            } else {
-                log(TAG, ERROR) { "Tink AES-GCM-SIV round-trip FAILED — new accounts will fall back to legacy SIV" }
-            }
-        }
-
-        internal fun platformHasWorkingGcmSiv(): Boolean = try {
-            val cipher = javax.crypto.Cipher.getInstance("AES/GCM-SIV/NoPadding")
-            cipher.init(
-                javax.crypto.Cipher.ENCRYPT_MODE,
-                javax.crypto.spec.SecretKeySpec(GCM_SIV_RFC8452_KEY, "AES"),
-                javax.crypto.spec.GCMParameterSpec(128, GCM_SIV_RFC8452_NONCE),
-            )
-            cipher.doFinal(ByteArray(0)).contentEquals(GCM_SIV_RFC8452_EXPECTED)
-        } catch (_: Throwable) {
-            false
-        }
-
-        // Mirrors Tink's EngineFactory.AndroidPolicy lookup order so we can detect
-        // "GmsCore_OpenSSL is broken even though AndroidOpenSSL is healthy" — Tink would
-        // hit the broken provider first.
-        private fun verifyTinkAesGcmSivWorks(): Boolean = try {
-            val testKeyset = KeysetHandle.generateNew(AesGcmSivKeyManager.aes256GcmSivTemplate())
-            val aead = testKeyset.getPrimitive(Aead::class.java)
-            val ciphertext = aead.encrypt("octi-init-probe".toByteArray(), null)
-            aead.decrypt(ciphertext, null).contentEquals("octi-init-probe".toByteArray())
-        } catch (_: Throwable) {
-            false
-        }
-
-        private fun installBundledConscrypt() {
-            // Tink's EngineFactory.AndroidPolicy looks up Cipher providers by *name* in
-            // [TINK_PREFERRED_PROVIDER_NAMES] order before falling through to default JCE
-            // lookup. Installing only at name "Conscrypt" leaves a broken system provider
-            // in place, so Tink would still pick up the platform cipher. We replace each
-            // preferred name with our bundled Conscrypt — `removeProvider` is a no-op when
-            // the name is absent, so this is safe regardless of the device's existing
-            // provider set.
-            try {
-                val conscryptClass = Class.forName("org.conscrypt.Conscrypt")
-                val newProvider = conscryptClass.getMethod("newProvider", String::class.java)
-                for (name in TINK_PREFERRED_PROVIDER_NAMES) {
-                    val provider = newProvider.invoke(null, name) as java.security.Provider
-                    java.security.Security.removeProvider(name)
-                    java.security.Security.insertProviderAt(provider, 1)
-                }
-                log(TAG) { "Installed bundled Conscrypt as ${TINK_PREFERRED_PROVIDER_NAMES.joinToString("+")} (Android API ${android.os.Build.VERSION.SDK_INT})" }
-            } catch (e: java.lang.reflect.InvocationTargetException) {
-                // Unwrap to surface the real failure — most commonly UnsatisfiedLinkError
-                // or ExceptionInInitializerError from Conscrypt's native-lib bootstrap.
-                val cause = e.targetException ?: e
-                log(TAG, ERROR) { "Conscrypt provider init failed (${cause.javaClass.simpleName}): ${cause.asLog()}" }
-            } catch (e: ClassNotFoundException) {
-                log(TAG, WARN) { "Conscrypt class not found at runtime: ${e.message}" }
-            } catch (e: ReflectiveOperationException) {
-                log(TAG, ERROR) { "Failed to instantiate Conscrypt provider: ${e.asLog()}" }
-            } catch (e: LinkageError) {
-                log(TAG, ERROR) { "Conscrypt native lib missing or incompatible: ${e.asLog()}" }
-            } catch (e: SecurityException) {
-                log(TAG, ERROR) { "SecurityManager denied Conscrypt registration: ${e.asLog()}" }
-            }
-        }
-
-        private fun installBouncyCastle() {
-            // JVM unit tests rely on BouncyCastle for AES-GCM-SIV. The Android runtime
-            // never takes this branch — it uses Conscrypt above.
-            try {
-                val bcClass = Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider")
-                val provider = bcClass.getDeclaredConstructor().newInstance() as java.security.Provider
-                java.security.Security.insertProviderAt(provider, 1)
-            } catch (_: ClassNotFoundException) {
-                // BouncyCastle not on classpath
-            } catch (e: ReflectiveOperationException) {
-                log(TAG, ERROR) { "Failed to instantiate BouncyCastle provider: ${e.asLog()}" }
-            }
-        }
     }
 }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/encryption/PayloadEncryptionTest.kt
@@ -137,17 +137,17 @@ class PayloadEncryptionTest : BaseTest() {
 
     @Test
     fun `RFC 8452 vector probe returns true after BouncyCastle is installed`() {
-        // BouncyCastle is on testImplementation and PayloadEncryption.companion.init has
-        // already installed it as a JCE provider by the time any test runs (instantiating
-        // any PayloadEncryption above triggers class load). Locks the RFC 8452 constants
-        // against accidental edits.
-        PayloadEncryption()  // ensure class init has fired
-        PayloadEncryption.platformHasWorkingGcmSiv() shouldBe true
+        // BouncyCastle is on testImplementation and CryptoBootstrap installs it as a JCE
+        // provider during its init block. Constructing any PayloadEncryption forces the
+        // bootstrap via its instance init. Locks the RFC 8452 constants against accidental
+        // edits.
+        PayloadEncryption()  // ensure CryptoBootstrap init has fired
+        CryptoBootstrap.platformHasWorkingGcmSiv() shouldBe true
     }
 
     @Test
     fun `gcmSivAvailable is true on JVM (BouncyCastle)`() {
-        PayloadEncryption()  // ensure class init has fired
-        PayloadEncryption.gcmSivAvailable shouldBe true
+        PayloadEncryption()  // ensure CryptoBootstrap init has fired
+        CryptoBootstrap.gcmSivAvailable shouldBe true
     }
 }


### PR DESCRIPTION
## Summary

Pure refactor of the post-#285 crypto-init code. No behavior change.

`PayloadEncryption`'s companion object had grown to do three different things:

1. **Process-global JCE provider mutation** — `Security.insertProviderAt` / `removeProvider` for bundled Conscrypt under `AndroidOpenSSL`+`GmsCore_OpenSSL` names.
2. **Tink registry mutation** — `DeterministicAeadConfig.register()`, `AeadConfig.register()`, `AesGcmSivKeyManager.register(true)`, `StreamingAeadConfig.register()`.
3. **Runtime feature-detection state** — RFC 8452 vector probe, `verifyTinkAesGcmSivWorks` end-to-end check, `gcmSivAvailable` flag.

That made `PayloadEncryption` a misleading name: instances are pure Tink-keyset wrappers, but touching the class altered process-global JCE state. SRP violation by name.

## Changes

- New top-level `internal object CryptoBootstrap` (`sync-core/.../encryption/CryptoBootstrap.kt`) holding all the bootstrap logic, helpers, RFC 8452 constants, and `gcmSivAvailable`. Exposes `ensureInitialized()` as a named no-op for sites that need to force class load without reading the property — using a property read for that side effect would be too subtle.
- `PayloadEncryption` shrinks to a focused Tink-keyset facade. A single instance `init { CryptoBootstrap.ensureInitialized() }` line preserves the existing "first construction triggers bootstrap" behavior so direct instantiation sites (tests, `OctiServerConnector` lazy init, etc.) stay covered without relying on `App.onCreate` having run first.
- `RealCryptoCapabilities` now delegates to `CryptoBootstrap.gcmSivAvailable` instead of `PayloadEncryption.gcmSivAvailable`.
- `PayloadEncryptionTest` references moved helpers via `CryptoBootstrap.platformHasWorkingGcmSiv()` and `CryptoBootstrap.gcmSivAvailable`.

## Why an `internal object`, not a `@Singleton`

JCE providers and Tink's registry are process-global state, not dependency-graph state. A Hilt singleton fires lazily on first injection — that wouldn't protect direct construction sites (tests, the `private val crypti by lazy { PayloadEncryption(...) }` in `OctiServerConnector`). DI stays at the `CryptoCapabilities` boundary; bootstrap stays at the object level.

## Validation

- 13 unit tests pass unchanged (`PayloadEncryptionTest`: 11 — including the RFC 8452 vector lock and `gcmSivAvailable` flag tests, both now reading from `CryptoBootstrap`; `OctiServerEndpointCreateAccountTest`: 2).
- R8-minified `assembleFossBeta` builds clean.
- No call-site changes outside the four touched files.

## Note on default constructor semantics

This refactor deliberately does **not** make `PayloadEncryption()` capability-aware. The default constructor still produces a GCM-SIV keyset; the SIV fall-back lives at `OctiServerEndpoint.createNewAccount` via `CryptoCapabilities`. Letting the constructor consult global state would re-tangle the responsibilities this PR is untangling.
