### PR TITLE
Show a clearer message when a shared file goes unreadable mid-upload

### DIFF
--- a/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
+++ b/modules-files/src/main/java/eu/darken/octi/modules/files/core/FileShareService.kt
@@ -53,6 +53,7 @@ import okio.Source
 import okio.source
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.FilterInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.security.DigestInputStream
@@ -512,17 +513,39 @@ class FileShareService @Inject constructor(
      * Build a single-call `() -> Source` factory that opens [uri], wraps the InputStream with a
      * [DigestInputStream] feeding [plaintextDigest], and returns an okio `Source`. A second call
      * is a contract violation (Tier B and B′ are single-connector — the factory is invoked
-     * exactly once by `BlobManager.put`). A source-open failure raises [SourceUnavailableException];
-     * because the factory runs inside `BlobManager.put`, that surfaces as a per-connector error and
-     * — when every connector saw only source failures — is mapped to [ShareResult.SourceUnavailable]
-     * by [mapAllFailedToShareResult].
+     * exactly once by `BlobManager.put`). A source-open failure ([openSourceStream]) or a source-read
+     * failure ([sourceReadGuard]) raises [SourceUnavailableException]; because the factory runs inside
+     * `BlobManager.put`, that surfaces as a per-connector error and — when every connector saw only
+     * source failures — is mapped to [ShareResult.SourceUnavailable] by [mapAllFailedToShareResult].
      */
     private fun singleUseUriSource(uri: Uri, plaintextDigest: MessageDigest): () -> Source {
         var opened = false
         return {
             check(!opened) { "single-use URI source factory invoked twice" }
             opened = true
-            DigestInputStream(openSourceStream(uri), plaintextDigest).source()
+            DigestInputStream(sourceReadGuard(uri, openSourceStream(uri)), plaintextDigest).source()
+        }
+    }
+
+    /**
+     * Wrap [stream] so a failure while *reading* the source URI maps to [SourceUnavailableException],
+     * mirroring [openSourceStream]'s open-time mapping and the staging tier's mid-copy handling. The
+     * streaming tiers read the URI inside `BlobManager.put`, so without this a URI that goes
+     * unreadable mid-upload (grant revoked / cloud file evicted) would surface as a generic connector
+     * failure. Only the source stream is wrapped — connector/network writes happen elsewhere in
+     * `store.put`, so they can't be mislabeled as a source problem.
+     */
+    private fun sourceReadGuard(uri: Uri, stream: InputStream): InputStream = object : FilterInputStream(stream) {
+        override fun read(): Int = guarded { super.read() }
+        override fun read(b: ByteArray, off: Int, len: Int): Int = guarded { super.read(b, off, len) }
+        private fun guarded(read: () -> Int): Int = try {
+            read()
+        } catch (e: IOException) {
+            throw SourceUnavailableException("read failed for $uri", e)
+        } catch (e: SecurityException) {
+            throw SourceUnavailableException("read permission lost for $uri", e)
+        } catch (e: IllegalArgumentException) {
+            throw SourceUnavailableException("read rejected for $uri", e)
         }
     }
 

--- a/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
+++ b/modules-files/src/test/java/eu/darken/octi/modules/files/core/FileShareServiceTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import okio.Buffer
 import okio.Source
 import java.io.ByteArrayInputStream
 import java.io.FileNotFoundException
@@ -526,6 +527,57 @@ class FileShareServiceTest : BaseTest() {
             val err = try {
                 openSource()
                 error("expected streaming re-open to throw")
+            } catch (e: Throwable) {
+                e
+            }
+            BlobManager.PutResult(successful = emptySet(), perConnectorErrors = mapOf(connectorA to err))
+        }
+
+        val result = createService().shareFile(uri)
+
+        result shouldBe FileShareService.ShareResult.SourceUnavailable
+
+        cacheDir.deleteRecursively()
+    }
+
+    @Test
+    fun `shareFile returns SourceUnavailable when single-connector streaming read fails mid-upload`() = runTest2 {
+        val cacheDir = java.nio.file.Files.createTempDirectory("files-service-test").toFile()
+        val ownDeviceId = DeviceId("self")
+        val connectorA = ConnectorId(ConnectorType.OCTISERVER, "srv-a.example.com", "acc-a")
+        val fileBytes = ByteArray(42) { it.toByte() }
+        val uri = mockk<Uri>()
+        val contentResolver = mockk<ContentResolver>()
+
+        every { context.cacheDir } returns cacheDir
+        every { context.contentResolver } returns contentResolver
+        // Force UriProbe.Unsized (null size cursor) so the tier choice is deliberate: single
+        // connector + Unsized -> Tier B′ (pre-count then stream).
+        every { contentResolver.query(uri, any(), any(), any(), any()) } returns null
+        every { contentResolver.getType(uri) } returns "application/octet-stream"
+        // Pre-count open reads fine; the streaming re-open opens fine but throws mid-read (grant
+        // revoked / cloud file evicted while uploading).
+        var opens = 0
+        every { contentResolver.openInputStream(uri) } answers {
+            opens++
+            if (opens == 1) {
+                ByteArrayInputStream(fileBytes)
+            } else {
+                object : java.io.InputStream() {
+                    override fun read(): Int = throw SecurityException("revoked mid-read")
+                    override fun read(b: ByteArray, off: Int, len: Int): Int = throw SecurityException("revoked mid-read")
+                }
+            }
+        }
+        every { syncSettings.deviceId } returns ownDeviceId
+        coEvery { blobManager.configuredConnectorIds() } returns setOf(connectorA)
+        // Drive the real openSource lambda and READ it (not just open) so the mid-read failure is
+        // exercised and mapped to SourceUnavailableException, then bucketed to SourceUnavailable.
+        coEvery { blobManager.put(any(), any(), any(), any(), any(), any(), any()) } answers {
+            val openSource = arg<() -> Source>(3)
+            val err = try {
+                openSource().use { src -> src.read(Buffer(), 8192L) }
+                error("expected streaming read to throw")
             } catch (e: Throwable) {
                 e
             }


### PR DESCRIPTION
## Summary

Follow-up to #323. Makes the **streaming** upload tiers report an unreadable source consistently with the **staging** tier.

Single-connector uploads (Tier B / B′) open and read the source URI *inside* `BlobManager.put`. #323 already mapped **open-time** source failures to `SourceUnavailable`, but a URI that went unreadable **mid-upload** (read grant revoked, cloud file evicted) surfaced as a generic per-connector error → `AllConnectorsFailed` ("Failed to share file"). The staging tier already maps mid-read source failures to `SourceUnavailable`, so this was an inconsistency #323 partly introduced.

## Changes

- Add `sourceReadGuard(uri, stream)` — a `FilterInputStream` that maps read-time `IOException` / `SecurityException` / `IllegalArgumentException` to `SourceUnavailableException`.
- `singleUseUriSource` now wraps the opened stream with it, so streaming mid-read source failures bucket into `SourceUnavailable` via the existing `mapAllFailedToShareResult` path.
- Only the source URI stream is wrapped — connector/network write failures keep their own classification and are never mislabeled as a source problem.

## Tests

`FileShareServiceTest`: single-connector Tier B′ where the pre-count read succeeds but the streaming re-open throws mid-`read()` → result is `SourceUnavailable` (the test drives and *reads* the `openSource` lambda, exercising the read path rather than open).

## Notes

Non-crashing refinement (both before and after, no crash) — it corrects a misleading error message for a rare mid-upload source failure. Independent of #324; both touch `FileShareService.kt`, so whichever merges second will need a trivial rebase.
