### PR TITLE
Remove unused rowSpacingForHeight from ClipboardWidgetSizing

### DIFF
--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -75,18 +75,6 @@ internal object ClipboardWidgetSizing {
         return rows.coerceAtMost(MAX_REMOTE_SLOTS)
     }
 
-    fun rowSpacingForHeight(heightDp: Float, visibleRowCount: Int): Dp {
-        if (visibleRowCount <= 1) return 0.dp
-        if (heightDp <= 0f || !heightDp.isFinite()) return ROW_SPACER
-
-        val innerHeightDp = (heightDp - OUTER_PADDING.value * 2f).coerceAtLeast(0f)
-        val rowsHeightDp = visibleRowCount * ROW_HEIGHT.value
-        val gapCount = visibleRowCount - 1
-        return ((innerHeightDp - rowsHeightDp) / gapCount)
-            .coerceAtLeast(ROW_SPACER.value)
-            .dp
-    }
-
     fun computeRemoteSlots(totalRemoteCount: Int, maxRemoteRows: Int): VisibleSlots {
         val cappedMaxRemoteRows = maxRemoteRows.coerceAtMost(MAX_REMOTE_SLOTS)
         return when {


### PR DESCRIPTION
## Summary

Stacked on top of #299. The function `ClipboardWidgetSizing.rowSpacingForHeight` was introduced for the original dynamic-spacing layout. When #299 switched back to fixed inter-row spacing (per a4833119), the helper was left behind but has no callers.

`grep -rn rowSpacingForHeight` confirms no remaining usages after removal.

## Test plan

- [x] `./gradlew :modules-clipboard:compileFossDebugKotlin :modules-clipboard:testFossDebugUnitTest --rerun-tasks` — pass.