### PR TITLE
Clean up leftover blobs when a file share is interrupted

### DIFF
--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
@@ -240,8 +240,9 @@ class FileShareService @Inject constructor(
                 return@withContext mapAllFailedToShareResult(outcome.plaintextSize, putResult)
             }
 
-            // Open the cleanup window — covers the gap between put returning and upsertFile
-            // taking effect. Cancellation in here triggers abortPostFinalize.
+            // Open the cleanup window: from here until upsertFile records the SharedFile, the blob
+            // is finalized on the server but not yet referenced by any local state. Any failure or
+            // cancellation in this window must abort the blob (see the finally block) or it orphans.
             pendingPostFinalizeCleanup = putResult
 
             val sharedFile = FileShareInfo.SharedFile(
@@ -255,7 +256,16 @@ class FileShareService @Inject constructor(
                 availableOn = putResult.successful.map { it.idString }.toSet(),
                 connectorRefs = putResult.remoteRefs.mapKeys { (connectorId, _) -> connectorId.idString },
             )
-            fileShareHandler.upsertFile(sharedFile)
+            // Record the reference and close the cleanup window atomically w.r.t. cancellation.
+            // upsertFile suspends (DynamicStateFlow.updateBlocking); if cancellation landed between
+            // the SharedFile being recorded and the window closing, the finally block would abort a
+            // blob the metadata now points at (dangling). NonCancellable defers cancellation until
+            // both have completed. A failure past this point must NOT abort the blob — a failed sync
+            // below keeps it, and BaseModuleRepo's writeFlow re-syncs the pending row later.
+            withContext(NonCancellable) {
+                fileShareHandler.upsertFile(sharedFile)
+                pendingPostFinalizeCleanup = null
+            }
 
             // Force the just-finalized blob to land in a persisted module revision before we
             // declare the share done. BaseModuleRepo's writeFLow eventually picks up the
@@ -277,7 +287,6 @@ class FileShareService @Inject constructor(
                     moduleFilter = setOf(FileShareModule.MODULE_ID),
                 ),
             )
-            pendingPostFinalizeCleanup = null
             // Invalidate the storage cache for connectors that received the blob — the server-side
             // numbers just changed. Done after commit (not inside BlobManager.put) so an aborted
             // commit doesn't leave us holding a stale "we just used X bytes" snapshot.
@@ -290,19 +299,6 @@ class FileShareService @Inject constructor(
             }
         } catch (e: CancellationException) {
             log(TAG, INFO) { "shareFile(${blobKey.id}) cancelled" }
-            pendingPostFinalizeCleanup?.let { result ->
-                withContext(NonCancellable) {
-                    try {
-                        blobManager.abortPostFinalize(
-                            deviceId = syncSettings.deviceId,
-                            moduleId = FileShareModule.MODULE_ID,
-                            targets = result.remoteRefs,
-                        )
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "abortPostFinalize cleanup failed: ${e.message}" }
-                    }
-                }
-            }
             ShareResult.Cancelled
         } catch (e: LocalStorageLowException) {
             log(TAG, WARN) { "shareFile(): local storage exhausted: ${e.message}" }
@@ -311,8 +307,31 @@ class FileShareService @Inject constructor(
             log(TAG, WARN) { "shareFile(): source URI unreadable: ${e.message}" }
             ShareResult.SourceUnavailable
         } finally {
+            // If the cleanup window is still open we exited abnormally (cancellation, or any failure
+            // between finalize and upsertFile) with a finalized-but-unreferenced blob — abort it so
+            // it doesn't orphan. Runs for every abnormal exit, not just cancellation; NonCancellable
+            // inside abortFinalized keeps it working even when the coroutine is already cancelled.
+            pendingPostFinalizeCleanup?.let { abortFinalized(it) }
             activeJobs.remove(blobKey.id)
             stagedFile?.delete()
+        }
+    }
+
+    /**
+     * Abort blobs that were finalized on the server but never got referenced by a persisted
+     * SharedFile — otherwise they orphan until server-side GC. Runs under [NonCancellable] so it
+     * completes even when invoked from a cancelled coroutine's finally block, and swallows its own
+     * failures so cleanup errors never mask the original exception.
+     */
+    private suspend fun abortFinalized(putResult: BlobManager.PutResult) = withContext(NonCancellable) {
+        try {
+            blobManager.abortPostFinalize(
+                deviceId = syncSettings.deviceId,
+                moduleId = FileShareModule.MODULE_ID,
+                targets = putResult.remoteRefs,
+            )
+        } catch (e: Exception) {
+            log(TAG, WARN) { "abortPostFinalize cleanup failed: ${e.message}" }
         }
     }
 
@@ -494,9 +513,16 @@ class FileShareService @Inject constructor(
         // share fails on its own merits when `successful` is empty — we don't need to layer a
         // spurious "URI changed" error on top.
         if (outcome.putResult.successful.isNotEmpty() && outcome.plaintextChecksum != precountChecksum) {
-            throw IOException(
+            // The URI's content changed between the pre-count and encrypt reads, so the blob the
+            // server just finalized holds bytes we can't vouch for. This throw happens before
+            // shareFile opens its cleanup window (the window lives inside this helper's own put),
+            // so abort the finalized blob here or it orphans. Surface as SourceUnavailable — the
+            // source wasn't stably readable — rather than a raw IOException handled by the guard.
+            abortFinalized(outcome.putResult)
+            throw SourceUnavailableException(
                 "URI content changed between pre-count and upload: precount=$precountChecksum " +
-                    "encrypt=${outcome.plaintextChecksum}"
+                    "encrypt=${outcome.plaintextChecksum}",
+                null,
             )
         }
         // For the all-failed case, surface the precount digest as the canonical plaintext

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
@@ -20,6 +20,7 @@ import eu.darken.octi.sync.core.blob.BlobManager
 import eu.darken.octi.sync.core.blob.BlobQuotaExceededException
 import eu.darken.octi.sync.core.blob.BlobServerStorageLowException
 import eu.darken.octi.sync.core.blob.StorageStatusManager
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -28,10 +29,14 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import okio.Buffer
 import okio.Source
 import java.io.ByteArrayInputStream
 import java.io.FileNotFoundException
@@ -535,6 +540,206 @@ class FileShareServiceTest : BaseTest() {
         val result = createService().shareFile(uri)
 
         result shouldBe FileShareService.ShareResult.SourceUnavailable
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile aborts the finalized blob and returns SourceUnavailable on B-prime URI content change`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val ref = RemoteBlobRef("ref-1")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // Single connector + unsized probe -> pre-count tier. First open (pre-count) and second
+        // open (encrypt/upload) return DIFFERENT bytes, so the checksum cross-check trips after the
+        // blob is already finalized on the server.
+        var opens = 0
+        every { contentResolver.openInputStream(uri) } answers {
+            opens++
+            if (opens == 1) ByteArrayInputStream(byteArrayOf(1, 2, 3)) else ByteArrayInputStream(byteArrayOf(9, 9, 9))
+        }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA)
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } answers {
+            val openSource = arg<() -> Source>(3)
+            openSource().use { src ->
+                val sink = Buffer()
+                while (src.read(sink, 8192L) != -1L) sink.clear()
+            }
+            BlobManager.PutResult(
+                successful = setOf(connectorA),
+                perConnectorErrors = emptyMap(),
+                remoteRefs = mapOf(connectorA to ref),
+            )
+        }
+        coEvery { blobManager.abortPostFinalize(any(), any(), any()) } returns emptyList<Unit>()
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+        // The finalized-but-unreferenced blob must be aborted, not orphaned.
+        coVerify(exactly = 1) {
+            blobManager.abortPostFinalize(ownDeviceId, FileShareModule.MODULE_ID, mapOf(connectorA to ref))
+        }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile does NOT abort the blob when a post-upsert sync failure occurs`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        every { contentResolver.openInputStream(uri) } answers { ByteArrayInputStream(ByteArray(42)) }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } returns BlobManager.PutResult(
+            successful = setOf(connectorA, connectorB),
+            perConnectorErrors = emptyMap(),
+            remoteRefs = mapOf(connectorA to RemoteBlobRef("ref-a"), connectorB to RemoteBlobRef("ref-b")),
+        )
+        coEvery { handler.upsertFile(any()) } just runs
+        coEvery { handler.currentOwn() } returns FileShareInfo()
+        // The forced sync fails AFTER upsertFile has recorded the SharedFile. Aborting the blob now
+        // would dangle that metadata, so the blob must be kept (writeFlow re-syncs later).
+        coEvery { syncManager.sync(any<SyncOptions>()) } throws IOException("sync boom")
+
+        shouldThrow<IOException> { createService().shareFile(uri) }
+
+        coVerify(exactly = 0) { blobManager.abortPostFinalize(any(), any(), any()) }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile succeeds without aborting the blob on the happy path`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        every { contentResolver.openInputStream(uri) } answers { ByteArrayInputStream(ByteArray(42)) }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } returns BlobManager.PutResult(
+            successful = setOf(connectorA, connectorB),
+            perConnectorErrors = emptyMap(),
+            remoteRefs = mapOf(connectorA to RemoteBlobRef("ref-a"), connectorB to RemoteBlobRef("ref-b")),
+        )
+        coEvery { handler.upsertFile(any()) } just runs
+        coEvery { handler.currentOwn() } returns FileShareInfo()
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.Success
+        coVerify(exactly = 0) { blobManager.abortPostFinalize(any(), any(), any()) }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile aborts the finalized blob when cancelled before upsert`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val remoteRefs = mapOf(connectorA to RemoteBlobRef("ref-a"), connectorB to RemoteBlobRef("ref-b"))
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        every { contentResolver.openInputStream(uri) } answers { ByteArrayInputStream(ByteArray(42)) }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } returns BlobManager.PutResult(
+            successful = setOf(connectorA, connectorB),
+            perConnectorErrors = emptyMap(),
+            remoteRefs = remoteRefs,
+        )
+        // Cancellation lands inside the cleanup window (after finalize, before the SharedFile is
+        // recorded) — the finalized blob must be aborted.
+        coEvery { handler.upsertFile(any()) } throws CancellationException("cancelled")
+        coEvery { blobManager.abortPostFinalize(any(), any(), any()) } returns emptyList<Unit>()
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.Cancelled
+        coVerify(exactly = 1) {
+            blobManager.abortPostFinalize(ownDeviceId, FileShareModule.MODULE_ID, remoteRefs)
+        }
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `cancellation during upsert still records the file and does not abort the blob`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val connectorB = ConnectorId(ConnectorType.OCTISERVER, "srv-b.example.com", "acc-b")
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        every { contentResolver.query(uri, null, null, null, null) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        every { contentResolver.openInputStream(uri) } answers { ByteArrayInputStream(ByteArray(42)) }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA, connectorB)
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } returns BlobManager.PutResult(
+            successful = setOf(connectorA, connectorB),
+            perConnectorErrors = emptyMap(),
+            remoteRefs = mapOf(connectorA to RemoteBlobRef("ref-a"), connectorB to RemoteBlobRef("ref-b")),
+        )
+        // upsertFile suspends; we cancel the share while it's mid-record. Because it runs under
+        // NonCancellable, it must finish (recording the SharedFile) and the blob must NOT be aborted
+        // — otherwise the metadata would dangle. Without the NonCancellable guard, upsertFile would
+        // throw CancellationException here and the finally block would abort the blob.
+        val upsertReached = CompletableDeferred<Unit>()
+        val releaseUpsert = CompletableDeferred<Unit>()
+        var upsertCompleted = false
+        coEvery { handler.upsertFile(any()) } coAnswers {
+            upsertReached.complete(Unit)
+            releaseUpsert.await()
+            upsertCompleted = true
+        }
+        coEvery { handler.currentOwn() } returns FileShareInfo()
+        coEvery { blobManager.abortPostFinalize(any(), any(), any()) } returns emptyList<Unit>()
+
+        val service = createService()
+        val job = launch { service.shareFile(uri) }
+        upsertReached.await()
+        job.cancel()
+        releaseUpsert.complete(Unit)
+        job.join()
+
+        upsertCompleted shouldBe true
+        coVerify(exactly = 0) { blobManager.abortPostFinalize(any(), any(), any()) }
 
         cacheDir.deleteRecursively()
     }


### PR DESCRIPTION
## Summary

Follow-up to #323. Fixes a pre-existing bug where a blob finalized on the server could be **orphaned** (left referenced by nothing until server-side GC) when a file share failed after the upload but before the `SharedFile` metadata was persisted.

The abort cleanup previously ran only in the `CancellationException` catch, and only for the window opened *after* the upload outcome was computed. Two gaps followed:

- The **Tier B′ checksum-mismatch** (`runPreCountThenStream`, when a URI's content changes between the pre-count and encrypt reads) throws *inside* the helper — before that window opened — and as a plain `IOException`, so no abort ran → orphan.
- Any **non-cancellation** failure after finalize (e.g. the forced sync throwing) also skipped the abort.

## Changes

- Extract `abortFinalized()` (runs `abortPostFinalize` under `NonCancellable`, swallowing its own errors).
- Run the abort from `shareFile`'s `finally` for **any** abnormal exit within the `[put-success, upsertFile)` window — cancellation and non-cancellation alike.
- **Close the window at `upsertFile`, not after `sync`.** Once the `SharedFile` references the blob, a later sync failure keeps the blob (BaseModuleRepo's `writeFlow` re-syncs the pending row); aborting it then would leave **dangling metadata** — worse than the orphan.
- Record-the-reference and close-the-window run together under `NonCancellable`, so a cancellation landing mid-`upsertFile` (which suspends via `DynamicStateFlow.updateBlocking`) can't record the file yet still trip the abort.
- The B′ mismatch now maps to `ShareResult.SourceUnavailable` instead of escaping to the caller's guard.

## Tests

`FileShareServiceTest`:
- B′ URI content change → blob aborted, result is `SourceUnavailable`.
- Post-`upsertFile` sync failure → blob **not** aborted (no dangling metadata).
- Happy path → no abort, `Success`.
- `upsertFile` fails outright (cancellation-typed) → blob aborted.
- Gated behavioral test: cancellation *during* a suspending `upsertFile` still records the file and does **not** abort the blob (fails without the `NonCancellable` guard).

## Out of scope

Cancellation atomicity *inside* `BlobManager.put` — a store finalizing, then `awaitAll` being cancelled so no `PutResult` ever reaches `shareFile` — is a separate, deeper seam in shared sync-core code (affects all backends). It is a distinct "blob kept, metadata not recorded" interleaving and is intentionally not addressed here.
