### PR TITLE
Show widget previews in the picker on Android 9-11

### DIFF
--- a/modules-clipboard/src/main/res/drawable/module_clipboard_widget_preview_image.xml
+++ b/modules-clipboard/src/main/res/drawable/module_clipboard_widget_preview_image.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
+  Mirrors the visual structure of module_clipboard_widget_preview.xml: a rounded container with
+  three stacked tiles — two standard tiles plus an accent tile at the bottom for the self device.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="150dp"
+    android:height="100dp"
+    android:viewportWidth="150"
+    android:viewportHeight="100">
+
+    <!-- Container -->
+    <path
+        android:fillColor="@color/widgetContainerBackground"
+        android:pathData="M16,0 L134,0 A16,16 0 0 1 150,16 L150,84 A16,16 0 0 1 134,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+
+    <!-- Tile 1 (standard) -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,10 L136,10 A6,6 0 0 1 142,16 L142,34 A6,6 0 0 1 136,40 L14,40 A6,6 0 0 1 8,34 L8,16 A6,6 0 0 1 14,10 Z" />
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M16,22 L24,22 L24,28 L16,28 Z" />
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M28,22 L60,22 L60,26 L28,26 Z" />
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M64,22 L130,22 L130,26 L64,26 Z" />
+
+    <!-- Tile 2 (standard) -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,44 L136,44 A6,6 0 0 1 142,50 L142,62 A6,6 0 0 1 136,68 L14,68 A6,6 0 0 1 8,62 L8,50 A6,6 0 0 1 14,44 Z" />
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M16,53 L24,53 L24,59 L16,59 Z" />
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M28,53 L60,53 L60,57 L28,57 Z" />
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M64,53 L130,53 L130,57 L64,57 Z" />
+
+    <!-- Tile 3 (accent — self device) -->
+    <path
+        android:fillColor="@color/widgetAccentBackground"
+        android:pathData="M14,72 L136,72 A6,6 0 0 1 142,78 L142,90 A6,6 0 0 1 136,96 L14,96 A6,6 0 0 1 8,90 L8,78 A6,6 0 0 1 14,72 Z" />
+    <path
+        android:fillColor="@color/widgetOnAccent"
+        android:pathData="M16,81 L24,81 L24,87 L16,87 Z" />
+    <path
+        android:fillColor="@color/widgetOnAccent"
+        android:pathData="M28,81 L60,81 L60,85 L28,85 Z" />
+    <path
+        android:fillColor="@color/widgetOnAccent"
+        android:pathData="M64,81 L130,81 L130,85 L64,85 Z" />
+</vector>

--- a/modules-clipboard/src/main/res/drawable/module_clipboard_widget_preview_image.xml
+++ b/modules-clipboard/src/main/res/drawable/module_clipboard_widget_preview_image.xml
@@ -1,59 +1,61 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
-  Mirrors the visual structure of module_clipboard_widget_preview.xml: a rounded container with
-  three stacked tiles — two standard tiles plus an accent tile at the bottom for the self device.
+  Viewport matches the widget's 110dp x 80dp aspect (~11:8) so the launcher renders the tile
+  full-bleed without pillarboxing. Mirrors module_clipboard_widget_preview.xml: rounded
+  container with three stacked tiles (two standard + one accent for the self device), each
+  containing an icon, a short device-label, and a wider clipboard-content placeholder line.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="150dp"
-    android:height="100dp"
-    android:viewportWidth="150"
-    android:viewportHeight="100">
+    android:width="220dp"
+    android:height="160dp"
+    android:viewportWidth="220"
+    android:viewportHeight="160">
 
     <!-- Container -->
     <path
         android:fillColor="@color/widgetContainerBackground"
-        android:pathData="M16,0 L134,0 A16,16 0 0 1 150,16 L150,84 A16,16 0 0 1 134,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+        android:pathData="M16,0 L204,0 A16,16 0 0 1 220,16 L220,144 A16,16 0 0 1 204,160 L16,160 A16,16 0 0 1 0,144 L0,16 A16,16 0 0 1 16,0 Z" />
 
     <!-- Tile 1 (standard) -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,10 L136,10 A6,6 0 0 1 142,16 L142,34 A6,6 0 0 1 136,40 L14,40 A6,6 0 0 1 8,34 L8,16 A6,6 0 0 1 14,10 Z" />
+        android:pathData="M18,14 L202,14 A6,6 0 0 1 208,20 L208,54 A6,6 0 0 1 202,60 L18,60 A6,6 0 0 1 12,54 L12,20 A6,6 0 0 1 18,14 Z" />
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M16,22 L24,22 L24,28 L16,28 Z" />
+        android:pathData="M22,30 L34,30 L34,44 L22,44 Z" />
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M28,22 L60,22 L60,26 L28,26 Z" />
+        android:pathData="M40,34 L100,34 L100,40 L40,40 Z" />
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M64,22 L130,22 L130,26 L64,26 Z" />
+        android:pathData="M106,35 L196,35 L196,39 L106,39 Z" />
 
     <!-- Tile 2 (standard) -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,44 L136,44 A6,6 0 0 1 142,50 L142,62 A6,6 0 0 1 136,68 L14,68 A6,6 0 0 1 8,62 L8,50 A6,6 0 0 1 14,44 Z" />
+        android:pathData="M18,64 L202,64 A6,6 0 0 1 208,70 L208,104 A6,6 0 0 1 202,110 L18,110 A6,6 0 0 1 12,104 L12,70 A6,6 0 0 1 18,64 Z" />
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M16,53 L24,53 L24,59 L16,59 Z" />
+        android:pathData="M22,80 L34,80 L34,94 L22,94 Z" />
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M28,53 L60,53 L60,57 L28,57 Z" />
+        android:pathData="M40,84 L100,84 L100,90 L40,90 Z" />
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M64,53 L130,53 L130,57 L64,57 Z" />
+        android:pathData="M106,85 L196,85 L196,89 L106,89 Z" />
 
     <!-- Tile 3 (accent — self device) -->
     <path
         android:fillColor="@color/widgetAccentBackground"
-        android:pathData="M14,72 L136,72 A6,6 0 0 1 142,78 L142,90 A6,6 0 0 1 136,96 L14,96 A6,6 0 0 1 8,90 L8,78 A6,6 0 0 1 14,72 Z" />
+        android:pathData="M18,114 L202,114 A6,6 0 0 1 208,120 L208,140 A6,6 0 0 1 202,146 L18,146 A6,6 0 0 1 12,140 L12,120 A6,6 0 0 1 18,114 Z" />
     <path
         android:fillColor="@color/widgetOnAccent"
-        android:pathData="M16,81 L24,81 L24,87 L16,87 Z" />
+        android:pathData="M22,124 L34,124 L34,136 L22,136 Z" />
     <path
         android:fillColor="@color/widgetOnAccent"
-        android:pathData="M28,81 L60,81 L60,85 L28,85 Z" />
+        android:pathData="M40,127 L100,127 L100,133 L40,133 Z" />
     <path
         android:fillColor="@color/widgetOnAccent"
-        android:pathData="M64,81 L130,81 L130,85 L64,85 Z" />
+        android:pathData="M106,128 L196,128 L196,132 L106,132 Z" />
 </vector>

--- a/modules-clipboard/src/main/res/xml/clipboard_widget_info.xml
+++ b/modules-clipboard/src/main/res/xml/clipboard_widget_info.xml
@@ -7,6 +7,7 @@
     android:targetCellHeight="2"
     android:updatePeriodMillis="86400000"
     android:description="@string/module_clipboard_widget_description"
+    android:previewImage="@drawable/module_clipboard_widget_preview_image"
     android:previewLayout="@layout/module_clipboard_widget_preview"
     android:initialLayout="@layout/module_clipboard_widget_initial"
     android:resizeMode="horizontal|vertical"

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetProviderInfoTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetProviderInfoTest.kt
@@ -7,9 +7,10 @@ import java.io.File
 
 class ClipboardWidgetProviderInfoTest : BaseTest() {
 
+    private val xml: String by lazy { File("src/main/res/xml/clipboard_widget_info.xml").readText() }
+
     @Test
     fun `widgetFeatures includes configuration_optional`() {
-        val xml = File("src/main/res/xml/clipboard_widget_info.xml").readText()
         val features = WIDGET_FEATURES_REGEX.find(xml)
             ?.groupValues?.get(1)
             ?.split("|")
@@ -18,7 +19,15 @@ class ClipboardWidgetProviderInfoTest : BaseTest() {
         (features?.contains("configuration_optional") ?: false) shouldBe true
     }
 
+    @Test
+    fun `previewImage is declared for Android pre-12 widget pickers`() {
+        // previewLayout is API 31+; on older Android the launcher's picker falls back to
+        // previewImage. Without this, Android 9-11 users see a generic app-icon tile.
+        PREVIEW_IMAGE_REGEX.containsMatchIn(xml) shouldBe true
+    }
+
     companion object {
         private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+        private val PREVIEW_IMAGE_REGEX = Regex("""android:previewImage="@drawable/[^"]+"""")
     }
 }

--- a/modules-connectivity/src/main/res/drawable/module_connectivity_widget_preview_image.xml
+++ b/modules-connectivity/src/main/res/drawable/module_connectivity_widget_preview_image.xml
@@ -1,59 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
-  Mirrors the visual structure of module_connectivity_widget_preview.xml: a rounded container
-  with two stacked tiles, each containing a small icon placeholder + two text-line placeholders.
+  Viewport matches the widget's 110dp x 80dp aspect (~11:8) so the launcher renders the tile
+  full-bleed without pillarboxing. Mirrors module_connectivity_widget_preview.xml: rounded
+  container with two stacked tiles, each containing a small icon + a device-label line + two
+  IP-style placeholder lines that span most of the tile width.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="150dp"
-    android:height="100dp"
-    android:viewportWidth="150"
-    android:viewportHeight="100">
+    android:width="220dp"
+    android:height="160dp"
+    android:viewportWidth="220"
+    android:viewportHeight="160">
 
     <!-- Container -->
     <path
         android:fillColor="@color/widgetContainerBackground"
-        android:pathData="M16,0 L134,0 A16,16 0 0 1 150,16 L150,84 A16,16 0 0 1 134,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+        android:pathData="M16,0 L204,0 A16,16 0 0 1 220,16 L220,144 A16,16 0 0 1 204,160 L16,160 A16,16 0 0 1 0,144 L0,16 A16,16 0 0 1 16,0 Z" />
 
     <!-- Tile 1 -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,12 L136,12 A6,6 0 0 1 142,18 L142,46 A6,6 0 0 1 136,52 L14,52 A6,6 0 0 1 8,46 L8,18 A6,6 0 0 1 14,12 Z" />
+        android:pathData="M18,14 L202,14 A6,6 0 0 1 208,20 L208,72 A6,6 0 0 1 202,78 L18,78 A6,6 0 0 1 12,72 L12,20 A6,6 0 0 1 18,14 Z" />
     <!-- Tile 1: icon placeholder -->
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M18,22 L26,22 L26,30 L18,30 Z" />
-    <!-- Tile 1: title placeholder -->
+        android:pathData="M22,26 L34,26 L34,38 L22,38 Z" />
+    <!-- Tile 1: device label placeholder -->
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M30,24 L70,24 L70,28 L30,28 Z" />
-    <!-- Tile 1: subtitle placeholder line 1 -->
+        android:pathData="M40,29 L116,29 L116,35 L40,35 Z" />
+    <!-- Tile 1: "last seen" placeholder -->
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M18,36 L60,36 L60,40 L18,40 Z" />
-    <!-- Tile 1: subtitle placeholder line 2 -->
+        android:pathData="M120,30 L170,30 L170,34 L120,34 Z" />
+    <!-- Tile 1: IP line 1 placeholder -->
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M18,44 L52,44 L52,48 L18,48 Z" />
+        android:pathData="M22,50 L150,50 L150,55 L22,55 Z" />
+    <!-- Tile 1: IP line 2 placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M22,60 L138,60 L138,65 L22,65 Z" />
 
     <!-- Tile 2 -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,56 L136,56 A6,6 0 0 1 142,62 L142,90 A6,6 0 0 1 136,96 L14,96 A6,6 0 0 1 8,90 L8,62 A6,6 0 0 1 14,56 Z" />
+        android:pathData="M18,82 L202,82 A6,6 0 0 1 208,88 L208,140 A6,6 0 0 1 202,146 L18,146 A6,6 0 0 1 12,140 L12,88 A6,6 0 0 1 18,82 Z" />
     <!-- Tile 2: icon placeholder -->
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M18,66 L26,66 L26,74 L18,74 Z" />
-    <!-- Tile 2: title placeholder -->
+        android:pathData="M22,94 L34,94 L34,106 L22,106 Z" />
+    <!-- Tile 2: device label placeholder -->
     <path
         android:fillColor="@color/widgetOnTile"
-        android:pathData="M30,68 L70,68 L70,72 L30,72 Z" />
-    <!-- Tile 2: subtitle placeholder line 1 -->
+        android:pathData="M40,97 L116,97 L116,103 L40,103 Z" />
+    <!-- Tile 2: "last seen" placeholder -->
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M18,80 L60,80 L60,84 L18,84 Z" />
-    <!-- Tile 2: subtitle placeholder line 2 -->
+        android:pathData="M120,98 L170,98 L170,102 L120,102 Z" />
+    <!-- Tile 2: IP line 1 placeholder -->
     <path
         android:fillColor="@color/widgetOnTileVariant"
-        android:pathData="M18,88 L52,88 L52,92 L18,92 Z" />
+        android:pathData="M22,118 L150,118 L150,123 L22,123 Z" />
+    <!-- Tile 2: IP line 2 placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M22,128 L138,128 L138,133 L22,133 Z" />
 </vector>

--- a/modules-connectivity/src/main/res/drawable/module_connectivity_widget_preview_image.xml
+++ b/modules-connectivity/src/main/res/drawable/module_connectivity_widget_preview_image.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
+  Mirrors the visual structure of module_connectivity_widget_preview.xml: a rounded container
+  with two stacked tiles, each containing a small icon placeholder + two text-line placeholders.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="150dp"
+    android:height="100dp"
+    android:viewportWidth="150"
+    android:viewportHeight="100">
+
+    <!-- Container -->
+    <path
+        android:fillColor="@color/widgetContainerBackground"
+        android:pathData="M16,0 L134,0 A16,16 0 0 1 150,16 L150,84 A16,16 0 0 1 134,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+
+    <!-- Tile 1 -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,12 L136,12 A6,6 0 0 1 142,18 L142,46 A6,6 0 0 1 136,52 L14,52 A6,6 0 0 1 8,46 L8,18 A6,6 0 0 1 14,12 Z" />
+    <!-- Tile 1: icon placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M18,22 L26,22 L26,30 L18,30 Z" />
+    <!-- Tile 1: title placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M30,24 L70,24 L70,28 L30,28 Z" />
+    <!-- Tile 1: subtitle placeholder line 1 -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M18,36 L60,36 L60,40 L18,40 Z" />
+    <!-- Tile 1: subtitle placeholder line 2 -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M18,44 L52,44 L52,48 L18,48 Z" />
+
+    <!-- Tile 2 -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,56 L136,56 A6,6 0 0 1 142,62 L142,90 A6,6 0 0 1 136,96 L14,96 A6,6 0 0 1 8,90 L8,62 A6,6 0 0 1 14,56 Z" />
+    <!-- Tile 2: icon placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M18,66 L26,66 L26,74 L18,74 Z" />
+    <!-- Tile 2: title placeholder -->
+    <path
+        android:fillColor="@color/widgetOnTile"
+        android:pathData="M30,68 L70,68 L70,72 L30,72 Z" />
+    <!-- Tile 2: subtitle placeholder line 1 -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M18,80 L60,80 L60,84 L18,84 Z" />
+    <!-- Tile 2: subtitle placeholder line 2 -->
+    <path
+        android:fillColor="@color/widgetOnTileVariant"
+        android:pathData="M18,88 L52,88 L52,92 L18,92 Z" />
+</vector>

--- a/modules-connectivity/src/main/res/xml/network_widget_info.xml
+++ b/modules-connectivity/src/main/res/xml/network_widget_info.xml
@@ -7,6 +7,7 @@
     android:targetCellHeight="2"
     android:updatePeriodMillis="86400000"
     android:description="@string/module_connectivity_widget_description"
+    android:previewImage="@drawable/module_connectivity_widget_preview_image"
     android:previewLayout="@layout/module_connectivity_widget_preview"
     android:initialLayout="@layout/module_connectivity_widget_initial"
     android:resizeMode="horizontal|vertical"

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetProviderInfoTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetProviderInfoTest.kt
@@ -7,9 +7,10 @@ import java.io.File
 
 class NetworkWidgetProviderInfoTest : BaseTest() {
 
+    private val xml: String by lazy { File("src/main/res/xml/network_widget_info.xml").readText() }
+
     @Test
     fun `widgetFeatures includes configuration_optional`() {
-        val xml = File("src/main/res/xml/network_widget_info.xml").readText()
         val features = WIDGET_FEATURES_REGEX.find(xml)
             ?.groupValues?.get(1)
             ?.split("|")
@@ -18,7 +19,15 @@ class NetworkWidgetProviderInfoTest : BaseTest() {
         (features?.contains("configuration_optional") ?: false) shouldBe true
     }
 
+    @Test
+    fun `previewImage is declared for Android pre-12 widget pickers`() {
+        // previewLayout is API 31+; on older Android the launcher's picker falls back to
+        // previewImage. Without this, Android 9-11 users see a generic app-icon tile.
+        PREVIEW_IMAGE_REGEX.containsMatchIn(xml) shouldBe true
+    }
+
     companion object {
         private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+        private val PREVIEW_IMAGE_REGEX = Regex("""android:previewImage="@drawable/[^"]+"""")
     }
 }

--- a/modules-power/src/main/res/drawable/module_power_widget_preview_image.xml
+++ b/modules-power/src/main/res/drawable/module_power_widget_preview_image.xml
@@ -1,43 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
-  Mirrors the visual structure of module_power_widget_preview.xml: a rounded container with
-  two horizontal progress-bar rows, each with a partial accent fill.
+  Viewport matches the widget's 180dp x 50dp aspect (~3.6:1) so the launcher renders the tile
+  full-bleed without pillarboxing. Mirrors module_power_widget_preview.xml: rounded container
+  with two horizontal progress-bar rows and a percentage indicator at the right.
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="200dp"
+    android:width="360dp"
     android:height="100dp"
-    android:viewportWidth="200"
+    android:viewportWidth="360"
     android:viewportHeight="100">
 
     <!-- Container -->
     <path
         android:fillColor="@color/widgetContainerBackground"
-        android:pathData="M16,0 L184,0 A16,16 0 0 1 200,16 L200,84 A16,16 0 0 1 184,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+        android:pathData="M16,0 L344,0 A16,16 0 0 1 360,16 L360,84 A16,16 0 0 1 344,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
 
     <!-- Row 1: tile background -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,16 L166,16 A6,6 0 0 1 172,22 L172,42 A6,6 0 0 1 166,48 L14,48 A6,6 0 0 1 8,42 L8,22 A6,6 0 0 1 14,16 Z" />
+        android:pathData="M20,18 L294,18 A6,6 0 0 1 300,24 L300,46 A6,6 0 0 1 294,52 L20,52 A6,6 0 0 1 14,46 L14,24 A6,6 0 0 1 20,18 Z" />
     <!-- Row 1: accent fill (~70%) -->
     <path
         android:fillColor="@color/widgetAccentBackground"
-        android:pathData="M14,16 L121,16 L121,48 L14,48 A6,6 0 0 1 8,42 L8,22 A6,6 0 0 1 14,16 Z" />
-    <!-- Row 1: percentage placeholder -->
+        android:pathData="M20,18 L214,18 L214,52 L20,52 A6,6 0 0 1 14,46 L14,24 A6,6 0 0 1 20,18 Z" />
+    <!-- Row 1: percent placeholder -->
     <path
         android:fillColor="@color/widgetOnContainer"
-        android:pathData="M178,28 L192,28 L192,36 L178,36 Z" />
+        android:pathData="M312,30 L348,30 L348,40 L312,40 Z" />
 
     <!-- Row 2: tile background -->
     <path
         android:fillColor="@color/widgetTileBackground"
-        android:pathData="M14,54 L166,54 A6,6 0 0 1 172,60 L172,80 A6,6 0 0 1 166,86 L14,86 A6,6 0 0 1 8,80 L8,60 A6,6 0 0 1 14,54 Z" />
+        android:pathData="M20,56 L294,56 A6,6 0 0 1 300,62 L300,84 A6,6 0 0 1 294,90 L20,90 A6,6 0 0 1 14,84 L14,62 A6,6 0 0 1 20,56 Z" />
     <!-- Row 2: accent fill (~45%) -->
     <path
         android:fillColor="@color/widgetAccentBackground"
-        android:pathData="M14,54 L84,54 L84,86 L14,86 A6,6 0 0 1 8,80 L8,60 A6,6 0 0 1 14,54 Z" />
-    <!-- Row 2: percentage placeholder -->
+        android:pathData="M20,56 L143,56 L143,90 L20,90 A6,6 0 0 1 14,84 L14,62 A6,6 0 0 1 20,56 Z" />
+    <!-- Row 2: percent placeholder -->
     <path
         android:fillColor="@color/widgetOnContainer"
-        android:pathData="M178,66 L192,66 L192,74 L178,74 Z" />
+        android:pathData="M312,68 L348,68 L348,78 L312,78 Z" />
 </vector>

--- a/modules-power/src/main/res/drawable/module_power_widget_preview_image.xml
+++ b/modules-power/src/main/res/drawable/module_power_widget_preview_image.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Static widget-picker preview used by Android < 12, where `previewLayout` is ignored.
+  Mirrors the visual structure of module_power_widget_preview.xml: a rounded container with
+  two horizontal progress-bar rows, each with a partial accent fill.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="200dp"
+    android:height="100dp"
+    android:viewportWidth="200"
+    android:viewportHeight="100">
+
+    <!-- Container -->
+    <path
+        android:fillColor="@color/widgetContainerBackground"
+        android:pathData="M16,0 L184,0 A16,16 0 0 1 200,16 L200,84 A16,16 0 0 1 184,100 L16,100 A16,16 0 0 1 0,84 L0,16 A16,16 0 0 1 16,0 Z" />
+
+    <!-- Row 1: tile background -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,16 L166,16 A6,6 0 0 1 172,22 L172,42 A6,6 0 0 1 166,48 L14,48 A6,6 0 0 1 8,42 L8,22 A6,6 0 0 1 14,16 Z" />
+    <!-- Row 1: accent fill (~70%) -->
+    <path
+        android:fillColor="@color/widgetAccentBackground"
+        android:pathData="M14,16 L121,16 L121,48 L14,48 A6,6 0 0 1 8,42 L8,22 A6,6 0 0 1 14,16 Z" />
+    <!-- Row 1: percentage placeholder -->
+    <path
+        android:fillColor="@color/widgetOnContainer"
+        android:pathData="M178,28 L192,28 L192,36 L178,36 Z" />
+
+    <!-- Row 2: tile background -->
+    <path
+        android:fillColor="@color/widgetTileBackground"
+        android:pathData="M14,54 L166,54 A6,6 0 0 1 172,60 L172,80 A6,6 0 0 1 166,86 L14,86 A6,6 0 0 1 8,80 L8,60 A6,6 0 0 1 14,54 Z" />
+    <!-- Row 2: accent fill (~45%) -->
+    <path
+        android:fillColor="@color/widgetAccentBackground"
+        android:pathData="M14,54 L84,54 L84,86 L14,86 A6,6 0 0 1 8,80 L8,60 A6,6 0 0 1 14,54 Z" />
+    <!-- Row 2: percentage placeholder -->
+    <path
+        android:fillColor="@color/widgetOnContainer"
+        android:pathData="M178,66 L192,66 L192,74 L178,74 Z" />
+</vector>

--- a/modules-power/src/main/res/xml/battery_widget_info.xml
+++ b/modules-power/src/main/res/xml/battery_widget_info.xml
@@ -9,6 +9,7 @@
     android:targetCellHeight="2"
     android:updatePeriodMillis="86400000"
     android:description="@string/module_power_widget_description"
+    android:previewImage="@drawable/module_power_widget_preview_image"
     android:previewLayout="@layout/module_power_widget_preview"
     android:initialLayout="@layout/module_power_widget_initial"
     android:resizeMode="horizontal|vertical"

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProviderInfoTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetProviderInfoTest.kt
@@ -44,6 +44,13 @@ class BatteryWidgetProviderInfoTest : BaseTest() {
         attributeInt("targetCellHeight")!! shouldBe 2
     }
 
+    @Test
+    fun `previewImage is declared for Android pre-12 widget pickers`() {
+        // previewLayout is API 31+; on older Android the launcher's picker falls back to
+        // previewImage. Without this, Android 9-11 users see a generic app-icon tile.
+        PREVIEW_IMAGE_REGEX.containsMatchIn(xml) shouldBe true
+    }
+
     private fun attributeDp(name: String): Int? {
         val match = Regex("""android:$name="(\d+)dp"""").find(xml) ?: return null
         return match.groupValues[1].toInt()
@@ -56,5 +63,6 @@ class BatteryWidgetProviderInfoTest : BaseTest() {
 
     companion object {
         private val WIDGET_FEATURES_REGEX = Regex("""android:widgetFeatures="([^"]+)"""")
+        private val PREVIEW_IMAGE_REGEX = Regex("""android:previewImage="@drawable/[^"]+"""")
     }
 }


### PR DESCRIPTION
## Summary

`android:previewLayout` is API 31+. On Android 9-11 launchers the widget picker falls back to `android:previewImage`, and without one each Octi widget rendered as a generic app-icon tile in the picker (verified on the OPPO A12 in #293's video, and just now reproduced on a Pixel 2 / API 28).

This PR adds a static vector drawable per widget that mirrors the shapes of the corresponding `previewLayout`:

- `module_power_widget_preview_image.xml` — rounded container with two horizontal progress bars
- `module_connectivity_widget_preview_image.xml` — rounded container with two stacked tiles, each with icon + text-line placeholders
- `module_clipboard_widget_preview_image.xml` — rounded container with two standard tiles + a bottom accent tile

All use the existing `@color/widget*` palette so light/dark theming carries over. Each widget XML now declares both `previewImage` and `previewLayout` — `previewLayout` still wins on API 31+; `previewImage` is what Android 9-11 picks up.

## Test plan

- [x] `./gradlew :modules-power:testDebugUnitTest :modules-connectivity:testDebugUnitTest :modules-clipboard:testDebugUnitTest` — green; each `WidgetProviderInfoTest` gained an assertion that `previewImage` is declared.
- [x] `./gradlew :app:assembleFossDebug` — green.
- [x] Visual verification on Pixel 2 (API 28) — all three Octi widgets in the system widget picker now render their preview tile instead of the generic Octi-logo fallback.
- [ ] Visual recheck on API 31+ to confirm `previewLayout` still wins on modern Android.
