### PR TITLE
Extract widgetCornerRadius helper to app-common

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -46,4 +46,9 @@ dependencies {
     addCompose()
     addNavigation3()
     addTesting()
+
+    // Compile-only so widget-shared extensions (e.g. WidgetCornerRadius) can reference Glance
+    // types without dragging the dependency into non-widget consumers of app-common. Each widget
+    // module brings glance-appwidget at runtime itself.
+    compileOnly("androidx.glance:glance-appwidget:1.2.0-rc01")
 }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetCornerRadius.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetCornerRadius.kt
@@ -1,0 +1,16 @@
+package eu.darken.octi.common.widget
+
+import android.os.Build
+import androidx.compose.ui.unit.Dp
+import androidx.glance.GlanceModifier
+import androidx.glance.appwidget.cornerRadius
+
+/**
+ * Apply rounded corners when running on API 31+, no-op otherwise.
+ *
+ * Glance's [cornerRadius] requires Android S; calling it on older releases throws at render
+ * time. The visual degradation (square corners pre-12) is the accepted tradeoff for a single
+ * widget surface that runs across API 28 → current.
+ */
+fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -2,11 +2,9 @@ package eu.darken.octi.modules.clipboard.ui.widget
 
 import android.appwidget.AppWidgetManager
 import android.content.Context
-import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
@@ -22,7 +20,6 @@ import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionStartActivity
-import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -49,6 +46,7 @@ import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.proState
 import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetCornerRadius
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -166,9 +164,6 @@ private fun ClipboardWidgetUpgradeRequired(
         }
     }
 }
-
-private fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this
 
 @AndroidEntryPoint
 class ClipboardWidgetProvider : GlanceAppWidgetReceiver() {

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.modules.clipboard.ui.widget
 
-import android.os.Build
 import android.text.format.DateUtils
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
@@ -20,7 +19,6 @@ import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.action.actionStartActivity
-import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -39,6 +37,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetCornerRadius
 import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
@@ -481,6 +480,3 @@ private fun SelfClipboardRow(
 
 private fun colorOrDefault(value: Int?, @ColorRes defaultRes: Int): ColorProvider =
     value?.let { ColorProvider(Color(it)) } ?: ColorProvider(defaultRes)
-
-private fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -2,11 +2,9 @@ package eu.darken.octi.modules.connectivity.ui.widget
 
 import android.appwidget.AppWidgetManager
 import android.content.Context
-import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.GlanceId
@@ -22,7 +20,6 @@ import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionStartActivity
-import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -49,6 +46,7 @@ import eu.darken.octi.common.upgrade.UpgradeLauncher
 import eu.darken.octi.common.upgrade.proState
 import eu.darken.octi.common.widget.WidgetSettings
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetCornerRadius
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -170,9 +168,6 @@ private fun NetworkWidgetUpgradeRequired(
         }
     }
 }
-
-private fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this
 
 @AndroidEntryPoint
 class NetworkWidgetProvider : GlanceAppWidgetReceiver() {

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -1,7 +1,6 @@
 package eu.darken.octi.modules.connectivity.ui.widget
 
 import android.content.Context
-import android.os.Build
 import android.text.format.DateUtils
 import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable
@@ -20,7 +19,6 @@ import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionRunCallback
 import androidx.glance.appwidget.action.actionStartActivity
-import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -38,6 +36,7 @@ import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetCornerRadius
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.connectivity.R
@@ -534,6 +533,3 @@ private fun NetworkOverflowCompactRow(
 
 private fun colorOrDefault(value: Int?, @ColorRes defaultRes: Int): ColorProvider =
     value?.let { ColorProvider(Color(it)) } ?: ColorProvider(defaultRes)
-
-private fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -1,11 +1,9 @@
 package eu.darken.octi.modules.power.ui.widget
 
-import android.os.Build
 import android.text.format.DateUtils
 import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.glance.ColorFilter
@@ -18,7 +16,6 @@ import androidx.glance.LocalSize
 import androidx.glance.action.Action
 import androidx.glance.action.clickable
 import androidx.glance.appwidget.action.actionStartActivity
-import androidx.glance.appwidget.cornerRadius
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
@@ -40,6 +37,7 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.navigation.WidgetDeeplink
 import eu.darken.octi.common.widget.WidgetTheme
+import eu.darken.octi.common.widget.widgetCornerRadius
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.meta.core.MetaInfo
@@ -370,6 +368,3 @@ private fun BatteryOverflowRowContent(
         )
     }
 }
-
-private fun GlanceModifier.widgetCornerRadius(radius: Dp): GlanceModifier =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) cornerRadius(radius) else this


### PR DESCRIPTION
## Summary

Stacked on top of #299. The SDK-gated `cornerRadius` wrapper introduced there was duplicated as a private extension in five widget files; this PR consolidates the implementation:

- New `app-common/.../widget/WidgetCornerRadius.kt` defines the helper once.
- Five widget files (`BatteryWidgetContent`, `ClipboardWidgetContent`, `ClipboardGlanceWidget`, `NetworkWidgetContent`, `NetworkGlanceWidget`) drop their private copies and import the shared one. `Build`/`Dp`/`cornerRadius` imports trimmed where the helper was the only consumer.
- `app-common/build.gradle.kts` adds `compileOnly("androidx.glance:glance-appwidget:1.2.0-rc01")` so the helper can reference Glance types. `compileOnly` (not `implementation`) keeps Glance out of non-widget consumers of `app-common`; each widget module already brings the runtime dep itself.

## Test plan

- [x] `./gradlew :app-common:compileDebugKotlin :modules-{power,clipboard,connectivity}:compileFossDebugKotlin --rerun-tasks`
- [x] `./gradlew :modules-{power,clipboard,connectivity}:testFossDebugUnitTest --rerun-tasks` — all pass.
- [x] `./gradlew :app:assembleFossDebug` — confirms the runtime link resolves (`compileOnly` in `app-common` satisfied by each widget module's runtime Glance dep).
- [ ] Re-base onto `main` once #299 merges; no logic conflict expected.

## Notes

- Glance version (`1.2.0-rc01`) hardcoded inline to match `modules-{power,clipboard,connectivity}` rather than introducing a `Versions.kt` entry in this PR. Centralising the version is a small follow-up.