### PR TITLE
Upgrade faraday from 1.10.5 to 1.10.6 in fastlane bundle

### DIFF
--- a/fastlane/Gemfile.lock
+++ b/fastlane/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     excon (0.112.0)
-    faraday (1.10.5)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)


### PR DESCRIPTION
Resolves Dependabot alert #19.

## What

Bumps `faraday` `1.10.5` → `1.10.6` in `fastlane/Gemfile.lock` (conservative update — stays on the 1.x line, no other gems moved).

## Why

**GHSA-98m9-hrrm-r99r / CVE-2026-54297** (High, CVSS 7.5): uncontrolled recursion in Faraday's `NestedParamsEncoder` allows a stack-exhaustion DoS via deeply nested query parameters. Vulnerable range `>= 1.0.0, <= 1.10.5`; patched in `1.10.6`.

## Risk assessment

Low real-world impact for this repo: `faraday` is a transitive dependency of **fastlane** and lives only in the release/CI bundle — it is never shipped in the Android APK. fastlane only issues outbound requests to trusted APIs (Google Play, GitHub), so there is no attacker-controlled input path into the vulnerable encoder. This is a hygiene bump to clear the alert.

## Diff

```
-    faraday (1.10.5)
+    faraday (1.10.6)
```