### PR TITLE
[smoke] No-op touch on PayloadEncryption.kt

### DIFF
--- a/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt
@@ -26,6 +26,7 @@ class PayloadEncryption(
     private val useLegacyEncryption: Boolean = false,
 ) {
 
+    // smoke: cross-repo-verify gate touch (no behavior change)
     init {
         // Process-global JCE provider install + Tink configuration registration must
         // happen before any keysetHandle / primitive call. CryptoBootstrap owns that;


### PR DESCRIPTION
Smoke test for #315's gate. Touches an allowlisted wire-format path with a single no-op comment — expect both verify-web and verify-desktop jobs to checkout the consumer, install/setup, run pnpm test / ./gradlew test against this PR's HEAD via INTEROP_FIXTURE_OVERRIDES, all green. Close once verified.