### PR TITLE
Upgrade Conscrypt from 2.5.2 to 2.5.3 for 16 KB pages

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -41,6 +41,6 @@ object Versions {
     }
 
     object Conscrypt {
-        const val core = "2.5.2"
+        const val core = "2.5.3"
     }
 }


### PR DESCRIPTION
## Summary

- Bumps `org.conscrypt:conscrypt-android` from 2.5.2 to 2.5.3 in `Versions.kt`
- Fixes Google Play rejection: *"Your app does not support 16 KB memory page sizes"* on the `1.0.2-rc0` open-testing → production promotion
- 2.5.2's `libconscrypt_jni.so` is linked with 4 KB ELF segment alignment (`Align 0x1000`); 2.5.3 was relinked with `-z max-page-size=16384` and is correctly aligned (`Align 0x4000`) across all 4 ABIs

No code changes — only the version constant. `CryptoBootstrap` uses the stable `Conscrypt.newProvider(String)` reflection API which is unchanged across the 2.5.x line. ProGuard rules already cover `org.conscrypt.**`.

### Why not drop bundled Conscrypt entirely

Considered as an alternative (no native dep at all → no 16 KB risk). Rejected: the bundled Conscrypt is what lets API ≤ 29 devices produce *and decrypt* AES-GCM-SIV ciphertext on the same Octi account as newer devices. Falling back to `AES256_SIV` legacy mode on older devices would split the keyset population across an account, breaking cross-device decrypt for users mixing old and new Android.

## Test plan

- [x] `./gradlew :app:bundleGplayRelease` — build succeeds
- [x] `./gradlew :app:assembleGplayRelease` — APK builds
- [x] `readelf -lW` on every `.so` in the AAB (4 ABIs × 2 libs: `libconscrypt_jni.so`, `libandroidx.graphics.path.so`) — all `LOAD` segments report `Align 0x4000` (16 KB)
- [x] `zipalign -c -v -P 16 4 app-gplay-release.apk` — `Verification successful`
- [x] `./gradlew :sync-core:testDebugUnitTest` — pass (regression guard for the JVM crypto path; JVM tests fall through to BouncyCastle, so they don't exercise the new native lib)
- [x] Install + launch on `sdk_gphone16k_x86_64` (API 37, `getconf PAGE_SIZE = 16384`) — no `dlopen` failures, no `UnsatisfiedLinkError`, app runs cleanly

## Release process notes

`versionCode 10002000` (the rejected `1.0.2-rc0`) is poisoned on Play and can't be re-used. Re-cut via the standard pipeline:

```bash
gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=true \
  -f expected_current=1.0.2-rc0
gh workflow run release-prepare.yml -f bump_kind=build -f dry_run=false \
  -f expected_current=1.0.2-rc0
```

Producing `1.0.2-rc1` (versionCode `10002010`).