### PR TITLE
Run web + desktop tests against wire-format PRs

### DIFF
--- a/.claude/rules/interop-fixtures.md
+++ b/.claude/rules/interop-fixtures.md
@@ -89,3 +89,76 @@ See [pull-request-guidelines.md](pull-request-guidelines.md) — sister PRs must
 be linked when a wire-format change crosses repos. The web/desktop side keeps a
 `fixture-lock.json` that pins this directory by app-main commit SHA, fetches via
 sparse-checkout, and verifies against `manifest.json` before running its tests.
+
+## Upstream gating (this repo's CI)
+
+`.github/workflows/cross-repo-verify.yml` runs on every PR. On PRs that touch the
+allowlisted wire-format paths (the crypto layer, this fixture dir, and the
+shared serialization module — see `ALLOWLIST` in the workflow), it checks out
+`octi-web` and `octi-desktop` at their default branches and runs their test
+suites against the PR's HEAD using the `INTEROP_FIXTURE_OVERRIDES` env var the
+consumer sync scripts already accept. A wire-incompatible change is blocked at
+the producer PR, not discovered weeks later when a consumer happens to bump its
+pin.
+
+The allowlist today covers what the **committed fixtures actually exercise**:
+the crypto vectors under `sync-core/src/test/resources/interop/`. Module-level
+fixtures (Phase B/C) will expand it. Don't widen prematurely — over-firing
+turns into "every PR pays the cross-repo CI cost for changes that can't
+actually break consumers."
+
+PRs that don't touch the allowlist still run the workflow but echo "skip: no
+relevant paths changed" and exit 0 — required-check status reports green
+without leaving the check pending.
+
+## Breaking a wire format on purpose
+
+The cross-repo gate makes "land producer change first, consumers later"
+impossible on its own. Two ways to break wire format intentionally:
+
+### 1. Coordinated sister PRs (default)
+
+Open the consumer PRs first (or simultaneously). Each includes the matching
+decoder change. The producer PR then merges because the consumers' default
+branches already have the updated decoders when the gate fetches them. The
+[pull-request-guidelines.md](pull-request-guidelines.md) sister-repo section
+covers the mechanics. Right tool for renames, additions of required fields, or
+new value-class shapes.
+
+### 2. Staged via capability flag
+
+For changes the consumers can't absorb synchronously (a serializer refactor on
+one side, a Tink upgrade requiring blob re-encoding, etc.), don't break — add a
+new format alongside the old and let consumers migrate on their own schedule.
+Full sequence:
+
+1. **Producer commits a new fixture vector** exercising the new shape, alongside
+   the existing one. Don't remove the old vector — the gate still requires
+   consumers to decode it.
+2. **Each consumer adds decode support** for the new shape (their own PR;
+   gate passes because the old vector still works AND the new vector is just
+   "yet another decodable thing").
+3. **Producer advertises a new capability tag** in `Octi-Device-Capabilities`
+   (see [device-capabilities.md](device-capabilities.md)). Consumers reading
+   peers' capabilities now know "peer X has the new format."
+4. **Producer adds dual-write**: emit old format unconditionally, emit new
+   format only for peers whose capabilities include the new tag.
+5. **Support floor moves** — once every peer that matters has advertised the
+   capability, the old format becomes dead code.
+6. **Producer removes the old write path** and the old fixture vector. This
+   step is the actual breaking change; by now, no peer in the network reads
+   the old format anyway.
+
+Steps 1–4 are the rollout; step 5 is calendar time; step 6 is a normal PR.
+None of this requires bypassing the gate. The fixture vector contract is what
+keeps producers honest: you can only remove the old vector once consumers have
+agreed (via their decoders) they no longer need it.
+
+### Bypass (emergency only)
+
+Admin-merge of the required check exists in branch protection settings. Don't
+use it for normal cross-repo work — it skips the safety the gate provides.
+Reserve for "the gate itself is broken" emergencies (e.g. GitHub Actions
+outage, a runner image issue, raw.githubusercontent.com unreachable from
+ubuntu-22.04). When using it, file a follow-up to fix whatever made the gate
+unavailable.

--- a/.github/workflows/cross-repo-verify.yml
+++ b/.github/workflows/cross-repo-verify.yml
@@ -1,0 +1,221 @@
+name: Cross-repo wire-format verify
+
+# Runs on every PR (no path filter at trigger level — branch-protection rules can require
+# these checks without GitHub leaving them pending on path-skipped PRs). The relevance
+# check happens inside the job, and irrelevant PRs early-exit with success.
+#
+# Sister workflows in octi-web and octi-desktop (Phase B4, C4) mirror this shape from
+# their respective directions once those repos start publishing fixtures of their own.
+
+on:
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-repo-verify-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  # Path prefixes that can affect the bytes app-main puts on the wire AND that are
+  # actually exercised by the consumer fixtures in sync-core/src/test/resources/interop/.
+  # Entries ending in `/` match any file under that prefix; bare file entries must
+  # match exactly. Module-specific paths (modules-meta/, etc.) are deliberately NOT
+  # here today — the committed fixtures only cover the crypto layer. Add per-module
+  # paths in the same PRs that ship module fixtures (Phase B/C).
+  ALLOWLIST: |
+    sync-core/src/main/java/eu/darken/octi/sync/core/encryption/
+    sync-core/src/main/java/eu/darken/octi/sync/core/blob/
+    sync-core/src/test/resources/interop/
+    app-common/src/main/java/eu/darken/octi/common/serialization/
+    sync-core/build.gradle.kts
+    app-common/build.gradle.kts
+    buildSrc/
+    gradle/wrapper/
+    .github/workflows/cross-repo-verify.yml
+
+jobs:
+  verify-web:
+    name: Verify octi-web decodes this PR's wire bytes
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout this repo at PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+          path: app-main
+          # Full history so `git merge-base` finds the PR's branch point on main.
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect wire-format-relevant changes
+        id: changed
+        working-directory: app-main
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          merge_base="$(git merge-base "$base" "$head")"
+
+          matches_allowlist() {
+            local path="$1" prefix
+            while IFS= read -r prefix; do
+              prefix="${prefix#"${prefix%%[![:space:]]*}"}"
+              [[ -z "$prefix" ]] && continue
+              if [[ "$prefix" == */ ]]; then
+                [[ "$path" == "$prefix"* ]] && return 0
+              else
+                [[ "$path" == "$prefix" ]] && return 0
+              fi
+            done <<< "$ALLOWLIST"
+            return 1
+          }
+
+          relevant=false
+          while IFS= read -r -d '' path; do
+            if matches_allowlist "$path"; then
+              echo "relevant: $path"
+              relevant=true
+            fi
+          done < <(git diff --name-only --no-renames -z "$merge_base" "$head" --)
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          if [[ "$relevant" == "false" ]]; then
+            echo "no wire-format-relevant paths changed; consumer verify will be skipped."
+          fi
+
+      - name: Checkout octi-web
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          repository: d4rken-org/octi-web
+          persist-credentials: false
+          path: octi-web
+
+      - name: Install pnpm
+        if: steps.changed.outputs.relevant == 'true'
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+        with:
+          version: 11.1.1
+
+      - name: Setup Node 24 with pnpm cache
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: octi-web/pnpm-lock.yaml
+
+      - name: Install octi-web dependencies
+        if: steps.changed.outputs.relevant == 'true'
+        working-directory: octi-web
+        run: pnpm install --frozen-lockfile
+
+      - name: Run octi-web tests with fixture override
+        if: steps.changed.outputs.relevant == 'true'
+        working-directory: octi-web
+        env:
+          INTEROP_FIXTURE_OVERRIDES: '{"d4rken-org/octi":"${{ github.event.pull_request.head.sha }}"}'
+        run: |
+          echo "Running octi-web tests against this PR's app-main HEAD (${{ github.event.pull_request.head.sha }})"
+          pnpm test
+
+  verify-desktop:
+    name: Verify octi-desktop decodes this PR's wire bytes
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout this repo at PR head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          persist-credentials: false
+          path: app-main
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Detect wire-format-relevant changes
+        id: changed
+        working-directory: app-main
+        shell: bash
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          merge_base="$(git merge-base "$base" "$head")"
+
+          matches_allowlist() {
+            local path="$1" prefix
+            while IFS= read -r prefix; do
+              prefix="${prefix#"${prefix%%[![:space:]]*}"}"
+              [[ -z "$prefix" ]] && continue
+              if [[ "$prefix" == */ ]]; then
+                [[ "$path" == "$prefix"* ]] && return 0
+              else
+                [[ "$path" == "$prefix" ]] && return 0
+              fi
+            done <<< "$ALLOWLIST"
+            return 1
+          }
+
+          relevant=false
+          while IFS= read -r -d '' path; do
+            if matches_allowlist "$path"; then
+              echo "relevant: $path"
+              relevant=true
+            fi
+          done < <(git diff --name-only --no-renames -z "$merge_base" "$head" --)
+
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          if [[ "$relevant" == "false" ]]; then
+            echo "no wire-format-relevant paths changed; consumer verify will be skipped."
+          fi
+
+      - name: Checkout octi-desktop
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        with:
+          repository: d4rken-org/octi-desktop
+          persist-credentials: false
+          path: octi-desktop
+
+      - name: Setup JDK 21
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 #v5.2.0
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Cache Gradle wrapper
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        with:
+          path: |
+            ~/.gradle/wrapper
+            !~/.gradle/wrapper/dists/**/gradle*.zip
+          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('octi-desktop/**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-wrapper-
+
+      - name: Cache Gradle dependencies
+        if: steps.changed.outputs.relevant == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        with:
+          path: |
+            ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('octi-desktop/**/*.gradle*', 'octi-desktop/**/gradle-wrapper.properties', 'octi-desktop/buildSrc/**/*.kt') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-caches-
+
+      - name: Run octi-desktop tests with fixture override
+        if: steps.changed.outputs.relevant == 'true'
+        working-directory: octi-desktop
+        env:
+          INTEROP_FIXTURE_OVERRIDES: '{"d4rken-org/octi":"${{ github.event.pull_request.head.sha }}"}'
+        run: |
+          echo "Running octi-desktop tests against this PR's app-main HEAD (${{ github.event.pull_request.head.sha }})"
+          chmod +x ./gradlew
+          ./gradlew test


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal: CI now runs the octi-web and octi-desktop test suites against the bytes this PR would produce, *before* the change can merge. A wire-format break that would silently land today and surface weeks later (when a consumer happens to bump its fixture pin) now blocks the producer PR.

The new workflow only fires the cross-repo tests on PRs that touch the crypto layer, the committed interop fixtures, or the shared serialization module. PRs to README, lint config, or unrelated app code still pass through the workflow but echo "skip: no relevant paths changed" — the required-check status reports green without leaving anything pending.

## Technical Context

- **Why "always trigger, gate inside" instead of `paths:`.** A `paths:`-filtered workflow that's required by branch protection can stay pending forever on PRs that don't match the filter. The "always run, no-op on irrelevant paths" pattern keeps required-check semantics clean.
- **Why merge-base diff (not raw base..head).** `git diff $BASE_SHA $HEAD_SHA` would include any commits that landed on main after the PR branched off — unrelated PRs would trip the gate. Using `git merge-base` (and `--no-renames -z` for deterministic behavior across renames and special chars) bounds the diff to what this PR actually changed.
- **Why the allowlist is narrow.** Today the committed fixtures only exercise the crypto layer (Tink AEAD, streaming AEAD). A change to `modules-meta/src/main/` doesn't affect any consumer-visible fixture — over-firing the gate on those paths would just burn CI minutes without catching anything. Module paths will join when Phase B/C lands per-module fixtures.
- **Why setup actions are inlined.** Both consumers ship composite setup actions, but they assume the consumer checkout is at workspace root (pnpm install, chmod gradlew, Gradle cache hashFiles all use root-relative paths). Calling them with the consumer in a subdir breaks subtly. Inlining the same action SHAs they use, with explicit working-directory + cache-dependency-path, sidesteps the coupling.
- **Why no PAT.** Both consumer repos are public; `actions/checkout` with `repository:` works with default `GITHUB_TOKEN` permissions.
- **Required-check enrollment is NOT in this PR.** That's an org settings change on the main-branch ruleset. The workflow lands first so the checks exist as named items; enrollment happens once they've passed on a few real PRs.
- **Review guidance.** The relevance-check bash is the trickiest part — it's the same logic in both jobs (kept as inline copies so the two job specs read top-to-bottom without a third reference). The `ALLOWLIST` env is at workflow level and shared by both jobs; widening it requires editing in one place.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(...)'` parses the workflow.
- [ ] First PR after merge: confirm both jobs run and report success on a no-op (e.g. README) change.
- [ ] Confirm a touch on `sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt` triggers the cross-repo verify (relevant=true, consumer tests actually execute).
- [ ] Confirm a deliberately broken wire change (rename a required field on `MetaInfo` without `@SerialName`) blocks the PR — both jobs go red.
- [ ] Once the workflow is stable for a few PRs, enroll `verify-web` / `verify-desktop` in the main-branch ruleset as required checks.

Sister PRs (consumer-side env-var support, both merged):
- [d4rken-org/octi-web#24](https://github.com/d4rken-org/octi-web/pull/24)
- [d4rken-org/octi-desktop#42](https://github.com/d4rken-org/octi-desktop/pull/42)
