### PR TITLE
Fix dashboard crash when a device appears in multiple sync services

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -47,6 +47,7 @@ import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.ConnectorIssueAggregator
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.IssueSeverity
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.disambiguatedAccountLabel
@@ -73,6 +74,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Instant
 
@@ -674,32 +676,19 @@ class DashboardVM @Inject constructor(
 
         // Build degraded device items from connector metadata (devices known but no module data)
         val normalDeviceIds = normalItems.map { it.deviceId }.toSet()
-        val degradedItems = activeConnectors.flatMap { connector ->
-            val connState = statesMap[connector.identifier] ?: return@flatMap emptyList()
-            connState.deviceMetadata
-                .filter { meta ->
-                    meta.deviceId !in normalDeviceIds
-                            && meta.deviceId != syncSettings.deviceId
-                            && meta.addedAt?.let { (Clock.System.now() - it) >= SyncSettings.FIRST_SYNC_GRACE_PERIOD } != false
-                }
-                .map { meta ->
-                    DeviceItem(
-                        now = now,
-                        deviceId = meta.deviceId,
-                        meta = null,
-                        moduleItems = emptyList(),
-                        isCollapsed = false,
-                        isLimited = false,
-                        isCurrentDevice = false,
-                        isDegraded = true,
-                        degradedConnectorId = connector.identifier,
-                        degradedLabel = meta.label,
-                        degradedPlatform = meta.platform,
-                        degradedVersion = meta.version,
-                        degradedLastSeen = meta.lastSeen,
-                    )
-                }
-        }
+        val connectorMetadata = activeConnectors
+            .mapNotNull { connector ->
+                val state = statesMap[connector.identifier] ?: return@mapNotNull null
+                connector.identifier to state.deviceMetadata
+            }
+            .toMap()
+        val degradedItems = buildDegradedDeviceItems(
+            now = now,
+            connectorMetadata = connectorMetadata,
+            normalDeviceIds = normalDeviceIds,
+            currentDeviceId = syncSettings.deviceId,
+            gracePeriod = SyncSettings.FIRST_SYNC_GRACE_PERIOD,
+        )
 
         val items = normalItems + degradedItems
         val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
@@ -783,6 +772,60 @@ class DashboardVM @Inject constructor(
             .filter { (id, _) -> id in blobCapableConnectorIds }
             .flatMap { (_, state) -> state.deviceMetadata.asSequence().map { it.deviceId } }
             .toSet()
+
+        /**
+         * Build degraded device items (devices known to a connector but lacking module data).
+         *
+         * Deduplicates across connectors: the dashboard's LazyVerticalGrid keys items by
+         * deviceId, so the same device appearing in multiple connectors' deviceMetadata
+         * would otherwise crash with "Key … was already used".
+         *
+         * Selection rule per deviceId (most-useful-wins):
+         *  1. Prefer non-null `label` so the card doesn't fall back to `deviceId.shortLabel`.
+         *  2. Newer `lastSeen` wins.
+         *  3. Stable tie-break by `connectorId.idString` so the displayed connector and the
+         *     `goToDeviceDetails(connectorId, deviceId)` navigation target don't flicker
+         *     across emissions when timestamps are equal/null.
+         */
+        internal fun buildDegradedDeviceItems(
+            now: Instant,
+            connectorMetadata: Map<ConnectorId, List<DeviceMetadata>>,
+            normalDeviceIds: Set<DeviceId>,
+            currentDeviceId: DeviceId,
+            gracePeriod: Duration,
+        ): List<DeviceItem> = connectorMetadata.entries
+            .flatMap { (connectorId, metadataList) ->
+                metadataList
+                    .filter { meta ->
+                        meta.deviceId !in normalDeviceIds
+                                && meta.deviceId != currentDeviceId
+                                && meta.addedAt?.let { (now - it) >= gracePeriod } != false
+                    }
+                    .map { meta -> connectorId to meta }
+            }
+            .groupBy { (_, meta) -> meta.deviceId }
+            .map { (_, candidates) ->
+                val (connectorId, meta) = candidates.minWith(
+                    compareBy<Pair<ConnectorId, DeviceMetadata>> { (_, m) -> if (m.label != null) 0 else 1 }
+                        .thenByDescending { (_, m) -> m.lastSeen ?: Instant.DISTANT_PAST }
+                        .thenBy { (id, _) -> id.idString }
+                )
+                DeviceItem(
+                    now = now,
+                    deviceId = meta.deviceId,
+                    meta = null,
+                    moduleItems = emptyList(),
+                    isCollapsed = false,
+                    isLimited = false,
+                    isCurrentDevice = false,
+                    isDegraded = true,
+                    degradedConnectorId = connectorId,
+                    degradedLabel = meta.label,
+                    degradedPlatform = meta.platform,
+                    degradedVersion = meta.version,
+                    degradedLastSeen = meta.lastSeen,
+                )
+            }
 
         private val INFO_ORDER = listOf(
             PowerInfo::class,

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/BuildDegradedDeviceItemsTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/BuildDegradedDeviceItemsTest.kt
@@ -1,0 +1,242 @@
+package eu.darken.octi.main.ui.dashboard
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class BuildDegradedDeviceItemsTest : BaseTest() {
+
+    private val now = Instant.parse("2026-05-05T12:00:00Z")
+    private val gracePeriod: Duration = 5.minutes
+    private val currentDeviceId = DeviceId("self")
+    private val deviceA = DeviceId("device-a")
+    private val deviceB = DeviceId("device-b")
+
+    private val gdrive = ConnectorId(ConnectorType.GDRIVE, "default", "alice@example.com")
+    private val octiserver = ConnectorId(ConnectorType.OCTISERVER, "default", "alice")
+
+    private fun metadata(
+        deviceId: DeviceId,
+        label: String? = "Phone",
+        platform: String? = "android",
+        version: String? = "1.0.0",
+        lastSeen: Instant? = now - 1.minutes,
+        addedAt: Instant? = now - 1.hours,
+    ) = DeviceMetadata(
+        deviceId = deviceId,
+        version = version,
+        platform = platform,
+        label = label,
+        lastSeen = lastSeen,
+        addedAt = addedAt,
+    )
+
+    private fun call(
+        connectorMetadata: Map<ConnectorId, List<DeviceMetadata>>,
+        normalDeviceIds: Set<DeviceId> = emptySet(),
+    ) = DashboardVM.buildDegradedDeviceItems(
+        now = now,
+        connectorMetadata = connectorMetadata,
+        normalDeviceIds = normalDeviceIds,
+        currentDeviceId = currentDeviceId,
+        gracePeriod = gracePeriod,
+    )
+
+    @Nested
+    inner class `cross-connector deduplication` {
+        @Test
+        fun `same deviceId reported by two connectors yields a single item`() {
+            // Regression: previously crashed LazyVerticalGrid with duplicate key.
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA)),
+                    octiserver to listOf(metadata(deviceA)),
+                ),
+            )
+
+            items shouldHaveSize 1
+            items.single().deviceId shouldBe deviceA
+        }
+
+        @Test
+        fun `distinct devices across connectors are kept separately`() {
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA)),
+                    octiserver to listOf(metadata(deviceB)),
+                ),
+            )
+
+            items shouldHaveSize 2
+            items.map { it.deviceId }.toSet() shouldBe setOf(deviceA, deviceB)
+        }
+    }
+
+    @Nested
+    inner class `selection rule` {
+        @Test
+        fun `non-null label wins over null label even when null-label has newer lastSeen`() {
+            val itemsLabelWins = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, label = null, lastSeen = now)),
+                    octiserver to listOf(metadata(deviceA, label = "RealLabel", lastSeen = now - 10.minutes)),
+                ),
+            )
+
+            itemsLabelWins.single().degradedLabel shouldBe "RealLabel"
+            itemsLabelWins.single().degradedConnectorId shouldBe octiserver
+            // degradedLastSeen mirrors the winner — not the absolute max across connectors.
+            itemsLabelWins.single().degradedLastSeen shouldBe (now - 10.minutes)
+        }
+
+        @Test
+        fun `newer lastSeen wins when both have non-null label`() {
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, label = "OldName", lastSeen = now - 10.minutes)),
+                    octiserver to listOf(metadata(deviceA, label = "NewName", lastSeen = now - 1.minutes)),
+                ),
+            )
+
+            items.single().degradedLabel shouldBe "NewName"
+            items.single().degradedConnectorId shouldBe octiserver
+            items.single().degradedLastSeen shouldBe (now - 1.minutes)
+        }
+
+        @Test
+        fun `equal lastSeen falls back to stable connectorId idString`() {
+            // gdrive.idString = "gdrive-default-alice@example.com",
+            // octiserver.idString = "kserver-default-alice".
+            // "gdrive…" < "kserver…" alphabetically, so gdrive wins.
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, lastSeen = now - 5.minutes)),
+                    octiserver to listOf(metadata(deviceA, lastSeen = now - 5.minutes)),
+                ),
+            )
+
+            items.single().degradedConnectorId shouldBe gdrive
+
+            // Running again (different map iteration order) yields the same winner.
+            val items2 = call(
+                mapOf(
+                    octiserver to listOf(metadata(deviceA, lastSeen = now - 5.minutes)),
+                    gdrive to listOf(metadata(deviceA, lastSeen = now - 5.minutes)),
+                ),
+            )
+            items2.single().degradedConnectorId shouldBe gdrive
+        }
+
+        @Test
+        fun `both lastSeen null still resolves deterministically`() {
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, lastSeen = null)),
+                    octiserver to listOf(metadata(deviceA, lastSeen = null)),
+                ),
+            )
+
+            items.single().degradedConnectorId shouldBe gdrive
+            items.single().degradedLastSeen shouldBe null
+        }
+    }
+
+    @Nested
+    inner class `filter preservation` {
+        @Test
+        fun `device present in normalDeviceIds is excluded`() {
+            val items = call(
+                connectorMetadata = mapOf(gdrive to listOf(metadata(deviceA))),
+                normalDeviceIds = setOf(deviceA),
+            )
+
+            items.shouldBeEmpty()
+        }
+
+        @Test
+        fun `current device is never reported as degraded`() {
+            val items = call(
+                mapOf(gdrive to listOf(metadata(currentDeviceId))),
+            )
+
+            items.shouldBeEmpty()
+        }
+
+        @Test
+        fun `device added within grace period is filtered out`() {
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, addedAt = now - 1.minutes)),
+                ),
+            )
+
+            items.shouldBeEmpty()
+        }
+
+        @Test
+        fun `device added before grace period is included`() {
+            val items = call(
+                mapOf(
+                    gdrive to listOf(metadata(deviceA, addedAt = now - 6.minutes)),
+                ),
+            )
+
+            items shouldHaveSize 1
+        }
+
+        @Test
+        fun `device with null addedAt is included`() {
+            // Matches the existing `?.let { … } != false` semantics: null grace check passes.
+            val items = call(
+                mapOf(gdrive to listOf(metadata(deviceA, addedAt = null))),
+            )
+
+            items shouldHaveSize 1
+        }
+    }
+
+    @Nested
+    inner class `degenerate inputs` {
+        @Test
+        fun `empty connector map yields empty list`() {
+            call(connectorMetadata = emptyMap()).shouldBeEmpty()
+        }
+
+        @Test
+        fun `connector with empty metadata yields empty list`() {
+            call(mapOf(gdrive to emptyList())).shouldBeEmpty()
+        }
+    }
+
+    @Nested
+    inner class `result shape` {
+        @Test
+        fun `degraded item has expected fixed fields`() {
+            val items = call(mapOf(gdrive to listOf(metadata(deviceA))))
+
+            val item = items.single()
+            item.isDegraded shouldBe true
+            item.isCurrentDevice shouldBe false
+            item.isCollapsed shouldBe false
+            item.isLimited shouldBe false
+            item.meta shouldBe null
+            item.moduleItems.shouldBeEmpty()
+            item.degradedConnectorId shouldBe gdrive
+            item.degradedLabel shouldBe "Phone"
+            item.degradedPlatform shouldBe "android"
+            item.degradedVersion shouldBe "1.0.0"
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary

- The dashboard's device list crashed on launch with `Key "…" was already used` when the same device was registered with multiple sync backends (e.g. GDrive + Octi Server) and the app could no longer fetch its module data from any of them.
- Degraded-device entries are now deduplicated across connectors before reaching the LazyVerticalGrid. When the same device shows up via multiple connectors, the entry with the most informative view wins: non-null label first, then newer last-seen, then a stable connector identifier so the chosen connector and navigation target don't flicker between emissions.
- Added `BuildDegradedDeviceItemsTest` covering cross-connector deduplication, the selection rule, filter preservation (current device, normal devices, first-sync grace period), and degenerate inputs.

## Test plan

- [x] `./gradlew :app:assembleFossDebug`
- [x] `./gradlew :app:testFossDebugUnitTest --tests "*BuildDegradedDeviceItemsTest"`
- [ ] Launch on a device with two configured sync backends that previously crashed — the dashboard should render with the affected device appearing once, marked as degraded.
