### PR TITLE
Fix crash when sharing a file that was moved or deleted

### DIFF
--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
@@ -52,6 +52,7 @@ import okio.Path.Companion.toPath
 import okio.Source
 import okio.source
 import java.io.File
+import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
 import java.security.DigestInputStream
@@ -90,6 +91,12 @@ class FileShareService @Inject constructor(
         data class FileTooLarge(val requestedBytes: Long, val maxBytes: Long) : ShareResult()
         data object NoEligibleConnectors : ShareResult()
         data object Cancelled : ShareResult()
+        /**
+         * The source content URI could not be read — the SAF/cloud provider revoked the read
+         * grant, or the underlying file was moved/deleted between the user picking it and the
+         * upload running. Distinct from a transport failure: nothing was ever readable to send.
+         */
+        data object SourceUnavailable : ShareResult()
         /** Every reachable connector reported `BlobServerStorageLowException`. */
         data object ServerStorageLow : ShareResult()
         /** Every reachable connector reported `BlobQuotaExceededException`. */
@@ -300,6 +307,9 @@ class FileShareService @Inject constructor(
         } catch (e: LocalStorageLowException) {
             log(TAG, WARN) { "shareFile(): local storage exhausted: ${e.message}" }
             ShareResult.LocalStorageLow(requestedBytes = e.requestedBytes, availableBytes = e.availableBytes)
+        } catch (e: SourceUnavailableException) {
+            log(TAG, WARN) { "shareFile(): source URI unreadable: ${e.message}" }
+            ShareResult.SourceUnavailable
         } finally {
             activeJobs.remove(blobKey.id)
             stagedFile?.delete()
@@ -328,31 +338,49 @@ class FileShareService @Inject constructor(
         val digest = MessageDigest.getInstance("SHA-256")
         var size = 0L
 
-        try {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                stagedFile.outputStream().use { output ->
+        // Attribute failures precisely: opening/reading the source URI failing means the shared
+        // content is gone (SourceUnavailableException); ENOSPC opening/writing/closing the staging
+        // file means local storage (LocalStorageLowException); any other local IO error propagates
+        // as a generic failure. Lumping them together mislabels a full disk as "file moved/deleted"
+        // and vice versa.
+        openSourceStream(uri).use { input ->
+            try {
+                stagedFile.outputStream().use { sink ->
                     val buffer = ByteArray(8192)
-                    var read: Int
-                    while (input.read(buffer).also { read = it } != -1) {
-                        output.write(buffer, 0, read)
+                    while (true) {
+                        val read = try {
+                            input.read(buffer)
+                        } catch (e: IOException) {
+                            throw SourceUnavailableException("read failed for $uri", e)
+                        } catch (e: SecurityException) {
+                            throw SourceUnavailableException("read permission lost for $uri", e)
+                        } catch (e: IllegalArgumentException) {
+                            throw SourceUnavailableException("read rejected for $uri", e)
+                        }
+                        if (read == -1) break
+                        // sink.write / the .use close below are staging-file IO — a failure here is
+                        // handled by the outer catch, not attributed to the source.
+                        sink.write(buffer, 0, read)
                         digest.update(buffer, 0, read)
                         size += read
                     }
                 }
-            } ?: throw IOException("openInputStream returned null for $uri")
-        } catch (e: IOException) {
-            // Local IO during staging is the only place a real ENOSPC fires for shareFile —
-            // distinguish it from generic transport failures so the UI can surface a useful
-            // error. Other IOException causes (provider revoked, permission lost) propagate
-            // as-is and get bucketed into AllConnectorsFailed by the outer `put` flow.
-            if (isNoSpaceOnDevice(e)) {
-                throw LocalStorageLowException(
-                    requestedBytes = size.coerceAtLeast(1L),
-                    availableBytes = stagingDir.usableSpace,
-                    cause = e,
-                )
+            } catch (e: SourceUnavailableException) {
+                // A source-read failure must not be reclassified as a local-storage failure below.
+                throw e
+            } catch (e: IOException) {
+                // Opening, writing, or closing the staging file failed. ENOSPC on the cache
+                // partition -> LocalStorageLow; any other local IO error propagates as a generic
+                // failure (the VM's appScope guard maps it), never mislabeled as "source gone".
+                if (isNoSpaceOnDevice(e)) {
+                    throw LocalStorageLowException(
+                        requestedBytes = size.coerceAtLeast(1L),
+                        availableBytes = stagingDir.usableSpace,
+                        cause = e,
+                    )
+                }
+                throw e
             }
-            throw e
         }
 
         val checksum = digest.digest().toLowercaseHex()
@@ -435,14 +463,27 @@ class FileShareService @Inject constructor(
     ): UploadOutcome {
         val precountDigest = MessageDigest.getInstance("SHA-256")
         var precountSize = 0L
-        context.contentResolver.openInputStream(uri)?.use { input ->
-            val buffer = ByteArray(8192)
-            var read: Int
-            while (input.read(buffer).also { read = it } != -1) {
-                precountDigest.update(buffer, 0, read)
-                precountSize += read
-            }
-        } ?: throw UriNotReopenableException("Pre-count open returned null for $uri")
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val buffer = ByteArray(8192)
+                var read: Int
+                while (input.read(buffer).also { read = it } != -1) {
+                    precountDigest.update(buffer, 0, read)
+                    precountSize += read
+                }
+            } ?: throw UriNotReopenableException("Pre-count open returned null for $uri")
+        } catch (e: UriNotReopenableException) {
+            throw e
+        } catch (e: IOException) {
+            // Open or read of the source URI failed (missing/moved file, provider error). Route
+            // to the staging fallback like the null case — the last-resort Tier A read maps a
+            // still-dead URI to SourceUnavailableException. Without this, a thrown FNF escapes.
+            throw UriNotReopenableException("Pre-count read failed for $uri: ${e.message}")
+        } catch (e: SecurityException) {
+            throw UriNotReopenableException("Pre-count read permission lost for $uri: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            throw UriNotReopenableException("Pre-count provider rejected $uri: ${e.message}")
+        }
         val precountChecksum = precountDigest.digest().toLowercaseHex()
         log(TAG, VERBOSE) { "runPreCountThenStream(): precount size=$precountSize" }
 
@@ -471,18 +512,36 @@ class FileShareService @Inject constructor(
      * Build a single-call `() -> Source` factory that opens [uri], wraps the InputStream with a
      * [DigestInputStream] feeding [plaintextDigest], and returns an okio `Source`. A second call
      * is a contract violation (Tier B and B′ are single-connector — the factory is invoked
-     * exactly once by `BlobManager.put`). [UriNotReopenableException] propagates when the
-     * provider returns null on open, signalling the orchestrator to drop to Tier A.
+     * exactly once by `BlobManager.put`). A source-open failure raises [SourceUnavailableException];
+     * because the factory runs inside `BlobManager.put`, that surfaces as a per-connector error and
+     * — when every connector saw only source failures — is mapped to [ShareResult.SourceUnavailable]
+     * by [mapAllFailedToShareResult].
      */
     private fun singleUseUriSource(uri: Uri, plaintextDigest: MessageDigest): () -> Source {
         var opened = false
         return {
             check(!opened) { "single-use URI source factory invoked twice" }
             opened = true
-            val input: InputStream = context.contentResolver.openInputStream(uri)
-                ?: throw UriNotReopenableException("openInputStream returned null for $uri")
-            DigestInputStream(input, plaintextDigest).source()
+            DigestInputStream(openSourceStream(uri), plaintextDigest).source()
         }
+    }
+
+    /**
+     * Open [uri] for reading, mapping every "source is gone" signal to [SourceUnavailableException]:
+     * the provider returned null, [FileNotFoundException] (file moved/deleted), [SecurityException]
+     * (read grant revoked), or [IllegalArgumentException] (provider rejected the URI). Callers that
+     * open the URI directly (outside `BlobManager.put`) rely on this so a stale content URI produces
+     * a mapped [ShareResult] instead of an uncaught crash.
+     */
+    private fun openSourceStream(uri: Uri): InputStream = try {
+        context.contentResolver.openInputStream(uri)
+            ?: throw SourceUnavailableException("openInputStream returned null for $uri", null)
+    } catch (e: FileNotFoundException) {
+        throw SourceUnavailableException("openInputStream failed for $uri", e)
+    } catch (e: SecurityException) {
+        throw SourceUnavailableException("read permission lost for $uri", e)
+    } catch (e: IllegalArgumentException) {
+        throw SourceUnavailableException("provider rejected $uri", e)
     }
 
     private suspend inline fun <T> withTransferRow(
@@ -521,6 +580,13 @@ class FileShareService @Inject constructor(
             return ShareResult.NoEligibleConnectors
         }
         val errs = putResult.perConnectorErrors.values
+        if (errs.isNotEmpty() && errs.all { it is SourceUnavailableException }) {
+            // Single-connector streaming tiers open the URI inside BlobManager.put, so a dead
+            // source surfaces as a per-connector error rather than throwing out of shareFile.
+            // Map it to the same result the staging path produces — this is a source problem,
+            // not a connector/transport failure.
+            return ShareResult.SourceUnavailable
+        }
         if (errs.isNotEmpty() && errs.all { it is BlobConnectorUnsupportedException }) {
             // Every reachable connector pointed at a legacy server. Surface as
             // "no eligible connectors" — same UX as never having one configured.
@@ -564,6 +630,12 @@ class FileShareService @Inject constructor(
     ) : IOException("Local storage exhausted (requested=$requestedBytes, available=$availableBytes)", cause)
 
     private class UriNotReopenableException(message: String) : IOException(message)
+
+    /**
+     * The source content URI could not be read (provider returned null, file moved/deleted, read
+     * grant revoked, or the provider rejected the URI). Mapped to [ShareResult.SourceUnavailable].
+     */
+    private class SourceUnavailableException(message: String, cause: Throwable?) : IOException(message, cause)
 
     private fun ByteArray.toLowercaseHex(): String = joinToString("") { "%02x".format(it) }
 

--- a/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/ui/list/FileShareListVM.kt
@@ -46,6 +46,7 @@ import eu.darken.octi.sync.core.blob.StorageStatus
 import eu.darken.octi.sync.core.blob.StorageStatusManager
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.sync.core.shortLabel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -467,25 +468,38 @@ class FileShareListVM @Inject constructor(
             return@launch
         }
         appScope.launch(dispatcherProvider.IO) {
-            when (val result = fileShareService.shareFile(uri)) {
-                is FileShareService.ShareResult.Success ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_success))
-                is FileShareService.ShareResult.PartialMirror ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_partial))
-                is FileShareService.ShareResult.AllConnectorsFailed ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_failed))
-                is FileShareService.ShareResult.FileTooLarge ->
-                    uiEvents.tryEmit(UiEvent.ShowMessageWithSize(R.string.module_files_upload_too_large, result.maxBytes))
-                is FileShareService.ShareResult.NoEligibleConnectors ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_no_connectors))
-                is FileShareService.ShareResult.Cancelled ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_cancelled))
-                is FileShareService.ShareResult.ServerStorageLow ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_server_storage_low))
-                is FileShareService.ShareResult.AccountQuotaFull ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_account_quota_full))
-                is FileShareService.ShareResult.LocalStorageLow ->
-                    uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_local_storage_low))
+            // appScope has no CoroutineExceptionHandler, so an exception escaping here crashes the
+            // app. shareFile maps known failures to ShareResult; the guard below turns an unexpected
+            // exception into a generic failure message instead of a crash (while letting genuine
+            // cancellation propagate). Mirrors the runCatching guards on the fire-and-forget sites.
+            try {
+                when (val result = fileShareService.shareFile(uri)) {
+                    is FileShareService.ShareResult.Success ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_success))
+                    is FileShareService.ShareResult.PartialMirror ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_partial))
+                    is FileShareService.ShareResult.AllConnectorsFailed ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_failed))
+                    is FileShareService.ShareResult.FileTooLarge ->
+                        uiEvents.tryEmit(UiEvent.ShowMessageWithSize(R.string.module_files_upload_too_large, result.maxBytes))
+                    is FileShareService.ShareResult.NoEligibleConnectors ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_no_connectors))
+                    is FileShareService.ShareResult.Cancelled ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_cancelled))
+                    is FileShareService.ShareResult.SourceUnavailable ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_source_unavailable))
+                    is FileShareService.ShareResult.ServerStorageLow ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_server_storage_low))
+                    is FileShareService.ShareResult.AccountQuotaFull ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_account_quota_full))
+                    is FileShareService.ShareResult.LocalStorageLow ->
+                        uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_local_storage_low))
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "onShareFile($uri) unexpected failure: ${e.asLog()}" }
+                uiEvents.tryEmit(UiEvent.ShowMessage(R.string.module_files_upload_failed))
             }
         }
     }

--- a/modules-files/src/main/res/values/strings.xml
+++ b/modules-files/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="module_files_upload_success">File shared successfully</string>
     <string name="module_files_upload_partial">File shared to some devices. Retry in progress\u2026</string>
     <string name="module_files_upload_failed">Failed to share file</string>
+    <string name="module_files_upload_source_unavailable">Couldn\'t read the selected file — it may have been moved or deleted</string>
     <string name="module_files_upload_too_large">File is too large to share (max %1$s)</string>
     <string name="module_files_upload_no_connectors">No sync service available for file sharing</string>
     <string name="module_files_save_success">File saved</string>

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
@@ -32,7 +32,10 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import okio.Source
 import java.io.ByteArrayInputStream
+import java.io.FileNotFoundException
+import java.io.IOException
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.hours
 
@@ -380,6 +383,158 @@ class FileShareServiceTest : BaseTest() {
         val result = createService().shareFile(uri)
 
         result.shouldBeInstanceOf<FileShareService.ShareResult.AllConnectorsFailed>()
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when staging source open throws FileNotFoundException`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        every { contentResolver.openInputStream(uri) } throws FileNotFoundException("gone")
+        every { syncSettings.deviceId } returns ownDeviceId
+        // Two connectors -> staging tier, which opens the URI directly before BlobManager.put.
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+        coVerify(exactly = 0) { blobManager.put(any(), any(), any(), any(), any(), any(), any()) }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when staging source open throws SecurityException`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // A revoked read grant surfaces as SecurityException, which is NOT an IOException — it must
+        // still be mapped rather than crashing the app.
+        every { contentResolver.openInputStream(uri) } throws SecurityException("permission revoked")
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when staging read fails mid-copy`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // Stream opens fine, then the provider drops mid-read (e.g. cloud file evicted).
+        every { contentResolver.openInputStream(uri) } answers {
+            object : java.io.InputStream() {
+                override fun read(): Int = throw IOException("mid-read boom")
+                override fun read(b: ByteArray): Int = throw IOException("mid-read boom")
+                override fun read(b: ByteArray, off: Int, len: Int): Int = throw IOException("mid-read boom")
+            }
+        }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when single-connector pre-count and staging fallback both fail`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // Single connector + unsized probe -> pre-count tier. Every open fails: the pre-count read
+        // routes to the staging fallback, which re-opens and maps the still-dead URI to
+        // SourceUnavailable. Without the fix, the thrown FileNotFoundException escapes -> crash.
+        every { contentResolver.openInputStream(uri) } throws FileNotFoundException("gone")
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA)
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+        coVerify(exactly = 0) { blobManager.put(any(), any(), any(), any(), any(), any(), any()) }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when single-connector streaming re-open fails`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val fileBytes = ByteArray(42) { it.toByte() }
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // First open (pre-count) succeeds; the streaming re-open inside BlobManager.put fails.
+        var opens = 0
+        every { contentResolver.openInputStream(uri) } answers {
+            opens++
+            if (opens == 1) ByteArrayInputStream(fileBytes) else throw FileNotFoundException("gone")
+        }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA)
+        // Drive the real openSource lambda so a genuine SourceUnavailableException lands in
+        // perConnectorErrors, then assert that an all-source-failure put maps to SourceUnavailable
+        // (the mapAllFailedToShareResult path for single-connector streaming tiers).
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } answers {
+            val openSource = arg<() -> Source>(3)
+            val err = try {
+                openSource()
+                error("expected streaming re-open to throw")
+            } catch (e: Throwable) {
+                e
+            }
+            BlobManager.PutResult(successful = emptySet(), perConnectorErrors = mapOf(connectorA to err))
+        }
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
 
         cacheDir.deleteRecursively()
     }

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/ui/list/FileShareListVMTest.kt
@@ -7,6 +7,7 @@ import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleManager
 import eu.darken.octi.modules.files.FileShareModule
+import eu.darken.octi.modules.files.R
 import eu.darken.octi.modules.files.core.FileKey
 import eu.darken.octi.modules.files.core.FileShareInfo
 import eu.darken.octi.modules.files.core.FileShareRepo
@@ -380,6 +381,38 @@ class FileShareListVMTest : BaseTest() {
         val uri = mockk<android.net.Uri>(relaxed = true)
         // Should not throw — runCatching wraps the failing call.
         vm.enqueueShareFile(uri)
+    }
+
+    @Test
+    fun `onShareFile shows source-unavailable message when service reports SourceUnavailable`() = runTest2 {
+        setupBaseMocks()
+        val uri = mockk<android.net.Uri>(relaxed = true)
+        coEvery { fileShareService.shareFile(uri) } returns FileShareService.ShareResult.SourceUnavailable
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = true))
+        vm.initialize(null)
+        vm.onShareFile(uri)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.ShowMessage>()
+        event.messageRes shouldBe R.string.module_files_upload_source_unavailable
+    }
+
+    @Test
+    fun `onShareFile surfaces generic failure and does not crash on unexpected exception`() = runTest2 {
+        setupBaseMocks()
+        val uri = mockk<android.net.Uri>(relaxed = true)
+        // shareFile maps known failures to ShareResult; an escaping throwable would otherwise crash
+        // appScope (no CoroutineExceptionHandler). The guard turns it into a generic failure.
+        coEvery { fileShareService.shareFile(uri) } throws IOException("unexpected")
+
+        val vm = makeVM(fakeUpgradeRepo(isPro = true))
+        vm.initialize(null)
+        vm.onShareFile(uri)
+
+        val event = vm.uiEvents.first()
+        event.shouldBeInstanceOf<FileShareListVM.UiEvent.ShowMessage>()
+        event.messageRes shouldBe R.string.module_files_upload_failed
     }
 
     @Test


### PR DESCRIPTION
## Summary

Sharing a file could crash the app. When a file was picked or shared, its content URI was opened only later, at upload time — by then the SAF/cloud provider may have revoked the read grant, or the file may have been moved or deleted. The resulting `FileNotFoundException` (or, commonly, `SecurityException`) was uncaught and crashed the app, because the upload runs on a scope with no exception handler.

Reported on 1.0.4-rc0 (Samsung Galaxy S22+, Android 16).

## Changes

- Map every unreadable-source signal — missing/moved file, revoked read grant, provider-rejected URI, or a mid-read drop — to a new `SourceUnavailable` result across all upload tiers (staging, pre-count, single-connector streaming). The user now sees "Couldn't read the selected file — it may have been moved or deleted" instead of a crash.
- Attribute staging failures precisely: a full cache partition still reports "not enough space"; other local I/O errors report a generic failure. No more mislabeling a full disk as "file moved/deleted" or vice versa.
- Add a crash guard to the file-list share action (the one `shareFile` call site that lacked one) that rethrows cancellation and turns any unexpected error into a generic failure message, so this path can no longer crash the app scope.

## Tests

- `FileShareServiceTest`: source open throws `FileNotFoundException`; source open throws `SecurityException`; read fails mid-copy; single-connector pre-count + staging fallback both fail; single-connector streaming re-open fails.
- `FileShareListVMTest`: `SourceUnavailable` surfaces the new message; an unexpected exception surfaces a generic failure without crashing.

## Out of scope (pre-existing, non-crashing)

- The B′ post-finalize checksum-mismatch path can still orphan a finalized server blob (needs `BlobManager` work).
- A single-connector streaming mid-read `SecurityException` still buckets to `AllConnectorsFailed` rather than `SourceUnavailable` (would need a wrapping stream; extremely rare, no crash).
