### PR TITLE
Add 'Remove device' to the dashboard card menu

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.icons.twotone.ChevronRight
 import androidx.compose.material.icons.twotone.Schedule
 import androidx.compose.material.icons.twotone.CloudSync
 import androidx.compose.material.icons.twotone.Coffee
+import androidx.compose.material.icons.twotone.DeleteSweep
 import androidx.compose.material.icons.twotone.ExpandLess
 import androidx.compose.material.icons.twotone.ExpandMore
 import androidx.compose.material.icons.twotone.Home
@@ -332,6 +333,7 @@ fun DashboardScreenHost(vm: DashboardVM = hiltViewModel()) {
             onResetTileLayout = { vm.resetTileLayout(it) },
             onMoveDeviceUp = { vm.moveDeviceUp(it) },
             onMoveDeviceDown = { vm.moveDeviceDown(it) },
+            onRemoveDevice = { connectorId, deviceId -> vm.goToDeviceDetails(connectorId, deviceId) },
             externalSheetTarget = externalSheetTarget,
             onExternalSheetHandled = { externalSheetTarget = null },
         )
@@ -373,6 +375,7 @@ fun DashboardScreen(
     onResetTileLayout: (String) -> Unit = {},
     onMoveDeviceUp: (String) -> Unit = {},
     onMoveDeviceDown: (String) -> Unit = {},
+    onRemoveDevice: (ConnectorId, DeviceId) -> Unit = { _, _ -> },
     externalSheetTarget: DashboardVM.ModuleItem? = null,
     onExternalSheetHandled: () -> Unit = {},
 ) {
@@ -580,6 +583,7 @@ fun DashboardScreen(
                     onSaveAsDefault = onSaveAsDefaultTileLayout,
                     onMoveUp = onMoveDeviceUp,
                     onMoveDown = onMoveDeviceDown,
+                    onRemoveDevice = onRemoveDevice,
                 )
             }
 
@@ -635,6 +639,7 @@ fun DashboardScreen(
                         onSaveAsDefault = onSaveAsDefaultTileLayout,
                         onMoveUp = onMoveDeviceUp,
                         onMoveDown = onMoveDeviceDown,
+                        onRemoveDevice = onRemoveDevice,
                     )
                 }
             }
@@ -1560,6 +1565,7 @@ private fun DashboardDeviceCard(
     onFileShareDownload: (DeviceId) -> Unit,
     onMetaClicked: (DashboardVM.ModuleItem.Meta) -> Unit,
     showMessage: (String) -> Unit,
+    onRemoveDevice: (ConnectorId, DeviceId) -> Unit,
 ) {
     val meta = device.meta?.data
     val isDegraded = device.isDegraded
@@ -1567,12 +1573,18 @@ private fun DashboardDeviceCard(
     val canEdit = hasModules && !device.isLimited && !isDegraded
     val shouldShowModules = !device.isLimited && hasModules && !device.isCollapsed && !isDegraded
 
+    val actionableTargets = remember(device.removalTargets) {
+        device.removalTargets.filterNot { it.isPaused }
+    }
+    val canRemove = !device.isCurrentDevice && actionableTargets.isNotEmpty()
+
     val chevronRotation by animateFloatAsState(
         targetValue = if (device.isCollapsed) 0f else 90f,
         label = "chevronRotation",
     )
 
     var showMenu by remember { mutableStateOf(false) }
+    var showRemovePicker by remember { mutableStateOf(false) }
 
     ElevatedCard(
         modifier = Modifier
@@ -1682,7 +1694,7 @@ private fun DashboardDeviceCard(
             }
 
             // Overflow menu (outside combinedClickable to avoid gesture conflicts)
-            if (canEdit) {
+            if (canEdit || canRemove) {
                 Box {
                     IconButton(onClick = { showMenu = true }) {
                         Icon(
@@ -1694,16 +1706,45 @@ private fun DashboardDeviceCard(
                         expanded = showMenu,
                         onDismissRequest = { showMenu = false },
                     ) {
-                        DropdownMenuItem(
-                            text = { Text(stringResource(R.string.dashboard_device_edit_card_action)) },
-                            onClick = {
-                                showMenu = false
-                                onEditCard(device.deviceId.id)
-                            },
-                        )
+                        if (canEdit) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.dashboard_device_edit_card_action)) },
+                                onClick = {
+                                    showMenu = false
+                                    onEditCard(device.deviceId.id)
+                                },
+                            )
+                        }
+                        if (canRemove) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.dashboard_device_remove_action)) },
+                                leadingIcon = {
+                                    Icon(imageVector = Icons.TwoTone.DeleteSweep, contentDescription = null)
+                                },
+                                onClick = {
+                                    showMenu = false
+                                    if (actionableTargets.size == 1) {
+                                        onRemoveDevice(actionableTargets.first().connectorId, device.deviceId)
+                                    } else {
+                                        showRemovePicker = true
+                                    }
+                                },
+                            )
+                        }
                     }
                 }
             }
+        }
+
+        if (showRemovePicker) {
+            RemoveDevicePickerDialog(
+                targets = actionableTargets,
+                onPick = { connectorId ->
+                    showRemovePicker = false
+                    onRemoveDevice(connectorId, device.deviceId)
+                },
+                onDismiss = { showRemovePicker = false },
+            )
         }
 
         // Info rows (shown for both normal expanded and degraded devices)
@@ -1749,6 +1790,58 @@ private fun DashboardDeviceCard(
 }
 
 @Composable
+private fun RemoveDevicePickerDialog(
+    targets: List<DashboardVM.DeviceRemovalTarget>,
+    onPick: (ConnectorId) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val contributions = LocalConnectorContributions.current
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.dashboard_device_remove_picker_title)) },
+        text = {
+            Column {
+                Text(
+                    text = stringResource(R.string.dashboard_device_remove_picker_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                targets.forEach { target ->
+                    val contribution = contributions[target.type]
+                    val typeLabel = contribution?.labelRes?.let { stringResource(it) } ?: target.type.name
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onPick(target.connectorId) }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        contribution?.Icon(modifier = Modifier.size(24.dp))
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(text = typeLabel, style = MaterialTheme.typography.bodyLarge)
+                            if (target.accountLabel.isNotBlank()) {
+                                Text(
+                                    text = target.accountLabel,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(CommonR.string.general_cancel_action))
+            }
+        },
+    )
+}
+
+@Composable
 private fun DeviceCardOrEditor(
     device: DashboardVM.DeviceItem,
     editingDeviceId: String?,
@@ -1782,6 +1875,7 @@ private fun DeviceCardOrEditor(
     onSaveAsDefault: (TileLayoutConfig) -> Unit,
     onMoveUp: (String) -> Unit,
     onMoveDown: (String) -> Unit,
+    onRemoveDevice: (ConnectorId, DeviceId) -> Unit,
 ) {
     val deviceId = device.deviceId.id
     if (editingDeviceId == deviceId) {
@@ -1822,6 +1916,7 @@ private fun DeviceCardOrEditor(
             onFileShareDownload = onFileShareDownload,
             onMetaClicked = onMetaClicked,
             showMessage = showMessage,
+            onRemoveDevice = onRemoveDevice,
         )
     }
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -45,10 +45,12 @@ import eu.darken.octi.modules.wifi.core.WifiInfo
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.ConnectorIssueAggregator
+import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
 import eu.darken.octi.sync.core.disambiguatedAccountLabel
 import eu.darken.octi.sync.core.SyncExecutor
@@ -102,6 +104,7 @@ class DashboardVM @Inject constructor(
     private val fileShareRepo: FileShareRepo,
     private val blobManager: BlobManager,
     private val storageStatusManager: StorageStatusManager,
+    private val connectorContributions: Map<ConnectorType, @JvmSuppressWildcards ConnectorUiContribution>,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     init {
@@ -206,11 +209,24 @@ class DashboardVM @Inject constructor(
         val degradedPlatform: String? = null,
         val degradedVersion: String? = null,
         val degradedLastSeen: Instant? = null,
+        val removalTargets: List<DeviceRemovalTarget> = emptyList(),
         val displayLabel: String = meta?.data?.labelOrFallback ?: degradedLabel ?: deviceId.shortLabel,
     ) {
         val baseLabel: String
             get() = meta?.data?.labelOrFallback ?: degradedLabel ?: deviceId.shortLabel
     }
+
+    /**
+     * One row in the "Choose sync service" picker shown when the user taps "Remove device" on a
+     * dashboard card. Empty for the current device (self-disconnect lives elsewhere); list is
+     * sorted by [ConnectorUiContribution.displayOrder] then account label.
+     */
+    data class DeviceRemovalTarget(
+        val connectorId: ConnectorId,
+        val type: ConnectorType,
+        val accountLabel: String,
+        val isPaused: Boolean,
+    )
 
     sealed interface ModuleItem {
         data class Power(
@@ -587,7 +603,8 @@ class DashboardVM @Inject constructor(
         alertManager.alerts,
         upgradeRepo.upgradeInfo,
         fileShareCtx,
-    ) { now, byDevice, missingPermissions, activeConnectors, activeStates, alerts, _, fileShare ->
+        syncSettings.pausedConnectorIds,
+    ) { now, byDevice, missingPermissions, activeConnectors, activeStates, alerts, _, fileShare, pausedIds ->
         val statesList = activeStates.toList()
         val statesMap = activeConnectors.zip(statesList).associate { (c, s) -> c.identifier to s }
         val fileDeleteRequests = byDevice.devices.values
@@ -690,7 +707,16 @@ class DashboardVM @Inject constructor(
             gracePeriod = SyncSettings.FIRST_SYNC_GRACE_PERIOD,
         )
 
-        val items = normalItems + degradedItems
+        val removalTargetsByDevice = buildRemovalTargetsByDevice(
+            activeConnectors = activeConnectors,
+            connectorMetadata = connectorMetadata,
+            pausedConnectorIds = pausedIds,
+            currentDeviceId = syncSettings.deviceId,
+            contributionDisplayOrder = { type -> connectorContributions[type]?.displayOrder ?: Int.MAX_VALUE },
+        )
+
+        val items = (normalItems + degradedItems)
+            .map { item -> item.copy(removalTargets = removalTargetsByDevice[item.deviceId].orEmpty()) }
         val labelsByDevice = disambiguateDeviceLabels(items.associate { it.deviceId to it.baseLabel })
 
         items
@@ -826,6 +852,55 @@ class DashboardVM @Inject constructor(
                     degradedLastSeen = meta.lastSeen,
                 )
             }
+
+        /**
+         * Per-device list of connectors that hold the device, with disambiguated account labels.
+         * Drives the "Remove device" overflow entry / picker dialog on dashboard device cards.
+         *
+         * The current device is excluded — self-disconnect lives in the connector ActionsSheet,
+         * not in this dashboard entry. Paused connectors are kept on the target with
+         * `isPaused = true` so callers can choose whether to filter (the screen does, because
+         * navigating to a paused connector's devices screen bounces back).
+         *
+         * Targets are sorted by [contributionDisplayOrder] then case-insensitive account label.
+         * Unknown connector types land last via `Int.MAX_VALUE`.
+         */
+        internal fun buildRemovalTargetsByDevice(
+            activeConnectors: List<SyncConnector>,
+            connectorMetadata: Map<ConnectorId, List<DeviceMetadata>>,
+            pausedConnectorIds: Set<ConnectorId>,
+            currentDeviceId: DeviceId,
+            contributionDisplayOrder: (ConnectorType) -> Int,
+        ): Map<DeviceId, List<DeviceRemovalTarget>> {
+            val peerKeys = activeConnectors.map { it.identifier.type to it.accountLabel }
+            val labelByConnector: Map<ConnectorId, String> = activeConnectors.associate { c ->
+                c.identifier to disambiguatedAccountLabel(
+                    type = c.identifier.type,
+                    account = c.identifier.account,
+                    accountLabel = c.accountLabel,
+                    peerKeys = peerKeys,
+                )
+            }
+            return connectorMetadata.entries
+                .flatMap { (cid, metas) -> metas.map { it.deviceId to cid } }
+                .filter { (deviceId, _) -> deviceId != currentDeviceId }
+                .groupBy({ it.first }, { it.second })
+                .mapValues { (_, cids) ->
+                    cids
+                        .map { cid ->
+                            DeviceRemovalTarget(
+                                connectorId = cid,
+                                type = cid.type,
+                                accountLabel = labelByConnector[cid].orEmpty(),
+                                isPaused = cid in pausedConnectorIds,
+                            )
+                        }
+                        .sortedWith(
+                            compareBy<DeviceRemovalTarget> { contributionDisplayOrder(it.type) }
+                                .thenBy(String.CASE_INSENSITIVE_ORDER) { it.accountLabel },
+                        )
+                }
+        }
 
         private val INFO_ORDER = listOf(
             PowerInfo::class,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,5 +267,8 @@
     <string name="dashboard_device_edit_card_action">Edit card</string>
     <string name="dashboard_device_move_up_action">Move up</string>
     <string name="dashboard_device_move_down_action">Move down</string>
+    <string name="dashboard_device_remove_action">Remove device</string>
+    <string name="dashboard_device_remove_picker_title">Choose sync service</string>
+    <string name="dashboard_device_remove_picker_message">This device is synced through multiple services. Pick which one to remove it from — you\'ll confirm on the next screen.</string>
 
 </resources>

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/BuildRemovalTargetsByDeviceTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/BuildRemovalTargetsByDeviceTest.kt
@@ -1,0 +1,225 @@
+package eu.darken.octi.main.ui.dashboard
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import eu.darken.octi.sync.core.SyncConnector
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Instant
+
+class BuildRemovalTargetsByDeviceTest : BaseTest() {
+
+    private val currentDeviceId = DeviceId("self")
+    private val deviceA = DeviceId("device-a")
+    private val deviceB = DeviceId("device-b")
+
+    private val gdriveAlice = ConnectorId(ConnectorType.GDRIVE, "default", "alice@example.com")
+    private val gdriveBob = ConnectorId(ConnectorType.GDRIVE, "default", "bob@example.com")
+    private val gdriveAliceDup = ConnectorId(ConnectorType.GDRIVE, "alt", "different-account-uuid")
+    private val octiserver = ConnectorId(ConnectorType.OCTISERVER, "default", "alice")
+
+    private fun connector(id: ConnectorId, accountLabel: String): SyncConnector = mockk(relaxed = true) {
+        every { identifier } returns id
+        every { this@mockk.accountLabel } returns accountLabel
+    }
+
+    private fun metadata(deviceId: DeviceId) = DeviceMetadata(
+        deviceId = deviceId,
+        version = "1.0.0",
+        platform = "android",
+        label = "Phone",
+        lastSeen = Instant.parse("2026-05-01T12:00:00Z"),
+    )
+
+    // Order by ConnectorType.ordinal — stable across the test, mirrors real contributions.
+    private val displayOrder: (ConnectorType) -> Int = { it.ordinal }
+
+    private fun call(
+        activeConnectors: List<SyncConnector>,
+        connectorMetadata: Map<ConnectorId, List<DeviceMetadata>>,
+        pausedConnectorIds: Set<ConnectorId> = emptySet(),
+        currentDeviceId: DeviceId = this.currentDeviceId,
+        contributionDisplayOrder: (ConnectorType) -> Int = displayOrder,
+    ) = DashboardVM.buildRemovalTargetsByDevice(
+        activeConnectors = activeConnectors,
+        connectorMetadata = connectorMetadata,
+        pausedConnectorIds = pausedConnectorIds,
+        currentDeviceId = currentDeviceId,
+        contributionDisplayOrder = contributionDisplayOrder,
+    )
+
+    @Nested
+    inner class `single connector` {
+        @Test
+        fun `device on one connector yields one non-paused target`() {
+            val gdrive = connector(gdriveAlice, "alice@example.com")
+            val result = call(
+                activeConnectors = listOf(gdrive),
+                connectorMetadata = mapOf(gdriveAlice to listOf(metadata(deviceA))),
+            )
+
+            val target = result.getValue(deviceA).also { it shouldHaveSize 1 }.single()
+            target.connectorId shouldBe gdriveAlice
+            target.type shouldBe ConnectorType.GDRIVE
+            target.accountLabel shouldBe "alice@example.com"
+            target.isPaused shouldBe false
+        }
+    }
+
+    @Nested
+    inner class `multi-connector disambiguation` {
+        @Test
+        fun `same-type connectors with identical account labels get disambiguated suffix`() {
+            val first = connector(gdriveAlice, "alice@example.com")
+            val second = connector(gdriveAliceDup, "alice@example.com")
+            val result = call(
+                activeConnectors = listOf(first, second),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(deviceA)),
+                    gdriveAliceDup to listOf(metadata(deviceA)),
+                ),
+            )
+
+            val targets = result.getValue(deviceA)
+            targets shouldHaveSize 2
+            // Both labels should be suffixed since they clash; neither equals the raw label.
+            targets.forEach { it.accountLabel shouldBe "alice@example.com (${it.connectorId.account.take(8)})" }
+        }
+
+        @Test
+        fun `distinct accounts retain their raw labels`() {
+            val alice = connector(gdriveAlice, "alice@example.com")
+            val bob = connector(gdriveBob, "bob@example.com")
+            val result = call(
+                activeConnectors = listOf(alice, bob),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(deviceA)),
+                    gdriveBob to listOf(metadata(deviceA)),
+                ),
+            )
+
+            val labels = result.getValue(deviceA).map { it.accountLabel }.toSet()
+            labels shouldBe setOf("alice@example.com", "bob@example.com")
+        }
+    }
+
+    @Nested
+    inner class `paused flag` {
+        @Test
+        fun `paused connector target has isPaused true`() {
+            val gdrive = connector(gdriveAlice, "alice@example.com")
+            val server = connector(octiserver, "alice")
+            val result = call(
+                activeConnectors = listOf(gdrive, server),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(deviceA)),
+                    octiserver to listOf(metadata(deviceA)),
+                ),
+                pausedConnectorIds = setOf(octiserver),
+            )
+
+            val byConnector = result.getValue(deviceA).associateBy { it.connectorId }
+            byConnector.getValue(gdriveAlice).isPaused shouldBe false
+            byConnector.getValue(octiserver).isPaused shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `current device exclusion` {
+        @Test
+        fun `current device is omitted from the resulting map`() {
+            val gdrive = connector(gdriveAlice, "alice@example.com")
+            val result = call(
+                activeConnectors = listOf(gdrive),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(currentDeviceId), metadata(deviceA)),
+                ),
+            )
+
+            result shouldNotContainKey currentDeviceId
+            result.getValue(deviceA) shouldHaveSize 1
+        }
+    }
+
+    @Nested
+    inner class `ordering` {
+        @Test
+        fun `targets sort by displayOrder then case-insensitive account label`() {
+            val gdriveLow = connector(gdriveAlice, "alice@example.com")
+            val gdriveHigh = connector(gdriveBob, "BOB@example.com")
+            val server = connector(octiserver, "carol")
+            val result = call(
+                // displayOrder: GDRIVE=0 < OCTISERVER=1; account-label tie-break is case-insensitive.
+                activeConnectors = listOf(server, gdriveHigh, gdriveLow),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(deviceA)),
+                    gdriveBob to listOf(metadata(deviceA)),
+                    octiserver to listOf(metadata(deviceA)),
+                ),
+                contributionDisplayOrder = { when (it) {
+                    ConnectorType.GDRIVE -> 0
+                    ConnectorType.OCTISERVER -> 1
+                } },
+            )
+
+            val ordered = result.getValue(deviceA).map { it.connectorId }
+            ordered shouldBe listOf(gdriveAlice, gdriveBob, octiserver)
+        }
+
+        @Test
+        fun `unknown connector types land last via Int MAX_VALUE`() {
+            val gdrive = connector(gdriveAlice, "alice@example.com")
+            val server = connector(octiserver, "alice")
+            val result = call(
+                activeConnectors = listOf(gdrive, server),
+                connectorMetadata = mapOf(
+                    gdriveAlice to listOf(metadata(deviceA)),
+                    octiserver to listOf(metadata(deviceA)),
+                ),
+                // Only GDRIVE known; OCTISERVER falls through to MAX_VALUE.
+                contributionDisplayOrder = { type -> if (type == ConnectorType.GDRIVE) 0 else Int.MAX_VALUE },
+            )
+
+            val ordered = result.getValue(deviceA).map { it.connectorId }
+            ordered shouldBe listOf(gdriveAlice, octiserver)
+        }
+    }
+
+    @Nested
+    inner class `degenerate inputs` {
+        @Test
+        fun `empty connector metadata yields empty map`() {
+            val result = call(activeConnectors = emptyList(), connectorMetadata = emptyMap())
+            result.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `connector with empty metadata is skipped`() {
+            val gdrive = connector(gdriveAlice, "alice@example.com")
+            val result = call(
+                activeConnectors = listOf(gdrive),
+                connectorMetadata = mapOf(gdriveAlice to emptyList()),
+            )
+            result.isEmpty() shouldBe true
+        }
+
+        @Test
+        fun `metadata for connector missing from activeConnectors still produces target with empty account label`() {
+            // Defensive: should not happen in production (connector list and metadata are derived together),
+            // but the function must not crash on a missing label lookup.
+            val result = call(
+                activeConnectors = emptyList(),
+                connectorMetadata = mapOf(gdriveAlice to listOf(metadata(deviceB))),
+            )
+            result.getValue(deviceB).single().accountLabel shouldBe ""
+        }
+    }
+}


### PR DESCRIPTION
Each dashboard device card now has a "Remove device" entry in its three-dots menu, putting device removal at the point of intent instead of buried under Sync Services → connector → Synced devices.

- Tap the menu → "Remove device" → the existing DeviceActionsSheet auto-opens for that device. The red Remove button and per-connector caveat text are unchanged.
- For devices synced through multiple services, a small "Choose sync service" dialog appears first.
- The entry is hidden on the current device's own card and on connectors that are paused (where the destination screen would bounce back).

Closes #292
