### PR TITLE
Consume octi-desktop's published wire-format fixtures

### DIFF
--- a/.claude/rules/interop-fixtures.md
+++ b/.claude/rules/interop-fixtures.md
@@ -113,30 +113,29 @@ without leaving the check pending.
 
 ## Consuming other repos' fixtures (Phase B onward)
 
-App-main also **consumes** fixtures published by `d4rken-org/octi-web` (and, in
-Phase C, `d4rken-org/octi-desktop`). The other side of the same bidirectional
-contract: producer-side serializer drift breaks the gate at the producer's PR,
-because every consumer's CI runs against the producer's HEAD via the
+App-main also **consumes** fixtures published by `d4rken-org/octi-web` and
+`d4rken-org/octi-desktop`. The other side of the same bidirectional contract:
+producer-side serializer drift breaks the gate at the producer's PR, because
+every consumer's CI runs against the producer's HEAD via the
 `INTEROP_FIXTURE_OVERRIDES` env var.
 
 ### Pinning
 
-`fixture-lock.json` at repo root pins each upstream source:
+`fixture-lock.json` at repo root pins each upstream source independently:
 
 ```json
 {
   "schemaVersion": 2,
   "sources": {
-    "d4rken-org/octi-web": {
-      "ref": "<40-char commit SHA>",
-      "manifest_sha256": "<sha256 of that source's manifest.json>"
-    }
+    "d4rken-org/octi-web":     { "ref": "<sha40>", "manifest_sha256": "<sha256>" },
+    "d4rken-org/octi-desktop": { "ref": "<sha40>", "manifest_sha256": "<sha256>" }
   }
 }
 ```
 
-Schema is v2 — multi-source from day one so Phase C can add `d4rken-org/octi-desktop`
-without a migration step.
+Schema is v2 multi-source from day one. Each source can be bumped independently
+of the others; the gating workflow on the matching producer repo can override
+just its own entry without disturbing the rest.
 
 ### Test layout
 
@@ -144,11 +143,17 @@ without a migration step.
   (`InteropFixtureSync`, `SyncRefResolver`, schemas). Lives there because
   `modules-meta`, `modules-clipboard`, `modules-files` depend on `sync-core`
   and each module's consumer test needs to import its own `*Info` model.
-- **Per-module consumer tests**: `modules-{meta,clipboard,files}/src/test/.../interop/Web*InteropTest.kt`.
-  Each calls `InteropFixtureSync.ensureSynced("d4rken-org/octi-web")` in
-  `@BeforeAll`, reads the relevant `octi-web-<module>.json` from the cache,
+- **Per-module consumer tests** (one pair per producer):
+  - `modules-{meta,clipboard,files}/src/test/.../interop/Web*InteropTest.kt`
+    consumes octi-web's fixtures.
+  - `modules-{meta,clipboard,files}/src/test/.../interop/Desktop*InteropTest.kt`
+    consumes octi-desktop's fixtures.
+  Each calls `InteropFixtureSync.ensureSynced("d4rken-org/<source>")` in
+  `@BeforeAll`, reads the relevant `octi-<source>-<module>.json` from the cache,
   and decodes every `payloadJson` through its production decoder with
-  field-by-field assertions.
+  field-by-field assertions. Desktop's fixtures pin a different wire shape for
+  `SharedFile.blobKey` (plain UUID, not `sha256:<hex>`) and emit a real
+  `deviceBootedAt` Instant for the `full` meta vector.
 
 ### Cache
 

--- a/app-common-test/src/main/java/testhelpers/interop/InteropFixtureSync.kt
+++ b/app-common-test/src/main/java/testhelpers/interop/InteropFixtureSync.kt
@@ -50,6 +50,11 @@ object InteropFixtureSync {
      * Populate (or reuse) the cache for every source in the lockfile. Returns a map
      * `source -> cache directory`. Safe to call from multiple test classes — only the
      * first call does work.
+     *
+     * Note: cache directories are per-source, but the FIRST call syncs *all* sources at once.
+     * If one source's lockfile entry is stale (e.g. upstream history was rewritten),
+     * subsequent tests against a different, still-valid source will fail before reading
+     * their own cache. Treat each lockfile bump as a single global event.
      */
     fun ensureSynced(): Map<String, Path> {
         cacheDirsRef.get()?.let { return it }
@@ -61,7 +66,11 @@ object InteropFixtureSync {
         }
     }
 
-    /** Convenience overload — return the cache dir for one specific source. */
+    /**
+     * Convenience overload — return the cache dir for one specific source. Same blocking
+     * sync semantics as the no-arg variant (all sources sync on the first caller); this is
+     * just sugar for picking one entry out of the resulting map.
+     */
     fun ensureSynced(source: String): Path {
         val dirs = ensureSynced()
         return dirs[source] ?: error(

--- a/app-common-test/src/main/java/testhelpers/interop/InteropFixtures.kt
+++ b/app-common-test/src/main/java/testhelpers/interop/InteropFixtures.kt
@@ -63,8 +63,9 @@ object InteropFixtures {
 }
 
 /**
- * Multi-source lockfile entry. App-main consumes from `d4rken-org/octi-web` today; later
- * phases (Phase C) add `d4rken-org/octi-desktop` to the same map.
+ * Multi-source lockfile entry. App-main consumes both `d4rken-org/octi-web` and
+ * `d4rken-org/octi-desktop` today; new sources land here by adding both the lockfile entry
+ * and the matching path in [SyncRefResolver.SOURCE_PATHS].
  */
 @Serializable
 data class FixtureLock(

--- a/app-common-test/src/main/java/testhelpers/interop/SyncRefResolver.kt
+++ b/app-common-test/src/main/java/testhelpers/interop/SyncRefResolver.kt
@@ -22,17 +22,21 @@ data class ResolvedSource(
  * + cache directories after `INTEROP_FIXTURE_OVERRIDES` is applied.
  *
  * Mirrors octi-web's `src/__interop__/sync-ref-resolver.ts` and octi-desktop's
- * `SyncRefResolver.kt`. Keep [SOURCE_PATHS] in lockstep across all three.
+ * `SyncRefResolver.kt`. Each consumer lists only the producers it consumes; the
+ * invariant is that for any shared source, the path string must agree across consumers.
  */
 object SyncRefResolver {
 
     /**
-     * Code-owned allowlist of upstream sources. Adding a fourth source requires a code
-     * change here — cross-repo trust is not a runtime config. The value is the path
-     * under the source repo root that hosts `manifest.json` + the fixture files.
+     * Code-owned allowlist of upstream sources THIS REPO consumes. Adding a new source
+     * requires a coordinated rollout: producer commits + ships its fixtures, then each
+     * consumer adds it here. Cross-repo trust is never a runtime config.
+     *
+     * Value is the path under the source repo root that hosts `manifest.json` + fixture files.
      */
     val SOURCE_PATHS: Map<String, String> = mapOf(
         "d4rken-org/octi-web" to "src/__interop__/published",
+        "d4rken-org/octi-desktop" to "src/test/resources/interop/published",
     )
 
     private val SHA40_RE = Regex("""^[a-f0-9]{40}$""")

--- a/fixture-lock.json
+++ b/fixture-lock.json
@@ -4,6 +4,10 @@
     "d4rken-org/octi-web": {
       "ref": "84b9e57ac72e9b113de4c0c661e81938f8588f9d",
       "manifest_sha256": "d5037e9c9ef02e7b36e6f69c2081a1cdd6adc398b8203e9e8c9409a5c2810bd0"
+    },
+    "d4rken-org/octi-desktop": {
+      "ref": "1e00e71fc60841fda80d7db4f630aa99b1112c9d",
+      "manifest_sha256": "ce2fd860ff124599bfc61a94f824c17c521cf79d744f06bc3551e284e6a37fe4"
     }
   }
 }

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/interop/DesktopClipboardInteropTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/interop/DesktopClipboardInteropTest.kt
@@ -1,0 +1,87 @@
+package eu.darken.octi.modules.clipboard.interop
+
+import eu.darken.octi.modules.clipboard.ClipboardInfo
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import testhelpers.interop.InteropFixtureSync
+import testhelpers.interop.InteropFixtures
+import testhelpers.interop.PublishedModuleFixture
+import testhelpers.interop.PublishedVector
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Verify app-main's ClipboardInfo decoder can consume what octi-desktop publishes.
+ * Same wire contract as web's clipboard fixtures (type enum + base64-encoded data); only the
+ * canonical payload contents differ ("hello from desktop" vs web's "hello clipboard").
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DesktopClipboardInteropTest {
+
+    private lateinit var cacheDir: Path
+
+    private val decoder: Json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @BeforeAll
+    fun setUp() {
+        cacheDir = InteropFixtureSync.ensureSynced("d4rken-org/octi-desktop")
+    }
+
+    @Test
+    fun `desktop clipboard fixture schema sanity`() {
+        val fixture = loadFixture()
+        fixture.schemaVersion shouldBe InteropFixtures.FIXTURE_SCHEMA_VERSION
+        fixture.module shouldBe "eu.darken.octi.module.core.clipboard"
+        fixture.producer shouldBe "d4rken-org/octi-desktop"
+        fixture.vectors.map { it.name } shouldBe
+            listOf("EMPTY", "SIMPLE_TEXT_short", "SIMPLE_TEXT_unicode")
+    }
+
+    @Test
+    fun `desktop clipboard 'EMPTY' vector decodes to empty data`() {
+        val info = decode(vector("EMPTY"))
+        info.type shouldBe ClipboardInfo.Type.EMPTY
+        info.data.size shouldBe 0
+    }
+
+    @Test
+    fun `desktop clipboard 'SIMPLE_TEXT_short' vector decodes ASCII payload`() {
+        val info = decode(vector("SIMPLE_TEXT_short"))
+        info.type shouldBe ClipboardInfo.Type.SIMPLE_TEXT
+        info.data shouldBe "hello from desktop".encodeUtf8()
+    }
+
+    @Test
+    fun `desktop clipboard 'SIMPLE_TEXT_unicode' vector decodes multi-codepoint payload`() {
+        val info = decode(vector("SIMPLE_TEXT_unicode"))
+        info.type shouldBe ClipboardInfo.Type.SIMPLE_TEXT
+        info.data shouldBe "café 👋 你好 — العربية".encodeUtf8()
+    }
+
+    private fun loadFixture(): PublishedModuleFixture {
+        val bytes = Files.readAllBytes(cacheDir.resolve("octi-desktop-clipboard.json"))
+        return InteropFixtures.json.decodeFromString(
+            PublishedModuleFixture.serializer(),
+            bytes.decodeToString(),
+        )
+    }
+
+    private fun vector(name: String): PublishedVector {
+        val fixture = loadFixture()
+        val v = fixture.vectors.firstOrNull { it.name == name }
+            ?: error("vector '$name' missing in ${fixture.module}")
+        InteropFixtures.verifyVectorIntegrity(v)
+        return v
+    }
+
+    private fun decode(v: PublishedVector): ClipboardInfo {
+        return decoder.decodeFromString(ClipboardInfo.serializer(), v.payloadJson)
+    }
+}

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/interop/DesktopFilesInteropTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/interop/DesktopFilesInteropTest.kt
@@ -1,0 +1,201 @@
+package eu.darken.octi.modules.files.interop
+
+import eu.darken.octi.modules.files.core.FileShareInfo
+import eu.darken.octi.sync.core.RemoteBlobRef
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import testhelpers.interop.InteropFixtureSync
+import testhelpers.interop.InteropFixtures
+import testhelpers.interop.PublishedModuleFixture
+import testhelpers.interop.PublishedVector
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.time.Instant
+
+/**
+ * Verify app-main's FileShareInfo decoder can consume what octi-desktop publishes.
+ *
+ * Wire-shape difference vs web's fixtures: desktop's `SharedFile.blobKey` is a plain UUID
+ * (`UUID.randomUUID().toString()`) rather than the `sha256:<hex>` form. The connector IDs are
+ * also desktop-flavoured (`kserver-prod...77777777-...` vs web's `aaaaaaaa-...`). Same Long
+ * size handling + multi-connector + delete-requests coverage as the web sister test.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DesktopFilesInteropTest {
+
+    private lateinit var cacheDir: Path
+
+    private val decoder: Json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val prodConnector =
+        "kserver-prod.kserver.octi.darken.eu-77777777-8888-9999-aaaa-bbbbbbbbbbbb"
+    private val betaConnector =
+        "kserver-beta.kserver.octi.darken.eu-cccccccc-1111-2222-3333-444444444444"
+
+    @BeforeAll
+    fun setUp() {
+        cacheDir = InteropFixtureSync.ensureSynced("d4rken-org/octi-desktop")
+    }
+
+    @Test
+    fun `desktop files fixture schema sanity`() {
+        val fixture = loadFixture()
+        fixture.schemaVersion shouldBe InteropFixtures.FIXTURE_SCHEMA_VERSION
+        fixture.module shouldBe "eu.darken.octi.module.core.files"
+        fixture.producer shouldBe "d4rken-org/octi-desktop"
+        fixture.vectors.map { it.name } shouldBe listOf(
+            "empty",
+            "single-file",
+            "with-multiple-files",
+            "with-delete-requests",
+            "multi-connector",
+            "files-large",
+        )
+    }
+
+    @Test
+    fun `desktop files 'empty' vector decodes to empty lists`() {
+        val info = decode(vector("empty"))
+        info.files shouldBe emptyList()
+        info.deleteRequests shouldBe emptyList()
+    }
+
+    @Test
+    fun `desktop files 'single-file' vector decodes one SharedFile with UUID blobKey`() {
+        val info = decode(vector("single-file"))
+        info.files.size shouldBe 1
+        info.deleteRequests shouldBe emptyList()
+
+        val f = info.files[0]
+        f.name shouldBe "notes.txt"
+        f.mimeType shouldBe "text/plain"
+        f.size shouldBe 1234L
+        f.blobKey shouldBe "00000000-0000-0000-0000-000000000001"
+        f.checksum shouldBe "11".repeat(32)
+        f.sharedAt shouldBe Instant.parse("2026-05-01T12:00:00Z")
+        f.expiresAt shouldBe Instant.parse("2026-05-31T12:00:00Z")
+        f.availableOn shouldBe setOf(prodConnector)
+        f.connectorRefs shouldBe mapOf(prodConnector to RemoteBlobRef("blob-id-aaaa"))
+    }
+
+    @Test
+    fun `desktop files 'with-multiple-files' vector decodes both entries field-by-field`() {
+        val info = decode(vector("with-multiple-files"))
+        info.files.size shouldBe 2
+        info.deleteRequests shouldBe emptyList()
+
+        val alpha = info.files[0]
+        alpha.name shouldBe "alpha.bin"
+        alpha.mimeType shouldBe "application/octet-stream"
+        alpha.size shouldBe 256L
+        alpha.blobKey shouldBe "00000000-0000-0000-0000-000000000002"
+        alpha.checksum shouldBe "22".repeat(32)
+        alpha.sharedAt shouldBe Instant.parse("2026-05-01T12:00:00Z")
+        alpha.expiresAt shouldBe Instant.parse("2026-05-31T12:00:00Z")
+        alpha.availableOn shouldBe setOf(prodConnector)
+        alpha.connectorRefs shouldBe mapOf(prodConnector to RemoteBlobRef("blob-id-bbbb"))
+
+        val beta = info.files[1]
+        beta.name shouldBe "beta.pdf"
+        beta.mimeType shouldBe "application/pdf"
+        beta.size shouldBe 4096L
+        beta.blobKey shouldBe "00000000-0000-0000-0000-000000000003"
+        beta.checksum shouldBe "33".repeat(32)
+        beta.sharedAt shouldBe Instant.parse("2026-05-01T13:00:00Z")
+        beta.expiresAt shouldBe Instant.parse("2026-05-31T13:00:00Z")
+        beta.availableOn shouldBe setOf(prodConnector)
+        beta.connectorRefs shouldBe mapOf(prodConnector to RemoteBlobRef("blob-id-cccc"))
+    }
+
+    @Test
+    fun `desktop files 'with-delete-requests' vector decodes the deleteRequests branch field-by-field`() {
+        val info = decode(vector("with-delete-requests"))
+        info.files.size shouldBe 1
+        info.deleteRequests.size shouldBe 1
+
+        val f = info.files[0]
+        f.name shouldBe "shared.txt"
+        f.mimeType shouldBe "text/plain"
+        f.size shouldBe 100L
+        f.blobKey shouldBe "00000000-0000-0000-0000-000000000004"
+        f.checksum shouldBe "44".repeat(32)
+        f.sharedAt shouldBe Instant.parse("2026-05-01T12:00:00Z")
+        f.expiresAt shouldBe Instant.parse("2026-05-31T12:00:00Z")
+        f.availableOn shouldBe setOf(prodConnector)
+        f.connectorRefs shouldBe mapOf(prodConnector to RemoteBlobRef("blob-id-dddd"))
+
+        val req = info.deleteRequests[0]
+        req.targetDeviceId shouldBe "99999999-8888-7777-6666-555555555555"
+        req.blobKey shouldBe "00000000-0000-0000-0000-000000000005"
+        req.requestedAt shouldBe Instant.parse("2026-05-10T00:00:00Z")
+        req.retainUntil shouldBe Instant.parse("2026-05-17T00:00:00Z")
+    }
+
+    @Test
+    fun `desktop files 'multi-connector' vector decodes both connectorRefs entries field-by-field`() {
+        val info = decode(vector("multi-connector"))
+        info.files.size shouldBe 1
+        info.deleteRequests shouldBe emptyList()
+
+        val f = info.files[0]
+        f.name shouldBe "shared-across.bin"
+        f.mimeType shouldBe "application/octet-stream"
+        f.size shouldBe 512L
+        f.blobKey shouldBe "00000000-0000-0000-0000-000000000007"
+        f.checksum shouldBe "77".repeat(32)
+        f.sharedAt shouldBe Instant.parse("2026-05-01T12:00:00Z")
+        f.expiresAt shouldBe Instant.parse("2026-05-31T12:00:00Z")
+        f.availableOn shouldBe setOf(prodConnector, betaConnector)
+        f.connectorRefs shouldBe mapOf(
+            prodConnector to RemoteBlobRef("blob-id-prod-7777"),
+            betaConnector to RemoteBlobRef("blob-id-beta-7777"),
+        )
+    }
+
+    @Test
+    fun `desktop files 'files-large' vector decodes size larger than Int MAX_VALUE`() {
+        // Pins Long handling on the JVM consumer. If SharedFile.size were typed `Int`, this
+        // 8e9-byte vector would fail decode in the right place.
+        val info = decode(vector("files-large"))
+        info.files.size shouldBe 1
+        info.deleteRequests shouldBe emptyList()
+
+        val f = info.files[0]
+        f.name shouldBe "big.iso"
+        f.mimeType shouldBe "application/octet-stream"
+        f.size shouldBe 8_000_000_000L
+        check(f.size > Int.MAX_VALUE.toLong()) { "vector did not exceed Int.MAX_VALUE" }
+        f.blobKey shouldBe "00000000-0000-0000-0000-000000000006"
+        f.checksum shouldBe "66".repeat(32)
+        f.sharedAt shouldBe Instant.parse("2026-05-01T12:00:00Z")
+        f.expiresAt shouldBe Instant.parse("2026-05-31T12:00:00Z")
+        f.availableOn shouldBe setOf(prodConnector)
+        f.connectorRefs shouldBe mapOf(prodConnector to RemoteBlobRef("blob-id-eeee"))
+    }
+
+    private fun loadFixture(): PublishedModuleFixture {
+        val bytes = Files.readAllBytes(cacheDir.resolve("octi-desktop-files.json"))
+        return InteropFixtures.json.decodeFromString(
+            PublishedModuleFixture.serializer(),
+            bytes.decodeToString(),
+        )
+    }
+
+    private fun vector(name: String): PublishedVector {
+        val fixture = loadFixture()
+        val v = fixture.vectors.firstOrNull { it.name == name }
+            ?: error("vector '$name' missing in ${fixture.module}")
+        InteropFixtures.verifyVectorIntegrity(v)
+        return v
+    }
+
+    private fun decode(v: PublishedVector): FileShareInfo {
+        return decoder.decodeFromString(FileShareInfo.serializer(), v.payloadJson)
+    }
+}

--- a/modules-meta/src/test/java/eu/darken/octi/modules/meta/interop/DesktopMetaInteropTest.kt
+++ b/modules-meta/src/test/java/eu/darken/octi/modules/meta/interop/DesktopMetaInteropTest.kt
@@ -1,0 +1,132 @@
+package eu.darken.octi.modules.meta.interop
+
+import eu.darken.octi.modules.meta.core.MetaInfo
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import testhelpers.interop.InteropFixtureSync
+import testhelpers.interop.InteropFixtures
+import testhelpers.interop.PublishedModuleFixture
+import testhelpers.interop.PublishedVector
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.time.Instant
+
+/**
+ * Verify app-main's MetaInfo decoder can consume what octi-desktop publishes.
+ *
+ * Loads `octi-desktop-meta.json` from `.cache/interop-fixtures/d4rken-org/octi-desktop/<ref>/`,
+ * parses each `payloadJson` through the production [MetaInfo] decoder, and asserts field
+ * values match the canonical inputs declared in octi-desktop's `InteropFixtureGenerator.kt`.
+ *
+ * Sister test: [WebMetaInteropTest] for octi-web's same module. Same shape, different source +
+ * vector contents (`deviceType=DESKTOP` instead of `BROWSER`, `deviceBootedAt` set instead of
+ * always null, etc.).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DesktopMetaInteropTest {
+
+    private lateinit var cacheDir: Path
+
+    private val decoder: Json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    @BeforeAll
+    fun setUp() {
+        cacheDir = InteropFixtureSync.ensureSynced("d4rken-org/octi-desktop")
+    }
+
+    @Test
+    fun `desktop meta fixture schema sanity`() {
+        val fixture = loadFixture()
+        fixture.schemaVersion shouldBe InteropFixtures.FIXTURE_SCHEMA_VERSION
+        fixture.module shouldBe "eu.darken.octi.module.core.meta"
+        fixture.producer shouldBe "d4rken-org/octi-desktop"
+        fixture.vectors.map { it.name } shouldBe listOf("full", "minimal", "unicode-label")
+    }
+
+    @Test
+    fun `desktop meta 'full' vector decodes to expected MetaInfo`() {
+        val info = decode(vector("full"))
+        info.deviceLabel shouldBe "Test Desktop"
+        info.deviceId.id shouldBe "22222222-3333-4444-5555-666666666666"
+        info.octiVersionName shouldBe "0.0.0-test"
+        info.octiGitSha shouldBe "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        info.deviceManufacturer shouldBe "Eclipse Adoptium"
+        info.deviceName shouldBe "octi-test-host"
+        info.deviceType shouldBe MetaInfo.DeviceType.DESKTOP
+        // Desktop's MetaWriter calls ProcessHandle.startInstant() — emits a real Instant, never
+        // null (unlike web). Consumers must accept this.
+        info.deviceBootedAt shouldBe Instant.parse("2026-05-01T10:00:00Z")
+        info.androidVersionName shouldBe null
+        info.androidApiLevel shouldBe null
+        info.androidSecurityPatch shouldBe null
+        info.osType shouldBe "Linux"
+        info.osVersionName shouldBe "6.8.0"
+    }
+
+    @Test
+    fun `desktop meta 'minimal' vector decodes with absent optionals as null`() {
+        // Schema-shape vector. The pinned `minimal` payload omits `deviceBootedAt` entirely
+        // (explicitNulls=false strips the field on the producer side); the decoder must
+        // re-materialize the absent field as null. Real desktop writer always emits a
+        // non-null Instant — this vector is forward-compat for that absence rather than a
+        // production-output snapshot.
+        val v = vector("minimal")
+        // Pin wire-shape absence too, not just the decoded null. If the producer ever
+        // started emitting `"deviceBootedAt": null` explicitly, this would catch it.
+        (v.payloadJson.contains("deviceBootedAt")) shouldBe false
+
+        val info = decode(v)
+        info.deviceLabel shouldBe null
+        info.deviceId.id shouldBe "22222222-3333-4444-5555-666666666666"
+        info.octiVersionName shouldBe "0.0.0-test"
+        info.octiGitSha shouldBe "desktop-dev"
+        info.deviceManufacturer shouldBe "Eclipse Adoptium"
+        info.deviceName shouldBe "octi-desktop"
+        info.deviceType shouldBe MetaInfo.DeviceType.DESKTOP
+        info.deviceBootedAt shouldBe null
+        info.osType shouldBe null
+        info.osVersionName shouldBe null
+    }
+
+    @Test
+    fun `desktop meta 'unicode-label' vector decodes every field including non-ASCII deviceLabel`() {
+        val info = decode(vector("unicode-label"))
+        // Mixed UTF-8: Japanese katakana + emoji + Arabic.
+        info.deviceLabel shouldBe "デスクトップ 🖥 العربية"
+        info.deviceId.id shouldBe "22222222-3333-4444-5555-666666666666"
+        info.octiVersionName shouldBe "0.0.0-test"
+        info.octiGitSha shouldBe "desktop-dev"
+        info.deviceManufacturer shouldBe "Eclipse Adoptium"
+        info.deviceName shouldBe "octi-desktop"
+        info.deviceType shouldBe MetaInfo.DeviceType.DESKTOP
+        info.deviceBootedAt shouldBe Instant.parse("2026-05-01T10:00:00Z")
+        info.osType shouldBe "Linux"
+        info.osVersionName shouldBe null
+    }
+
+    private fun loadFixture(): PublishedModuleFixture {
+        val bytes = Files.readAllBytes(cacheDir.resolve("octi-desktop-meta.json"))
+        return InteropFixtures.json.decodeFromString(
+            PublishedModuleFixture.serializer(),
+            bytes.decodeToString(),
+        )
+    }
+
+    private fun vector(name: String): PublishedVector {
+        val fixture = loadFixture()
+        val v = fixture.vectors.firstOrNull { it.name == name }
+            ?: error("vector '$name' missing in ${fixture.module}")
+        InteropFixtures.verifyVectorIntegrity(v)
+        return v
+    }
+
+    private fun decode(v: PublishedVector): MetaInfo {
+        return decoder.decodeFromString(MetaInfo.serializer(), v.payloadJson)
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/interop/SyncRefResolverTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/interop/SyncRefResolverTest.kt
@@ -152,23 +152,50 @@ class SyncRefResolverTest {
     }
 
     @Test
-    fun `resolveAll throws when override targets a source not present in the lock`() {
-        // Workflow misconfiguration guard: a override for an allowlisted-but-not-yet-locked
-        // source (e.g. octi-desktop before Phase C lands it in app-main's lock) must fail loudly,
-        // not silently fall back to the locked refs.
+    fun `resolveAllFromEnv throws when override targets a source not present in the lock`() {
+        // Workflow misconfiguration guard: an override for an allowlisted source that isn't
+        // present in this repo's lock must fail loudly, not silently fall back. Goes through
+        // the full env → parseOverrides → resolveAll path so SOURCE_PATHS validation is also
+        // exercised on the way in.
+        val env = mapOf(
+            "INTEROP_FIXTURE_OVERRIDES" to """{"d4rken-org/octi-desktop":"${"a".repeat(40)}"}""",
+        )
+        // validLock() only carries octi-web; the desktop override is allowlisted by SOURCE_PATHS
+        // but not present in the lock → resolveAll's missing-source guard fires.
         shouldThrow<IllegalArgumentException> {
-            // Use any SOURCE_PATHS-known key OTHER than what's in this lock. We only have one
-            // SOURCE_PATHS entry today, so simulate a second one being added to overrides without
-            // first being added to the lock by reaching for an arbitrary known string from the
-            // override path's validation set. Since SOURCE_PATHS only has octi-web today, this
-            // test uses parseOverrides validation as a precondition — any other key would be
-            // rejected at parse-time, so the only way to exercise resolveAll's check is to call
-            // it directly with a manually-constructed override map.
-            SyncRefResolver.resolveAll(
-                validLock(),
-                mapOf("d4rken-org/octi-future" to "0000000000000000000000000000000000000003"),
-            )
+            SyncRefResolver.resolveAllFromEnv(validLock(), env = env)
         }
+    }
+
+    @Test
+    fun `resolveAllFromEnv applies an override to one source of a multi-source lock and leaves the other anchored`() {
+        // Phase C2 onward: app-main's lock has both octi-web and octi-desktop. An override
+        // workflow (e.g. octi-desktop's symmetric gate) pins only its own source; the other
+        // must keep its locked ref + manifestSha256 anchor. End-to-end test via the env path
+        // — the same path the production gate exercises.
+        val secondSource = "d4rken-org/octi-desktop"
+        val secondRef = "1e00e71fc60841fda80d7db4f630aa99b1112c9d"
+        val secondSha = "ce2fd860ff124599bfc61a94f824c17c521cf79d744f06bc3551e284e6a37fe4"
+        val multiSourceLock = FixtureLock(
+            schemaVersion = InteropFixtures.LOCK_SCHEMA_VERSION,
+            sources = mapOf(
+                validSourceA to LockedSource(validRefA, validShaA),
+                secondSource to LockedSource(secondRef, secondSha),
+            ),
+        )
+        val override = "1111111111111111111111111111111111111111"
+        val resolved = SyncRefResolver.resolveAllFromEnv(
+            multiSourceLock,
+            env = mapOf("INTEROP_FIXTURE_OVERRIDES" to """{"$secondSource":"$override"}"""),
+        )
+
+        val webEntry = resolved.getValue(validSourceA)
+        webEntry.ref shouldBe validRefA
+        webEntry.manifestSha256 shouldBe validShaA
+
+        val desktopEntry = resolved.getValue(secondSource)
+        desktopEntry.ref shouldBe override
+        desktopEntry.manifestSha256 shouldBe null
     }
 
     @Test


### PR DESCRIPTION
## What changed

No user-facing behavior change. Internal: app-main now consumes `d4rken-org/octi-desktop`'s published wire-format fixtures alongside the existing `d4rken-org/octi-web` ones. A serializer change in either producer that drops a required field, retypes a value, or renames an enum entry breaks the matching consumer test here.

Mirror of B2 (`d4rken-org/octi#318`, merged) pointed at the second producer. The multi-source v2 lockfile + sync infrastructure landed in B2 already supports two (or more) sources; this PR just wires up the desktop entry.

## Technical Context

- **Second source pinned in `fixture-lock.json`.** `d4rken-org/octi-desktop @ 1e00e71fc60841fda80d7db4f630aa99b1112c9d` (the C1 merge SHA), manifest_sha256 `ce2fd860ff124599bfc61a94f824c17c521cf79d744f06bc3551e284e6a37fe4`. The existing `d4rken-org/octi-web` entry is untouched. Each source bumps independently; one stale entry doesn't poison the other on cache (though the first sync call still does fetch both — see note in `InteropFixtureSync.kt`).
- **`SyncRefResolver.SOURCE_PATHS`** gains `"d4rken-org/octi-desktop" to "src/test/resources/interop/published"`. The doc comment was sharpened along the way ("Keep in lockstep across all three" → "for any shared source, the path string must agree across consumers") — the registry is subset-based per consumer, not a single global allowlist.
- **Three new `Desktop*InteropTest` files**, one per module, sitting next to the existing `Web*InteropTest` siblings. Each calls `InteropFixtureSync.ensureSynced("d4rken-org/octi-desktop")` in `@BeforeAll`, parses every vector through the production decoder, and asserts field-by-field against octi-desktop's canonical inputs in `InteropFixtureGenerator.kt`.
- **Wire-shape differences pinned explicitly:**
  - `MetaInfo.deviceType = DESKTOP` (not BROWSER like web).
  - `MetaInfo.deviceBootedAt = Instant.parse("2026-05-01T10:00:00Z")` in the `full` and `unicode-label` vectors. Desktop's `MetaWriter` calls `ProcessHandle.startInstant()` and emits a real Instant — never null, unlike web.
  - The `minimal` meta vector's `deviceBootedAt` is *absent* on the wire (the test pins `payloadJson.contains("deviceBootedAt") shouldBe false` AND `info.deviceBootedAt shouldBe null` so a future shift from "absent" to "explicitly null" is caught).
  - `SharedFile.blobKey` is a plain UUID (`00000000-0000-0000-0000-000000000001`), NOT the `sha256:<hex>` shape web/android use. Verified via `FileShareRepo.kt` — desktop calls `UUID.randomUUID().toString()`. Consumers see two different `blobKey` shapes on the wire depending on which producer wrote the payload; the dashboard treats the string as opaque so the asymmetry is fine. Codex confirmed app-main itself also emits UUIDs for its own blobs.
  - Connector IDs are desktop-flavoured (`kserver-prod.kserver.octi.darken.eu-77777777-...` vs web's `aaaaaaaa-...`). Routed through `ConnectorId(...).idString` on the producer side so a future format change propagates.
- **`SyncRefResolverTest` gets one new regression test + one comment cleanup.** The renamed `resolveAllFromEnv throws when override targets a source not present in the lock` now goes through the full env → parseOverrides → resolveAll path (was directly hitting `resolveAll`, which bypassed SOURCE_PATHS validation). A new `resolveAllFromEnv applies an override to one source of a multi-source lock and leaves the other anchored` test pins the exact path the C4 cross-repo workflow will exercise: override desktop, leave web on its locked ref + manifestSha256.
- **`InteropFixtureSync` doc comment softened.** The previous "per-source independent" framing was misleading: cache directories are per-source, but the first `ensureSynced()` call syncs *all* sources before any test executes. Codex flagged this; the doc now states it explicitly.

## Review guidance

- Diff is ~500 lines, ~400 of which are three Desktop*InteropTest files that mirror the existing Web*InteropTest pattern. Compare the meta tests side-by-side for the most informative diff.
- The lockfile bump is the C1 merge SHA on `d4rken-org/octi-desktop` — verified by fetching `manifest.json` at that SHA and `sha256sum`-ing it.
- Desktop's UUID blobKey shape is intentional, not a fixture bug. The consumer test pins it explicitly so a future desktop-side migration to `sha256:` would surface here.

## Test plan

- [x] `./gradlew :sync-core:testDebugUnitTest :modules-meta:testDebugUnitTest :modules-clipboard:testDebugUnitTest :modules-files:testDebugUnitTest` green on cold cache (fetched both octi-web and octi-desktop fixtures).
- [x] Same command green on warm cache (both sources cache-hit).
- [x] 4 new tests in `DesktopMetaInteropTest`, 4 in `DesktopClipboardInteropTest`, 7 in `DesktopFilesInteropTest`, +1 new resolver test.
- [x] Existing `Web*InteropTest` files untouched and still pass — the two consumer test families coexist without coupling.
- [ ] Live cross-repo verify: covered by the symmetric upstream-gating workflow that lands on octi-desktop in C4 (after both consumers — this PR + C3 — are on `main`).

Sister PRs:
- d4rken-org/octi-desktop#56 — C1, the producer of these fixtures (merged).
- d4rken-org/octi-web#TBD — C3, the other consumer.
- d4rken-org/octi-desktop#TBD — C4, the symmetric upstream-gating workflow.
