### PR TITLE
Update README screenshots to current Fastlane en-US set

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ If you like the app, consider:
 
 ## Screenshots
 
-<img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot1.png" width="200"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot2.png" width="100"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot3.png" width="100"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot4.png" width="100">
-<img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/screenshot5.png" width="100">
+<img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/01_dashboard_light.png" width="150"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/02_dashboard_dark.png" width="150"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/03_file_sharing.png" width="150"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/04_apps.png" width="150"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/05_sync_services.png" width="150"><img src="https://github.com/d4rken-org/octi/raw/main/fastlane/metadata/android/en-US/images/phoneScreenshots/06_widgets.png" width="150">
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replaces the broken Screenshots section in the README (it referenced `screenshot1.png`…`screenshot5.png`, which no longer exist after the rename to `01_dashboard_light.png`…`06_widgets.png` in 4a0b87e).
- Renders all 6 current Fastlane en-US phone screenshots inline at `width="150"` so they fit in a single row in the GitHub-rendered README.

## Test plan
- [ ] Open the PR in GitHub and confirm all 6 screenshots render in one row.