### PR TITLE
Add ecosystem entry to settings menu

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
@@ -71,6 +71,9 @@ object Nav {
         data object Acknowledgements : Settings
 
         @Serializable
+        data object Ecosystem : Settings
+
+        @Serializable
         data object Modules : Settings
 
         @Serializable

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.Book
+import androidx.compose.material.icons.twotone.Devices
 import androidx.compose.material.icons.twotone.Extension
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Settings
@@ -49,6 +50,7 @@ fun SettingsIndexScreenHost(vm: SettingsIndexVM = hiltViewModel()) {
             onModuleSettings = { vm.navTo(Nav.Settings.Modules) },
             onSupport = { vm.navTo(Nav.Settings.Support) },
             onChangelog = { vm.openUrl("https://octi.darken.eu/changelog") },
+            onEcosystem = { vm.navTo(Nav.Settings.Ecosystem) },
             onHelpTranslate = { vm.openUrl("https://crowdin.com/project/octi") },
             onAcknowledgements = { vm.navTo(Nav.Settings.Acknowledgements) },
             onPrivacyPolicy = { vm.openUrl(PrivacyPolicy.URL) },
@@ -65,6 +67,7 @@ fun SettingsIndexScreen(
     onModuleSettings: () -> Unit,
     onSupport: () -> Unit,
     onChangelog: () -> Unit,
+    onEcosystem: () -> Unit,
     onHelpTranslate: () -> Unit,
     onAcknowledgements: () -> Unit,
     onPrivacyPolicy: () -> Unit,
@@ -132,6 +135,14 @@ fun SettingsIndexScreen(
             }
             item {
                 SettingsBaseItem(
+                    title = stringResource(R.string.settings_ecosystem_label),
+                    subtitle = stringResource(R.string.settings_ecosystem_desc),
+                    icon = Icons.TwoTone.Devices,
+                    onClick = onEcosystem,
+                )
+            }
+            item {
+                SettingsBaseItem(
                     title = stringResource(R.string.help_translate_label),
                     subtitle = stringResource(R.string.help_translate_description),
                     icon = Icons.TwoTone.Translate,
@@ -169,6 +180,7 @@ private fun SettingsIndexScreenPreview() = PreviewWrapper {
         onModuleSettings = {},
         onSupport = {},
         onChangelog = {},
+        onEcosystem = {},
         onHelpTranslate = {},
         onAcknowledgements = {},
         onPrivacyPolicy = {},

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemNavigation.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemNavigation.kt
@@ -1,0 +1,26 @@
+package eu.darken.octi.main.ui.settings.ecosystem
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.navigation.NavigationEntry
+import javax.inject.Inject
+
+class EcosystemNavigation @Inject constructor() : NavigationEntry {
+    override fun EntryProviderScope<NavKey>.setup() {
+        entry<Nav.Settings.Ecosystem> { EcosystemScreenHost() }
+    }
+
+    @Module
+    @InstallIn(SingletonComponent::class)
+    abstract class Mod {
+        @Binds
+        @IntoSet
+        abstract fun bind(entry: EcosystemNavigation): NavigationEntry
+    }
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Code
 import androidx.compose.material.icons.twotone.DesktopWindows
 import androidx.compose.material.icons.twotone.Dns
 import androidx.compose.material.icons.twotone.Language
@@ -72,6 +73,14 @@ fun EcosystemScreen(
                     title = stringResource(R.string.settings_ecosystem_web_label),
                     subtitle = stringResource(R.string.settings_ecosystem_web_desc),
                     icon = Icons.TwoTone.Language,
+                    onClick = { onOpenUrl("https://web.octi.darken.eu") },
+                )
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_ecosystem_web_source_label),
+                    subtitle = stringResource(R.string.settings_ecosystem_web_source_desc),
+                    icon = Icons.TwoTone.Code,
                     onClick = { onOpenUrl("https://github.com/d4rken-org/octi-web") },
                 )
             }

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemScreen.kt
@@ -1,0 +1,102 @@
+package eu.darken.octi.main.ui.settings.ecosystem
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.DesktopWindows
+import androidx.compose.material.icons.twotone.Dns
+import androidx.compose.material.icons.twotone.Language
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.error.ErrorEventHandler
+import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.common.settings.SettingsBaseItem
+
+@Composable
+fun EcosystemScreenHost(vm: EcosystemVM = hiltViewModel()) {
+    ErrorEventHandler(vm)
+    NavigationEventHandler(vm)
+
+    EcosystemScreen(
+        onNavigateUp = { vm.navUp() },
+        onOpenUrl = { url -> vm.openUrl(url) },
+    )
+}
+
+@Composable
+fun EcosystemScreen(
+    onNavigateUp: () -> Unit,
+    onOpenUrl: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(R.string.settings_ecosystem_label)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = null,
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        LazyColumn(modifier = Modifier.padding(innerPadding)) {
+            item {
+                Text(
+                    text = stringResource(R.string.settings_ecosystem_header_desc),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+                )
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_ecosystem_web_label),
+                    subtitle = stringResource(R.string.settings_ecosystem_web_desc),
+                    icon = Icons.TwoTone.Language,
+                    onClick = { onOpenUrl("https://github.com/d4rken-org/octi-web") },
+                )
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_ecosystem_desktop_label),
+                    subtitle = stringResource(R.string.settings_ecosystem_desktop_desc),
+                    icon = Icons.TwoTone.DesktopWindows,
+                    onClick = { onOpenUrl("https://github.com/d4rken-org/octi-desktop") },
+                )
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_ecosystem_server_label),
+                    subtitle = stringResource(R.string.settings_ecosystem_server_desc),
+                    icon = Icons.TwoTone.Dns,
+                    onClick = { onOpenUrl("https://github.com/d4rken-org/octi-server") },
+                )
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun EcosystemScreenPreview() = PreviewWrapper {
+    EcosystemScreen(onNavigateUp = {}, onOpenUrl = {})
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/ecosystem/EcosystemVM.kt
@@ -1,0 +1,23 @@
+package eu.darken.octi.main.ui.settings.ecosystem
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.WebpageTool
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.uix.ViewModel4
+import javax.inject.Inject
+
+@HiltViewModel
+class EcosystemVM @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    private val webpageTool: WebpageTool,
+) : ViewModel4(dispatcherProvider) {
+
+    fun openUrl(url: String) {
+        webpageTool.open(url)
+    }
+
+    companion object {
+        private val TAG = logTag("Settings", "Ecosystem", "VM")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,9 @@
     <string name="settings_ecosystem_desc">Web, desktop, and self-hosted sync</string>
     <string name="settings_ecosystem_header_desc">Use Octi from a browser or desktop app, connected through Octi Server.</string>
     <string name="settings_ecosystem_web_label">Octi Web</string>
-    <string name="settings_ecosystem_web_desc">Browser companion — view source and self-host instructions</string>
+    <string name="settings_ecosystem_web_desc">Use Octi from any browser</string>
+    <string name="settings_ecosystem_web_source_label">Octi Web (source)</string>
+    <string name="settings_ecosystem_web_source_desc">View source and self-host instructions</string>
     <string name="settings_ecosystem_desktop_label">Octi Desktop</string>
     <string name="settings_ecosystem_desktop_desc">Native client for Windows, macOS, and Linux</string>
     <string name="settings_ecosystem_server_label">Octi Server</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,16 @@
     <string name="settings_acknowledgements_label">Acknowledgements</string>
     <string name="documentation_label">Documentation</string>
 
+    <string name="settings_ecosystem_label">More ways to use Octi</string>
+    <string name="settings_ecosystem_desc">Web, desktop, and self-hosted sync</string>
+    <string name="settings_ecosystem_header_desc">Use Octi from a browser or desktop app, connected through Octi Server.</string>
+    <string name="settings_ecosystem_web_label">Octi Web</string>
+    <string name="settings_ecosystem_web_desc">Browser companion — view source and self-host instructions</string>
+    <string name="settings_ecosystem_desktop_label">Octi Desktop</string>
+    <string name="settings_ecosystem_desktop_desc">Native client for Windows, macOS, and Linux</string>
+    <string name="settings_ecosystem_server_label">Octi Server</string>
+    <string name="settings_ecosystem_server_desc">Self-host your own sync backend</string>
+
     <string name="help_translate_label">Translation</string>
     <string name="help_translate_description">Help translate this app into your favorite language.</string>
 


### PR DESCRIPTION
## Summary
- Adds a new **More ways to use Octi** entry to Settings (between Changelog and Translation, under the Other section)
- Opens a dedicated screen with three rows linking to the companion projects: [octi-web](https://github.com/d4rken-org/octi-web), [octi-desktop](https://github.com/d4rken-org/octi-desktop), and [octi-server](https://github.com/d4rken-org/octi-server)
- Same UI surface for both `foss` and `gplay` flavors — cross-promoting non-Android companion software is allowed under Play policy

## Screenshot description
Settings → Other → **More ways to use Octi** → screen with header explainer + three `SettingsBaseItem` rows (Web / Desktop / Server), each opening the project's GitHub repo via the standard `WebpageTool`.

## Test plan
- [ ] Tap the new entry from Settings — opens the Ecosystem screen
- [ ] Tap each row — opens the correct GitHub URL in the browser
- [ ] Back button returns to Settings index
- [ ] Compose previews render (`EcosystemScreenPreview`, updated `SettingsIndexScreenPreview`)
- [ ] `./gradlew :app:compileFossDebugKotlin :app:compileGplayDebugKotlin` — passes (verified locally)