### PR TITLE
Avoid orphaned blobs when cancelling a multi-device share

### DIFF
--- a/sync-core/src/main/java/eu/darken/octi/sync/core/blob/BlobManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/blob/BlobManager.kt
@@ -19,8 +19,10 @@ import eu.darken.octi.sync.core.RemoteBlobRef
 import eu.darken.octi.sync.core.SyncSettings
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -173,7 +175,7 @@ class BlobManager @Inject constructor(
             ProgressAggregator(expectedConnectors = candidates.size, downstream = it)
         }
 
-        candidates.map { store ->
+        val uploads = candidates.map { store ->
             async {
                 try {
                     // Pre-flight via the storage-status snapshot. Always refresh first — TTL +
@@ -273,7 +275,41 @@ class BlobManager @Inject constructor(
                     recordFailure(store.connectorId, blobKey)
                 }
             }
-        }.awaitAll()
+        }
+        try {
+            uploads.awaitAll()
+        } catch (e: CancellationException) {
+            // A store may have finalized its blob and recorded a remoteRef before this put was
+            // cancelled (e.g. the user cancelled a multi-connector share while another connector was
+            // still uploading). A cancelled put never returns a PutResult, so the caller can't clean
+            // these up — abort them here or they orphan on the server until GC. joinAll first so a
+            // child that returns a ref as cancellation propagates is still captured; then abort
+            // against the original candidate store instances (NOT the public abortPostFinalize, which
+            // re-resolves via allStores and would skip a connector that paused after uploading).
+            kotlinx.coroutines.withContext(NonCancellable) {
+                // Cancel any still-running uploads before the join barrier. In the user-cancel path
+                // the parent is already cancelling them; this also covers a store throwing its own
+                // (Timeout)CancellationException while the parent is still active, so a sibling can't
+                // keep uploading indefinitely under this NonCancellable join.
+                uploads.forEach { it.cancel() }
+                uploads.joinAll()
+                val finalized = remoteRefs.toMap()
+                if (finalized.isNotEmpty()) {
+                    log(TAG, WARN) { "put(${blobKey.id}): cancelled — aborting ${finalized.size} finalized blob(s)" }
+                    val storesById = candidates.associateBy { it.connectorId }
+                    finalized.forEach { (connectorId, ref) ->
+                        storesById[connectorId]?.let { store ->
+                            try {
+                                store.abortPostFinalize(deviceId, moduleId, ref)
+                            } catch (ex: Exception) {
+                                log(TAG, WARN) { "put(${blobKey.id}): abort $connectorId failed: ${ex.message}" }
+                            }
+                        }
+                    }
+                }
+            }
+            throw e
+        }
 
         // Quota refresh after success is handled by the caller (FileShareService /
         // BlobMaintenance) AFTER its module commit lands, so the cache reflects committed state

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/blob/BlobManagerTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/blob/BlobManagerTest.kt
@@ -14,7 +14,11 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.Flow
@@ -472,6 +476,77 @@ class BlobManagerTest : BaseTest() {
         storeB.getCalls shouldBe 0
     }
 
+    @Test
+    fun `put aborts finalized blobs when cancelled mid-fan-out`() = runTest2 {
+        val connectorIdA = connectorId
+        val connectorIdB = ConnectorId(ConnectorType.OCTISERVER, "b.example.com", "acc-b")
+        val gateB = CompletableDeferred<Unit>()
+        val reachedB = CompletableDeferred<Unit>()
+        val storeA = FakeBlobStore(connectorIdA, StorageStatus.Ready(connectorIdA, snap(used = 0, total = 1_000)))
+        val storeB = FakeBlobStore(
+            connectorId = connectorIdB,
+            initial = StorageStatus.Ready(connectorIdB, snap(used = 0, total = 1_000, cId = connectorIdB)),
+            putGate = gateB,
+            putReached = reachedB,
+        )
+        val manager = createManager(backgroundScope, storeA, storeB)
+
+        val job = launch {
+            manager.put(
+                deviceId = deviceId,
+                moduleId = moduleId,
+                blobKey = blobKey,
+                openSource = { Buffer().writeUtf8("payload") },
+                metadata = metadata,
+            )
+        }
+        // storeA finalizes immediately; storeB is suspended inside put() when we cancel.
+        reachedB.await()
+        job.cancel()
+        job.join()
+
+        storeA.putCalls shouldBe 1
+        storeA.abortCalls shouldBe 1
+        storeA.abortedRefs shouldBe listOf(RemoteBlobRef(blobKey.id))
+        storeB.abortCalls shouldBe 0
+    }
+
+    @Test
+    fun `put aborts a blob finalized by a store that ignores cancellation`() = runTest2 {
+        val connectorIdA = connectorId
+        val connectorIdB = ConnectorId(ConnectorType.OCTISERVER, "b.example.com", "acc-b")
+        val gateB = CompletableDeferred<Unit>()
+        val reachedB = CompletableDeferred<Unit>()
+        val storeA = FakeBlobStore(connectorIdA, StorageStatus.Ready(connectorIdA, snap(used = 0, total = 1_000)))
+        val storeB = FakeBlobStore(
+            connectorId = connectorIdB,
+            initial = StorageStatus.Ready(connectorIdB, snap(used = 0, total = 1_000, cId = connectorIdB)),
+            putGate = gateB,
+            putReached = reachedB,
+            ignoreCancellationInPut = true,
+        )
+        val manager = createManager(backgroundScope, storeA, storeB)
+
+        val job = launch {
+            manager.put(
+                deviceId = deviceId,
+                moduleId = moduleId,
+                blobKey = blobKey,
+                openSource = { Buffer().writeUtf8("payload") },
+                metadata = metadata,
+            )
+        }
+        reachedB.await()
+        job.cancel()          // cancellation requested while storeB.put is still running
+        gateB.complete(Unit)  // storeB finalizes and returns a ref AFTER cancellation
+        job.join()
+
+        // The joinAll barrier must capture storeB's late ref so it, too, gets aborted.
+        storeA.abortCalls shouldBe 1
+        storeB.abortCalls shouldBe 1
+        storeB.abortedRefs shouldBe listOf(RemoteBlobRef(blobKey.id))
+    }
+
     private fun createManager(
         scope: CoroutineScope,
         vararg stores: BlobStore,
@@ -500,9 +575,14 @@ class BlobManagerTest : BaseTest() {
         var throwOnPut: Throwable? = null,
         var throwOnGet: Throwable? = null,
         var getMetadata: BlobMetadata? = null,
+        private val putGate: CompletableDeferred<Unit>? = null,
+        private val putReached: CompletableDeferred<Unit>? = null,
+        private val ignoreCancellationInPut: Boolean = false,
     ) : BlobStore {
         var putCalls: Int = 0
         var getCalls: Int = 0
+        var abortCalls: Int = 0
+        val abortedRefs = mutableListOf<RemoteBlobRef>()
 
         override val storageStatus: StorageStatusProvider = object : StorageStatusProvider {
             override val connectorId: ConnectorId = this@FakeBlobStore.connectorId
@@ -523,7 +603,22 @@ class BlobManagerTest : BaseTest() {
             putCalls += 1
             throwOnPut?.let { throw it }
             if (failOnPut) throw RuntimeException("put() failed (test)")
+            putReached?.complete(Unit)
+            putGate?.let { gate ->
+                if (ignoreCancellationInPut) {
+                    // Simulate a store that finalizes despite cancellation: the ref returns after
+                    // the surrounding put() is cancelled, exercising BlobManager's joinAll barrier.
+                    withContext(NonCancellable) { gate.await() }
+                } else {
+                    gate.await()
+                }
+            }
             return RemoteBlobRef(key.id)
+        }
+
+        override suspend fun abortPostFinalize(deviceId: DeviceId, moduleId: ModuleId, remoteRef: RemoteBlobRef) {
+            abortCalls += 1
+            abortedRefs += remoteRef
         }
 
         override suspend fun get(


### PR DESCRIPTION
## Summary

Follow-up to #324 (documented there as out of scope). Fixes the deeper orphan seam inside `BlobManager.put`.

`put` fans out to candidate stores concurrently; a store that finishes records its `RemoteBlobRef`. If the whole `put` is cancelled **mid-fan-out** — e.g. the user cancels a multi-connector share while one connector already finished and another is still uploading — `awaitAll()` threw `CancellationException` and `put` propagated it **without returning a `PutResult`**. The caller (`FileShareService.shareFile`) never receives the result, so its own post-finalize cleanup (from #324) can't run (`pendingPostFinalizeCleanup` stays null). The already-finalized blob(s) orphan on the server until GC.

## Changes

- Wrap `awaitAll()` in `catch (CancellationException)`. On cancellation:
  - **Cancel** the remaining uploads, then **`joinAll()`** them under `NonCancellable` — a completion barrier so a store that finalizes as cancellation propagates (or one that ignores cancellation) still has its ref captured before the snapshot. Cancelling first prevents a sibling from uploading indefinitely under the barrier if a store threw its own timeout/cancellation while the parent was still active.
  - **Abort** each finalized blob against its **original candidate store instance** (not the public `abortPostFinalize`, which re-resolves via `allStores` and would skip a connector that paused after uploading), swallowing per-store errors.
  - Rethrow the original `CancellationException`.
- Normal success, partial-failure, and single-candidate `BlobSizeMismatchException` paths are unchanged (the `try` wraps only `awaitAll`; per-connector failures are still caught inside each child).

All `put` callers (file share, mirror maintenance) benefit.

## Tests

`BlobManagerTest` (extended `FakeBlobStore` with a put gate/reached signal, a cancellation-ignoring mode, and abort tracking):
- Cancel mid-fan-out with one store finalized and another suspended → only the finalized store's blob is aborted.
- A store that **ignores cancellation** and returns its ref *after* cancel → the `joinAll` barrier captures it and it is also aborted (this test fails without the barrier).

## Known residual & related follow-ups (not fixed here)

- A store whose `store.put` finalizes server-side but throws before returning the ref is never recorded in `remoteRefs`, so it can't be aborted at this layer (per-store atomicity). `BlobStore.abortPostFinalize` is also a no-op by default, so cleanup only applies to stores that implement it.
- `BlobMaintenance` has an analogous caller-side window (cancellation after `put` returns but before it persists refs), the mirror-upload equivalent of the `shareFile` window #324 fixed. Separate change.
