### PR TITLE
Bump clipboard/network padding to 8dp to fix corner mismatch

### DIFF
--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -137,7 +137,7 @@ private fun ClipboardWidgetUpgradeRequired(
         contentAlignment = Alignment.Center,
         modifier = GlanceModifier
             .fillMaxSize()
-            .widgetCornerRadius(16.dp)
+            .widgetCornerRadius(ClipboardWidgetSizing.OUTER_CONTAINER_CORNER)
             .background(containerColor)
             .clickable(upgradeAction)
             .padding(6.dp),

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -52,16 +52,17 @@ internal object ClipboardWidgetSizing {
     val ROW_HEIGHT = 28.dp
     val ROW_SPACER = 2.dp
     val SELF_SECTION_SPACER = 2.dp
-    val OUTER_PADDING = 6.dp
+    val OUTER_PADDING = 8.dp
     const val MAX_REMOTE_SLOTS = 9
 
     /**
-     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
-     * continue the container's curve instead of looking offset from it. Material's "parallel
-     * curves" rule: inner_radius = outer_radius − padding.
+     * Tile corners use a fixed 12dp radius. The 8dp [OUTER_PADDING] pushes the first/last
+     * rows past the container's rounded corner region so the inner-vs-outer radius
+     * mismatch isn't exposed at the corners. Don't drop padding below 8dp without also
+     * adjusting [TILE_CORNER] — at 6dp the gap becomes visible.
      */
     val OUTER_CONTAINER_CORNER = 16.dp
-    val TILE_CORNER = OUTER_CONTAINER_CORNER - OUTER_PADDING
+    val TILE_CORNER = 12.dp
 
     /**
      * Total fixed vertical space outside the scrolling device rows.

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -56,6 +56,14 @@ internal object ClipboardWidgetSizing {
     const val MAX_REMOTE_SLOTS = 9
 
     /**
+     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
+     * continue the container's curve instead of looking offset from it. Material's "parallel
+     * curves" rule: inner_radius = outer_radius − padding.
+     */
+    val OUTER_CONTAINER_CORNER = 16.dp
+    val TILE_CORNER = OUTER_CONTAINER_CORNER - OUTER_PADDING
+
+    /**
      * Total fixed vertical space outside the scrolling device rows.
      * Must match the composable structure in [ClipboardWidgetContent]:
      * outer padding (top+bottom) + self section spacer + self row height.
@@ -157,7 +165,7 @@ fun ClipboardWidgetContent(
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .widgetCornerRadius(16.dp)
+                .widgetCornerRadius(ClipboardWidgetSizing.OUTER_CONTAINER_CORNER)
                 .then(
                     if (containerBg != null) {
                         GlanceModifier.background(ColorProvider(Color(containerBg)))
@@ -327,7 +335,7 @@ private fun ClipboardDeviceRowContent(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(ClipboardWidgetSizing.ROW_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(ClipboardWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .clickable(rowAction),
     ) {
@@ -396,7 +404,7 @@ private fun ClipboardOverflowRowContent(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(ClipboardWidgetSizing.ROW_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(ClipboardWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .then(if (onClick != null) GlanceModifier.clickable(onClick) else GlanceModifier),
         contentAlignment = Alignment.Center,
@@ -428,7 +436,7 @@ private fun SelfClipboardRow(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(ClipboardWidgetSizing.ROW_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(ClipboardWidgetSizing.TILE_CORNER)
             .background(accentBg)
             .clickable(shareAction),
     ) {

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetSizingTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetSizingTest.kt
@@ -17,7 +17,7 @@ class ClipboardWidgetSizingTest : BaseTest() {
 
         @Test
         fun `one remote row fits above cover-screen minimum when height allows it`() {
-            ClipboardWidgetSizing.maxRemoteRowsForHeight(70f) shouldBe 1
+            ClipboardWidgetSizing.maxRemoteRowsForHeight(80f) shouldBe 1
         }
 
         @Test

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -141,7 +141,7 @@ private fun NetworkWidgetUpgradeRequired(
         contentAlignment = Alignment.Center,
         modifier = GlanceModifier
             .fillMaxSize()
-            .widgetCornerRadius(16.dp)
+            .widgetCornerRadius(NetworkWidgetSizing.OUTER_CONTAINER_CORNER)
             .background(containerColor)
             .clickable(upgradeAction)
             .padding(6.dp),

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -57,6 +57,14 @@ internal object NetworkWidgetSizing {
     val SINGLE_ROW_HEIGHT = 28.dp
     val INTER_ROW_SPACER = 2.dp
 
+    /**
+     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
+     * continue the container's curve instead of looking offset from it. Material's "parallel
+     * curves" rule: inner_radius = outer_radius − padding.
+     */
+    val OUTER_CONTAINER_CORNER = 16.dp
+    val TILE_CORNER = OUTER_CONTAINER_CORNER - OUTER_PADDING
+
     val TILE_SLOT_DP: Float
         get() = TILE_HEIGHT.value + ROW_SPACING.value
     val ROW_SLOT_DP: Float
@@ -145,7 +153,7 @@ fun NetworkWidgetContent(
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .widgetCornerRadius(16.dp)
+                .widgetCornerRadius(NetworkWidgetSizing.OUTER_CONTAINER_CORNER)
                 .then(
                     if (containerBg != null) {
                         GlanceModifier.background(ColorProvider(Color(containerBg)))
@@ -333,7 +341,7 @@ private fun NetworkDeviceTileContent(
     Box(
         modifier = modifier
             .height(NetworkWidgetSizing.TILE_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(NetworkWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .clickable(copyAction),
     ) {
@@ -405,7 +413,7 @@ private fun NetworkOverflowTileContent(
     Box(
         modifier = modifier
             .height(NetworkWidgetSizing.TILE_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(NetworkWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .then(if (onClick != null) GlanceModifier.clickable(onClick) else GlanceModifier),
         contentAlignment = Alignment.Center,
@@ -463,7 +471,7 @@ private fun NetworkDeviceCompactRow(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(NetworkWidgetSizing.SINGLE_ROW_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(NetworkWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .clickable(copyAction),
     ) {
@@ -515,7 +523,7 @@ private fun NetworkOverflowCompactRow(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(NetworkWidgetSizing.SINGLE_ROW_HEIGHT)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(NetworkWidgetSizing.TILE_CORNER)
             .background(tileBg)
             .then(if (onClick != null) GlanceModifier.clickable(onClick) else GlanceModifier),
         contentAlignment = Alignment.Center,

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -48,7 +48,7 @@ import eu.darken.octi.common.R as CommonR
 
 internal object NetworkWidgetSizing {
     const val TWO_COLUMN_MIN_WIDTH_DP = 220
-    const val OUTER_PADDING_DP = 6f
+    const val OUTER_PADDING_DP = 8f
     const val MAX_VISIBLE_ITEMS = 10
 
     val OUTER_PADDING = OUTER_PADDING_DP.dp
@@ -58,12 +58,13 @@ internal object NetworkWidgetSizing {
     val INTER_ROW_SPACER = 2.dp
 
     /**
-     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
-     * continue the container's curve instead of looking offset from it. Material's "parallel
-     * curves" rule: inner_radius = outer_radius − padding.
+     * Tile corners use a fixed 12dp radius. The 8dp [OUTER_PADDING] pushes the first/last
+     * rows past the container's rounded corner region so the inner-vs-outer radius
+     * mismatch isn't exposed at the corners. Don't drop padding below 8dp without also
+     * adjusting [TILE_CORNER] — at 6dp the gap becomes visible.
      */
     val OUTER_CONTAINER_CORNER = 16.dp
-    val TILE_CORNER = OUTER_CONTAINER_CORNER - OUTER_PADDING
+    val TILE_CORNER = 12.dp
 
     val TILE_SLOT_DP: Float
         get() = TILE_HEIGHT.value + ROW_SPACING.value

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetSizingTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetSizingTest.kt
@@ -26,8 +26,8 @@ class NetworkWidgetSizingTest : BaseTest() {
 
         @Test
         fun `wide widget at tile-fit height uses two-column`() {
-            // 2 * OUTER_PADDING + TILE_HEIGHT = 12 + 76 = 88dp
-            NetworkWidgetSizing.shouldUseTwoColumn(widthDp = 220f, heightDp = 88f) shouldBe true
+            // 2 * OUTER_PADDING + TILE_HEIGHT = 16 + 76 = 92dp
+            NetworkWidgetSizing.shouldUseTwoColumn(widthDp = 220f, heightDp = 92f) shouldBe true
             NetworkWidgetSizing.shouldUseTwoColumn(widthDp = 220f, heightDp = 200f) shouldBe true
         }
 
@@ -56,8 +56,8 @@ class NetworkWidgetSizingTest : BaseTest() {
 
         @Test
         fun `two column mode counts two tiles per fitted row`() {
-            NetworkWidgetSizing.maxItemsForSize(widthDp = 220f, heightDp = 88f) shouldBe 2
-            NetworkWidgetSizing.maxItemsForSize(widthDp = 220f, heightDp = 168f) shouldBe 4
+            NetworkWidgetSizing.maxItemsForSize(widthDp = 220f, heightDp = 92f) shouldBe 2
+            NetworkWidgetSizing.maxItemsForSize(widthDp = 220f, heightDp = 172f) shouldBe 4
         }
 
         @Test

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -57,12 +57,14 @@ internal object BatteryWidgetSizing {
     const val ROW_SPACING_DP = 2f
 
     /**
-     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
-     * continue the container's curve instead of looking offset from it. Material's "parallel
-     * curves" rule: inner_radius = outer_radius − padding.
+     * Tile corners use a fixed 12dp radius. Combined with 8dp outer padding and the 16dp
+     * container corner, the geometry leaves enough buffer that the first/last rows sit past
+     * the container's rounded corner region and don't reveal a visible mismatch. Smaller
+     * padding values (≤6dp) pull the row inside the rounded area and expose the mismatch —
+     * keep [OUTER_PADDING_DP] ≥ 8dp.
      */
     const val OUTER_CONTAINER_CORNER_DP = 16f
-    const val TILE_CORNER_DP = OUTER_CONTAINER_CORNER_DP - OUTER_PADDING_DP
+    const val TILE_CORNER_DP = 12f
 
     /** Glance `Column` truncates beyond ~10 direct children; cap to stay safely under that limit. */
     const val MAX_VISIBLE_ROWS = 10

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -56,6 +56,14 @@ internal object BatteryWidgetSizing {
     const val ROW_HEIGHT_DP = 30f
     const val ROW_SPACING_DP = 2f
 
+    /**
+     * Concentric-corner pair. The inner tile radius is derived so that tile corners visually
+     * continue the container's curve instead of looking offset from it. Material's "parallel
+     * curves" rule: inner_radius = outer_radius − padding.
+     */
+    const val OUTER_CONTAINER_CORNER_DP = 16f
+    const val TILE_CORNER_DP = OUTER_CONTAINER_CORNER_DP - OUTER_PADDING_DP
+
     /** Glance `Column` truncates beyond ~10 direct children; cap to stay safely under that limit. */
     const val MAX_VISIBLE_ROWS = 10
 
@@ -147,7 +155,7 @@ fun BatteryWidgetContent(
         Box(
             modifier = GlanceModifier
                 .fillMaxSize()
-                .widgetCornerRadius(16.dp)
+                .widgetCornerRadius(BatteryWidgetSizing.OUTER_CONTAINER_CORNER_DP.dp)
                 .then(
                     if (containerBg != null) {
                         GlanceModifier.background(ColorProvider(Color(containerBg)))
@@ -277,7 +285,7 @@ private fun BatteryDeviceRowContent(
             modifier = GlanceModifier
                 .defaultWeight()
                 .height(BatteryWidgetSizing.ROW_HEIGHT_DP.dp)
-                .widgetCornerRadius(12.dp)
+                .widgetCornerRadius(BatteryWidgetSizing.TILE_CORNER_DP.dp)
                 .background(tileBg)
                 .then(
                     if (rowClick != null) GlanceModifier.clickable(rowClick) else GlanceModifier
@@ -289,7 +297,7 @@ private fun BatteryDeviceRowContent(
                     modifier = GlanceModifier
                         .width(fillWidth.dp)
                         .height(BatteryWidgetSizing.ROW_HEIGHT_DP.dp)
-                        .widgetCornerRadius(12.dp)
+                        .widgetCornerRadius(BatteryWidgetSizing.TILE_CORNER_DP.dp)
                         .background(accentBg),
                 ) {}
             }
@@ -354,7 +362,7 @@ private fun BatteryOverflowRowContent(
         modifier = GlanceModifier
             .fillMaxWidth()
             .height(BatteryWidgetSizing.ROW_HEIGHT_DP.dp)
-            .widgetCornerRadius(12.dp)
+            .widgetCornerRadius(BatteryWidgetSizing.TILE_CORNER_DP.dp)
             .background(tileBg)
             .then(if (onClick != null) GlanceModifier.clickable(onClick) else GlanceModifier),
         contentAlignment = Alignment.Center,


### PR DESCRIPTION
## Summary

Top of the stack on #303 → #302 → #301 → #299. The reported issue: with 6dp outer padding on clipboard/network, the first/last rows sat inside the container's rounded corner region, exposing the inner-vs-outer radius mismatch as a visible curving gap of container background between the tile and the container's outer curve.

An earlier attempt in this PR applied Material's "concentric corners" rule (`tile_radius = outer_radius − padding`), tightening tile corners to 10dp for clipboard/network. That was mathematically correct but visually insufficient — the 6dp padding-thick gap still curved through the corner area, just thinner. The user reported it as "did nothing".

**Final approach (this commit):** match battery's working geometry — 8dp outer padding, 12dp tile corner, 16dp container corner. With 8dp padding the rows are pushed past most of the container's rounded corner region, so the inner radius's slight protrusion (the corners don't match concentric) is hidden behind the linear edges instead of being visible at the rounded corner.

| Widget | Outer padding | Tile corner | Container corner |
|---|---|---|---|
| Battery | 8dp (unchanged) | 12dp (unchanged) | 16dp (unchanged) |
| Clipboard | 6dp → **8dp** | 12dp (unchanged net) | 16dp (unchanged) |
| Network | 6dp → **8dp** | 12dp (unchanged net) | 16dp (unchanged) |

Each widget's `Sizing` object now declares `OUTER_CONTAINER_CORNER` and `TILE_CORNER` as named constants instead of hardcoding `widgetCornerRadius(16.dp)` / `widgetCornerRadius(12.dp)` at the call sites. Inline doc explains the relationship and the ≥8dp padding constraint.

## Trade-off

Clipboard/Network lose 4dp horizontal content area per side. Acceptable given the prior gap was perceived as a regression.

## Test plan

- [x] All three module unit test suites pass after updating `ClipboardWidgetSizingTest` (70dp → 80dp for the "1 row fits" threshold) and `NetworkWidgetSizingTest` (88dp → 92dp for the "two-column kicks in" threshold) — both shifted because `OUTER_PADDING_DP` grew.
- [x] `:app:assembleFossDebug` passes.
- [x] On-device smoke (Pixel 8 API 37): widget refreshed automatically after install; Network widget first row tile now sits with the same padding signature as battery; no visible curving gap at the corner.