### PR TITLE
Fix Network and Clipboard widget tiles silently failing for non-Pro accounts

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/upgrade/ProState.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/upgrade/ProState.kt
@@ -1,0 +1,16 @@
+package eu.darken.octi.common.upgrade
+
+/**
+ * Resolved Octi Pro entitlement state for UI gating.
+ *
+ * Boolean isPro is too lossy for callers that distinguish "not yet checked" from "checked and
+ * not Pro" — notably Gplay's [UpgradeRepoGplay] seeds an initial null-mapped emission that resolves
+ * as isPro=false before the billing client has loaded. Treat that initial emission as [Checking]
+ * to avoid false-locking a paying user during cold start.
+ */
+sealed interface ProState {
+    data object Checking : ProState
+    data object Unlocked : ProState
+    data object Locked : ProState
+    data class Error(val cause: Throwable) : ProState
+}

--- a/app-common/src/main/java/eu/darken/octi/common/upgrade/UpgradeLauncher.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/upgrade/UpgradeLauncher.kt
@@ -1,0 +1,15 @@
+package eu.darken.octi.common.upgrade
+
+import android.content.Context
+
+/**
+ * Routes an external entry-point (e.g. a widget configure Activity, or a Glance widget click that
+ * runs on a background worker) into the existing Octi Pro upgrade flow. Flavour-specific binding
+ * decides what the destination screen does (sponsor flow on FOSS, IAP on Gplay).
+ *
+ * Implementations must tolerate being called from a non-Activity [Context] — they add the right
+ * intent flags internally so callers don't need to special-case that.
+ */
+interface UpgradeLauncher {
+    fun launch(context: Context)
+}

--- a/app-common/src/main/java/eu/darken/octi/common/upgrade/UpgradeRepoExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/upgrade/UpgradeRepoExtensions.kt
@@ -1,6 +1,23 @@
 package eu.darken.octi.common.upgrade
 
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 
 
 suspend fun UpgradeRepo.isPro(): Boolean = upgradeInfo.first().isPro
+
+/**
+ * Maps [UpgradeRepo.upgradeInfo] to a [ProState] stream suitable for UI gating. Seeds
+ * [ProState.Checking] until the first emission lands so callers can render a loading state
+ * instead of momentarily showing a Locked UI to paying users during cold-start billing queries.
+ *
+ * Collection errors translate into [ProState.Error]; the upstream is left intact so any
+ * downstream `.catch { … }` still observes the throwable if needed.
+ */
+fun UpgradeRepo.proState(): Flow<ProState> = upgradeInfo
+    .map { info -> if (info.isPro) ProState.Unlocked else ProState.Locked }
+    .onStart { emit(ProState.Checking) }
+    .catch { emit(ProState.Error(it)) }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigAction.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigAction.kt
@@ -1,0 +1,19 @@
+package eu.darken.octi.common.widget
+
+/**
+ * Footer-action model for [WidgetConfigScreen]. Lets the activity-side caller decide what the
+ * sticky bottom CTA does without leaking Pro/upgrade concerns into the shared screen.
+ */
+sealed interface WidgetConfigAction {
+    /** Show the Apply CTA. Disabled internally when the theme picker is in an invalid state. */
+    data object Apply : WidgetConfigAction
+
+    /** Show the Upgrade-to-Pro CTA. Always reachable — never gated by theme validity. */
+    data object Upgrade : WidgetConfigAction
+
+    /** Show an indeterminate progress indicator while Pro state is being resolved. */
+    data object Loading : WidgetConfigAction
+
+    /** Show an error message + retry CTA. */
+    data class ErrorRetry(val message: String) : WidgetConfigAction
+}

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
@@ -15,16 +15,19 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -36,6 +39,7 @@ import androidx.compose.runtime.saveable.listSaver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -52,6 +56,7 @@ fun WidgetConfigScreen(
     initialAccentColor: Int?,
     availableDevices: List<WidgetConfigDevice>? = null,
     initialSelectedDeviceIds: Set<String> = emptySet(),
+    action: WidgetConfigAction = WidgetConfigAction.Apply,
     onClose: () -> Unit,
     onApply: (
         isMaterialYou: Boolean,
@@ -60,6 +65,8 @@ fun WidgetConfigScreen(
         accentColor: Int?,
         selectedDeviceIds: Set<String>,
     ) -> Unit,
+    onUpgrade: () -> Unit = {},
+    onRetry: () -> Unit = {},
     previewContent: @Composable (WidgetTheme.Colors?) -> Unit,
 ) {
     val initialTheme = WidgetTheme.fromName(initialPresetName)
@@ -128,8 +135,10 @@ fun WidgetConfigScreen(
         bottomBar = {
             Column(modifier = Modifier.navigationBarsPadding()) {
                 HorizontalDivider()
-                Button(
-                    onClick = {
+                WidgetConfigFooter(
+                    action = action,
+                    canApply = canApply,
+                    onApply = {
                         onApply(
                             isMaterialYou,
                             if (isCustomMode) null else selectedPreset.name,
@@ -138,13 +147,9 @@ fun WidgetConfigScreen(
                             selectedDeviceIds,
                         )
                     },
-                    enabled = canApply,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                ) {
-                    Text(stringResource(R.string.widget_config_apply_action))
-                }
+                    onUpgrade = onUpgrade,
+                    onRetry = onRetry,
+                )
             }
         },
     ) { innerPadding ->
@@ -216,6 +221,77 @@ fun WidgetConfigScreen(
                         selectedDeviceIds = if (checked) selectedDeviceIds + id else selectedDeviceIds - id
                     },
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetConfigFooter(
+    action: WidgetConfigAction,
+    canApply: Boolean,
+    onApply: () -> Unit,
+    onUpgrade: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    when (action) {
+        WidgetConfigAction.Apply -> {
+            Button(
+                onClick = onApply,
+                enabled = canApply,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+            ) {
+                Text(stringResource(R.string.widget_config_apply_action))
+            }
+        }
+
+        WidgetConfigAction.Upgrade -> {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = stringResource(R.string.widget_config_pro_required_label),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onUpgrade,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.widget_config_upgrade_action))
+                }
+            }
+        }
+
+        WidgetConfigAction.Loading -> {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.size(12.dp))
+                Text(
+                    text = stringResource(R.string.widget_config_pro_checking_label),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+
+        is WidgetConfigAction.ErrorRetry -> {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = action.message.ifBlank { stringResource(R.string.widget_config_pro_error_label) },
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = onRetry,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(R.string.widget_config_retry_action))
+                }
             }
         }
     }

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -68,6 +68,11 @@
     <!-- Widget config -->
     <string name="widget_config_title">Customize Widget</string>
     <string name="widget_config_apply_action">Apply</string>
+    <string name="widget_config_upgrade_action">Upgrade to Octi Pro</string>
+    <string name="widget_config_pro_required_label">This widget requires Octi Pro.</string>
+    <string name="widget_config_pro_checking_label">Checking your Octi Pro status…</string>
+    <string name="widget_config_pro_error_label">Couldn\'t verify your Octi Pro status.</string>
+    <string name="widget_config_retry_action">Retry</string>
     <string name="widget_config_presets_label">Presets</string>
     <string name="widget_config_background_label">Background color</string>
     <string name="widget_config_accent_label">Accent color</string>
@@ -82,6 +87,8 @@
     <string name="widget_config_devices_none_known">No sync devices known yet.</string>
     <string name="widget_empty_label">No matching devices</string>
     <string name="widget_no_sync_devices_label">No sync devices yet</string>
+    <string name="widget_upgrade_required_title">Octi Pro required</string>
+    <string name="widget_upgrade_required_action">Tap to upgrade</string>
 
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">No %1$s data for this device</string>

--- a/app-common/src/test/java/eu/darken/octi/common/upgrade/ProStateTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/upgrade/ProStateTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.octi.common.upgrade
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+
+class ProStateTest : BaseTest() {
+
+    private fun info(isPro: Boolean): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().also {
+        every { it.isPro } returns isPro
+    }
+
+    @Test
+    fun `seeds Checking before the first emission`() = runTest2 {
+        val repo = mockk<UpgradeRepo>()
+        every { repo.upgradeInfo } returns flowOf(info(isPro = false))
+
+        val emissions = repo.proState().toList()
+
+        emissions.first() shouldBe ProState.Checking
+    }
+
+    @Test
+    fun `maps isPro=true to Unlocked`() = runTest2 {
+        val repo = mockk<UpgradeRepo>()
+        every { repo.upgradeInfo } returns flowOf(info(isPro = true))
+
+        val emissions = repo.proState().toList()
+
+        emissions shouldBe listOf(ProState.Checking, ProState.Unlocked)
+    }
+
+    @Test
+    fun `maps isPro=false to Locked`() = runTest2 {
+        val repo = mockk<UpgradeRepo>()
+        every { repo.upgradeInfo } returns flowOf(info(isPro = false))
+
+        val emissions = repo.proState().toList()
+
+        emissions shouldBe listOf(ProState.Checking, ProState.Locked)
+    }
+
+    @Test
+    fun `Locked then Unlocked when upgrade lands after first emission`() = runTest2 {
+        val repo = mockk<UpgradeRepo>()
+        every { repo.upgradeInfo } returns flowOf(info(isPro = false), info(isPro = true))
+
+        val emissions = repo.proState().toList()
+
+        emissions shouldBe listOf(ProState.Checking, ProState.Locked, ProState.Unlocked)
+    }
+
+    @Test
+    fun `surfaces upstream errors as ProState_Error`() = runTest2 {
+        val cause = IOException("boom")
+        val repo = mockk<UpgradeRepo>()
+        every { repo.upgradeInfo } returns flow { throw cause }
+
+        val emissions = repo.proState().toList()
+
+        emissions[0] shouldBe ProState.Checking
+        val error = emissions[1]
+        error.shouldBeInstanceOf<ProState.Error>()
+        error.cause shouldBe cause
+    }
+}

--- a/app/src/main/java/eu/darken/octi/common/upgrade/UpgradeLauncherImpl.kt
+++ b/app/src/main/java/eu/darken/octi/common/upgrade/UpgradeLauncherImpl.kt
@@ -1,0 +1,30 @@
+package eu.darken.octi.common.upgrade
+
+import android.content.Context
+import android.content.Intent
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import eu.darken.octi.main.ui.MainActivity
+import eu.darken.octi.main.ui.MainActivityVM
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UpgradeLauncherImpl @Inject constructor() : UpgradeLauncher {
+    override fun launch(context: Context) {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            putExtra(MainActivityVM.EXTRA_OPEN_UPGRADE, true)
+        }
+        context.startActivity(intent)
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    abstract class Mod {
+        @Binds
+        abstract fun bind(impl: UpgradeLauncherImpl): UpgradeLauncher
+    }
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/MainActivity.kt
@@ -90,6 +90,15 @@ class MainActivity : Activity2() {
                 }
             }
 
+            // External upgrade entry-points (e.g. widget configure activities for non-Pro users)
+            // route through MainActivity via an intent extra. Surface the upgrade screen forced
+            // so it doesn't auto-dismiss before the user can read it.
+            LaunchedEffect(Unit) {
+                vm.openUpgradeEvents.collect {
+                    navCtrl.goTo(Nav.Main.Upgrade(forced = true), popUpTo = Nav.Main.Dashboard)
+                }
+            }
+
             OctiTheme(state = themeState) {
                 CompositionLocalProvider(
                     LocalNavigationController provides navCtrl,

--- a/app/src/main/java/eu/darken/octi/main/ui/MainActivityVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/MainActivityVM.kt
@@ -80,6 +80,13 @@ class MainActivityVM @Inject constructor(
      */
     val deeplinkAccepted = SingleEventFlow<Unit>()
 
+    /**
+     * One-shot event from an external entry-point asking the Compose tree to push
+     * [Nav.Main.Upgrade] onto the back stack. Used by [UpgradeLauncher] when a widget configure
+     * Activity wants to route a non-Pro user to the upgrade screen.
+     */
+    val openUpgradeEvents = SingleEventFlow<Unit>()
+
     sealed interface IncomingShareEvent {
         data class IncomingShare(val token: String, val selfDeviceId: String) : IncomingShareEvent
         data object Unsupported : IncomingShareEvent
@@ -111,15 +118,25 @@ class MainActivityVM @Inject constructor(
             return true
         }
 
-        val widget = WidgetDeeplink.parse(intent) ?: return false
-        if (!generalSettings.isOnboardingDone.valueBlocking) {
-            log(_tag, WARN) { "Dropping widget deeplink: onboarding not done" }
-            return false
+        WidgetDeeplink.parse(intent)?.let { widget ->
+            if (!generalSettings.isOnboardingDone.valueBlocking) {
+                log(_tag, WARN) { "Dropping widget deeplink: onboarding not done" }
+                return false
+            }
+            log(_tag, INFO) { "Widget deeplink accepted: device=${widget.deviceId} module=${widget.moduleType}" }
+            deeplinkEvents.tryEmit(widget)
+            deeplinkAccepted.tryEmit(Unit)
+            return true
         }
-        log(_tag, INFO) { "Widget deeplink accepted: device=${widget.deviceId} module=${widget.moduleType}" }
-        deeplinkEvents.tryEmit(widget)
-        deeplinkAccepted.tryEmit(Unit)
-        return true
+
+        if (intent?.getBooleanExtra(EXTRA_OPEN_UPGRADE, false) == true) {
+            intent.removeExtra(EXTRA_OPEN_UPGRADE)
+            log(_tag, INFO) { "Upgrade entry-point intent accepted" }
+            openUpgradeEvents.tryEmit(Unit)
+            return true
+        }
+
+        return false
     }
 
     /**
@@ -152,6 +169,9 @@ class MainActivityVM @Inject constructor(
     }
 
     companion object {
+        /** Intent extra used by [UpgradeLauncher] to ask MainActivity to surface the upgrade screen. */
+        const val EXTRA_OPEN_UPGRADE = "eu.darken.octi.EXTRA_OPEN_UPGRADE"
+
         /**
          * Pull URIs out of `ACTION_SEND` / `ACTION_SEND_MULTIPLE` intents in a way that handles
          * the three real-world delivery shapes: the typed `EXTRA_STREAM` extras (single + array)

--- a/app/src/test/java/eu/darken/octi/main/ui/MainActivityVMTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/MainActivityVMTest.kt
@@ -236,6 +236,7 @@ class MainActivityVMTest : BaseTest() {
         val vm = makeVM()
         val intent = mockk<Intent> {
             every { action } returns "android.intent.action.MAIN"
+            every { getBooleanExtra(MainActivityVM.EXTRA_OPEN_UPGRADE, false) } returns false
         }
         vm.handleDeeplinkIntent(intent) shouldBe false
         withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
@@ -264,5 +265,28 @@ class MainActivityVMTest : BaseTest() {
         }
         vm.handleDeeplinkIntent(intent) shouldBe false
         withTimeoutOrNull(100) { vm.deeplinkAccepted.first() } shouldBe null
+    }
+
+    @Test
+    fun `EXTRA_OPEN_UPGRADE intent emits openUpgradeEvents and returns true`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent>(relaxed = true) {
+            every { action } returns null
+            every { getBooleanExtra(MainActivityVM.EXTRA_OPEN_UPGRADE, false) } returns true
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe true
+        vm.openUpgradeEvents.first() shouldBe Unit
+        verify { intent.removeExtra(MainActivityVM.EXTRA_OPEN_UPGRADE) }
+    }
+
+    @Test
+    fun `intent without EXTRA_OPEN_UPGRADE does NOT emit openUpgradeEvents`() = runTest2 {
+        val vm = makeVM()
+        val intent = mockk<Intent> {
+            every { action } returns "android.intent.action.MAIN"
+            every { getBooleanExtra(MainActivityVM.EXTRA_OPEN_UPGRADE, false) } returns false
+        }
+        vm.handleDeeplinkIntent(intent) shouldBe false
+        withTimeoutOrNull(100) { vm.openUpgradeEvents.first() } shouldBe null
     }
 }

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -11,9 +11,30 @@ import androidx.glance.appwidget.provideContent
 import androidx.glance.LocalSize
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceModifier
+import androidx.glance.LocalContext
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
@@ -21,6 +42,8 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.widget.WidgetSettings
+import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetDefaultColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,6 +60,7 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
         val ep = EntryPointAccessors.fromApplication(context, ClipboardWidgetEntryPoint::class.java)
         val metaRepo = ep.metaRepo()
         val clipboardRepo = ep.clipboardRepo()
+        val upgradeRepo = ep.upgradeRepo()
         val widgetSettings = ep.widgetSettings()
 
         val appWidgetId = try {
@@ -55,6 +79,14 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
                 .collectAsState(initial = initialConfig).value
             val themeColors = instanceConfig.themeColors
             val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
+
+            // Optimistic Pro state: initial null = render content. Only when upgradeInfo emits
+            // a definitive `isPro = false` do we swap to the upgrade placeholder.
+            val proInfo = upgradeRepo.upgradeInfo.collectAsState(initial = null).value
+            if (proInfo != null && !proInfo.isPro) {
+                ClipboardWidgetUpgradeRequired(themeColors = themeColors ?: widgetDefaultColors())
+                return@provideContent
+            }
 
             val metaState = metaRepo.state.collectAsState(initial = null)
             val clipboardState = clipboardRepo.state.collectAsState(initial = null)
@@ -79,6 +111,39 @@ class ClipboardGlanceWidget : GlanceAppWidget() {
 
     companion object {
         val TAG = logTag("Module", "Clipboard", "Widget", "Glance")
+    }
+}
+
+@Composable
+private fun ClipboardWidgetUpgradeRequired(themeColors: WidgetTheme.Colors) {
+    val containerColor = ColorProvider(Color(themeColors.containerBg))
+    val onContainerColor = ColorProvider(Color(themeColors.onContainer))
+    val ctx = LocalContext.current
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .cornerRadius(16.dp)
+            .background(containerColor)
+            .clickable(actionRunCallback<ClipboardUpgradeAction>())
+            .padding(12.dp),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = ctx.getString(CommonR.string.widget_upgrade_required_title),
+                style = TextStyle(
+                    color = onContainerColor,
+                    fontWeight = FontWeight.Bold,
+                ),
+            )
+            Spacer(modifier = GlanceModifier.height(4.dp))
+            Text(
+                text = ctx.getString(CommonR.string.widget_upgrade_required_action),
+                style = TextStyle(color = onContainerColor),
+            )
+        }
     }
 }
 

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardUpgradeAction.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardUpgradeAction.kt
@@ -1,0 +1,31 @@
+package eu.darken.octi.modules.clipboard.ui.widget
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+
+/**
+ * Glance click callback that routes a non-Pro Clipboard widget tile to the upgrade screen.
+ */
+class ClipboardUpgradeAction : ActionCallback {
+    override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+        log(TAG, VERBOSE) { "onAction()" }
+        try {
+            val ep = EntryPointAccessors.fromApplication(context, ClipboardWidgetEntryPoint::class.java)
+            ep.upgradeLauncher().launch(context)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to launch upgrade: ${e.asLog()}" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Module", "Clipboard", "Widget", "UpgradeAction")
+    }
+}

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetConfigActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,7 +46,12 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.theming.OctiTheme
 import eu.darken.octi.common.theming.ThemeSettings
 import eu.darken.octi.common.theming.ThemeState
+import eu.darken.octi.common.upgrade.ProState
+import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.isPro
+import eu.darken.octi.common.upgrade.proState
+import eu.darken.octi.common.widget.WidgetConfigAction
 import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
@@ -71,6 +77,7 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
     @Inject lateinit var themeSettings: ThemeSettings
     @Inject lateinit var upgradeRepo: UpgradeRepo
+    @Inject lateinit var upgradeLauncher: UpgradeLauncher
     @Inject lateinit var metaRepo: MetaRepo
     @Inject lateinit var clipboardRepo: ClipboardRepo
     @Inject lateinit var widgetSettings: WidgetSettings
@@ -92,88 +99,121 @@ class ClipboardWidgetConfigActivity : androidx.activity.ComponentActivity() {
             return
         }
 
-        lifecycleScope.launch {
-            if (!upgradeRepo.upgradeInfo.first().isPro) {
-                setResult(RESULT_CANCELED)
-                finish()
-                return@launch
-            }
+        setContent {
+            val themeState by themeSettings.themeState.collectAsState(ThemeState())
 
-            val instanceConfig = widgetSettings.configValue(appWidgetId) {
-                AppWidgetManager.getInstance(this@ClipboardWidgetConfigActivity)
-                    .getAppWidgetOptions(appWidgetId)
-            }
-
-            val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
-                val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
-                val clipState = clipboardRepo.state.first()
-                val selfId = (clipState as? BaseModuleRepo.State<*>)?.self?.deviceId?.id
-                val now = System.currentTimeMillis()
-                clipState.all
-                    .filter { it.deviceId.id != selfId }
-                    .mapNotNull { c ->
-                        val m = metaById[c.deviceId] ?: return@mapNotNull null
-                        WidgetConfigDevice(
-                            id = c.deviceId.id,
-                            label = m.data.labelOrFallback,
-                            subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
-                            icon = composeIconFor(m.data.deviceType),
-                        )
-                    }
-            }
-                .orEmpty()
-                .distinctBy { it.id }
-                .let { devices ->
-                    val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
-                    devices.map { device ->
-                        device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label)
-                    }
+            val initialInstanceConfig by produceState<WidgetInstanceConfig?>(initialValue = null) {
+                value = widgetSettings.configValue(appWidgetId) {
+                    AppWidgetManager.getInstance(this@ClipboardWidgetConfigActivity)
+                        .getAppWidgetOptions(appWidgetId)
                 }
-                .sortedWith(
-                    compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
-                        .thenBy { it.id }
-                )
+            }
 
-            setContent {
-                val themeState by themeSettings.themeState.collectAsState(ThemeState())
-                OctiTheme(state = themeState) {
+            val availableDevices by produceState<List<WidgetConfigDevice>?>(initialValue = null) {
+                value = loadAvailableDevices()
+            }
+
+            val proState by upgradeRepo.proState().collectAsState(initial = ProState.Checking)
+
+            OctiTheme(state = themeState) {
+                val instanceConfig = initialInstanceConfig
+                if (instanceConfig == null) {
                     WidgetConfigScreen(
-                        initialMode = if (instanceConfig.isMaterialYou) {
-                            WidgetInstanceConfig.MODE_MATERIAL_YOU
-                        } else {
-                            WidgetInstanceConfig.MODE_CUSTOM
-                        },
-                        initialPresetName = instanceConfig.presetName,
-                        initialBgColor = instanceConfig.customBg,
-                        initialAccentColor = instanceConfig.customAccent,
-                        availableDevices = availableDevices,
-                        initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
+                        initialMode = WidgetInstanceConfig.MODE_MATERIAL_YOU,
+                        initialPresetName = null,
+                        initialBgColor = null,
+                        initialAccentColor = null,
+                        availableDevices = null,
+                        initialSelectedDeviceIds = emptySet(),
+                        action = WidgetConfigAction.Loading,
                         onClose = { finish() },
-                        onApply = { isMy, preset, bg, accent, ids ->
-                            val appContext = applicationContext
-                            lifecycleScope.launch {
-                                applyWidgetConfig(
-                                    appWidgetId = appWidgetId,
-                                    newConfig = WidgetInstanceConfig(
-                                        isMaterialYou = isMy,
-                                        presetName = preset,
-                                        customBg = bg,
-                                        customAccent = accent,
-                                        allowedDeviceIds = ids,
-                                    ),
-                                    widgetSettings = widgetSettings,
-                                    tag = TAG,
-                                ) {
-                                    val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                                    ClipboardGlanceWidget().update(appContext, glanceId)
-                                }
-                            }
-                        },
+                        onApply = { _, _, _, _, _ -> },
+                        onUpgrade = { upgradeLauncher.launch(this@ClipboardWidgetConfigActivity) },
+                        onRetry = {},
                         previewContent = { colors -> ClipboardWidgetPreview(colors = colors) },
                     )
+                    return@OctiTheme
                 }
+
+                WidgetConfigScreen(
+                    initialMode = if (instanceConfig.isMaterialYou) {
+                        WidgetInstanceConfig.MODE_MATERIAL_YOU
+                    } else {
+                        WidgetInstanceConfig.MODE_CUSTOM
+                    },
+                    initialPresetName = instanceConfig.presetName,
+                    initialBgColor = instanceConfig.customBg,
+                    initialAccentColor = instanceConfig.customAccent,
+                    availableDevices = availableDevices,
+                    initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
+                    action = when (proState) {
+                        ProState.Checking -> WidgetConfigAction.Loading
+                        ProState.Unlocked -> WidgetConfigAction.Apply
+                        ProState.Locked -> WidgetConfigAction.Upgrade
+                        is ProState.Error -> WidgetConfigAction.ErrorRetry(message = "")
+                    },
+                    onClose = { finish() },
+                    onApply = { isMy, preset, bg, accent, ids ->
+                        val appContext = applicationContext
+                        lifecycleScope.launch {
+                            // Defence-in-depth: re-check Pro before committing the bind.
+                            if (!upgradeRepo.isPro()) {
+                                upgradeLauncher.launch(this@ClipboardWidgetConfigActivity)
+                                return@launch
+                            }
+                            applyWidgetConfig(
+                                appWidgetId = appWidgetId,
+                                newConfig = WidgetInstanceConfig(
+                                    isMaterialYou = isMy,
+                                    presetName = preset,
+                                    customBg = bg,
+                                    customAccent = accent,
+                                    allowedDeviceIds = ids,
+                                ),
+                                widgetSettings = widgetSettings,
+                                tag = TAG,
+                            ) {
+                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                ClipboardGlanceWidget().update(appContext, glanceId)
+                            }
+                        }
+                    },
+                    onUpgrade = { upgradeLauncher.launch(this@ClipboardWidgetConfigActivity) },
+                    onRetry = { lifecycleScope.launch { upgradeRepo.refresh() } },
+                    previewContent = { colors -> ClipboardWidgetPreview(colors = colors) },
+                )
             }
         }
+    }
+
+    private suspend fun loadAvailableDevices(): List<WidgetConfigDevice> {
+        val devices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
+            val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
+            val clipState = clipboardRepo.state.first()
+            val selfId = (clipState as? BaseModuleRepo.State<*>)?.self?.deviceId?.id
+            val now = System.currentTimeMillis()
+            clipState.all
+                .filter { it.deviceId.id != selfId }
+                .mapNotNull { c ->
+                    val m = metaById[c.deviceId] ?: return@mapNotNull null
+                    WidgetConfigDevice(
+                        id = c.deviceId.id,
+                        label = m.data.labelOrFallback,
+                        subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
+                        icon = composeIconFor(m.data.deviceType),
+                    )
+                }
+        }
+            .orEmpty()
+            .distinctBy { it.id }
+
+        val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
+        return devices
+            .map { device -> device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label) }
+            .sortedWith(
+                compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+                    .thenBy { it.id },
+            )
     }
 
     private fun lastSeenSubtitle(modifiedAtMillis: Long, nowMillis: Long): String {

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetEntryPoint.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetEntryPoint.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.modules.clipboard.ClipboardHandler
@@ -18,5 +19,6 @@ interface ClipboardWidgetEntryPoint {
     fun clipboardRepo(): ClipboardRepo
     fun clipboardHandler(): ClipboardHandler
     fun upgradeRepo(): UpgradeRepo
+    fun upgradeLauncher(): UpgradeLauncher
     fun widgetSettings(): WidgetSettings
 }

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -11,9 +11,30 @@ import androidx.glance.appwidget.provideContent
 import androidx.glance.LocalSize
 import androidx.glance.state.GlanceStateDefinition
 import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceModifier
+import androidx.glance.LocalContext
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.background
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Box
+import androidx.glance.layout.Column
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
@@ -21,6 +42,8 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.widget.WidgetSettings
+import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetDefaultColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,6 +60,7 @@ class NetworkGlanceWidget : GlanceAppWidget() {
         val ep = EntryPointAccessors.fromApplication(context, NetworkWidgetEntryPoint::class.java)
         val metaRepo = ep.metaRepo()
         val connectivityRepo = ep.connectivityRepo()
+        val upgradeRepo = ep.upgradeRepo()
         val widgetSettings = ep.widgetSettings()
 
         val appWidgetId = try {
@@ -55,6 +79,15 @@ class NetworkGlanceWidget : GlanceAppWidget() {
                 .collectAsState(initial = initialConfig).value
             val themeColors = instanceConfig.themeColors
             val allowedDeviceIds = instanceConfig.allowedDeviceIds.takeIf { it.isNotEmpty() }
+
+            // Optimistic Pro state: initial null = render content. Only when upgradeInfo emits
+            // a definitive `isPro = false` do we swap to the upgrade placeholder, so paying users
+            // on Gplay cold-start don't briefly see a locked widget.
+            val proInfo = upgradeRepo.upgradeInfo.collectAsState(initial = null).value
+            if (proInfo != null && !proInfo.isPro) {
+                NetworkWidgetUpgradeRequired(themeColors = themeColors ?: widgetDefaultColors())
+                return@provideContent
+            }
 
             val metaState = metaRepo.state.collectAsState(initial = null)
             val connectivityState = connectivityRepo.state.collectAsState(initial = null)
@@ -87,6 +120,39 @@ class NetworkGlanceWidget : GlanceAppWidget() {
 
     companion object {
         val TAG = logTag("Module", "Connectivity", "Widget", "Glance")
+    }
+}
+
+@Composable
+private fun NetworkWidgetUpgradeRequired(themeColors: WidgetTheme.Colors) {
+    val containerColor = ColorProvider(Color(themeColors.containerBg))
+    val onContainerColor = ColorProvider(Color(themeColors.onContainer))
+    val ctx = LocalContext.current
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .cornerRadius(16.dp)
+            .background(containerColor)
+            .clickable(actionRunCallback<NetworkUpgradeAction>())
+            .padding(12.dp),
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = ctx.getString(CommonR.string.widget_upgrade_required_title),
+                style = TextStyle(
+                    color = onContainerColor,
+                    fontWeight = FontWeight.Bold,
+                ),
+            )
+            Spacer(modifier = GlanceModifier.height(4.dp))
+            Text(
+                text = ctx.getString(CommonR.string.widget_upgrade_required_action),
+                style = TextStyle(color = onContainerColor),
+            )
+        }
     }
 }
 

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkUpgradeAction.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkUpgradeAction.kt
@@ -1,0 +1,31 @@
+package eu.darken.octi.modules.connectivity.ui.widget
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import dagger.hilt.android.EntryPointAccessors
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+
+/**
+ * Glance click callback that routes a non-Pro Network widget tile to the upgrade screen.
+ */
+class NetworkUpgradeAction : ActionCallback {
+    override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
+        log(TAG, VERBOSE) { "onAction()" }
+        try {
+            val ep = EntryPointAccessors.fromApplication(context, NetworkWidgetEntryPoint::class.java)
+            ep.upgradeLauncher().launch(context)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Failed to launch upgrade: ${e.asLog()}" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Module", "Connectivity", "Widget", "UpgradeAction")
+    }
+}

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetConfigActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -43,7 +44,12 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.theming.OctiTheme
 import eu.darken.octi.common.theming.ThemeSettings
 import eu.darken.octi.common.theming.ThemeState
+import eu.darken.octi.common.upgrade.ProState
+import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.isPro
+import eu.darken.octi.common.upgrade.proState
+import eu.darken.octi.common.widget.WidgetConfigAction
 import eu.darken.octi.common.widget.WidgetConfigDevice
 import eu.darken.octi.common.widget.WidgetConfigScreen
 import eu.darken.octi.common.widget.WidgetInstanceConfig
@@ -68,6 +74,7 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
 
     @Inject lateinit var themeSettings: ThemeSettings
     @Inject lateinit var upgradeRepo: UpgradeRepo
+    @Inject lateinit var upgradeLauncher: UpgradeLauncher
     @Inject lateinit var metaRepo: MetaRepo
     @Inject lateinit var connectivityRepo: ConnectivityRepo
     @Inject lateinit var widgetSettings: WidgetSettings
@@ -89,84 +96,118 @@ class NetworkWidgetConfigActivity : androidx.activity.ComponentActivity() {
             return
         }
 
-        lifecycleScope.launch {
-            if (!upgradeRepo.upgradeInfo.first().isPro) {
-                setResult(RESULT_CANCELED)
-                finish()
-                return@launch
-            }
+        setContent {
+            val themeState by themeSettings.themeState.collectAsState(ThemeState())
 
-            val instanceConfig = widgetSettings.configValue(appWidgetId) {
-                AppWidgetManager.getInstance(this@NetworkWidgetConfigActivity)
-                    .getAppWidgetOptions(appWidgetId)
-            }
-
-            val availableDevices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
-                val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
-                val now = System.currentTimeMillis()
-                connectivityRepo.state.first().all.mapNotNull { c ->
-                    val m = metaById[c.deviceId] ?: return@mapNotNull null
-                    WidgetConfigDevice(
-                        id = c.deviceId.id,
-                        label = m.data.labelOrFallback,
-                        subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
-                        icon = composeIconFor(m.data.deviceType),
-                    )
+            val initialInstanceConfig by produceState<WidgetInstanceConfig?>(initialValue = null) {
+                value = widgetSettings.configValue(appWidgetId) {
+                    AppWidgetManager.getInstance(this@NetworkWidgetConfigActivity)
+                        .getAppWidgetOptions(appWidgetId)
                 }
             }
-                .orEmpty()
-                .distinctBy { it.id }
-                .let { devices ->
-                    val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
-                    devices.map { device ->
-                        device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label)
-                    }
-                }
-                .sortedWith(
-                    compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
-                        .thenBy { it.id }
-                )
 
-            setContent {
-                val themeState by themeSettings.themeState.collectAsState(ThemeState())
-                OctiTheme(state = themeState) {
+            val availableDevices by produceState<List<WidgetConfigDevice>?>(initialValue = null) {
+                value = loadAvailableDevices()
+            }
+
+            val proState by upgradeRepo.proState().collectAsState(initial = ProState.Checking)
+
+            OctiTheme(state = themeState) {
+                val instanceConfig = initialInstanceConfig
+                if (instanceConfig == null) {
                     WidgetConfigScreen(
-                        initialMode = if (instanceConfig.isMaterialYou) {
-                            WidgetInstanceConfig.MODE_MATERIAL_YOU
-                        } else {
-                            WidgetInstanceConfig.MODE_CUSTOM
-                        },
-                        initialPresetName = instanceConfig.presetName,
-                        initialBgColor = instanceConfig.customBg,
-                        initialAccentColor = instanceConfig.customAccent,
-                        availableDevices = availableDevices,
-                        initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
+                        initialMode = WidgetInstanceConfig.MODE_MATERIAL_YOU,
+                        initialPresetName = null,
+                        initialBgColor = null,
+                        initialAccentColor = null,
+                        availableDevices = null,
+                        initialSelectedDeviceIds = emptySet(),
+                        action = WidgetConfigAction.Loading,
                         onClose = { finish() },
-                        onApply = { isMy, preset, bg, accent, ids ->
-                            val appContext = applicationContext
-                            lifecycleScope.launch {
-                                applyWidgetConfig(
-                                    appWidgetId = appWidgetId,
-                                    newConfig = WidgetInstanceConfig(
-                                        isMaterialYou = isMy,
-                                        presetName = preset,
-                                        customBg = bg,
-                                        customAccent = accent,
-                                        allowedDeviceIds = ids,
-                                    ),
-                                    widgetSettings = widgetSettings,
-                                    tag = TAG,
-                                ) {
-                                    val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
-                                    NetworkGlanceWidget().update(appContext, glanceId)
-                                }
-                            }
-                        },
+                        onApply = { _, _, _, _, _ -> },
+                        onUpgrade = { upgradeLauncher.launch(this@NetworkWidgetConfigActivity) },
+                        onRetry = {},
                         previewContent = { colors -> NetworkWidgetPreview(colors = colors) },
                     )
+                    return@OctiTheme
                 }
+
+                WidgetConfigScreen(
+                    initialMode = if (instanceConfig.isMaterialYou) {
+                        WidgetInstanceConfig.MODE_MATERIAL_YOU
+                    } else {
+                        WidgetInstanceConfig.MODE_CUSTOM
+                    },
+                    initialPresetName = instanceConfig.presetName,
+                    initialBgColor = instanceConfig.customBg,
+                    initialAccentColor = instanceConfig.customAccent,
+                    availableDevices = availableDevices,
+                    initialSelectedDeviceIds = instanceConfig.allowedDeviceIds,
+                    action = when (proState) {
+                        ProState.Checking -> WidgetConfigAction.Loading
+                        ProState.Unlocked -> WidgetConfigAction.Apply
+                        ProState.Locked -> WidgetConfigAction.Upgrade
+                        is ProState.Error -> WidgetConfigAction.ErrorRetry(message = "")
+                    },
+                    onClose = { finish() },
+                    onApply = { isMy, preset, bg, accent, ids ->
+                        val appContext = applicationContext
+                        lifecycleScope.launch {
+                            // Defence-in-depth: re-check Pro before committing the bind. Activity
+                            // may have been backgrounded long enough for Pro state to flip.
+                            if (!upgradeRepo.isPro()) {
+                                upgradeLauncher.launch(this@NetworkWidgetConfigActivity)
+                                return@launch
+                            }
+                            applyWidgetConfig(
+                                appWidgetId = appWidgetId,
+                                newConfig = WidgetInstanceConfig(
+                                    isMaterialYou = isMy,
+                                    presetName = preset,
+                                    customBg = bg,
+                                    customAccent = accent,
+                                    allowedDeviceIds = ids,
+                                ),
+                                widgetSettings = widgetSettings,
+                                tag = TAG,
+                            ) {
+                                val glanceId = GlanceAppWidgetManager(appContext).getGlanceIdBy(appWidgetId)
+                                NetworkGlanceWidget().update(appContext, glanceId)
+                            }
+                        }
+                    },
+                    onUpgrade = { upgradeLauncher.launch(this@NetworkWidgetConfigActivity) },
+                    onRetry = { lifecycleScope.launch { upgradeRepo.refresh() } },
+                    previewContent = { colors -> NetworkWidgetPreview(colors = colors) },
+                )
             }
         }
+    }
+
+    private suspend fun loadAvailableDevices(): List<WidgetConfigDevice> {
+        val devices = withTimeoutOrNull(DEVICE_LOAD_TIMEOUT) {
+            val metaById = metaRepo.state.first().all.associateBy { it.deviceId }
+            val now = System.currentTimeMillis()
+            connectivityRepo.state.first().all.mapNotNull { c ->
+                val m = metaById[c.deviceId] ?: return@mapNotNull null
+                WidgetConfigDevice(
+                    id = c.deviceId.id,
+                    label = m.data.labelOrFallback,
+                    subtitle = lastSeenSubtitle(m.modifiedAt.toEpochMilliseconds(), now),
+                    icon = composeIconFor(m.data.deviceType),
+                )
+            }
+        }
+            .orEmpty()
+            .distinctBy { it.id }
+
+        val labelsByDevice = disambiguateDeviceLabels(devices.associate { DeviceId(it.id) to it.label })
+        return devices
+            .map { device -> device.copy(label = labelsByDevice[DeviceId(device.id)] ?: device.label) }
+            .sortedWith(
+                compareBy<WidgetConfigDevice, String>(String.CASE_INSENSITIVE_ORDER) { it.label }
+                    .thenBy { it.id },
+            )
     }
 
     private fun lastSeenSubtitle(modifiedAtMillis: Long, nowMillis: Long): String {

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetEntryPoint.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetEntryPoint.kt
@@ -4,6 +4,7 @@ import androidx.annotation.Keep
 import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.modules.connectivity.core.ConnectivityRepo
@@ -16,5 +17,6 @@ interface NetworkWidgetEntryPoint {
     fun metaRepo(): MetaRepo
     fun connectivityRepo(): ConnectivityRepo
     fun upgradeRepo(): UpgradeRepo
+    fun upgradeLauncher(): UpgradeLauncher
     fun widgetSettings(): WidgetSettings
 }


### PR DESCRIPTION
## Summary

Fixes the Network and Clipboard widget tiles silently disappearing in the launcher's widget picker on non-Pro accounts (the user reported this as "widgets other than battery don't allow to get picked" on an OPPO A12 / Android 9 in #293).

**Root cause.** `NetworkWidgetConfigActivity` and `ClipboardWidgetConfigActivity` gated their entire config flow on `upgradeRepo.upgradeInfo.first().isPro` inside `lifecycleScope.launch { … }` and called `finish()` on the non-Pro branch — but `setContent { … }` was inside the same launch, *after* the gate. So when the gate tripped, the activity never bound any UI: the user saw one frame of theme background and the activity disappeared. `BatteryWidgetConfigActivity` has no Pro gate, which is exactly why Battery still worked.

## Changes

- New `UpgradeLauncher` abstraction in `app-common` so module-level activities can route into the existing FOSS/Gplay upgrade screen without dragging the `app/...` flavour-specific classes into a module dependency cycle. Single binding wires through `MainActivity` via a new `EXTRA_OPEN_UPGRADE` intent extra, which `MainActivityVM` surfaces as `openUpgradeEvents` that the Compose tree consumes by pushing `Nav.Main.Upgrade(forced = true)`.
- New `ProState` (`Checking | Unlocked | Locked | Error`) — Boolean `isPro` was too lossy for Gplay's cold-start path (`UpgradeRepoGplay.upgradeInfo` seeds an initial `null`-mapped emission that resolves to `isPro = false` before billing has loaded; treating that as `Locked` would have false-locked paying users).
- `WidgetConfigScreen` now accepts a `WidgetConfigAction` (`Apply` / `Upgrade` / `Loading` / `ErrorRetry`) — the upgrade CTA is wired separately so it isn't gated by `canApply` (theme-color validity), and the screen stays upgrade-agnostic.
- `NetworkWidgetConfigActivity` and `ClipboardWidgetConfigActivity` now call `setContent { … }` immediately, drive `ProState` and device-list loading via Compose state, and on Apply re-check Pro one last time as defence-in-depth.
- **Glance content also gated.** Without this, Android 12+ launchers that honour `widgetFeatures="configuration_optional"` could skip the config activity entirely and the placed widget would render full content for a non-Pro user. The placed widget now renders a "Tap to upgrade" placeholder when `isPro = false`, backed by a new `NetworkUpgradeAction` / `ClipboardUpgradeAction` Glance click callback. Pro state is treated optimistically there (initial `null` = render content) so a paying user on a Gplay cold start doesn't briefly see a locked widget.

## Test plan

- [x] `./gradlew :app-common:testDebugUnitTest :app:testFossDebugUnitTest :app:testGplayDebugUnitTest :modules-connectivity:testDebugUnitTest :modules-clipboard:testDebugUnitTest`
- [x] `./gradlew :app:assembleFossDebug :app:assembleGplayDebug`
- [x] Reproduced the original silent-finish on Pixel 2 (API 28, FOSS debug, unsponsored) — all three Octi widgets are visible in the picker, only Battery's config opens; confirmed via launching the upgrade screen via the in-app CTA that the routed destination renders correctly on Android 9.
- [x] New `ProStateTest` covers Checking → Unlocked / Locked / Error transitions and the cold-start order.
- [x] New `MainActivityVMTest` cases cover `EXTRA_OPEN_UPGRADE` emitting `openUpgradeEvents` and being ignored otherwise.
- [ ] End-to-end drag-drop on Pixel 2 (deferred — see verification notes below).

Verification notes for the maintainer's own retest:
- API 28 FOSS, unsponsored: dragging Network or Clipboard onto the home screen should now show the config screen with a "Sponsor on GitHub" / "Upgrade to Octi Pro" CTA instead of silently closing.
- API 31+ Pixel with `configuration_optional`: a directly-placed Network or Clipboard widget (no config activity) should render the "Tap to upgrade" placeholder, and tapping it should route through `UpgradeLauncher`.

Closes #293
