### PR TITLE
Add per-device capability tags to sync metadata

### DIFF
--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
@@ -315,7 +315,7 @@ class DeviceInfoBuilderTest : BaseTest() {
         fun `non-legacy issue with the same deviceId passes through even when blob-reachable`() {
             // Use EncryptionCompatibilityIncompatible (not CurrentDeviceNotRegistered, which
             // has its own paused-but-shown special case that would muddle this assertion).
-            val incompat = OctiServerIssue.EncryptionCompatibilityIncompatible(
+            val incompat = OctiServerIssue.EncryptionCompatibilityIncompatible.AndroidClientTooOld(
                 connectorId = connectorId,
                 deviceId = remoteDeviceId,
                 minClientVersion = "1.2.3",

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/CapabilitiesCodec.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/CapabilitiesCodec.kt
@@ -1,0 +1,116 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Shared wire-format encoder/decoder for [DeviceMetadata.capabilities]. Used by every
+ * connector that publishes or consumes capabilities so encoding and validation cannot drift.
+ *
+ * Validation limits (applied on encode AND decode):
+ *   - at most [MAX_TAGS] tags
+ *   - each tag at most [MAX_TAG_LENGTH] chars
+ *   - each tag matches [TAG_REGEX] (ASCII namespace:value form)
+ *   - header strings at most [MAX_HEADER_LENGTH] bytes
+ *
+ * Decode failures return null + WARN log (don't throw — untrusted input). Encode failures
+ * throw (local producer drift is a bug, not a runtime degradation).
+ *
+ * The encoder canonicalises ordering by sorting tags so two equivalent capability sets
+ * produce byte-identical wire output (enables stable hashing / cache comparison).
+ */
+@Singleton
+class CapabilitiesCodec @Inject constructor(
+    private val json: Json,
+) {
+
+    /** Encodes a capability set as a JSON array string suitable for an HTTP header. */
+    fun encodeToHeader(caps: Set<String>): String {
+        validateOrThrow(caps)
+        return json.encodeToString(stringListSerializer, caps.sorted())
+    }
+
+    /** Encodes a capability set as a JSON array element suitable for a request/manifest body. */
+    fun encodeToJson(caps: Set<String>): JsonElement {
+        validateOrThrow(caps)
+        return json.encodeToJsonElement(stringListSerializer, caps.sorted())
+    }
+
+    /**
+     * Decodes a server- or manifest-supplied [JsonElement]. Inspects the element BEFORE
+     * materialising into a Set so a malicious oversized array doesn't allocate. Returns
+     * null on any validation failure.
+     */
+    fun decode(element: JsonElement?): Set<String>? {
+        if (element == null || element is JsonNull) return null
+        val array = element as? JsonArray ?: run {
+            log(TAG, WARN) { "decode: not a JSON array" }
+            return null
+        }
+        if (array.size > MAX_TAGS) {
+            log(TAG, WARN) { "decode: too many tags (${array.size})" }
+            return null
+        }
+        val result = LinkedHashSet<String>(array.size.coerceAtLeast(1))
+        for (item in array) {
+            val str = (item as? JsonPrimitive)?.takeIf { it.isString }?.content ?: run {
+                log(TAG, WARN) { "decode: non-string element" }
+                return null
+            }
+            if (str.length > MAX_TAG_LENGTH || !TAG_REGEX.matches(str)) {
+                log(TAG, WARN) { "decode: invalid tag shape '$str'" }
+                return null
+            }
+            result.add(str)
+        }
+        return result
+    }
+
+    /**
+     * Convenience for the HTTP-header path. Parses the string into a JsonElement and
+     * delegates to [decode]. Enforces [MAX_HEADER_LENGTH] before parsing.
+     */
+    fun decodeFromString(value: String?): Set<String>? {
+        if (value.isNullOrBlank()) return null
+        if (value.length > MAX_HEADER_LENGTH) {
+            log(TAG, WARN) { "decode: header too long (${value.length})" }
+            return null
+        }
+        val element = try {
+            json.parseToJsonElement(value)
+        } catch (e: SerializationException) {
+            log(TAG, WARN) { "decode: malformed header JSON: ${e.message}" }
+            return null
+        }
+        return decode(element)
+    }
+
+    private fun validateOrThrow(caps: Set<String>) {
+        require(caps.size <= MAX_TAGS) { "too many tags (${caps.size}, max $MAX_TAGS)" }
+        caps.forEach {
+            require(it.length <= MAX_TAG_LENGTH && TAG_REGEX.matches(it)) {
+                "invalid tag '$it' (length/charset)"
+            }
+        }
+    }
+
+    companion object {
+        const val MAX_TAGS = 64
+        const val MAX_TAG_LENGTH = 128
+        const val MAX_HEADER_LENGTH = 4096
+        val TAG_REGEX = Regex("""[a-z][a-z0-9]*:[A-Za-z0-9._\-]+""")
+        private val TAG = logTag("Sync", "CapabilitiesCodec")
+        private val stringListSerializer = ListSerializer(String.serializer())
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/Capability.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/Capability.kt
@@ -1,0 +1,45 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.sync.core.encryption.EncryptionMode
+
+/**
+ * Central registry of capability tags for [DeviceMetadata.capabilities].
+ *
+ * Tag format: `<namespace>:<value>` (e.g. `encryption:AES256_GCM_SIV`). Each namespace
+ * has a sentinel marker `<namespace>:_reported` emitted by any producer that participates
+ * in that namespace; consumers use it to distinguish "peer doesn't speak this namespace"
+ * (unknown) from "peer speaks it and explicitly doesn't support this value" (known
+ * unsupported). Authority rules:
+ *
+ * - `caps == null` → peer reports no capabilities at all → unknown
+ * - non-null, `X:_reported` absent → namespace X unknown for this peer
+ * - non-null, `X:_reported` present, value tag absent → known unsupported
+ * - non-null, `X:_reported` present, value tag present → known supported
+ *
+ * To add a new namespace:
+ *   1. Add a `<X>_NAMESPACE_REPORTED` constant.
+ *   2. Add tag-construction helpers (`<x>(value)`).
+ *   3. Add a `supports<X>(caps, value): Boolean?` semantic helper that handles authority.
+ *   4. Update [DeviceCapabilitiesProvider] to publish the marker and value tags supported
+ *      by the local device.
+ */
+object Capability {
+
+    // --- encryption namespace ---
+
+    const val ENCRYPTION_NAMESPACE_REPORTED = "encryption:_reported"
+
+    fun encryption(mode: EncryptionMode): String = "encryption:${mode.typeString}"
+
+    /**
+     * Tri-state encryption-mode check:
+     *   - null  → caps null, OR peer doesn't participate in the encryption namespace
+     *   - true  → peer participates and reports support for [mode]
+     *   - false → peer participates and explicitly doesn't support [mode]
+     */
+    fun supportsEncryption(caps: Set<String>?, mode: EncryptionMode): Boolean? {
+        if (caps == null) return null
+        if (ENCRYPTION_NAMESPACE_REPORTED !in caps) return null
+        return encryption(mode) in caps
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceCapabilitiesProvider.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceCapabilitiesProvider.kt
@@ -1,0 +1,30 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.sync.core.encryption.CryptoCapabilities
+import eu.darken.octi.sync.core.encryption.EncryptionMode
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Computes the local device's current capability tag set, used as the value of
+ * [DeviceMetadata.capabilities] when publishing to peers via connectors.
+ *
+ * To declare a new capability namespace from the Android client: extend the buildSet
+ * block to emit the namespace's `_reported` marker plus value tags for whatever this
+ * device actually supports. See [Capability] for the authority semantics.
+ */
+@Singleton
+class DeviceCapabilitiesProvider @Inject constructor(
+    private val cryptoCapabilities: CryptoCapabilities,
+) {
+
+    fun current(): Set<String> = buildSet {
+        // Encryption namespace
+        add(Capability.ENCRYPTION_NAMESPACE_REPORTED)
+        add(Capability.encryption(EncryptionMode.AES256_SIV))
+        if (cryptoCapabilities.gcmSivAvailable) {
+            add(Capability.encryption(EncryptionMode.AES256_GCM_SIV))
+        }
+        // Future namespaces: add NAMESPACE_REPORTED + value tags here.
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/DeviceMetadata.kt
@@ -21,6 +21,22 @@ data class DeviceMetadata(
     @Serializable(with = InstantSerializer::class)
     @SerialName("addedAt")
     val addedAt: Instant? = null,
+    /**
+     * Set of feature tags this peer reports supporting. Format: `<namespace>:<value>`
+     * (e.g. `encryption:AES256_GCM_SIV`). Use the [Capability] helpers to construct/check
+     * tags rather than hand-rolling strings.
+     *
+     * Tri-state at the wrapper level:
+     *   - null      → peer doesn't report capabilities (legacy / not yet rolled out).
+     *                 Consumers fall back to other heuristics.
+     *   - non-null  → peer participates. Within each namespace, support is determined
+     *                 by the `<namespace>:_reported` marker; see [Capability].
+     *
+     * Advisory only — not signed. A hostile substrate can rewrite; real incompatibilities
+     * surface at decrypt/use time regardless. See [CapabilitiesCodec] for validation limits.
+     */
+    @SerialName("capabilities")
+    val capabilities: Set<String>? = null,
 )
 
 val SyncConnectorState.knownDevices: Set<DeviceId>

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/CapabilitiesCodecTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/CapabilitiesCodecTest.kt
@@ -1,0 +1,111 @@
+package eu.darken.octi.sync.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNull
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CapabilitiesCodecTest : BaseTest() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private val codec = CapabilitiesCodec(json)
+
+    @Test
+    fun `encodeToHeader produces canonical sorted JSON array`() {
+        val caps = setOf("encryption:AES256_SIV", "encryption:_reported", "encryption:AES256_GCM_SIV")
+        val header = codec.encodeToHeader(caps)
+        header shouldBe """["encryption:AES256_GCM_SIV","encryption:AES256_SIV","encryption:_reported"]"""
+    }
+
+    @Test
+    fun `encodeToHeader rejects oversized set`() {
+        val caps = (0 until CapabilitiesCodec.MAX_TAGS + 1).map { "ns:value$it" }.toSet()
+        shouldThrow<IllegalArgumentException> { codec.encodeToHeader(caps) }
+    }
+
+    @Test
+    fun `encodeToHeader rejects invalid tag shape`() {
+        shouldThrow<IllegalArgumentException> { codec.encodeToHeader(setOf("not a tag")) }
+        shouldThrow<IllegalArgumentException> { codec.encodeToHeader(setOf("Encryption:GCM_SIV")) } // uppercase namespace
+        shouldThrow<IllegalArgumentException> { codec.encodeToHeader(setOf("encryption:")) }
+        shouldThrow<IllegalArgumentException> { codec.encodeToHeader(setOf(":value")) }
+    }
+
+    @Test
+    fun `decodeFromString roundtrips an encoded set`() {
+        val caps = setOf("encryption:AES256_GCM_SIV", "encryption:_reported", "encryption:AES256_SIV")
+        val header = codec.encodeToHeader(caps)
+        codec.decodeFromString(header)!! shouldContainExactlyInAnyOrder caps
+    }
+
+    @Test
+    fun `decode returns null for null input`() {
+        codec.decode(null).shouldBeNull()
+        codec.decode(JsonNull).shouldBeNull()
+    }
+
+    @Test
+    fun `decode returns null for non-array element`() {
+        codec.decode(json.parseToJsonElement("\"a string\"")).shouldBeNull()
+        codec.decode(json.parseToJsonElement("{\"a\": 1}")).shouldBeNull()
+        codec.decode(json.parseToJsonElement("42")).shouldBeNull()
+    }
+
+    @Test
+    fun `decode returns null for array with non-string elements`() {
+        codec.decode(json.parseToJsonElement("""["encryption:AES256_GCM_SIV", 42]""")).shouldBeNull()
+        codec.decode(json.parseToJsonElement("""["encryption:AES256_GCM_SIV", null]""")).shouldBeNull()
+    }
+
+    @Test
+    fun `decode rejects oversized array before allocating`() {
+        val items = (0 until CapabilitiesCodec.MAX_TAGS + 1).joinToString(",") { "\"ns:value$it\"" }
+        codec.decode(json.parseToJsonElement("[$items]")).shouldBeNull()
+    }
+
+    @Test
+    fun `decode rejects tag exceeding MAX_TAG_LENGTH`() {
+        val tooLong = "encryption:" + "a".repeat(CapabilitiesCodec.MAX_TAG_LENGTH)
+        codec.decode(json.parseToJsonElement("""["$tooLong"]""")).shouldBeNull()
+    }
+
+    @Test
+    fun `decode rejects tag with bad shape`() {
+        codec.decode(json.parseToJsonElement("""["bad tag"]""")).shouldBeNull()
+        codec.decode(json.parseToJsonElement("""[":value"]""")).shouldBeNull()
+    }
+
+    @Test
+    fun `decode returns empty set for empty array`() {
+        codec.decode(json.parseToJsonElement("[]")) shouldContainExactly emptySet()
+    }
+
+    @Test
+    fun `decodeFromString returns null for blank or empty input`() {
+        codec.decodeFromString(null).shouldBeNull()
+        codec.decodeFromString("").shouldBeNull()
+        codec.decodeFromString("   ").shouldBeNull()
+    }
+
+    @Test
+    fun `decodeFromString returns null for header exceeding MAX_HEADER_LENGTH`() {
+        codec.decodeFromString("[" + "x".repeat(CapabilitiesCodec.MAX_HEADER_LENGTH + 1) + "]").shouldBeNull()
+    }
+
+    @Test
+    fun `decodeFromString returns null for malformed JSON`() {
+        codec.decodeFromString("not json").shouldBeNull()
+        codec.decodeFromString("[unclosed").shouldBeNull()
+    }
+
+    @Test
+    fun `encode of same set is deterministic across calls`() {
+        val caps = setOf("encryption:AES256_GCM_SIV", "encryption:_reported", "encryption:AES256_SIV")
+        codec.encodeToHeader(caps) shouldBe codec.encodeToHeader(caps)
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/CapabilityTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/CapabilityTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.sync.core.encryption.EncryptionMode
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CapabilityTest : BaseTest() {
+
+    @Test
+    fun `encryption tag uses EncryptionMode typeString`() {
+        Capability.encryption(EncryptionMode.AES256_GCM_SIV) shouldBe "encryption:AES256_GCM_SIV"
+        Capability.encryption(EncryptionMode.AES256_SIV) shouldBe "encryption:AES256_SIV"
+    }
+
+    @Test
+    fun `namespace marker is constant`() {
+        Capability.ENCRYPTION_NAMESPACE_REPORTED shouldBe "encryption:_reported"
+    }
+
+    @Test
+    fun `supportsEncryption returns null for null caps`() {
+        Capability.supportsEncryption(null, EncryptionMode.AES256_GCM_SIV).shouldBeNull()
+    }
+
+    @Test
+    fun `supportsEncryption returns null when namespace marker is absent`() {
+        // Other namespaces present but encryption not declared.
+        val caps = setOf("clipboard:rich")
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_GCM_SIV).shouldBeNull()
+    }
+
+    @Test
+    fun `supportsEncryption returns null even with value tag if marker is absent`() {
+        // Defensive: a producer that emits a mode tag without the marker is misbehaving.
+        // Treat as unknown so we don't accidentally trust an unreported namespace.
+        val caps = setOf("encryption:AES256_GCM_SIV")
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_GCM_SIV).shouldBeNull()
+    }
+
+    @Test
+    fun `supportsEncryption returns true when marker and value tag both present`() {
+        val caps = setOf(
+            Capability.ENCRYPTION_NAMESPACE_REPORTED,
+            Capability.encryption(EncryptionMode.AES256_GCM_SIV),
+        )
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_GCM_SIV) shouldBe true
+    }
+
+    @Test
+    fun `supportsEncryption returns false when marker present but value tag absent`() {
+        val caps = setOf(
+            Capability.ENCRYPTION_NAMESPACE_REPORTED,
+            Capability.encryption(EncryptionMode.AES256_SIV),
+        )
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_GCM_SIV) shouldBe false
+    }
+
+    @Test
+    fun `supportsEncryption distinguishes per-mode`() {
+        val caps = setOf(
+            Capability.ENCRYPTION_NAMESPACE_REPORTED,
+            Capability.encryption(EncryptionMode.AES256_SIV),
+        )
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_SIV) shouldBe true
+        Capability.supportsEncryption(caps, EncryptionMode.AES256_GCM_SIV) shouldBe false
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadataSerializationTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/cache/CachedConnectorDeviceMetadataSerializationTest.kt
@@ -80,4 +80,36 @@ class CachedConnectorDeviceMetadataSerializationTest : BaseTest() {
         val decoded = json.decodeFromString<CachedConnectorDeviceMetadata>(futureJson)
         decoded.devices shouldBe emptyList()
     }
+
+    @Test
+    fun `round-trips when capabilities are populated`() {
+        val withCaps = fullCache.copy(
+            devices = fullCache.devices.map {
+                it.copy(capabilities = setOf("encryption:_reported", "encryption:AES256_GCM_SIV"))
+            },
+        )
+        val encoded = json.encodeToString(withCaps)
+        val decoded = json.decodeFromString<CachedConnectorDeviceMetadata>(encoded)
+        decoded shouldBe withCaps
+    }
+
+    @Test
+    fun `backward compatibility - legacy cache without capabilities field decodes`() {
+        val legacyJson = """
+            {
+                "schemaVersion": 1,
+                "connectorId": {"type": "kserver", "subtype": "prod", "account": "acc-123"},
+                "cachedAt": "2026-05-02T10:15:30Z",
+                "devices": [
+                    {
+                        "deviceId": {"id": "device-abc"},
+                        "version": "1.2.3",
+                        "platform": "android"
+                    }
+                ]
+            }
+        """
+        val decoded = json.decodeFromString<CachedConnectorDeviceMetadata>(legacyJson)
+        decoded.devices.single().capabilities shouldBe null
+    }
 }

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -20,6 +20,7 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.DynamicStateFlow
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.ConnectorCapabilities
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorId
@@ -27,6 +28,7 @@ import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorOperation
 import eu.darken.octi.sync.core.ConnectorProcessor
 import eu.darken.octi.sync.core.ConnectorSyncState
+import eu.darken.octi.sync.core.DeviceCapabilitiesProvider
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceRemovalPolicy
 import eu.darken.octi.common.BuildConfigWrap
@@ -94,6 +96,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
     private val syncState: ConnectorSyncState,
     private val syncCache: SyncCache,
     private val json: Json,
+    private val capabilitiesProvider: DeviceCapabilitiesProvider,
+    private val capabilitiesCodec: CapabilitiesCodec,
 ) : GDriveBaseConnector(dispatcherProvider, context, account), SyncConnector {
 
     data class State(
@@ -536,6 +540,14 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 val lastSeen = index.children(dir)
                     .filter { it.name != DEVICE_INFO_FILE && !it.isDirectory }
                     .maxOfOrNull { Instant.fromEpochMilliseconds(it.modifiedTime.value) }
+                val capabilities = info?.capabilities?.let {
+                    try {
+                        capabilitiesCodec.decode(it)
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "readDeviceMetadata(): capabilities decode failed for ${dir.name}: ${e.message}" }
+                        null
+                    }
+                }
                 DeviceMetadata(
                     deviceId = deviceId,
                     version = info?.version,
@@ -543,6 +555,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     label = info?.label,
                     lastSeen = lastSeen,
                     addedAt = dir.createdTime?.let { Instant.fromEpochMilliseconds(it.value) },
+                    capabilities = capabilities,
                 )
             }
         }.awaitAll()
@@ -939,10 +952,17 @@ class GDriveAppDataConnector @AssistedInject constructor(
 
         // Write device info metadata only when changed
         try {
+            val capsJson = try {
+                capabilitiesCodec.encodeToJson(capabilitiesProvider.current())
+            } catch (e: Exception) {
+                log(TAG, WARN) { "writeDrive(): capability encode failed: ${e.message}" }
+                null
+            }
             val deviceInfo = GDriveDeviceInfo(
                 version = deviceInfoVersionName(),
                 platform = "android",
                 label = syncSettings.deviceLabel.value(),
+                capabilities = capsJson,
             )
             if (deviceInfo != lastWrittenDeviceInfo) {
                 val infoPayload = json.encodeToString(deviceInfo).encodeToByteArray().toByteString()

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveDeviceInfo.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveDeviceInfo.kt
@@ -2,10 +2,17 @@ package eu.darken.octi.syncs.gdrive.core
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class GDriveDeviceInfo(
     @SerialName("version") val version: String? = null,
     @SerialName("platform") val platform: String? = null,
     @SerialName("label") val label: String? = null,
+    /**
+     * Per-device capability tag set. Stored as raw [JsonElement] so a malformed value on
+     * one device's manifest doesn't tank the whole `_device.json` decode. Mapped through
+     * [eu.darken.octi.sync.core.CapabilitiesCodec.decode] at the boundary.
+     */
+    @SerialName("capabilities") val capabilities: JsonElement? = null,
 )

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -13,10 +13,13 @@ import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.BlobKey
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.ConnectorCommand
 import eu.darken.octi.sync.core.ConnectorSyncState
+import eu.darken.octi.sync.core.DeviceCapabilitiesProvider
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceMetadata
+import eu.darken.octi.sync.core.encryption.CryptoCapabilities
 import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncOptions
 import eu.darken.octi.sync.core.SyncSettings
@@ -123,6 +126,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         )
         val cache = syncCache ?: SyncCache(json, testDispatcher, context)
 
+        val capabilitiesCodec = CapabilitiesCodec(json)
         val connector = GDriveAppDataConnector(
             account = testAccount,
             initialDeviceMetadata = initialDeviceMetadata,
@@ -135,6 +139,10 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             syncState = ConnectorSyncState(),
             syncCache = cache,
             json = json,
+            capabilitiesProvider = DeviceCapabilitiesProvider(
+                object : CryptoCapabilities { override val gcmSivAvailable: Boolean = true },
+            ),
+            capabilitiesCodec = capabilitiesCodec,
         )
 
         // Inject mock Drive via reflection, bypassing GDriveBaseConnector's lazy init

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderInterceptor.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderInterceptor.kt
@@ -1,20 +1,21 @@
 package eu.darken.octi.syncs.octiserver.core
 
-import android.os.Build
 import dagger.Reusable
-import eu.darken.octi.common.BuildConfigWrap
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
 
 @Reusable
-class DeviceHeaderInterceptor @Inject constructor() : Interceptor {
+class DeviceHeaderInterceptor @Inject constructor(
+    private val values: DeviceHeaderValuesProvider,
+) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request().newBuilder().apply {
-            header("Octi-Device-Version", BuildConfigWrap.VERSION_NAME)
-            header("Octi-Device-Platform", "android")
-            header("Octi-Device-Label", Build.MODEL.replace(Regex("[^\\x20-\\x7E]"), "").take(128))
+            header("Octi-Device-Version", values.version())
+            header("Octi-Device-Platform", values.platform())
+            header("Octi-Device-Label", values.label())
+            header("Octi-Device-Capabilities", values.capabilitiesHeader())
         }.build()
         return chain.proceed(request)
     }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderValuesProvider.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderValuesProvider.kt
@@ -1,0 +1,35 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import android.os.Build
+import eu.darken.octi.common.BuildConfigWrap
+import eu.darken.octi.sync.core.CapabilitiesCodec
+import eu.darken.octi.sync.core.DeviceCapabilitiesProvider
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Computes the values for the `Octi-Device-*` HTTP headers sent by [DeviceHeaderInterceptor].
+ *
+ * Pulled out of the interceptor so the values can be unit-tested on the JVM (the interceptor
+ * itself reads [Build.MODEL] which is unmocked off-device). Tests inject a fake instance of
+ * this provider; the interceptor logic is then trivially correct.
+ */
+@Singleton
+class DeviceHeaderValuesProvider @Inject constructor(
+    private val capabilitiesProvider: DeviceCapabilitiesProvider,
+    private val capabilitiesCodec: CapabilitiesCodec,
+) {
+
+    fun version(): String = BuildConfigWrap.VERSION_NAME
+
+    fun platform(): String = PLATFORM_ANDROID
+
+    fun label(): String = Build.MODEL.replace(NON_PRINTABLE_ASCII, "").take(128)
+
+    fun capabilitiesHeader(): String = capabilitiesCodec.encodeToHeader(capabilitiesProvider.current())
+
+    companion object {
+        const val PLATFORM_ANDROID = "android"
+        private val NON_PRINTABLE_ASCII = Regex("[^\\x20-\\x7E]")
+    }
+}

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerApi.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerApi.kt
@@ -4,6 +4,7 @@ import eu.darken.octi.common.serialization.serializer.InstantSerializer
 import eu.darken.octi.sync.core.DeviceId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -59,6 +60,12 @@ interface OctiServerApi {
             @SerialName("label") val label: String? = null,
             @SerialName("addedAt") @Serializable(with = InstantSerializer::class) val addedAt: Instant? = null,
             @SerialName("lastSeen") @Serializable(with = InstantSerializer::class) val lastSeen: Instant? = null,
+            /**
+             * Per-peer capability tag set. Stored as raw JsonElement so a malformed value
+             * on one device doesn't tank the whole response decode. Mapped through
+             * [eu.darken.octi.sync.core.CapabilitiesCodec.decode] at the boundary.
+             */
+            @SerialName("capabilities") val capabilities: JsonElement? = null,
         )
     }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -308,6 +308,7 @@ class OctiServerConnector @AssistedInject constructor(
                         label = it.label,
                         lastSeen = it.lastSeen,
                         addedAt = it.addedAt,
+                        capabilities = it.capabilities,
                     )
                 }
                 updateDeviceMetadata(metadata)

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssues.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssues.kt
@@ -1,10 +1,12 @@
 package eu.darken.octi.syncs.octiserver.core
 
+import eu.darken.octi.sync.core.Capability
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceMetadata
 import eu.darken.octi.sync.core.VersionCompat
+import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import eu.darken.octi.sync.core.usesAndroidReleaseVersioning
 import kotlin.time.Duration
@@ -18,6 +20,46 @@ import kotlin.time.Instant
  * platform-agnostic VersionCompat and OctiServerEncryptionCompat tables.
  */
 internal object OctiServerEncryptionIssues {
+
+    /**
+     * Tri-valued classification of a peer's support for an encryption mode. Carries the
+     * *reason* alongside the verdict so the caller can pick the right user-facing issue
+     * variant (capability-mode vs Android-version remedy).
+     */
+    sealed interface PeerSupport {
+        object Supported : PeerSupport
+        object UnsupportedByCapabilities : PeerSupport
+        data class UnsupportedByAndroidVersion(val minVersion: String) : PeerSupport
+        object Unknown : PeerSupport
+    }
+
+    /**
+     * Determines whether [peer] supports encryption [mode].
+     *
+     * Capability check is primary: if the peer publishes explicit capabilities, that
+     * verdict wins regardless of platform or version. Otherwise we fall back to the
+     * Android-version heuristic, which only applies to Android peers and only the GCM-SIV
+     * gate (SIV has no minimum Android version — every Android client could read SIV).
+     */
+    fun peerSupports(peer: DeviceMetadata, mode: EncryptionMode): PeerSupport {
+        when (Capability.supportsEncryption(peer.capabilities, mode)) {
+            true -> return PeerSupport.Supported
+            false -> return PeerSupport.UnsupportedByCapabilities
+            null -> Unit  // capabilities unknown for this namespace; fall through to version fallback
+        }
+        if (!peer.usesAndroidReleaseVersioning) return PeerSupport.Unknown
+        return when (mode) {
+            EncryptionMode.AES256_GCM_SIV ->
+                if (VersionCompat.isAtLeast(peer.version, OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION)) {
+                    PeerSupport.Supported
+                } else if (peer.version != null) {
+                    PeerSupport.UnsupportedByAndroidVersion(OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION)
+                } else {
+                    PeerSupport.Unknown
+                }
+            EncryptionMode.AES256_SIV -> PeerSupport.Supported
+        }
+    }
 
     fun buildLegacyEncryptionIssues(
         connectorId: ConnectorId,
@@ -46,25 +88,46 @@ internal object OctiServerEncryptionIssues {
         now: Instant,
         gracePeriod: Duration,
     ): List<ConnectorIssue> {
-        val minClientVersion = OctiServerEncryptionCompat.expectedMinClientVersion(keyset)
-            ?: return emptyList()
+        // The required mode is whatever the account currently uses. We check capability
+        // for that mode against every peer — including SIV accounts, so a future peer
+        // that explicitly lacks SIV would be flagged. (Previously this code short-circuited
+        // on SIV accounts via expectedMinClientVersion returning null.)
+        val requiredMode = EncryptionMode.fromTypeString(keyset.type) ?: return emptyList()
         return metadata.mapNotNull { device ->
             if (device.deviceId == ownDeviceId) return@mapNotNull null
-            if (!device.usesAndroidReleaseVersioning) return@mapNotNull null
-
-            val version = device.version
-            val knownTooOld = version != null && !VersionCompat.isAtLeast(version, minClientVersion)
-            val unknownAndNotSyncing = version == null &&
-                device.deviceId !in dataDeviceIds &&
-                device.addedAt?.let { (now - it) >= gracePeriod } == true
-
-            if (!knownTooOld && !unknownAndNotSyncing) return@mapNotNull null
-
-            OctiServerIssue.EncryptionCompatibilityIncompatible(
-                connectorId = connectorId,
-                deviceId = device.deviceId,
-                minClientVersion = minClientVersion,
-            )
+            when (val support = peerSupports(device, requiredMode)) {
+                PeerSupport.Supported -> null
+                PeerSupport.UnsupportedByCapabilities ->
+                    OctiServerIssue.EncryptionCompatibilityIncompatible.UnsupportedEncryptionMode(
+                        connectorId = connectorId,
+                        deviceId = device.deviceId,
+                        requiredMode = requiredMode,
+                    )
+                is PeerSupport.UnsupportedByAndroidVersion ->
+                    OctiServerIssue.EncryptionCompatibilityIncompatible.AndroidClientTooOld(
+                        connectorId = connectorId,
+                        deviceId = device.deviceId,
+                        minClientVersion = support.minVersion,
+                    )
+                PeerSupport.Unknown -> {
+                    // Preserve PR #308's grace-period heuristic strictly for Android-shaped
+                    // peers (platform == "android" or null for v0.8.1-era legacy clients).
+                    // Non-Android peers with unknown capabilities stay unflagged — their
+                    // grace period concept doesn't apply, and version-string fallback
+                    // doesn't either.
+                    val unknownAndNotSyncing = device.capabilities == null &&
+                        device.version == null &&
+                        device.usesAndroidReleaseVersioning &&
+                        device.deviceId !in dataDeviceIds &&
+                        device.addedAt?.let { (now - it) >= gracePeriod } == true
+                    if (!unknownAndNotSyncing) null
+                    else OctiServerIssue.EncryptionCompatibilityIncompatible.AndroidClientTooOld(
+                        connectorId = connectorId,
+                        deviceId = device.deviceId,
+                        minClientVersion = OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION,
+                    )
+                }
+            }
         }
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
@@ -13,6 +13,7 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.serialization.RetrofitJson
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.encryption.CryptoCapabilities
@@ -39,6 +40,7 @@ class OctiServerEndpoint @AssistedInject constructor(
     private val basicAuthInterceptor: BasicAuthInterceptor,
     private val deviceHeaderInterceptor: DeviceHeaderInterceptor,
     private val cryptoCapabilities: CryptoCapabilities,
+    private val capabilitiesCodec: CapabilitiesCodec,
 ) {
 
     private val httpClient by lazy {
@@ -132,6 +134,7 @@ class OctiServerEndpoint @AssistedInject constructor(
         val label: String?,
         val addedAt: Instant?,
         val lastSeen: Instant?,
+        val capabilities: Set<String>?,
     )
 
     suspend fun listDevices(): Collection<LinkedDevice> = withContext(dispatcherProvider.IO) {
@@ -144,6 +147,13 @@ class OctiServerEndpoint @AssistedInject constructor(
             throw OctiServerHttpException(e)
         }
         response.devices.map {
+            // Decode per-device so one malformed capability doesn't poison the whole list.
+            val caps = try {
+                capabilitiesCodec.decode(it.capabilities)
+            } catch (e: Exception) {
+                log(TAG, WARN) { "listDevices(): capabilities decode failed for ${it.id}: ${e.message}" }
+                null
+            }
             LinkedDevice(
                 deviceId = DeviceId(it.id),
                 version = it.version,
@@ -151,6 +161,7 @@ class OctiServerEndpoint @AssistedInject constructor(
                 label = it.label,
                 addedAt = it.addedAt,
                 lastSeen = it.lastSeen,
+                capabilities = caps,
             )
         }
     }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerIssue.kt
@@ -6,6 +6,7 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.ConnectorIssue
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.IssueSeverity
+import eu.darken.octi.sync.core.encryption.EncryptionMode
 import eu.darken.octi.syncs.octiserver.R
 
 sealed interface OctiServerIssue : ConnectorIssue {
@@ -28,17 +29,49 @@ sealed interface OctiServerIssue : ConnectorIssue {
         override val description: CaString = caString { it.getString(R.string.sync_octiserver_legacy_encryption_account) }
     }
 
-    data class EncryptionCompatibilityIncompatible(
-        override val connectorId: ConnectorId,
-        override val deviceId: DeviceId,
-        val minClientVersion: String,
-    ) : OctiServerIssue {
-        override val severity: IssueSeverity = IssueSeverity.ERROR
-        override val label: CaString = caString {
-            it.getString(R.string.sync_octiserver_issues_type_encryption_compatibility)
+    sealed interface EncryptionCompatibilityIncompatible : OctiServerIssue {
+        override val connectorId: ConnectorId
+        override val deviceId: DeviceId
+
+        /**
+         * Android peer whose reported version is below the GCM-SIV-capable minimum, and
+         * which hasn't published explicit capabilities yet. The remedy is to update the
+         * Octi Android app on that device.
+         */
+        data class AndroidClientTooOld(
+            override val connectorId: ConnectorId,
+            override val deviceId: DeviceId,
+            val minClientVersion: String,
+        ) : EncryptionCompatibilityIncompatible {
+            override val severity: IssueSeverity = IssueSeverity.ERROR
+            override val label: CaString = caString {
+                it.getString(R.string.sync_octiserver_issues_type_encryption_compatibility)
+            }
+            override val description: CaString = caString {
+                it.getString(R.string.sync_octiserver_encryption_compatibility_incompatible, minClientVersion)
+            }
         }
-        override val description: CaString = caString {
-            it.getString(R.string.sync_octiserver_encryption_compatibility_incompatible, minClientVersion)
+
+        /**
+         * Any peer (Android or otherwise) that explicitly reports it doesn't support the
+         * encryption mode this account uses. The remedy is for that device's maintainer
+         * to add support — there's nothing the user can do on this device.
+         */
+        data class UnsupportedEncryptionMode(
+            override val connectorId: ConnectorId,
+            override val deviceId: DeviceId,
+            val requiredMode: EncryptionMode,
+        ) : EncryptionCompatibilityIncompatible {
+            override val severity: IssueSeverity = IssueSeverity.ERROR
+            override val label: CaString = caString {
+                it.getString(R.string.sync_octiserver_issues_type_encryption_compatibility)
+            }
+            override val description: CaString = caString {
+                it.getString(
+                    R.string.sync_octiserver_encryption_compatibility_unsupported_mode,
+                    requiredMode.typeString,
+                )
+            }
         }
     }
 }

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="sync_octiserver_add_create_account_title">Create account?</string>
     <string name="sync_octiserver_add_create_account_desc">A new encrypted sync account will be created on this server.</string>
     <string name="sync_octiserver_encryption_compatibility_incompatible">This account requires Octi %1$s or newer. Update this device or remove it from the account.</string>
+    <string name="sync_octiserver_encryption_compatibility_unsupported_mode">This device doesn\'t support the encryption mode this account uses (%1$s). Reach out to that device\'s maintainer.</string>
     <string name="sync_octiserver_legacy_encryption_account">File sharing is unavailable on this device because this account uses legacy encryption. Create a new account on an updated device and re-link your other devices to use file sharing.</string>
     <string name="sync_octiserver_issues_type_encryption_compatibility">Incompatible encryption</string>
     <string name="sync_octiserver_issues_type_legacy_encryption">File sharing unavailable</string>

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderInterceptorTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/DeviceHeaderInterceptorTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DeviceHeaderInterceptorTest : BaseTest() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun fakeValuesProvider(
+        version: String = "1.2.3",
+        platform: String = "android",
+        label: String = "Test Device",
+        capabilities: Set<String> = setOf("encryption:_reported", "encryption:AES256_SIV"),
+    ): DeviceHeaderValuesProvider = mockk(relaxed = true) {
+        every { version() } returns version
+        every { platform() } returns platform
+        every { label() } returns label
+        every { capabilitiesHeader() } returns json.encodeToString(capabilities.sorted())
+    }
+
+    private fun runInterceptor(interceptor: DeviceHeaderInterceptor): Request {
+        val original = Request.Builder().url("https://example.com/").build()
+        val captured = slot<Request>()
+        val chain = mockk<Interceptor.Chain>().also {
+            every { it.request() } returns original
+            every { it.proceed(capture(captured)) } returns Response.Builder()
+                .request(original)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200).message("OK").build()
+        }
+        interceptor.intercept(chain)
+        return captured.captured
+    }
+
+    @Test
+    fun `adds expected headers`() {
+        val interceptor = DeviceHeaderInterceptor(fakeValuesProvider())
+        val request = runInterceptor(interceptor)
+        request.header("Octi-Device-Version") shouldBe "1.2.3"
+        request.header("Octi-Device-Platform") shouldBe "android"
+        request.header("Octi-Device-Label") shouldBe "Test Device"
+    }
+
+    @Test
+    fun `capabilities header decodes to the provided set regardless of element order`() {
+        val caps = setOf(
+            "encryption:_reported",
+            "encryption:AES256_SIV",
+            "encryption:AES256_GCM_SIV",
+        )
+        val interceptor = DeviceHeaderInterceptor(fakeValuesProvider(capabilities = caps))
+        val request = runInterceptor(interceptor)
+        val headerValue = request.header("Octi-Device-Capabilities")!!
+        val decoded = json.parseToJsonElement(headerValue).jsonArray.map { it.toString().trim('"') }
+        decoded shouldContainExactlyInAnyOrder caps.toList()
+    }
+}

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssuesTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEncryptionIssuesTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.syncs.octiserver.core
 
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.Capability
 import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.DeviceMetadata
@@ -10,6 +11,7 @@ import eu.darken.octi.sync.core.encryption.PayloadEncryption
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.types.shouldBeInstanceOf
 import okio.ByteString.Companion.encodeUtf8
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -33,16 +35,28 @@ class OctiServerEncryptionIssuesTest : BaseTest() {
         key = "dummy".encodeUtf8(),
     )
 
+    private val fullCapabilities = setOf(
+        Capability.ENCRYPTION_NAMESPACE_REPORTED,
+        Capability.encryption(EncryptionMode.AES256_SIV),
+        Capability.encryption(EncryptionMode.AES256_GCM_SIV),
+    )
+    private val sivOnlyCapabilities = setOf(
+        Capability.ENCRYPTION_NAMESPACE_REPORTED,
+        Capability.encryption(EncryptionMode.AES256_SIV),
+    )
+
     private fun peer(
         id: String = "peer",
         version: String? = null,
         platform: String? = "android",
         addedAt: kotlin.time.Instant? = now - 1.minutes,
+        capabilities: Set<String>? = null,
     ) = DeviceMetadata(
         deviceId = DeviceId(id),
         version = version,
         platform = platform,
         addedAt = addedAt,
+        capabilities = capabilities,
     )
 
     @Nested
@@ -61,7 +75,7 @@ class OctiServerEncryptionIssuesTest : BaseTest() {
                 gracePeriod = gracePeriod,
             )
             issues shouldContainExactly listOf(
-                OctiServerIssue.EncryptionCompatibilityIncompatible(
+                OctiServerIssue.EncryptionCompatibilityIncompatible.AndroidClientTooOld(
                     connectorId = connectorId,
                     deviceId = p.deviceId,
                     minClientVersion = OctiServerEncryptionCompat.MIN_GCM_SIV_CLIENT_VERSION,
@@ -171,7 +185,7 @@ class OctiServerEncryptionIssuesTest : BaseTest() {
         }
 
         @Test
-        fun `legacy keyset returns empty (no min version applies)`() {
+        fun `SIV account does not flag Android peer (SIV is always supported on Android)`() {
             val p = peer(version = "0.5.0", platform = "android")
             OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
                 connectorId = connectorId,
@@ -182,6 +196,129 @@ class OctiServerEncryptionIssuesTest : BaseTest() {
                 now = now,
                 gracePeriod = gracePeriod,
             ).shouldBeEmpty()
+        }
+
+        // --- capability-based path tests ---
+
+        @Test
+        fun `peer with full capabilities is never flagged on GCM account, any platform`() {
+            val androidPeer = peer(version = "0.5.0", platform = "android", capabilities = fullCapabilities)
+            val webPeer = peer(id = "web-peer", version = "octi-web/0.0.0", platform = "web", capabilities = fullCapabilities)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(androidPeer, webPeer),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `web peer with only SIV capability is flagged as UnsupportedEncryptionMode on GCM account`() {
+            val p = peer(version = "1.0.0", platform = "web", capabilities = sivOnlyCapabilities)
+            val issues = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            )
+            issues shouldContainExactly listOf(
+                OctiServerIssue.EncryptionCompatibilityIncompatible.UnsupportedEncryptionMode(
+                    connectorId = connectorId,
+                    deviceId = p.deviceId,
+                    requiredMode = EncryptionMode.AES256_GCM_SIV,
+                ),
+            )
+        }
+
+        @Test
+        fun `peer with only namespace marker (empty value tags) is flagged as UnsupportedEncryptionMode`() {
+            val p = peer(
+                version = "1.0.0",
+                platform = "web",
+                capabilities = setOf(Capability.ENCRYPTION_NAMESPACE_REPORTED),
+            )
+            val issues = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            )
+            issues.first().shouldBeInstanceOf<OctiServerIssue.EncryptionCompatibilityIncompatible.UnsupportedEncryptionMode>()
+        }
+
+        @Test
+        fun `peer reporting tags only in unrelated namespaces is not falsely flagged`() {
+            // Per-namespace authority: peer publishes future:foo but doesn't speak the encryption
+            // namespace. Encryption support is therefore "unknown" → falls back to per-peer heuristic.
+            val p = peer(
+                version = null,
+                platform = "web",
+                capabilities = setOf("clipboard:rich"),
+            )
+            // Non-Android peer with unknown encryption + null version → no flag.
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `Android peer with old version but explicit GCM capability is not flagged`() {
+            // Capabilities win over version when both are known. Useful if a forked / dev build
+            // reports an old version but actually supports GCM-SIV.
+            val p = peer(version = "0.5.0", platform = "android", capabilities = fullCapabilities)
+            OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = gcmSivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            ).shouldBeEmpty()
+        }
+
+        @Test
+        fun `SIV account flags peer explicitly lacking SIV (no early-return on SIV)`() {
+            // Previously the SIV-keyset path short-circuited via expectedMinClientVersion returning null.
+            // With the refactor, capabilities run on SIV too — a (hypothetical) peer reporting it
+            // doesn't support SIV is correctly flagged.
+            val sivLackingCapabilities = setOf(
+                Capability.ENCRYPTION_NAMESPACE_REPORTED,
+                Capability.encryption(EncryptionMode.AES256_GCM_SIV),
+                // Note: AES256_SIV intentionally absent.
+            )
+            val p = peer(version = "1.0.0", platform = "web", capabilities = sivLackingCapabilities)
+            val issues = OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues(
+                connectorId = connectorId,
+                ownDeviceId = ownDeviceId,
+                keyset = sivKeyset,
+                metadata = listOf(p),
+                dataDeviceIds = emptySet(),
+                now = now,
+                gracePeriod = gracePeriod,
+            )
+            issues shouldContainExactly listOf(
+                OctiServerIssue.EncryptionCompatibilityIncompatible.UnsupportedEncryptionMode(
+                    connectorId = connectorId,
+                    deviceId = p.deviceId,
+                    requiredMode = EncryptionMode.AES256_SIV,
+                ),
+            )
         }
     }
 

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.syncs.octiserver.core
 
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.encryption.CryptoCapabilities
@@ -70,6 +71,7 @@ class OctiServerEndpointCreateAccountTest : BaseTest() {
             basicAuthInterceptor = basicAuthInterceptor,
             deviceHeaderInterceptor = deviceHeaderInterceptor,
             cryptoCapabilities = cryptoCapabilities,
+            capabilitiesCodec = CapabilitiesCodec(retrofitJson),
         )
     }
 

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointWriteModuleTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointWriteModuleTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.syncs.octiserver.core
 
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.encryption.CryptoCapabilities
@@ -75,6 +76,7 @@ class OctiServerEndpointWriteModuleTest : BaseTest() {
             basicAuthInterceptor = basicAuthInterceptor,
             deviceHeaderInterceptor = deviceHeaderInterceptor,
             cryptoCapabilities = cryptoCapabilities,
+            capabilitiesCodec = CapabilitiesCodec(retrofitJson),
         )
     }
 

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.syncs.octiserver.regression
 
 import eu.darken.octi.common.serialization.SerializationModule
 import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.CapabilitiesCodec
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncSettings
 import eu.darken.octi.sync.core.encryption.CryptoCapabilities
@@ -103,6 +104,7 @@ class CrossVersionLegacyServerTest : BaseTest() {
             cryptoCapabilities = object : CryptoCapabilities {
                 override val gcmSivAvailable: Boolean = true
             },
+            capabilitiesCodec = CapabilitiesCodec(SerializationModule().retrofitJson()),
         )
     }
 


### PR DESCRIPTION
## Summary

Introduces a generic per-peer capability tag set on `DeviceMetadata` so peer-side feature support can be checked without parsing the peer's app version string. Replaces the version-string heuristic in the OctiServer encryption-compatibility check; lays groundwork for any future capability that needs cross-platform negotiation.

This is speculative architectural cleanup — the *immediate* user-visible effect is limited to a more accurate warning when a non-Android peer explicitly reports it can't decrypt:

- **Before**: "This account requires Octi X.Y.Z or newer. Update this device or remove it from the account." (nonsense for a web peer that lacks GCM-SIV)
- **After**: "This device doesn't support the encryption mode this account uses (AES256_GCM_SIV). Reach out to that device's maintainer." (for non-Android peers; Android peers still get the existing string).

Sets the stage for cross-platform clients (web, desktop) to declare their feature support uniformly across sync connectors.

## Changes

**Data model (`sync-core`)**
- New `DeviceMetadata.capabilities: Set<String>?` — nullable tag set.
- `Capability` registry centralises tag construction (`Capability.encryption(mode)`) and a per-namespace authority rule: each namespace has a `<namespace>:_reported` marker so partial-rollout clients aren't falsely flagged. Tri-state semantic helpers (`Capability.supportsEncryption(caps, mode): Boolean?`).
- `CapabilitiesCodec` — shared encode/decode + validation (max 64 tags, 128 chars/tag, ASCII regex, canonical sorted ordering, JsonArray-shape-checked-before-allocation).
- `DeviceCapabilitiesProvider` — Android-side producer, currently emits `encryption:_reported` + the mode tags this device can actually use.

**OctiServer wiring**
- `DeviceHeaderInterceptor` sends a new `Octi-Device-Capabilities` HTTP header; `Build.MODEL` access extracted into `DeviceHeaderValuesProvider` for JVM testability.
- `OctiServerApi.DevicesResponse.Device.capabilities` is `JsonElement?` so one malformed device's value doesn't tank the whole `/devices` decode; per-device try/catch in `OctiServerEndpoint.listDevices()`.
- `OctiServerEncryptionIssues.buildEncryptionCompatibilityIssues` rewritten around a `PeerSupport` sealed result so the right issue variant gets emitted. Drops the SIV-account early-return so a hypothetical peer that explicitly lacks SIV is flagged correctly. Grace-period heuristic for unknown peers is preserved but now strictly Android-shaped.

**GDrive wiring**
- `GDriveDeviceInfo.capabilities` (`JsonElement?`) added; mapped through `CapabilitiesCodec.decode(...)` on read.
- `_device.json` write path extended to include capabilities (existing `lastWrittenDeviceInfo` cache means propagation is implicit on the next write-bearing sync). `syncSettings.deviceLabel.value()` preserved as the label source. Write is best-effort — failure does not break sync.

**Issue type split**
- `OctiServerIssue.EncryptionCompatibilityIncompatible` is now a sealed interface with two variants:
  - `AndroidClientTooOld(minClientVersion)` — Android peer below the GCM-SIV-capable minimum; user remedy = update Octi.
  - `UnsupportedEncryptionMode(requiredMode)` — any peer that explicitly reports unsupported encryption mode; user remedy = ask that device's maintainer.
- New string `sync_octiserver_encryption_compatibility_unsupported_mode`. Existing string unchanged.

**Untouched on purpose**
- `OutdatedVersion` (Android-only "your Octi app is old, please update" warning).
- `LegacyEncryptionAccount` (about file/blob sharing — separate concern from raw GCM-SIV decryption support).
- Local account-creation encryption-mode selection (already uses local `CryptoCapabilities.gcmSivAvailable`).

## Trust model

Capabilities live on `DeviceMetadata` (server/manifest-visible), not `MetaInfo` (E2E encrypted) — that's load-bearing for the encryption-compat check, which needs to predict decryptability *before* trying to decrypt. The trade-off is that a hostile substrate could rewrite tags to suppress a warning; real incompatibilities still surface at decrypt time. Documented in the data class KDoc.

## Phased rollout

1. **This PR (Android)**: header is sent unconditionally, GDrive manifest is populated. No-op against existing servers — they ignore the unknown header and the response field is nullable. **Forward-compatible**.
2. **OctiServer** (separate ticket, separate repo): accept/store/echo the `Octi-Device-Capabilities` header on any state-updating authenticated request (including register/link + heartbeat). Once deployed, Android peers running this code start seeing each other's capabilities authoritatively.
3. **Web/desktop clients** (separate repos): emit the same header/manifest field with their own tag set. Their capabilities then become authoritative for the encryption check, bypassing the Android-version fallback.

## Test plan

- [x] `./gradlew :sync-core:testDebugUnitTest :syncs-octiserver:testDebugUnitTest :syncs-gdrive:testDebugUnitTest :app:testFossDebugUnitTest` — all pass.
- [x] `./gradlew assembleDebug` — clean build.
- [x] New tests cover: tag construction; codec encode/decode round-trip; codec rejects oversize / bad-regex / non-string / non-array input; namespace authority semantics; encryption-issue classifier for capability-supported / -unsupported / unknown-namespace / Android-too-old / non-Android peers; cache serialization round-trips with and without capabilities; legacy cache decode (no capabilities field).
- [ ] Manual (OctiServer post-server-deploy): two Android peers see each other's capabilities; flip one device's `CryptoCapabilities.gcmSivAvailable=false` via test injection; the other shows `UnsupportedEncryptionMode`.
- [ ] Manual (GDrive): install on two devices, sync, verify both `_device.json` contain a sorted `capabilities` array; verify `label` matches the user-configured label (not `Build.MODEL`).

## Out of scope (separate work)

- Cross-platform `blob:share-v1` capability (would let `LegacyEncryptionAccount` warning cross platforms).
- Cryptographic attestation of capabilities (explicitly not a security boundary).
