### PR TITLE
Don't apply Android version checks to web and desktop peers

### DIFF
--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorIssueAggregator.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorIssueAggregator.kt
@@ -117,7 +117,7 @@ class ConnectorIssueAggregator @Inject constructor(
                 }
 
                 val version = device.version
-                if (version != null && VersionCompat.isOutdated(version)) {
+                if (device.usesAndroidReleaseVersioning && version != null && VersionCompat.isOutdated(version)) {
                     add(
                         CommonIssue.OutdatedVersion(
                             connectorId = connector.identifier,

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
@@ -25,3 +25,14 @@ data class DeviceMetadata(
 
 val SyncConnectorState.knownDevices: Set<DeviceId>
     get() = deviceMetadata.map { it.deviceId }.toSet()
+
+/**
+ * True if the peer's [DeviceMetadata.version] is comparable to Octi Android's release numbers.
+ *
+ * Non-Android clients (web, desktop) have independent release trains, so comparing their version
+ * strings against Android-specific gates like MIN_COMPATIBLE_VERSION or MIN_GCM_SIV_CLIENT_VERSION
+ * is meaningless. `null` is treated as Android for backward compatibility with pre-`platform`
+ * Android clients (see CrossVersionLegacyServerTest for the v0.8.1 case).
+ */
+val DeviceMetadata.usesAndroidReleaseVersioning: Boolean
+    get() = platform == null || platform.equals("android", ignoreCase = true)

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorIssueAggregatorTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorIssueAggregatorTest.kt
@@ -195,4 +195,101 @@ class ConnectorIssueAggregatorTest : BaseTest() {
         val b = CommonIssue.LowStorage(connectorId = connectorA, deviceId = deviceId)
         a shouldBe b
     }
+
+    private fun stateWithPeer(peer: DeviceMetadata): SyncConnectorState = mockk(relaxed = true) {
+        every { issues } returns emptyList()
+        every { deviceMetadata } returns listOf(peer)
+        every { isAvailable } returns true
+    }
+
+    @Test
+    fun `OutdatedVersion emitted for Android peer below MIN_COMPATIBLE_VERSION`() = runTest2 {
+        val peer = DeviceMetadata(
+            deviceId = DeviceId("peer-android-old"),
+            version = "0.10.0",
+            platform = "android",
+        )
+        val aggregator = createAggregator(
+            scope = backgroundScope,
+            connectors = listOf(connector(connectorA)),
+            states = listOf(stateWithPeer(peer)),
+        )
+
+        aggregator.issues.first() shouldContain CommonIssue.OutdatedVersion(
+            connectorId = connectorA,
+            deviceId = peer.deviceId,
+            version = "0.10.0",
+        )
+    }
+
+    @Test
+    fun `OutdatedVersion emitted for legacy Android peer with null platform`() = runTest2 {
+        // Pre-`platform`-field Android clients (v0.8.1 era per CrossVersionLegacyServerTest)
+        // report platform=null. Treat them as Android so the existing gate still warns.
+        val peer = DeviceMetadata(
+            deviceId = DeviceId("peer-android-legacy"),
+            version = "0.10.0",
+            platform = null,
+        )
+        val aggregator = createAggregator(
+            scope = backgroundScope,
+            connectors = listOf(connector(connectorA)),
+            states = listOf(stateWithPeer(peer)),
+        )
+
+        aggregator.issues.first()
+            .filterIsInstance<CommonIssue.OutdatedVersion>()
+            .map { it.deviceId } shouldContain peer.deviceId
+    }
+
+    @Test
+    fun `OutdatedVersion not emitted for web peer with garbage version`() = runTest2 {
+        // The headline fix: 'octi-web/0.0.0' must NOT trip the Android-version gate.
+        val peer = DeviceMetadata(
+            deviceId = DeviceId("peer-web"),
+            version = "octi-web/0.0.0",
+            platform = "web",
+        )
+        val aggregator = createAggregator(
+            scope = backgroundScope,
+            connectors = listOf(connector(connectorA)),
+            states = listOf(stateWithPeer(peer)),
+        )
+
+        aggregator.issues.first().filterIsInstance<CommonIssue.OutdatedVersion>().shouldBeEmpty()
+    }
+
+    @Test
+    fun `OutdatedVersion not emitted for desktop peer even with parseable low semver`() = runTest2 {
+        // Conceptual fix: desktop has an independent release train, so '0.0.0' on desktop
+        // doesn't mean 'older than Android 0.14.0'.
+        val peer = DeviceMetadata(
+            deviceId = DeviceId("peer-desktop"),
+            version = "0.0.0",
+            platform = "desktop",
+        )
+        val aggregator = createAggregator(
+            scope = backgroundScope,
+            connectors = listOf(connector(connectorA)),
+            states = listOf(stateWithPeer(peer)),
+        )
+
+        aggregator.issues.first().filterIsInstance<CommonIssue.OutdatedVersion>().shouldBeEmpty()
+    }
+
+    @Test
+    fun `OutdatedVersion not emitted for Android peer at or above MIN_COMPATIBLE_VERSION`() = runTest2 {
+        val peer = DeviceMetadata(
+            deviceId = DeviceId("peer-android-current"),
+            version = "0.14.0",
+            platform = "android",
+        )
+        val aggregator = createAggregator(
+            scope = backgroundScope,
+            connectors = listOf(connector(connectorA)),
+            states = listOf(stateWithPeer(peer)),
+        )
+
+        aggregator.issues.first().filterIsInstance<CommonIssue.OutdatedVersion>().shouldBeEmpty()
+    }
 }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/DeviceMetadataTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/DeviceMetadataTest.kt
@@ -1,0 +1,37 @@
+package eu.darken.octi.sync.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DeviceMetadataTest : BaseTest() {
+
+    private fun meta(platform: String?) = DeviceMetadata(
+        deviceId = DeviceId("test"),
+        platform = platform,
+    )
+
+    @Test
+    fun `null platform is treated as Android for backward compat`() {
+        meta(null).usesAndroidReleaseVersioning shouldBe true
+    }
+
+    @Test
+    fun `lowercase android is Android`() {
+        meta("android").usesAndroidReleaseVersioning shouldBe true
+    }
+
+    @Test
+    fun `platform check is case-insensitive`() {
+        meta("Android").usesAndroidReleaseVersioning shouldBe true
+        meta("ANDROID").usesAndroidReleaseVersioning shouldBe true
+    }
+
+    @Test
+    fun `non-Android platforms are not Android`() {
+        meta("web").usesAndroidReleaseVersioning shouldBe false
+        meta("desktop").usesAndroidReleaseVersioning shouldBe false
+        meta("ios").usesAndroidReleaseVersioning shouldBe false
+        meta("").usesAndroidReleaseVersioning shouldBe false
+    }
+}

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -43,7 +43,6 @@ import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.SyncWrite
 import eu.darken.octi.sync.core.SyncWriteContainer
-import eu.darken.octi.sync.core.VersionCompat
 import eu.darken.octi.sync.core.cache.SyncCache
 import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
@@ -431,44 +430,24 @@ class OctiServerConnector @AssistedInject constructor(
     private fun buildLegacyEncryptionIssues(
         metadata: List<DeviceMetadata>,
         isGcmSiv: Boolean,
-    ): List<ConnectorIssue> {
-        if (isGcmSiv) return emptyList()
-        return metadata.mapNotNull { device ->
-            if (!VersionCompat.isAtLeast(device.version, OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION)) {
-                return@mapNotNull null
-            }
-
-            OctiServerIssue.LegacyEncryptionAccount(
-                connectorId = identifier,
-                deviceId = device.deviceId,
-            )
-        }
-    }
+    ): List<ConnectorIssue> = OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+        connectorId = identifier,
+        metadata = metadata,
+        isGcmSiv = isGcmSiv,
+    )
 
     private fun buildEncryptionCompatibilityIssues(
         metadata: List<DeviceMetadata>,
         dataDeviceIds: Set<DeviceId>,
-    ): List<ConnectorIssue> {
-        val minClientVersion = OctiServerEncryptionCompat.expectedMinClientVersion(credentials.encryptionKeyset)
-            ?: return emptyList()
-        return metadata.mapNotNull { device ->
-            if (device.deviceId == syncSettings.deviceId) return@mapNotNull null
-
-            val version = device.version
-            val knownTooOld = version != null && !VersionCompat.isAtLeast(version, minClientVersion)
-            val unknownAndNotSyncing = version == null &&
-                device.deviceId !in dataDeviceIds &&
-                device.addedAt?.let { (Clock.System.now() - it) >= SyncSettings.FIRST_SYNC_GRACE_PERIOD } == true
-
-            if (!knownTooOld && !unknownAndNotSyncing) return@mapNotNull null
-
-            OctiServerIssue.EncryptionCompatibilityIncompatible(
-                connectorId = identifier,
-                deviceId = device.deviceId,
-                minClientVersion = minClientVersion,
-            )
-        }
-    }
+    ): List<ConnectorIssue> = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+        connectorId = identifier,
+        ownDeviceId = syncSettings.deviceId,
+        keyset = credentials.encryptionKeyset,
+        metadata = metadata,
+        dataDeviceIds = dataDeviceIds,
+        now = Clock.System.now(),
+        gracePeriod = SyncSettings.FIRST_SYNC_GRACE_PERIOD,
+    )
 
     private suspend fun buildCurrentDeviceRegistrationIssues(): List<ConnectorIssue> {
         val isUnknownDevicePause = syncSettings.pauseReason(identifier) == ConnectorPauseReason.AuthIssue

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssues.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssues.kt
@@ -1,0 +1,70 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.ConnectorIssue
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import eu.darken.octi.sync.core.VersionCompat
+import eu.darken.octi.sync.core.encryption.PayloadEncryption
+import eu.darken.octi.sync.core.usesAndroidReleaseVersioning
+import kotlin.time.Duration
+import kotlin.time.Instant
+
+/**
+ * Pure helpers for computing OctiServer encryption-related connector issues.
+ *
+ * Extracted from OctiServerConnector so the logic is unit-testable without spinning up the
+ * whole connector. All inputs are passed explicitly; the only static dependencies are the
+ * platform-agnostic VersionCompat and OctiServerEncryptionCompat tables.
+ */
+internal object OctiServerEncryptionIssues {
+
+    fun buildLegacyEncryptionIssues(
+        connectorId: ConnectorId,
+        metadata: List<DeviceMetadata>,
+        isGcmSiv: Boolean,
+    ): List<ConnectorIssue> {
+        if (isGcmSiv) return emptyList()
+        return metadata.mapNotNull { device ->
+            if (!device.usesAndroidReleaseVersioning) return@mapNotNull null
+            if (!VersionCompat.isAtLeast(device.version, OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION)) {
+                return@mapNotNull null
+            }
+            OctiServerIssue.LegacyEncryptionAccount(
+                connectorId = connectorId,
+                deviceId = device.deviceId,
+            )
+        }
+    }
+
+    fun buildEncryptionCompatibilityIssues(
+        connectorId: ConnectorId,
+        ownDeviceId: DeviceId,
+        keyset: PayloadEncryption.KeySet,
+        metadata: List<DeviceMetadata>,
+        dataDeviceIds: Set<DeviceId>,
+        now: Instant,
+        gracePeriod: Duration,
+    ): List<ConnectorIssue> {
+        val minClientVersion = OctiServerEncryptionCompat.expectedMinClientVersion(keyset)
+            ?: return emptyList()
+        return metadata.mapNotNull { device ->
+            if (device.deviceId == ownDeviceId) return@mapNotNull null
+            if (!device.usesAndroidReleaseVersioning) return@mapNotNull null
+
+            val version = device.version
+            val knownTooOld = version != null && !VersionCompat.isAtLeast(version, minClientVersion)
+            val unknownAndNotSyncing = version == null &&
+                device.deviceId !in dataDeviceIds &&
+                device.addedAt?.let { (now - it) >= gracePeriod } == true
+
+            if (!knownTooOld && !unknownAndNotSyncing) return@mapNotNull null
+
+            OctiServerIssue.EncryptionCompatibilityIncompatible(
+                connectorId = connectorId,
+                deviceId = device.deviceId,
+                minClientVersion = minClientVersion,
+            )
+        }
+    }
+}

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssuesTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssuesTest.kt
@@ -1,0 +1,248 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.encryption.EncryptionMode
+import eu.darken.octi.sync.core.encryption.PayloadEncryption
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+
+class OctiServerEncryptionIssuesTest : BaseTest() {
+
+    private val connectorId = ConnectorId(ConnectorType.OCTISERVER, "host", "acc")
+    private val ownDeviceId = DeviceId("self")
+    private val gracePeriod = SyncSettings.FIRST_SYNC_GRACE_PERIOD
+    private val now = Clock.System.now()
+
+    private val gcmSivKeyset = PayloadEncryption.KeySet(
+        type = EncryptionMode.AES256_GCM_SIV.typeString,
+        key = "dummy".encodeUtf8(),
+    )
+    private val sivKeyset = PayloadEncryption.KeySet(
+        type = EncryptionMode.AES256_SIV.typeString,
+        key = "dummy".encodeUtf8(),
+    )
+
+    private fun peer(
+        id: String = "peer",
+        version: String? = null,
+        platform: String? = "android",
+        addedAt: kotlin.time.Instant? = now - 1.minutes,
+    ) = DeviceMetadata(
+        deviceId = DeviceId(id),
+        version = version,
+        platform = platform,
+        addedAt = addedAt,
+    )
+
+    @Nested
+    inner class EncryptionCompatibility {
+
+        @Test
+        fun `flagged when Android peer has known too-old version`() {
+            val p = peer(version = "0.14.0", platform = "android")
+            val issues = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            )
+            issues shouldContainExactly listOf(
+                OctiServerIssue.EncryptionCompatibilityIncompatible(
+                    connectorId = connectorId,
+                    deviceId = p.deviceId,
+                    minClientVersion = OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION,
+                ),
+            )
+        }
+
+        @Test
+        fun `not flagged when Android peer is at min version`() {
+            val p = peer(version = "1.0.0", platform = "android")
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `flagged when Android peer has null version, past grace, not syncing`() {
+            // Preserves the legacy-Android heuristic: old client that hasn't yet upgraded
+            // to a version-reporting build.
+            val p = peer(version = null, platform = "android", addedAt = now - gracePeriod - 1.minutes)
+            val issues = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            )
+            issues.shouldNotBeEmpty()
+        }
+
+        @Test
+        fun `not flagged when Android peer has null version within grace`() {
+            val p = peer(version = null, platform = "android", addedAt = now - 1.minutes)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `headline fix - web peer with garbage version never flagged`() {
+            val p = peer(version = "octi-web/0.0.0", platform = "web", addedAt = now - gracePeriod - 1.minutes)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `conceptual fix - desktop peer with parseable low semver never flagged`() {
+            val p = peer(version = "0.0.0", platform = "desktop", addedAt = now - gracePeriod - 1.minutes)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `non-Android peer with null version is also never flagged`() {
+            val p = peer(version = null, platform = "web", addedAt = now - gracePeriod - 1.minutes)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `own device is never flagged`() {
+            val p = peer(id = ownDeviceId.id, version = "0.5.0", platform = "android")
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `legacy keyset returns empty (no min version applies)`() {
+            val p = peer(version = "0.5.0", platform = "android")
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = sivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+    }
+
+    @Nested
+    inner class LegacyEncryption {
+
+        @Test
+        fun `flagged when Android peer is at GCM-SIV-capable version on legacy account`() {
+            val p = peer(version = "1.0.0", platform = "android")
+            val issues = OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+                connectorId = connectorId,
+                metadata = listOf(p),
+                isGcmSiv = false,
+            )
+            issues shouldContainExactly listOf(
+                OctiServerIssue.LegacyEncryptionAccount(
+                    connectorId = connectorId,
+                    deviceId = p.deviceId,
+                ),
+            )
+        }
+
+        @Test
+        fun `not flagged when account is already GCM-SIV`() {
+            val p = peer(version = "1.0.0", platform = "android")
+            OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+                connectorId = connectorId,
+                metadata = listOf(p),
+                isGcmSiv = true,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `not flagged when Android peer is below GCM-SIV-capable version`() {
+            val p = peer(version = "0.14.0", platform = "android")
+            OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+                connectorId = connectorId,
+                metadata = listOf(p),
+                isGcmSiv = false,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `not flagged for web peer regardless of version`() {
+            // Conceptual fix: web release numbers don't predict Android capability.
+            val p = peer(version = "2.0.0", platform = "web")
+            OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+                connectorId = connectorId,
+                metadata = listOf(p),
+                isGcmSiv = false,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `not flagged for desktop peer regardless of version`() {
+            val p = peer(version = "5.0.0", platform = "desktop")
+            OctiServerEncryptionIssues.buildLegacyEncryptionIssues(
+                connectorId = connectorId,
+                metadata = listOf(p),
+                isGcmSiv = false,
+            ).shouldBeEmpty()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The "running outdated version" and "this account requires Octi X.Y.Z or newer (encryption)" warnings compare a peer's reported version against Octi *Android's* release numbers. Web and desktop clients have their own, independent release trains — applying Android version gates to them is meaningless.

This was triggering live: the web client reports `octi-web/0.0.0`, which the version parser silently coerces to `[0, 0, 0]` and flags the peer as "too old to use the modern encryption". Even with a clean semver, the comparison would still be wrong across release trains.

## Changes

- Gate `OutdatedVersion`, `EncryptionCompatibilityIncompatible`, and `LegacyEncryptionAccount` on `DeviceMetadata.platform` — only emit them for Android peers.
- `platform == null` is still treated as Android, so the existing grace-period heuristic for pre-`platform`-field legacy clients (see `CrossVersionLegacyServerTest`) is preserved.
- Extract the OctiServer encryption-issue builders into `OctiServerEncryptionIssues` so the logic is unit-testable without spinning up the connector.

## Test plan

- [x] `./gradlew :sync-core:testDebugUnitTest` — new `DeviceMetadataTest` and `ConnectorIssueAggregatorTest` cases (web/desktop peers no longer flagged; Android peers below `MIN_COMPATIBLE_VERSION` still flagged).
- [x] `./gradlew :syncs-octiserver:testDebugUnitTest` — new `OctiServerEncryptionIssuesTest` covers both `buildLegacyEncryptionIssues` and `buildEncryptionCompatibilityIssues` against Android / web / desktop / legacy-null-platform peers.
- [ ] Manual: web peer in an OctiServer account no longer shows "This account requires Octi 1.0.0 or newer".
- [ ] Manual sanity: an Android peer below `0.14.0` *still* shows "Running outdated version"; an Android peer below `1.0.0` on a GCM-SIV account *still* shows the encryption incompatibility warning.

## Out of scope

- The web client should still stop sending `octi-web/0.0.0` as its `octiVersionName` (the `octi-web/` prefix belongs in `osType` / `deviceManufacturer`, not the version string). Separate repo; with this change landed, it's no longer user-visible on Android.
- Long-term, replacing the "infer capability from app version" heuristic with an explicit `MetaInfo.supportedEncryptionModes` (or `protocolVersion`) would let the checks apply uniformly across platforms. Own ticket.
