### PR TITLE
Add Glance render tests for battery and network widgets

### DIFF
--- a/modules-connectivity/build.gradle.kts
+++ b/modules-connectivity/build.gradle.kts
@@ -43,6 +43,9 @@ dependencies {
     implementation(project(":modules-meta"))
     implementation("androidx.glance:glance-appwidget:1.2.0-rc01")
     implementation("androidx.glance:glance-material3:1.2.0-rc01")
+    testImplementation("androidx.glance:glance-appwidget-testing:1.2.0-rc01")
+    testImplementation("androidx.glance:glance-testing:1.2.0-rc01")
+    testImplementation("org.robolectric:robolectric:4.16.1")
 
     addAndroidCore()
     addDI()

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
@@ -1,0 +1,218 @@
+package eu.darken.octi.modules.connectivity.ui.widget
+
+import android.content.Context
+import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.unit.hasText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.connectivity.core.ConnectivityInfo
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class NetworkWidgetContentGlanceTest {
+
+    private val selfDeviceId = DeviceId(id = "self-device")
+    private val connectivityModuleId = ModuleId("eu.darken.octi.module.core.connectivity")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private fun connectivityInfo(
+        type: ConnectivityInfo.ConnectionType? = ConnectivityInfo.ConnectionType.WIFI,
+        localIp: String? = "192.168.1.10",
+        publicIp: String? = "203.0.113.5",
+    ) = ConnectivityInfo(
+        connectionType = type,
+        publicIp = publicIp,
+        localAddressIpv4 = localIp,
+        localAddressIpv6 = null,
+        gatewayIp = null,
+        dnsServers = null,
+    )
+
+    private fun connectivityModuleData(
+        deviceId: DeviceId,
+        info: ConnectivityInfo = connectivityInfo(),
+    ): ModuleData<ConnectivityInfo> = ModuleData(
+        modifiedAt = Instant.fromEpochMilliseconds(0),
+        deviceId = deviceId,
+        moduleId = connectivityModuleId,
+        data = info,
+    )
+
+    private fun metaModuleData(deviceId: DeviceId, label: String): ModuleData<MetaInfo> = ModuleData(
+        modifiedAt = Instant.fromEpochMilliseconds(0),
+        deviceId = deviceId,
+        moduleId = metaModuleId,
+        data = MetaInfo(
+            deviceLabel = label,
+            deviceId = deviceId,
+            octiVersionName = "test",
+            octiGitSha = "test",
+            deviceManufacturer = "test",
+            deviceName = label,
+            deviceType = MetaInfo.DeviceType.PHONE,
+            deviceBootedAt = Instant.fromEpochMilliseconds(0),
+            androidVersionName = "test",
+            androidApiLevel = 34,
+            androidSecurityPatch = null,
+        ),
+    )
+
+    private fun connectivityState(
+        selfInfo: ConnectivityInfo = connectivityInfo(),
+        extras: List<Pair<DeviceId, ConnectivityInfo>> = emptyList(),
+    ): BaseModuleRepo.State<ConnectivityInfo> = BaseModuleRepo.State(
+        moduleId = connectivityModuleId,
+        self = connectivityModuleData(selfDeviceId, selfInfo),
+        isOthersInitialized = true,
+        others = extras.map { (id, info) -> connectivityModuleData(id, info) },
+    )
+
+    private fun metaState(
+        selfLabel: String = "MyPhone",
+        extras: List<Pair<DeviceId, String>> = emptyList(),
+    ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
+        moduleId = metaModuleId,
+        self = metaModuleData(selfDeviceId, selfLabel),
+        isOthersInitialized = true,
+        others = extras.map { (id, label) -> metaModuleData(id, label) },
+    )
+
+    @Test
+    fun `two-column tile renders the device label and IPs`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(selfLabel = "Pixel 9"),
+                connectivityState = connectivityState(
+                    selfInfo = connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
+                ),
+                themeColors = null,
+                maxRows = 4,
+                widthDp = 300f,
+                heightDp = 200f,
+            )
+        }
+        onNode(hasText("Pixel 9")).assertExists()
+        onNode(hasText("10.0.0.5")).assertExists()
+        onNode(hasText("1.2.3.4")).assertExists()
+    }
+
+    @Test
+    fun `compact row renders name and combined IP string`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(selfLabel = "Pixel 9"),
+                connectivityState = connectivityState(
+                    selfInfo = connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
+                ),
+                themeColors = null,
+                maxRows = 4,
+                widthDp = 150f,
+                heightDp = 200f,
+            )
+        }
+        onNode(hasText("Pixel 9")).assertExists()
+        // Compact row joins local and public into a single string.
+        onNode(hasText("10.0.0.5 · 1.2.3.4")).assertExists()
+    }
+
+    @Test
+    fun `wide-short widget falls back to compact rows`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        // 220 wide, 50 tall — width hits the two-column threshold but height doesn't.
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(selfLabel = "Pixel 9"),
+                connectivityState = connectivityState(
+                    selfInfo = connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
+                ),
+                themeColors = null,
+                maxRows = 1,
+                widthDp = 220f,
+                heightDp = 50f,
+            )
+        }
+        // Compact-row signature: name + joined-IP single string. The tile layout would split
+        // them and not produce this combined string.
+        onNode(hasText("10.0.0.5 · 1.2.3.4")).assertExists()
+    }
+
+    @Test
+    fun `more-than-maxRows devices show overflow indicator`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val extras = (1..5).map { DeviceId("dev-$it") to "Device $it" }
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(extras = extras),
+                connectivityState = connectivityState(
+                    extras = extras.map { (id, _) -> id to connectivityInfo() },
+                ),
+                themeColors = null,
+                maxRows = 3,
+                widthDp = 150f,
+                heightDp = 200f,
+            )
+        }
+        // 6 devices, maxRows=3 → 2 visible + 1 overflow.
+        onNode(hasText("Device 1")).assertExists()
+        onNode(hasText("Device 2")).assertExists()
+        onNode(hasText("Device 3")).assertDoesNotExist()
+        onNode(hasText(context.getString(CommonR.string.widget_more_items, 4))).assertExists()
+    }
+
+    @Test
+    fun `single slot overflow takes the only slot`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val extras = listOf(
+            DeviceId("a") to "Alpha",
+            DeviceId("b") to "Bravo",
+        )
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(extras = extras),
+                connectivityState = connectivityState(
+                    extras = extras.map { (id, _) -> id to connectivityInfo() },
+                ),
+                themeColors = null,
+                maxRows = 1,
+                widthDp = 150f,
+                heightDp = 200f,
+            )
+        }
+        onNode(hasText("MyPhone")).assertDoesNotExist()
+        onNode(hasText("Alpha")).assertDoesNotExist()
+        onNode(hasText(context.getString(CommonR.string.widget_more_items, 3))).assertExists()
+    }
+
+    @Test
+    fun `filter with unknown id renders the empty state`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(),
+                connectivityState = connectivityState(),
+                themeColors = null,
+                maxRows = 5,
+                widthDp = 300f,
+                heightDp = 200f,
+                allowedDeviceIds = setOf("unknown-device-id"),
+            )
+        }
+        onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertExists()
+        onNode(hasText("MyPhone")).assertDoesNotExist()
+    }
+}

--- a/modules-power/build.gradle.kts
+++ b/modules-power/build.gradle.kts
@@ -54,4 +54,7 @@ dependencies {
 
     implementation("androidx.glance:glance-appwidget:1.2.0-rc01")
     implementation("androidx.glance:glance-material3:1.2.0-rc01")
+    testImplementation("androidx.glance:glance-appwidget-testing:1.2.0-rc01")
+    testImplementation("androidx.glance:glance-testing:1.2.0-rc01")
+    testImplementation("org.robolectric:robolectric:4.16.1")
 }

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentGlanceTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentGlanceTest.kt
@@ -1,0 +1,175 @@
+package eu.darken.octi.modules.power.ui.widget
+
+import android.content.Context
+import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.unit.hasText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.sync.core.DeviceId
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class BatteryWidgetContentGlanceTest {
+
+    private val selfDeviceId = DeviceId(id = "self-device")
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private fun powerInfo(level: Int = 80, scale: Int = 100, charging: Boolean = false) = PowerInfo(
+        status = if (charging) PowerInfo.Status.CHARGING else PowerInfo.Status.DISCHARGING,
+        battery = PowerInfo.Battery(level = level, scale = scale, health = 1, temp = 25f),
+        chargeIO = PowerInfo.ChargeIO(
+            currentNow = null,
+            currenAvg = null,
+            fullSince = null,
+            fullAt = null,
+            emptyAt = null,
+        ),
+    )
+
+    private fun powerModuleData(deviceId: DeviceId, info: PowerInfo = powerInfo()): ModuleData<PowerInfo> =
+        ModuleData(
+            modifiedAt = Instant.fromEpochMilliseconds(0),
+            deviceId = deviceId,
+            moduleId = powerModuleId,
+            data = info,
+        )
+
+    private fun metaModuleData(deviceId: DeviceId, label: String): ModuleData<MetaInfo> = ModuleData(
+        modifiedAt = Instant.fromEpochMilliseconds(0),
+        deviceId = deviceId,
+        moduleId = metaModuleId,
+        data = MetaInfo(
+            deviceLabel = label,
+            deviceId = deviceId,
+            octiVersionName = "test",
+            octiGitSha = "test",
+            deviceManufacturer = "test",
+            deviceName = label,
+            deviceType = MetaInfo.DeviceType.PHONE,
+            deviceBootedAt = Instant.fromEpochMilliseconds(0),
+            androidVersionName = "test",
+            androidApiLevel = 34,
+            androidSecurityPatch = null,
+        ),
+    )
+
+    private fun powerState(
+        selfInfo: PowerInfo = powerInfo(),
+        extras: List<Pair<DeviceId, PowerInfo>> = emptyList(),
+    ): BaseModuleRepo.State<PowerInfo> = BaseModuleRepo.State(
+        moduleId = powerModuleId,
+        self = powerModuleData(selfDeviceId, selfInfo),
+        isOthersInitialized = true,
+        others = extras.map { (id, info) -> powerModuleData(id, info) },
+    )
+
+    private fun metaState(
+        selfLabel: String = "MyPhone",
+        extras: List<Pair<DeviceId, String>> = emptyList(),
+    ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
+        moduleId = metaModuleId,
+        self = metaModuleData(selfDeviceId, selfLabel),
+        isOthersInitialized = true,
+        others = extras.map { (id, label) -> metaModuleData(id, label) },
+    )
+
+    @Test
+    fun `device row renders the label and percent`() = runGlanceAppWidgetUnitTest {
+        setContext(ApplicationProvider.getApplicationContext())
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(),
+                powerState = powerState(selfInfo = powerInfo(level = 73)),
+                themeColors = null,
+                maxRows = 5,
+            )
+        }
+        onNode(hasText("MyPhone")).assertExists()
+        onNode(hasText("73%")).assertExists()
+    }
+
+    @Test
+    fun `more-than-maxRows devices show overflow indicator instead of truncating`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val extraDevices = (1..5).map { DeviceId("dev-$it") }
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(extras = extraDevices.mapIndexed { i, id -> id to "Device ${i + 1}" }),
+                powerState = powerState(extras = extraDevices.map { it to powerInfo() }),
+                themeColors = null,
+                maxRows = 3,
+            )
+        }
+        // 6 devices total (self + 5), maxRows=3 → 2 visible + 1 overflow row.
+        onNode(hasText("Device 1")).assertExists()
+        onNode(hasText("Device 2")).assertExists()
+        onNode(hasText("Device 3")).assertDoesNotExist()
+        onNode(hasText(context.getString(CommonR.string.widget_more_items, 4))).assertExists()
+    }
+
+    @Test
+    fun `maxRows=1 with overflow uses the only slot for the indicator`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val extras = listOf(
+            DeviceId("a") to "Alpha",
+            DeviceId("b") to "Bravo",
+        )
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(extras = extras),
+                powerState = powerState(extras = extras.map { (id, _) -> id to powerInfo() }),
+                themeColors = null,
+                maxRows = 1,
+            )
+        }
+        // 3 devices total, maxRows=1 → 0 visible + overflow taking the only slot.
+        onNode(hasText("MyPhone")).assertDoesNotExist()
+        onNode(hasText("Alpha")).assertDoesNotExist()
+        onNode(hasText(context.getString(CommonR.string.widget_more_items, 3))).assertExists()
+    }
+
+    @Test
+    fun `filter with unknown id renders the empty state`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(),
+                powerState = powerState(),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf("unknown-device-id"),
+            )
+        }
+        onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertExists()
+        onNode(hasText("MyPhone")).assertDoesNotExist()
+    }
+
+    @Test
+    fun `unfiltered empty state renders no-sync-devices label`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = BaseModuleRepo.State<MetaInfo>(moduleId = metaModuleId, self = null),
+                powerState = BaseModuleRepo.State<PowerInfo>(moduleId = powerModuleId, self = null),
+                themeColors = null,
+                maxRows = 5,
+            )
+        }
+        onNode(hasText(context.getString(CommonR.string.widget_no_sync_devices_label))).assertExists()
+    }
+}


### PR DESCRIPTION
## Summary

Top of the stack on #304 → #303 → #302 → #301 → #299. This was the deferred follow-up flagged at the end of #303 — modules-clipboard had `glance-testing` infra and a render test class, but modules-power and modules-connectivity didn't.

Adds the testing dependencies and parallel test classes for both:

- `modules-power/build.gradle.kts` + `modules-connectivity/build.gradle.kts` — add `androidx.glance:glance-appwidget-testing`, `androidx.glance:glance-testing`, and `org.robolectric:robolectric` as `testImplementation`, mirroring the existing setup in `modules-clipboard`.
- **`BatteryWidgetContentGlanceTest`** (5 tests) — device row rendering (label + percent), overflow indicator for `total > maxRows`, single-slot overflow edge case (`maxRows=1` with multiple devices uses the slot for the indicator), filtered-empty-state, unfiltered no-sync-devices empty state.
- **`NetworkWidgetContentGlanceTest`** (6 tests) — two-column tile rendering (label + local/public IPs), compact-row rendering (combined IP string), wide-short fallback to compact (the 220×50dp regression case from #299/#304), overflow indicator, single-slot overflow, filtered-empty-state.

All tests use `runGlanceAppWidgetUnitTest { provideComposable { … } }` with `onNode(hasText(…))` assertions — same pattern as the existing `ClipboardWidgetContentGlanceTest`.

## Test plan

- [x] `:modules-power:testFossDebugUnitTest --tests "BatteryWidgetContentGlanceTest"` — 5/5 pass.
- [x] `:modules-connectivity:testFossDebugUnitTest --tests "NetworkWidgetContentGlanceTest"` — 6/6 pass.
- [x] Full widget module test suite (`:modules-power:` `:modules-clipboard:` `:modules-connectivity:testFossDebugUnitTest`) — all pass.
- [x] `:app:assembleFossDebug` — pass.