### PR TITLE
Refresh widgets on Pro entitlement changes app-wide

### DIFF
--- a/app/src/main/java/eu/darken/octi/App.kt
+++ b/app/src/main/java/eu/darken/octi/App.kt
@@ -17,6 +17,7 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.debug.recording.core.DebugSessionManager
 import eu.darken.octi.common.theming.Theming
+import eu.darken.octi.common.upgrade.UpgradeEntitlementObserver
 import eu.darken.octi.main.core.CurriculumVitae
 import eu.darken.octi.main.core.GeneralSettings
 import eu.darken.octi.main.core.release.ReleaseManager
@@ -49,6 +50,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var blobMaintenance: BlobMaintenance
     @Inject lateinit var incomingFileNotifier: IncomingFileNotifier
     @Inject lateinit var cryptoCapabilities: CryptoCapabilities
+    @Inject lateinit var upgradeEntitlementObserver: UpgradeEntitlementObserver
 
     override fun onCreate() {
         super.onCreate()
@@ -75,6 +77,7 @@ open class App : Application(), Configuration.Provider {
         syncOrchestrator.start()
         blobMaintenance.start()
         incomingFileNotifier.start()
+        upgradeEntitlementObserver.start()
 
         curriculumVitae.updateAppLaunch()
 

--- a/app/src/main/java/eu/darken/octi/common/upgrade/UpgradeEntitlementObserver.kt
+++ b/app/src/main/java/eu/darken/octi/common/upgrade/UpgradeEntitlementObserver.kt
@@ -1,0 +1,65 @@
+package eu.darken.octi.common.upgrade
+
+import eu.darken.octi.common.coroutine.AppScope
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.widget.WidgetManager
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * App-scope observer that force-refreshes Glance widgets when Pro entitlement transitions
+ * outside of the upgrade screen — e.g. a Play subscription expires while the user isn't
+ * looking at [UpgradeViewModel], or a sync detects a Pro grant.
+ *
+ * `UpgradeViewModel` already refreshes widgets on its own isPro emission, but only while it
+ * is alive. This observer covers the rest of the app's lifetime. The initial emission is
+ * dropped — widgets are repainted by Glance on attach anyway, so refreshing them on every
+ * cold start is wasted work; only subsequent transitions need a force-update.
+ */
+@Singleton
+class UpgradeEntitlementObserver @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val upgradeRepo: UpgradeRepo,
+    private val widgetManagers: Set<@JvmSuppressWildcards WidgetManager>,
+) {
+
+    fun start() {
+        log(TAG) { "start()" }
+        upgradeRepo.upgradeInfo
+            .map { it.isPro }
+            .distinctUntilChanged()
+            .drop(1)
+            .onEach { isPro ->
+                log(TAG, INFO) { "Pro entitlement transitioned: isPro=$isPro" }
+                refreshAllWidgets()
+            }
+            .launchIn(appScope)
+    }
+
+    private suspend fun refreshAllWidgets() {
+        for (manager in widgetManagers) {
+            try {
+                manager.refreshWidgets()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "Failed to refresh widgets after entitlement change: ${e.asLog()}" }
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Upgrade", "Entitlement", "Observer")
+    }
+}

--- a/app/src/test/java/eu/darken/octi/common/upgrade/UpgradeEntitlementObserverTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/UpgradeEntitlementObserverTest.kt
@@ -1,0 +1,137 @@
+package eu.darken.octi.common.upgrade
+
+import eu.darken.octi.common.widget.WidgetManager
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Instant
+
+class UpgradeEntitlementObserverTest : BaseTest() {
+
+    private val upgradeInfo = MutableSharedFlow<UpgradeRepo.Info>()
+    private val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).also {
+        every { it.upgradeInfo } returns upgradeInfo
+    }
+
+    private val battery = mockk<WidgetManager>(relaxed = true)
+    private val clipboard = mockk<WidgetManager>(relaxed = true)
+    private val network = mockk<WidgetManager>(relaxed = true)
+    private val widgetManagers = setOf(battery, clipboard, network)
+
+    private fun createObserver(scope: CoroutineScope) = UpgradeEntitlementObserver(
+        appScope = scope,
+        upgradeRepo = upgradeRepo,
+        widgetManagers = widgetManagers,
+    )
+
+    private fun proInfo(isPro: Boolean) = object : UpgradeRepo.Info {
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS
+        override val isPro: Boolean = isPro
+        override val upgradedAt: Instant? = null
+    }
+
+    @Nested
+    inner class `start()` {
+
+        @Test
+        fun `first emission does not trigger refresh - widgets repaint on Glance attach`() = runTest2(autoCancel = true) {
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { battery.refreshWidgets() }
+            coVerify(exactly = 0) { clipboard.refreshWidgets() }
+            coVerify(exactly = 0) { network.refreshWidgets() }
+        }
+
+        @Test
+        fun `isPro false to true transition refreshes all widgets`() = runTest2(autoCancel = true) {
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { battery.refreshWidgets() }
+            coVerify(exactly = 1) { clipboard.refreshWidgets() }
+            coVerify(exactly = 1) { network.refreshWidgets() }
+        }
+
+        @Test
+        fun `isPro true to false transition refreshes all widgets`() = runTest2(autoCancel = true) {
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = true))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { battery.refreshWidgets() }
+            coVerify(exactly = 1) { clipboard.refreshWidgets() }
+            coVerify(exactly = 1) { network.refreshWidgets() }
+        }
+
+        @Test
+        fun `repeated identical emissions do not refresh`() = runTest2(autoCancel = true) {
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { battery.refreshWidgets() }
+        }
+
+        @Test
+        fun `multiple transitions each fire one refresh`() = runTest2(autoCancel = true) {
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = true))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 3) { battery.refreshWidgets() }
+            coVerify(exactly = 3) { clipboard.refreshWidgets() }
+            coVerify(exactly = 3) { network.refreshWidgets() }
+        }
+
+        @Test
+        fun `failing widget manager does not block sibling refreshes`() = runTest2(autoCancel = true) {
+            coEvery { battery.refreshWidgets() } throws RuntimeException("boom")
+
+            createObserver(this).start()
+            advanceUntilIdle()
+
+            upgradeInfo.emit(proInfo(isPro = false))
+            advanceUntilIdle()
+            upgradeInfo.emit(proInfo(isPro = true))
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { clipboard.refreshWidgets() }
+            coVerify(exactly = 1) { network.refreshWidgets() }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on top of #301 → #299. `UpgradeViewModel` already refreshed widgets when its own observer saw an `isPro` transition (added in #299), but only while the upgrade screen was alive. This PR adds `UpgradeEntitlementObserver`, an app-scope singleton started from `App.onCreate()`, that observes `UpgradeRepo.upgradeInfo.isPro` for the entire process lifetime and force-refreshes all `WidgetManager`s on every transition after the first emission.

## Behaviour

- `upgradeInfo.map { it.isPro }.distinctUntilChanged().drop(1)` — the initial emission is dropped because widgets repaint via Glance attach on cold start; only mid-session transitions need a force-update. `distinctUntilChanged` prevents redundant refreshes for repeated identical emissions.
- Failures in one `WidgetManager.refreshWidgets()` are caught and logged so siblings still refresh.
- The existing `UpgradeViewModel` refresh logic stays — it fires earlier (before `navUp()`), so the upgrade screen dismisses against fresh widgets without waiting for the global observer's next dispatch. The global observer is the safety net for entitlement changes that don't go through that screen.

## What it covers

- Play subscription expiry while the app is in foreground/background but not on the upgrade screen.
- `restorePurchase` paths that don't route through `UpgradeViewModel.initialize()`.
- Future server-driven Pro toggles (e.g., a sync-detected entitlement change).

## Test plan

- [x] New `UpgradeEntitlementObserverTest` covers:
  - First emission does not trigger refresh.
  - `false → true` transition refreshes all three managers exactly once.
  - `true → false` transition refreshes all three managers exactly once.
  - Repeated identical emissions: zero refresh.
  - Multiple transitions: one refresh each.
  - Failing widget manager does not block sibling refreshes.
- [x] `./gradlew :app:compileFossDebugKotlin :app:compileGplayDebugKotlin :app:assembleFossDebug` — pass.

## Notes

- Adds a permanent subscriber to `upgradeRepo.upgradeInfo`. The Gplay `shareIn(WhileSubscribed(3.seconds))` means the upstream billing flow will be kept active for the app's process lifetime instead of being released between observations. Play Billing's idle-connection cost is small, but worth flagging.