### PR TITLE
Fix reappearing battery alert for stale devices

### DIFF
--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertManager.kt
@@ -31,8 +31,9 @@ import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.Instant
 
 @Singleton
 class PowerAlertManager @Inject constructor(
@@ -44,7 +45,6 @@ class PowerAlertManager @Inject constructor(
 ) {
 
     private val mutex = Mutex()
-    private val shownNotifications = mutableSetOf<AlertNotificationKey>()
 
     val alerts: Flow<Collection<PowerAlert<*>>> = combine(
         powerSettings.alertRules.flow,
@@ -95,78 +95,83 @@ class PowerAlertManager @Inject constructor(
                     return@forEach
                 }
 
+                val event = alertEvents.find { it.id == rule.id }
+                log(TAG) { "Found $event for $rule" }
+
+                // Freshness gate: a peer's battery reading is only actionable while recent.
+                // Stale data (peer offline for a while) — or data timestamped in the future by a
+                // skewed peer clock — must not raise or keep alerts alive. Evaluated on each alert
+                // check (cold-start init + per-sync checkAlerts), not via a timer.
+                val dataAge = Clock.System.now() - powerState.modifiedAt
+                if (dataAge > ALERT_DATA_MAX_AGE || dataAge < -CLOCK_SKEW_TOLERANCE) {
+                    if (event != null) {
+                        log(TAG, INFO) { "Power data for $rule is stale (age=$dataAge), clearing alert" }
+                        powerSettings.alertEvents.update { events -> events.filterNot { it.id == rule.id }.toSet() }
+                        notifications.dismiss(rule)
+                    } else {
+                        log(TAG, VERBOSE) { "Skipping stale $rule (age=$dataAge)" }
+                    }
+                    return@forEach
+                }
+
                 val metaState = metaRepo.device(rule.deviceId)
                 if (metaState == null) {
                     log(TAG, WARN) { "No MetaInfo available for $rule" }
                     return@forEach
                 }
 
-                val event = alertEvents.find { it.id == rule.id }
-                log(TAG) { "Found $event for $rule" }
-
+                val isTriggered: Boolean
+                val isRecovered: Boolean
                 when (rule) {
                     is BatteryLowAlertRule -> {
-                        val isTriggered = !powerState.data.isCharging &&
+                        isTriggered = !powerState.data.isCharging &&
                                 powerState.data.battery.percent < rule.threshold
-                        val isRecovered = powerState.data.isCharging ||
+                        isRecovered = powerState.data.isCharging ||
                                 powerState.data.battery.percent > (rule.threshold + 0.05f).coerceAtMost(0.95f)
-                        when {
-                            event == null && isTriggered && !isRecovered -> {
-                                log(TAG, INFO) { "Rule has triggered" }
-                                val newEvent = PowerAlertRule.Event(rule.id)
-                                powerSettings.alertEvents.update { it + newEvent }
-                                showNotificationIfNeeded(rule, newEvent, powerState.data, metaState.data)
-                            }
-
-                            event != null && !isTriggered && isRecovered -> {
-                                log(TAG, INFO) { "Rule is no longer triggered" }
-                                shownNotifications.remove(event.notificationKey)
-                                powerSettings.alertEvents.update { it - event }
-                                notifications.dismiss(rule)
-                            }
-
-                            event == null && !isTriggered -> {
-                                log(TAG, VERBOSE) { "Rule is not triggered" }
-                            }
-
-                            event != null && event.dismissedAt == null && isTriggered && !isRecovered -> {
-                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed)" }
-                                showNotificationIfNeeded(rule, event, powerState.data, metaState.data)
-                            }
-                        }
                     }
 
                     is BatteryHighAlertRule -> {
-                        val isTriggered = powerState.data.isCharging &&
+                        isTriggered = powerState.data.isCharging &&
                                 powerState.data.battery.percent >= rule.threshold
-                        val isRecovered = !powerState.data.isCharging ||
+                        isRecovered = !powerState.data.isCharging ||
                                 powerState.data.battery.percent < (rule.threshold - 0.05f).coerceAtLeast(0.05f)
-                        when {
-                            event == null && isTriggered && !isRecovered -> {
-                                log(TAG, INFO) { "Rule has triggered" }
-                                val newEvent = PowerAlertRule.Event(rule.id)
-                                powerSettings.alertEvents.update { it + newEvent }
-                                showNotificationIfNeeded(rule, newEvent, powerState.data, metaState.data)
-                            }
-
-                            event != null && !isTriggered && isRecovered -> {
-                                log(TAG, INFO) { "Rule is no longer triggered" }
-                                shownNotifications.remove(event.notificationKey)
-                                powerSettings.alertEvents.update { it - event }
-                                notifications.dismiss(rule)
-                            }
-
-                            event == null && !isTriggered -> {
-                                log(TAG, VERBOSE) { "Rule is not triggered" }
-                            }
-
-                            event != null && event.dismissedAt == null && isTriggered && !isRecovered -> {
-                                log(TAG, VERBOSE) { "Rule is triggered (not dismissed)" }
-                                showNotificationIfNeeded(rule, event, powerState.data, metaState.data)
-                            }
-                        }
                     }
                 }
+
+                evaluateAlert(rule, event, isTriggered, isRecovered, powerState.data, metaState.data)
+            }
+        }
+    }
+
+    private suspend fun evaluateAlert(
+        rule: PowerAlertRule,
+        event: PowerAlertRule.Event?,
+        isTriggered: Boolean,
+        isRecovered: Boolean,
+        power: PowerInfo,
+        meta: MetaInfo,
+    ) {
+        when {
+            event == null && isTriggered && !isRecovered -> {
+                log(TAG, INFO) { "Rule has triggered" }
+                val newEvent = PowerAlertRule.Event(rule.id)
+                powerSettings.alertEvents.update { it + newEvent }
+                showNotificationIfNeeded(rule, newEvent, power, meta)
+            }
+
+            event != null && !isTriggered && isRecovered -> {
+                log(TAG, INFO) { "Rule is no longer triggered" }
+                powerSettings.alertEvents.update { events -> events.filterNot { it.id == rule.id }.toSet() }
+                notifications.dismiss(rule)
+            }
+
+            event == null && !isTriggered -> {
+                log(TAG, VERBOSE) { "Rule is not triggered" }
+            }
+
+            event != null && event.dismissedAt == null && isTriggered && !isRecovered -> {
+                log(TAG, VERBOSE) { "Rule is triggered (not dismissed)" }
+                showNotificationIfNeeded(rule, event, power, meta)
             }
         }
     }
@@ -177,21 +182,20 @@ class PowerAlertManager @Inject constructor(
         power: PowerInfo,
         meta: MetaInfo,
     ) {
-        val key = event.notificationKey
-        if (key in shownNotifications) {
-            log(TAG, VERBOSE) { "Notification already shown for $key" }
+        // `notifiedAt` is persisted, so a delivered notification is not re-posted after a process
+        // restart (the in-memory-only guard we replaced reset on every cold start). Stamped after a
+        // successful show() so a failed delivery is retried on the next check rather than silently lost.
+        if (event.notifiedAt != null) {
+            log(TAG, VERBOSE) { "Notification already shown for ${event.id} at ${event.notifiedAt}" }
             return
         }
 
         notifications.show(rule, power, meta)
-        shownNotifications += key
+        powerSettings.alertEvents.update { events ->
+            val target = events.firstOrNull { it.id == event.id } ?: return@update events
+            (events.filterNot { it.id == event.id } + target.copy(notifiedAt = Clock.System.now())).toSet()
+        }
     }
-
-    private val PowerAlertRule.Event.notificationKey: AlertNotificationKey
-        get() = AlertNotificationKey(
-            alertId = id,
-            triggeredAt = triggeredAt,
-        )
 
     private fun ModuleRepo.State<PowerInfo>.alertRelevantStateKey(): Set<AlertRelevantPowerState> = all
         .map {
@@ -204,11 +208,6 @@ class PowerAlertManager @Inject constructor(
         }
         .toSet()
 
-    private data class AlertNotificationKey(
-        val alertId: PowerAlertRuleId,
-        val triggeredAt: Instant,
-    )
-
     private data class AlertRelevantPowerState(
         val deviceId: DeviceId,
         val isCharging: Boolean,
@@ -219,49 +218,41 @@ class PowerAlertManager @Inject constructor(
     suspend fun setBatteryLowAlert(deviceId: DeviceId, threshold: Float?): Unit = mutex.withLock {
         log(TAG) { "setBatteryLowAlert($deviceId,$threshold)" }
 
-        var newRule: BatteryLowAlertRule? = null
-
         powerSettings.alertRules.update { oldRules ->
             val otherRules = oldRules.filterNot { it.deviceId == deviceId && it is BatteryLowAlertRule }
-
             if (threshold == null) {
-                otherRules
+                otherRules.toSet()
             } else {
-                otherRules + BatteryLowAlertRule(deviceId = deviceId, threshold = threshold).also {
-                    newRule = it
-                }
-            }.toSet()
+                (otherRules + BatteryLowAlertRule(deviceId = deviceId, threshold = threshold)).toSet()
+            }
         }
 
-        powerSettings.alertEvents.update { old ->
-            val previousEvent = old.singleOrNull { it.id == newRule?.id } ?: return@update old
-            log(TAG) { "setBatteryLowAlert(...): Removing old event" }
-            (old - previousEvent).toSet()
-        }
+        // Clear any lingering event + notification for this rule id, whether we created, replaced, or
+        // disabled it. `id` and the notification id depend only on deviceId + rule type, so a placeholder
+        // threshold is fine. Dismiss unconditionally: a replaced rule that still triggers is re-shown by
+        // the next evaluation, while a lowered/disabled rule must not leave a stale notification visible.
+        val ruleRef = BatteryLowAlertRule(deviceId = deviceId, threshold = threshold ?: 0f)
+        log(TAG) { "setBatteryLowAlert(...): Clearing any existing event for ${ruleRef.id}" }
+        powerSettings.alertEvents.update { old -> old.filterNot { it.id == ruleRef.id }.toSet() }
+        notifications.dismiss(ruleRef)
     }
 
     suspend fun setBatteryHighAlert(deviceId: DeviceId, threshold: Float?): Unit = mutex.withLock {
         log(TAG) { "setBatteryHighAlert($deviceId,$threshold)" }
 
-        var newRule: BatteryHighAlertRule? = null
-
         powerSettings.alertRules.update { oldRules ->
             val otherRules = oldRules.filterNot { it.deviceId == deviceId && it is BatteryHighAlertRule }
-
             if (threshold == null) {
-                otherRules
+                otherRules.toSet()
             } else {
-                otherRules + BatteryHighAlertRule(deviceId = deviceId, threshold = threshold).also {
-                    newRule = it
-                }
-            }.toSet()
+                (otherRules + BatteryHighAlertRule(deviceId = deviceId, threshold = threshold)).toSet()
+            }
         }
 
-        powerSettings.alertEvents.update { old ->
-            val previousEvent = old.singleOrNull { it.id == newRule?.id } ?: return@update old
-            log(TAG) { "setBatteryHighAlert(...): Removing old event" }
-            (old - previousEvent).toSet()
-        }
+        val ruleRef = BatteryHighAlertRule(deviceId = deviceId, threshold = threshold ?: 0f)
+        log(TAG) { "setBatteryHighAlert(...): Clearing any existing event for ${ruleRef.id}" }
+        powerSettings.alertEvents.update { old -> old.filterNot { it.id == ruleRef.id }.toSet() }
+        notifications.dismiss(ruleRef)
     }
 
     suspend fun dismissAlert(alertId: PowerAlertRuleId): Unit = mutex.withLock {
@@ -306,5 +297,11 @@ class PowerAlertManager @Inject constructor(
 
     companion object {
         val TAG = logTag("Module", "Power", "Alert", "Manager")
+
+        // A peer's battery reading is only actionable while recent; older data no longer raises alerts.
+        private val ALERT_DATA_MAX_AGE = 24.hours
+
+        // Tolerance for peer clock skew: data timestamped this far into the future is treated as stale.
+        private val CLOCK_SKEW_TOLERANCE = 5.minutes
     }
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertRule.kt
@@ -17,6 +17,7 @@ sealed interface PowerAlertRule {
         val id: PowerAlertRuleId,
         @Serializable(with = InstantSerializer::class) val triggeredAt: Instant = Clock.System.now(),
         @Serializable(with = InstantSerializer::class) val dismissedAt: Instant? = null,
+        @Serializable(with = InstantSerializer::class) val notifiedAt: Instant? = null,
     )
 }
 

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertManagerTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertManagerTest.kt
@@ -11,6 +11,8 @@ import eu.darken.octi.modules.power.core.PowerInfo
 import eu.darken.octi.modules.power.core.PowerRepo
 import eu.darken.octi.modules.power.core.PowerSettings
 import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -24,6 +26,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Instant
 
 class PowerAlertManagerTest : BaseTest() {
@@ -91,6 +94,156 @@ class PowerAlertManagerTest : BaseTest() {
         coVerify(exactly = 1) { notifications.dismiss(rule) }
     }
 
+    @Test
+    fun `stale peer data does not raise an alert and clears an active event`() = runTest2 {
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(setOf(PowerAlertRule.Event(id = rule.id)))
+        val powerStates = MutableStateFlow(
+            powerState(
+                remote = powerInfo(status = PowerInfo.Status.DISCHARGING, level = 4),
+                remoteModifiedAt = Clock.System.now() - 25.hours,
+            )
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { notifications.show(any(), any(), any()) }
+        coVerify { notifications.dismiss(rule) }
+        events.flow.value shouldBe emptySet()
+    }
+
+    @Test
+    fun `stale peer data does not re-notify a dismissed alert`() = runTest2 {
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(
+            setOf(
+                PowerAlertRule.Event(
+                    id = rule.id,
+                    dismissedAt = Clock.System.now(),
+                    notifiedAt = Clock.System.now(),
+                )
+            )
+        )
+        // Stale data that also looks "recovered" (charging): the freshness gate must handle it, not the
+        // recovery branch, which would delete the event and let a later low reading re-trigger a fresh one.
+        val powerStates = MutableStateFlow(
+            powerState(
+                remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 50),
+                remoteModifiedAt = Clock.System.now() - 25.hours,
+            )
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { notifications.show(any(), any(), any()) }
+        events.flow.value shouldBe emptySet()
+    }
+
+    @Test
+    fun `already-notified alert is not re-shown on a fresh evaluation`() = runTest2 {
+        // Simulates a process restart: the event was already delivered (notifiedAt set) and the peer is
+        // still low with fresh data. The persisted notifiedAt must prevent a re-post.
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(setOf(PowerAlertRule.Event(id = rule.id, notifiedAt = Clock.System.now())))
+        val powerStates = MutableStateFlow(
+            powerState(remote = powerInfo(status = PowerInfo.Status.DISCHARGING, level = 20))
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { notifications.show(any(), any(), any()) }
+    }
+
+    @Test
+    fun `fresh low battery triggers once and stamps notifiedAt`() = runTest2 {
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(emptySet<PowerAlertRule.Event>())
+        val powerStates = MutableStateFlow(
+            powerState(remote = powerInfo(status = PowerInfo.Status.DISCHARGING, level = 20))
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { notifications.show(rule, any(), any()) }
+        events.flow.value.single().notifiedAt shouldNotBe null
+    }
+
+    @Test
+    fun `disabling an alert clears its event and dismisses the notification`() = runTest2 {
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(setOf(PowerAlertRule.Event(id = rule.id, notifiedAt = Clock.System.now())))
+        // No power data for the peer -> processAlerts leaves the event untouched, isolating the setter.
+        val powerStates = MutableStateFlow(powerState(remote = null))
+
+        val manager = setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        manager.setBatteryLowAlert(remoteDevice, null)
+        advanceUntilIdle()
+
+        events.flow.value shouldBe emptySet()
+        rules.flow.value shouldBe emptySet()
+        coVerify { notifications.dismiss(any()) }
+    }
+
+    @Test
+    fun `lowering the threshold below the current level dismisses the stale notification`() = runTest2 {
+        val rule = BatteryLowAlertRule(deviceId = remoteDevice, threshold = 0.3f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(setOf(PowerAlertRule.Event(id = rule.id, notifiedAt = Clock.System.now())))
+        val powerStates = MutableStateFlow(
+            powerState(remote = powerInfo(status = PowerInfo.Status.DISCHARGING, level = 20))
+        )
+
+        val manager = setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        // Battery is 20%; lowering the alert to 10% means it no longer triggers, so the previously shown
+        // notification must be cancelled rather than left visible.
+        manager.setBatteryLowAlert(remoteDevice, 0.1f)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { notifications.dismiss(any()) }
+        coVerify(exactly = 0) { notifications.show(any(), any(), any()) }
+        events.flow.value shouldBe emptySet()
+    }
+
+    @Test
+    fun `stale charging data clears a high battery alert without notifying`() = runTest2 {
+        val rule = BatteryHighAlertRule(deviceId = remoteDevice, threshold = 0.85f)
+        val rules = statefulValue(setOf<PowerAlertRule>(rule))
+        val events = statefulValue(setOf(PowerAlertRule.Event(id = rule.id)))
+        val powerStates = MutableStateFlow(
+            powerState(
+                remote = powerInfo(status = PowerInfo.Status.CHARGING, level = 95),
+                remoteModifiedAt = Clock.System.now() - 25.hours,
+            )
+        )
+
+        setupManager(rules, events, powerStates)
+        advanceTimeBy(1_100)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { notifications.show(any(), any(), any()) }
+        coVerify { notifications.dismiss(rule) }
+        events.flow.value shouldBe emptySet()
+    }
+
     private fun kotlinx.coroutines.test.TestScope.setupManager(
         rules: StatefulValue<Set<PowerAlertRule>>,
         events: StatefulValue<Set<PowerAlertRule.Event>>,
@@ -118,8 +271,9 @@ class PowerAlertManagerTest : BaseTest() {
     }
 
     private fun powerState(
-        remote: PowerInfo,
+        remote: PowerInfo?,
         self: PowerInfo = powerInfo(status = PowerInfo.Status.CHARGING, level = 80),
+        remoteModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<PowerInfo> = BaseModuleRepo.State(
         moduleId = PowerModule.MODULE_ID,
         self = ModuleData(
@@ -128,13 +282,15 @@ class PowerAlertManagerTest : BaseTest() {
             moduleId = PowerModule.MODULE_ID,
             data = self,
         ),
-        others = listOf(
-            ModuleData(
-                modifiedAt = Clock.System.now(),
-                deviceId = remoteDevice,
-                moduleId = PowerModule.MODULE_ID,
-                data = remote,
-            )
+        others = listOfNotNull(
+            remote?.let {
+                ModuleData(
+                    modifiedAt = remoteModifiedAt,
+                    deviceId = remoteDevice,
+                    moduleId = PowerModule.MODULE_ID,
+                    data = it,
+                )
+            }
         ),
     )
 

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertRuleSerializationTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertRuleSerializationTest.kt
@@ -110,4 +110,27 @@ class PowerAlertRuleSerializationTest : BaseTest() {
         decoded.triggeredAt shouldBe event.triggeredAt
         decoded.dismissedAt shouldBe null
     }
+
+    @Test
+    fun `Event round-trip with notifiedAt`() {
+        val event = PowerAlertRule.Event(
+            id = "device-1-batterlow",
+            triggeredAt = Instant.parse("2024-06-15T12:00:00Z"),
+            dismissedAt = Instant.parse("2024-06-15T13:00:00Z"),
+            notifiedAt = Instant.parse("2024-06-15T12:30:00Z"),
+        )
+        val encoded = json.encodeToString(event)
+        val decoded = json.decodeFromString<PowerAlertRule.Event>(encoded)
+        decoded shouldBe event
+    }
+
+    @Test
+    fun `Event backward compatibility - old JSON without notifiedAt decodes to null`() {
+        val oldJson = """{"id":"device-1-batterlow","triggeredAt":"2024-06-15T12:00:00Z"}"""
+        val decoded = json.decodeFromString<PowerAlertRule.Event>(oldJson)
+        decoded.id shouldBe "device-1-batterlow"
+        decoded.triggeredAt shouldBe Instant.parse("2024-06-15T12:00:00Z")
+        decoded.dismissedAt shouldBe null
+        decoded.notifiedAt shouldBe null
+    }
 }


### PR DESCRIPTION
The battery alert check evaluated each device's last-known battery reading with no freshness check, so a device that went offline while low on battery kept raising its low-battery notification from days-old data — and it reappeared on every app restart even after being dismissed twice.

**Changes**

- Ignore battery readings older than 24h when deciding whether to raise or keep a battery alert (with a small guard against clocks set in the future); any alert already shown for a device that has since gone stale is cleared and dismissed.
- Persist a "notification already shown" timestamp on the alert event, replacing an in-memory-only guard that reset on every process restart — so a delivered alert is no longer re-posted on cold start.
- Cancel the notification and clear its stored state when a device's battery alert is turned off or its threshold is changed.

**Verification**

- Unit tests covering the freshness gate (stale suppressed, stale-recovered keeps a dismissal, stale high-battery cleared), the restart de-duplication guard, and the disable/lower-threshold cleanup.
- Verified live on a device: a genuinely stale device (last reading 45 days old) is skipped with no notification, while a fresh device still triggers and shows one, and a shown alert is not re-posted after a restart.
