### PR TITLE
Guide second devices to link instead of creating a new account

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
@@ -42,7 +42,13 @@ object Nav {
         data object Add : Sync
 
         @Serializable
-        data object AddGDrive : Sync
+        data class AddPicker(val mode: Mode) : Sync {
+            @Serializable
+            enum class Mode { CREATE, LINK }
+        }
+
+        @Serializable
+        data class AddGDrive(val linking: Boolean = false) : Sync
 
         @Serializable
         data object AddOctiServer : Sync

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddNavigation.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddNavigation.kt
@@ -9,11 +9,13 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationEntry
+import eu.darken.octi.sync.ui.add.intent.SyncSetupIntentScreenHost
 import javax.inject.Inject
 
 class SyncAddNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Sync.Add> { SyncAddScreenHost() }
+        entry<Nav.Sync.Add> { SyncSetupIntentScreenHost() }
+        entry<Nav.Sync.AddPicker> { key -> SyncAddScreenHost(mode = key.mode) }
     }
 
     @Module

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
@@ -1,14 +1,9 @@
 package eu.darken.octi.sync.ui.add
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -32,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.octi.R
@@ -50,9 +46,13 @@ import eu.darken.octi.sync.core.ConnectorPauseReason
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.sync.core.SyncConnector
 import eu.darken.octi.sync.core.SyncConnectorState
+import eu.darken.octi.sync.ui.add.SyncAddVM.Companion.forMode
 
 @Composable
-fun SyncAddScreenHost(vm: SyncAddVM = hiltViewModel()) {
+fun SyncAddScreenHost(
+    mode: Nav.Sync.AddPicker.Mode,
+    vm: SyncAddVM = hiltViewModel(),
+) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
@@ -60,6 +60,8 @@ fun SyncAddScreenHost(vm: SyncAddVM = hiltViewModel()) {
     state?.let {
         SyncAddScreen(
             state = it,
+            mode = mode,
+            onContributionClicked = { contribution -> vm.onContributionClicked(contribution, mode) },
             onNavigateUp = { vm.navUp() },
         )
     }
@@ -68,15 +70,27 @@ fun SyncAddScreenHost(vm: SyncAddVM = hiltViewModel()) {
 @Composable
 fun SyncAddScreen(
     state: SyncAddVM.State,
+    mode: Nav.Sync.AddPicker.Mode,
+    onContributionClicked: (ConnectorUiContribution) -> Unit,
     onNavigateUp: () -> Unit,
 ) {
     var showHelpDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    val items = remember(state.contributions, mode) { state.contributions.forMode(mode) }
 
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(text = stringResource(R.string.sync_add_label)) },
+                title = {
+                    Text(
+                        text = stringResource(
+                            when (mode) {
+                                Nav.Sync.AddPicker.Mode.CREATE -> R.string.sync_add_pick_create_title
+                                Nav.Sync.AddPicker.Mode.LINK -> R.string.sync_add_pick_link_title
+                            }
+                        )
+                    )
+                },
                 navigationIcon = {
                     IconButton(onClick = onNavigateUp) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
@@ -90,13 +104,36 @@ fun SyncAddScreen(
             )
         },
     ) { innerPadding ->
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding),
-        ) {
-            items(state.items, key = { it.contribution.type.name }) { item ->
-                SyncAddItemRow(item = item)
+        if (items.isEmpty() && mode == Nav.Sync.AddPicker.Mode.LINK) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.sync_add_link_none_available),
+                    style = MaterialTheme.typography.bodyMedium,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(32.dp),
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+            ) {
+                items(items, key = { it.type.name }) { contribution ->
+                    SyncSetupRow(
+                        icon = { modifier -> contribution.Icon(modifier = modifier) },
+                        title = stringResource(contribution.labelRes),
+                        description = stringResource(contribution.descriptionRes),
+                        onClick = { onContributionClicked(contribution) },
+                    )
+                }
             }
         }
     }
@@ -122,56 +159,71 @@ fun SyncAddScreen(
     }
 }
 
+@Preview2
 @Composable
-private fun SyncAddItemRow(item: SyncAddVM.SyncAddItem) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { item.onClick() }
-            .padding(16.dp),
-        verticalAlignment = Alignment.Top,
-    ) {
-        item.contribution.Icon(modifier = Modifier.size(20.dp))
-
-        Spacer(modifier = Modifier.width(4.dp))
-
-        Column {
-            Text(
-                text = stringResource(item.contribution.labelRes),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Text(
-                text = stringResource(item.contribution.descriptionRes),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-        }
-    }
+private fun SyncAddScreenCreatePreview() = PreviewWrapper {
+    SyncAddScreen(
+        state = SyncAddVM.State(
+            contributions = listOf(
+                previewContribution(
+                    type = ConnectorType.GDRIVE,
+                    labelRes = R.string.sync_add_label,
+                    descriptionRes = R.string.sync_add_help_desc,
+                ),
+                previewContribution(
+                    type = ConnectorType.OCTISERVER,
+                    labelRes = R.string.sync_add_label,
+                    descriptionRes = R.string.sync_add_help_desc,
+                ),
+            ),
+        ),
+        mode = Nav.Sync.AddPicker.Mode.CREATE,
+        onContributionClicked = {},
+        onNavigateUp = {},
+    )
 }
 
 @Preview2
 @Composable
-private fun SyncAddScreenPreview() = PreviewWrapper {
+private fun SyncAddScreenLinkPreview() = PreviewWrapper {
     SyncAddScreen(
         state = SyncAddVM.State(
-            items = listOf(
-                SyncAddVM.SyncAddItem(
-                    contribution = previewContribution(
-                        type = ConnectorType.GDRIVE,
-                        labelRes = R.string.sync_add_label,
-                        descriptionRes = R.string.sync_add_help_desc,
-                    ),
-                    onClick = {},
+            contributions = listOf(
+                previewContribution(
+                    type = ConnectorType.GDRIVE,
+                    labelRes = R.string.sync_add_label,
+                    descriptionRes = R.string.sync_add_help_desc,
+                    joinDestination = Nav.Sync.AddGDrive(linking = true),
                 ),
-                SyncAddVM.SyncAddItem(
-                    contribution = previewContribution(
-                        type = ConnectorType.OCTISERVER,
-                        labelRes = R.string.sync_add_label,
-                        descriptionRes = R.string.sync_add_help_desc,
-                    ),
-                    onClick = {},
+                previewContribution(
+                    type = ConnectorType.OCTISERVER,
+                    labelRes = R.string.sync_add_label,
+                    descriptionRes = R.string.sync_add_help_desc,
+                    joinDestination = Nav.Sync.OctiServerLinkClient,
                 ),
             ),
         ),
+        mode = Nav.Sync.AddPicker.Mode.LINK,
+        onContributionClicked = {},
+        onNavigateUp = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun SyncAddScreenLinkEmptyPreview() = PreviewWrapper {
+    SyncAddScreen(
+        state = SyncAddVM.State(
+            contributions = listOf(
+                previewContribution(
+                    type = ConnectorType.GDRIVE,
+                    labelRes = R.string.sync_add_label,
+                    descriptionRes = R.string.sync_add_help_desc,
+                ),
+            ),
+        ),
+        mode = Nav.Sync.AddPicker.Mode.LINK,
+        onContributionClicked = {},
         onNavigateUp = {},
     )
 }
@@ -180,13 +232,15 @@ private fun previewContribution(
     type: ConnectorType,
     labelRes: Int,
     descriptionRes: Int,
+    joinDestination: NavigationDestination? = null,
 ): ConnectorUiContribution = object : ConnectorUiContribution {
     override val type = type
     override val displayOrder = 0
     override val labelRes = labelRes
     override val descriptionRes = descriptionRes
     @Composable override fun Icon(modifier: Modifier, tint: Color) {}
-    override fun addAccountDestination(): NavigationDestination = Nav.Sync.Add
+    override fun addAccountDestination(): NavigationDestination = Nav.Sync.AddPicker(Nav.Sync.AddPicker.Mode.CREATE)
+    override fun joinDeviceDestination(): NavigationDestination? = joinDestination
     @Composable override fun listCardTitle(connector: SyncConnector): String = ""
     @Composable override fun listCardAccountValue(connector: SyncConnector): String = ""
     @Composable override fun ActionsSheet(

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddVM.kt
@@ -3,7 +3,9 @@ package eu.darken.octi.sync.ui.add
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.ConnectorUiContribution
 import eu.darken.octi.common.uix.ViewModel4
@@ -18,24 +20,30 @@ class SyncAddVM @Inject constructor(
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     data class State(
-        val items: List<SyncAddItem> = emptyList(),
-    )
-
-    data class SyncAddItem(
-        val contribution: ConnectorUiContribution,
-        val onClick: () -> Unit,
+        val contributions: List<ConnectorUiContribution> = emptyList(),
     )
 
     val state = flow {
-        val items = contributions.values
-            .sortedBy { it.displayOrder }
-            .map { contribution ->
-                SyncAddItem(contribution) { navTo(contribution.addAccountDestination()) }
-            }
-        emit(State(items = items))
+        emit(State(contributions = contributions.values.sortedBy { it.displayOrder }))
     }.asStateFlow()
 
+    fun onContributionClicked(contribution: ConnectorUiContribution, mode: Nav.Sync.AddPicker.Mode) {
+        log(TAG) { "onContributionClicked(type=${contribution.type}, mode=$mode)" }
+        when (mode) {
+            Nav.Sync.AddPicker.Mode.CREATE -> navTo(contribution.addAccountDestination())
+            Nav.Sync.AddPicker.Mode.LINK -> contribution.joinDeviceDestination()?.let { navTo(it) }
+        }
+    }
+
     companion object {
+        /** LINK mode only lists backends that can join an existing account — no dead taps. */
+        fun List<ConnectorUiContribution>.forMode(
+            mode: Nav.Sync.AddPicker.Mode,
+        ): List<ConnectorUiContribution> = when (mode) {
+            Nav.Sync.AddPicker.Mode.CREATE -> this
+            Nav.Sync.AddPicker.Mode.LINK -> filter { it.joinDeviceDestination() != null }
+        }
+
         private val TAG = logTag("Sync", "Add", "VM")
     }
 }

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncSetupRow.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncSetupRow.kt
@@ -1,0 +1,50 @@
+package eu.darken.octi.sync.ui.add
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared row visual for the sync setup flow: intent screen (new vs link) and backend picker.
+ */
+@Composable
+internal fun SyncSetupRow(
+    icon: @Composable (Modifier) -> Unit,
+    title: String,
+    description: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(16.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        icon(Modifier.size(20.dp))
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Column {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentScreen.kt
@@ -1,0 +1,131 @@
+package eu.darken.octi.sync.ui.add.intent
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Link
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.common.WebpageTool
+import eu.darken.octi.common.compose.Preview2
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.error.ErrorEventHandler
+import eu.darken.octi.common.navigation.NavigationEventHandler
+import eu.darken.octi.sync.ui.add.SyncSetupRow
+
+@Composable
+fun SyncSetupIntentScreenHost(vm: SyncSetupIntentVM = hiltViewModel()) {
+    ErrorEventHandler(vm)
+    NavigationEventHandler(vm)
+
+    SyncSetupIntentScreen(
+        onNew = { vm.goNew() },
+        onLink = { vm.goLink() },
+        onNavigateUp = { vm.navUp() },
+    )
+}
+
+@Composable
+fun SyncSetupIntentScreen(
+    onNew: () -> Unit,
+    onLink: () -> Unit,
+    onNavigateUp: () -> Unit,
+) {
+    var showHelpDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = stringResource(R.string.sync_setup_intent_label)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showHelpDialog = true }) {
+                        Icon(Icons.AutoMirrored.Filled.HelpOutline, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            SyncSetupRow(
+                icon = { modifier ->
+                    Icon(Icons.Filled.Add, contentDescription = null, modifier = modifier)
+                },
+                title = stringResource(R.string.sync_setup_intent_new_title),
+                description = stringResource(R.string.sync_setup_intent_new_desc),
+                onClick = onNew,
+            )
+
+            SyncSetupRow(
+                icon = { modifier ->
+                    Icon(Icons.Filled.Link, contentDescription = null, modifier = modifier)
+                },
+                title = stringResource(R.string.sync_setup_intent_link_title),
+                description = stringResource(R.string.sync_setup_intent_link_desc),
+                onClick = onLink,
+            )
+        }
+    }
+
+    if (showHelpDialog) {
+        AlertDialog(
+            onDismissRequest = { showHelpDialog = false },
+            text = { Text(text = stringResource(R.string.sync_add_help_desc)) },
+            confirmButton = {
+                TextButton(onClick = { showHelpDialog = false }) {
+                    Text(text = stringResource(CommonR.string.general_gotit_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = {
+                    showHelpDialog = false
+                    WebpageTool(context).open("https://github.com/d4rken-org/octi/wiki/Syncs")
+                }) {
+                    Text(text = stringResource(R.string.documentation_label))
+                }
+            },
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SyncSetupIntentScreenPreview() = PreviewWrapper {
+    SyncSetupIntentScreen(
+        onNew = {},
+        onLink = {},
+        onNavigateUp = {},
+    )
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentVM.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentVM.kt
@@ -1,0 +1,31 @@
+package eu.darken.octi.sync.ui.add.intent
+
+import androidx.lifecycle.SavedStateHandle
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.coroutine.DispatcherProvider
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.uix.ViewModel4
+import javax.inject.Inject
+
+@HiltViewModel
+class SyncSetupIntentVM @Inject constructor(
+    @Suppress("UNUSED_PARAMETER") handle: SavedStateHandle,
+    dispatcherProvider: DispatcherProvider,
+) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+
+    fun goNew() {
+        log(TAG) { "goNew()" }
+        navTo(Nav.Sync.AddPicker(Nav.Sync.AddPicker.Mode.CREATE))
+    }
+
+    fun goLink() {
+        log(TAG) { "goLink()" }
+        navTo(Nav.Sync.AddPicker(Nav.Sync.AddPicker.Mode.LINK))
+    }
+
+    companion object {
+        private val TAG = logTag("Sync", "Setup", "Intent", "VM")
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -156,11 +157,13 @@ fun SyncListScreen(
                     return@items
                 }
                 val isHighlighted = state.highlightedConnectorIds.contains(item.connectorId)
+                val linkDestination = contribution.linkDeviceDestination(item.connector)
                 ConnectorCard(
                     item = item,
                     contribution = contribution,
                     isHighlighted = isHighlighted,
                     onClick = { showActionsForId = item.connectorId },
+                    onLinkDevice = linkDestination?.let { dest -> { onLinkNewDevice(dest) } },
                 )
             }
 
@@ -225,6 +228,7 @@ private fun ConnectorCard(
     contribution: eu.darken.octi.sync.core.ConnectorUiContribution,
     isHighlighted: Boolean,
     onClick: () -> Unit,
+    onLinkDevice: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val borderColor by animateColorAsState(
@@ -301,6 +305,16 @@ private fun ConnectorCard(
             DevicesField(state = item.ourState, otherStates = item.otherStates)
 
             ConnectorIssuesRow(issues = item.issues)
+
+            if (onLinkDevice != null) {
+                TextButton(
+                    onClick = onLinkDevice,
+                    enabled = !item.isPaused && !item.isBusy,
+                    modifier = Modifier.align(Alignment.End),
+                ) {
+                    Text(text = stringResource(SyncR.string.sync_link_device_action))
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -109,6 +109,14 @@
     <string name="sync_services_label">Sync services</string>
 
     <string name="sync_add_label">Add sync service</string>
+    <string name="sync_setup_intent_label">Set up sync</string>
+    <string name="sync_setup_intent_new_title">Set up a new sync</string>
+    <string name="sync_setup_intent_new_desc">Create a new account. Choose this on your first device.</string>
+    <string name="sync_setup_intent_link_title">Add this device</string>
+    <string name="sync_setup_intent_link_desc">Link to an Octi setup you already use on another device.</string>
+    <string name="sync_add_pick_create_title">Choose a sync service</string>
+    <string name="sync_add_pick_link_title">Which service does your other device use?</string>
+    <string name="sync_add_link_none_available">None of your sync services support linking a device yet.</string>
     <string name="sync_add_help_desc">A synchronization service is required for information exchange between Octi installs.\n\nDevices can only see each other if they have a common sync service!</string>
 
     <string name="sync_device_id_label">Device ID</string>

--- a/app/src/test/java/eu/darken/octi/sync/ui/add/SyncAddVMTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/ui/add/SyncAddVMTest.kt
@@ -1,0 +1,126 @@
+package eu.darken.octi.sync.ui.add
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.navigation.NavEvent
+import eu.darken.octi.common.navigation.NavigationDestination
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorUiContribution
+import eu.darken.octi.sync.ui.add.SyncAddVM.Companion.forMode
+import eu.darken.octi.syncs.gdrive.ui.GDriveUiContribution
+import eu.darken.octi.syncs.octiserver.ui.OctiServerUiContribution
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class SyncAddVMTest : BaseTest() {
+
+    private object CreateDestination : NavigationDestination
+    private object JoinDestination : NavigationDestination
+
+    private fun fakeContribution(
+        type: ConnectorType = ConnectorType.GDRIVE,
+        displayOrder: Int = 0,
+        joinDestination: NavigationDestination? = null,
+    ): ConnectorUiContribution = mockk<ConnectorUiContribution>().apply {
+        every { this@apply.type } returns type
+        every { this@apply.displayOrder } returns displayOrder
+        every { addAccountDestination() } returns CreateDestination
+        every { joinDeviceDestination() } returns joinDestination
+    }
+
+    private fun makeVM(vararg contributions: ConnectorUiContribution) = SyncAddVM(
+        handle = SavedStateHandle(),
+        dispatcherProvider = TestDispatcherProvider(),
+        contributions = contributions.associateBy { it.type },
+    )
+
+    @Nested
+    inner class `click dispatch` {
+        @Test
+        fun `CREATE mode navigates to addAccountDestination`() = runTest2 {
+            val contribution = fakeContribution()
+            val vm = makeVM(contribution)
+
+            vm.onContributionClicked(contribution, Nav.Sync.AddPicker.Mode.CREATE)
+
+            vm.navEvents.first() shouldBe NavEvent.GoTo(CreateDestination)
+        }
+
+        @Test
+        fun `LINK mode navigates to joinDeviceDestination`() = runTest2 {
+            val contribution = fakeContribution(joinDestination = JoinDestination)
+            val vm = makeVM(contribution)
+
+            vm.onContributionClicked(contribution, Nav.Sync.AddPicker.Mode.LINK)
+
+            vm.navEvents.first() shouldBe NavEvent.GoTo(JoinDestination)
+        }
+
+        @Test
+        fun `LINK mode without join destination emits no navigation`() = runTest2 {
+            val contribution = fakeContribution(joinDestination = null)
+            val vm = makeVM(contribution)
+
+            vm.onContributionClicked(contribution, Nav.Sync.AddPicker.Mode.LINK)
+
+            withTimeoutOrNull(100) { vm.navEvents.firstOrNull() } shouldBe null
+        }
+    }
+
+    @Nested
+    inner class `mode filtering` {
+        @Test
+        fun `CREATE mode keeps all contributions`() {
+            val joinable = fakeContribution(type = ConnectorType.OCTISERVER, joinDestination = JoinDestination)
+            val nonJoinable = fakeContribution(type = ConnectorType.GDRIVE, joinDestination = null)
+
+            listOf(joinable, nonJoinable).forMode(Nav.Sync.AddPicker.Mode.CREATE) shouldContainExactly listOf(
+                joinable,
+                nonJoinable,
+            )
+        }
+
+        @Test
+        fun `LINK mode filters out contributions without join destination`() {
+            val joinable = fakeContribution(type = ConnectorType.OCTISERVER, joinDestination = JoinDestination)
+            val nonJoinable = fakeContribution(type = ConnectorType.GDRIVE, joinDestination = null)
+
+            listOf(joinable, nonJoinable).forMode(Nav.Sync.AddPicker.Mode.LINK) shouldContainExactly listOf(joinable)
+        }
+
+        @Test
+        fun `LINK mode is empty when no contribution can join`() {
+            val nonJoinable = fakeContribution(type = ConnectorType.GDRIVE, joinDestination = null)
+
+            listOf(nonJoinable).forMode(Nav.Sync.AddPicker.Mode.LINK) shouldBe emptyList()
+        }
+    }
+
+    @Nested
+    inner class `real contributions` {
+        @Test
+        fun `GDrive joins via its add screen in linking mode`() {
+            GDriveUiContribution().joinDeviceDestination() shouldBe Nav.Sync.AddGDrive(linking = true)
+        }
+
+        @Test
+        fun `GDrive creates via its add screen in non-linking mode`() {
+            GDriveUiContribution().addAccountDestination() shouldBe Nav.Sync.AddGDrive(linking = false)
+        }
+
+        @Test
+        fun `OctiServer joins via the link client screen`() {
+            OctiServerUiContribution().joinDeviceDestination() shouldBe Nav.Sync.OctiServerLinkClient
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentVMTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/ui/add/intent/SyncSetupIntentVMTest.kt
@@ -1,0 +1,37 @@
+package eu.darken.octi.sync.ui.add.intent
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.navigation.NavEvent
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class SyncSetupIntentVMTest : BaseTest() {
+
+    private fun makeVM() = SyncSetupIntentVM(
+        handle = SavedStateHandle(),
+        dispatcherProvider = TestDispatcherProvider(),
+    )
+
+    @Test
+    fun `new sync routes to picker in CREATE mode`() = runTest2 {
+        val vm = makeVM()
+
+        vm.goNew()
+
+        vm.navEvents.first() shouldBe NavEvent.GoTo(Nav.Sync.AddPicker(Nav.Sync.AddPicker.Mode.CREATE))
+    }
+
+    @Test
+    fun `add this device routes to picker in LINK mode`() = runTest2 {
+        val vm = makeVM()
+
+        vm.goLink()
+
+        vm.navEvents.first() shouldBe NavEvent.GoTo(Nav.Sync.AddPicker(Nav.Sync.AddPicker.Mode.LINK))
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorUiContribution.kt
@@ -33,6 +33,14 @@ interface ConnectorUiContribution {
     fun addAccountDestination(): NavigationDestination
 
     /**
+     * Destination for adding THIS device to an already-existing remote account (client side,
+     * no local connector yet), or null if the backend cannot join an existing account without
+     * creating one. OctiServer returns its link-client (QR scan) screen; GDrive returns its
+     * add screen in linking mode (same-account sign-in).
+     */
+    fun joinDeviceDestination(): NavigationDestination? = null
+
+    /**
      * Destination for the "link new device" action for this connector, or null if the backend
      * does not support device linking. OctiServer returns its link-host screen; GDrive returns null.
      */

--- a/sync-core/src/main/res/values/strings.xml
+++ b/sync-core/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="sync_connector_progress_device_updating">Updating devices...</string>
     <string name="sync_connector_progress_device_update_queued">Device update queued...</string>
     <string name="sync_synced_devices_label">Synced devices</string>
+    <string name="sync_link_device_action">Link a device</string>
 
     <string name="sync_devices_sort_label">Sort</string>
     <string name="sync_devices_sort_date_added_label">By date added</string>

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
@@ -60,7 +60,9 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
         )
     }
 
-    override fun addAccountDestination(): NavigationDestination = Nav.Sync.AddGDrive
+    override fun addAccountDestination(): NavigationDestination = Nav.Sync.AddGDrive(linking = false)
+
+    override fun joinDeviceDestination(): NavigationDestination = Nav.Sync.AddGDrive(linking = true)
 
     @Composable
     override fun listCardTitle(connector: SyncConnector): String = stringResource(R.string.sync_gdrive_type_label)

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveNavigation.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class AddGDriveNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Sync.AddGDrive> { AddGDriveScreenHost() }
+        entry<Nav.Sync.AddGDrive> { key -> AddGDriveScreenHost(linking = key.linking) }
     }
 
     @Module

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveScreen.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/add/AddGDriveScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -29,6 +31,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,12 +46,16 @@ import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.syncs.gdrive.R as GDriveR
 
 @Composable
-fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
+fun AddGDriveScreenHost(
+    linking: Boolean,
+    vm: AddGDriveVM = hiltViewModel(),
+) {
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
     val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
+    val currentLinking by rememberUpdatedState(linking)
     var pendingAuthEmail by remember { mutableStateOf<String?>(null) }
 
     val authLauncher = rememberLauncherForActivityResult(
@@ -86,7 +93,13 @@ fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
 
                 is AddGDriveEvents.AccountAlreadyConnected -> {
                     snackbarHostState.showSnackbar(
-                        context.getString(GDriveR.string.sync_gdrive_error_account_already_connected)
+                        context.getString(
+                            if (currentLinking) {
+                                GDriveR.string.sync_gdrive_link_already_connected
+                            } else {
+                                GDriveR.string.sync_gdrive_error_account_already_connected
+                            }
+                        )
                     )
                 }
             }
@@ -94,6 +107,7 @@ fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
     }
 
     AddGDriveScreen(
+        linking = linking,
         snackbarHostState = snackbarHostState,
         onNavigateUp = { vm.navUp() },
         onSignIn = { vm.startSignIn() },
@@ -102,10 +116,12 @@ fun AddGDriveScreenHost(vm: AddGDriveVM = hiltViewModel()) {
 
 @Composable
 fun AddGDriveScreen(
+    linking: Boolean,
     snackbarHostState: SnackbarHostState = SnackbarHostState(),
     onNavigateUp: () -> Unit,
     onSignIn: () -> Unit,
 ) {
+    val actionLabelRes = if (linking) GDriveR.string.sync_gdrive_link_label else GDriveR.string.sync_gdrive_add_label
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
@@ -114,7 +130,7 @@ fun AddGDriveScreen(
                     Column {
                         Text(text = stringResource(GDriveR.string.sync_gdrive_type_label))
                         Text(
-                            text = stringResource(GDriveR.string.sync_gdrive_add_label),
+                            text = stringResource(actionLabelRes),
                             style = MaterialTheme.typography.bodySmall,
                         )
                     }
@@ -135,16 +151,42 @@ fun AddGDriveScreen(
                 .padding(32.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
+            if (linking) {
+                Card(
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                    ),
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = stringResource(GDriveR.string.sync_gdrive_link_same_account_warning),
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(16.dp),
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
             Text(
                 text = stringResource(GDriveR.string.sync_gdrive_add_description),
                 style = MaterialTheme.typography.bodyMedium,
                 modifier = Modifier.fillMaxWidth(),
             )
 
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(GDriveR.string.sync_gdrive_add_same_account_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
             Spacer(modifier = Modifier.height(32.dp))
 
             Button(onClick = onSignIn) {
-                Text(text = stringResource(GDriveR.string.sync_gdrive_add_label))
+                Text(text = stringResource(actionLabelRes))
             }
         }
     }
@@ -154,6 +196,17 @@ fun AddGDriveScreen(
 @Composable
 private fun AddGDriveScreenPreview() = PreviewWrapper {
     AddGDriveScreen(
+        linking = false,
+        onNavigateUp = {},
+        onSignIn = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun AddGDriveScreenLinkingPreview() = PreviewWrapper {
+    AddGDriveScreen(
+        linking = true,
         onNavigateUp = {},
         onSignIn = {},
     )

--- a/syncs-gdrive/src/main/res/values/strings.xml
+++ b/syncs-gdrive/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="sync_gdrive_appdata_label">App-data scope</string>
     <string name="sync_gdrive_type_appdata_description">Data is placed in Google Drive. This specific variant uses the "app-data" scope. Access is only granted to a new folder just for this app. The folder is not visible in your drive. It is similar to how WhatsApp backups work.</string>
     <string name="sync_gdrive_add_label">Add new Google Drive</string>
+    <string name="sync_gdrive_link_label">Link this device</string>
+    <string name="sync_gdrive_add_same_account_hint">Use the same Google account on every device — that\'s what links them.</string>
+    <string name="sync_gdrive_link_same_account_warning">Sign in with the SAME Google account you used on your other device. A different account creates a separate, unlinked backup.</string>
+    <string name="sync_gdrive_link_already_connected">This device is already linked with that account.</string>
     <string name="sync_gdrive_add_description">Click the sign in button below to set up Google Drive access.</string>
     <string name="sync_gdrive_reset_confirmation_desc">Reset all Octi data stored on Google Drive. Your device stays logged into Google Drive.</string>
     <string name="sync_gdrive_disconnect_confirmation_desc">Log out from Google Drive and delete data related to this device.</string>

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
@@ -57,6 +57,8 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
 
     override fun addAccountDestination(): NavigationDestination = Nav.Sync.AddOctiServer
 
+    override fun joinDeviceDestination(): NavigationDestination = Nav.Sync.OctiServerLinkClient
+
     override fun linkDeviceDestination(connector: SyncConnector): NavigationDestination? {
         val octi = connector as? OctiServerConnector ?: return null
         return Nav.Sync.OctiServerLinkHost(octi.identifier.idString)

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -63,7 +62,6 @@ fun AddOctiServerScreenHost(vm: AddOctiServerVM = hiltViewModel()) {
             onNavigateUp = { vm.navUp() },
             onSelectType = { type -> vm.selectType(type) },
             onCreateAccount = { customServer -> vm.createAccount(customServer) },
-            onLinkAccount = { vm.linkAccount() },
         )
     }
 }
@@ -74,7 +72,6 @@ fun AddOctiServerScreen(
     onNavigateUp: () -> Unit,
     onSelectType: (OctiServer.Official?) -> Unit,
     onCreateAccount: (String?) -> Unit,
-    onLinkAccount: () -> Unit,
 ) {
     var showAboutDialog by remember { mutableStateOf(false) }
     var showCreateDialog by remember { mutableStateOf(false) }
@@ -162,27 +159,6 @@ fun AddOctiServerScreen(
 
             Text(
                 text = stringResource(OctiServerR.string.sync_octiserver_add_create_action_hint),
-                style = MaterialTheme.typography.labelSmall,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                textAlign = TextAlign.Center,
-            )
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            FilledTonalButton(
-                onClick = onLinkAccount,
-                enabled = !state.isBusy,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 32.dp),
-            ) {
-                Text(text = stringResource(OctiServerR.string.sync_octiserver_add_link_existing_action))
-            }
-
-            Text(
-                text = stringResource(OctiServerR.string.sync_octiserver_add_link_action_hint),
                 style = MaterialTheme.typography.labelSmall,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -286,7 +262,6 @@ private fun AddOctiServerScreenPreview() = PreviewWrapper {
         onNavigateUp = {},
         onSelectType = {},
         onCreateAccount = {},
-        onLinkAccount = {},
     )
 }
 
@@ -298,7 +273,6 @@ private fun AddOctiServerScreenCustomPreview() = PreviewWrapper {
         onNavigateUp = {},
         onSelectType = {},
         onCreateAccount = {},
-        onLinkAccount = {},
     )
 }
 
@@ -310,6 +284,5 @@ private fun AddOctiServerScreenBusyPreview() = PreviewWrapper {
         onNavigateUp = {},
         onSelectType = {},
         onCreateAccount = {},
-        onLinkAccount = {},
     )
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerVM.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/add/AddOctiServerVM.kt
@@ -69,16 +69,6 @@ class AddOctiServerVM @Inject constructor(
         }
     }
 
-    fun linkAccount() = launch {
-        log(TAG) { "linkAccount()" }
-        _state.value = _state.value.copy(isBusy = true)
-        try {
-            navTo(Nav.Sync.OctiServerLinkClient)
-        } finally {
-            _state.value = _state.value.copy(isBusy = false)
-        }
-    }
-
     companion object {
         private val TAG = logTag("Sync", "Add", "OctiServer", "VM")
     }


### PR DESCRIPTION
Setting up sync on a second device had two paths that silently produced a *second, isolated* account instead of linking to the existing one — with no error shown:

- **Octi Server**: the add screen emphasized "Create account" while "Link to existing account" was a secondary button, and the host-side "Link new device" action was hidden behind the connector card's bottom sheet.
- **Google Drive**: nothing stated that all devices must sign into the *same* Google account; picking a different account "succeeds" into a folder no other device can see.

Either way the devices never see each other and the app looks broken — a likely driver of first-session uninstalls.

### Changes

- Sync setup now asks **intent first**: "Set up a new sync" vs "Add this device". The link path routes Octi Server users straight to the QR-scan screen and Google Drive users to a link-mode sign-in with a prominent same-account warning; "Create account" is unreachable from the link path.
- The backend picker is mode-aware: in link mode it only lists backends that support joining an existing account (with an empty state instead of dead taps), via a new `joinDeviceDestination()` on `ConnectorUiContribution`.
- The Octi Server add screen is now create-only.
- Google Drive add screen copy is mode-aware ("Link this device"), always shows a short same-account hint, and shows a link-mode warning card.
- Connector cards on the sync list show a visible "Link a device" button (disabled while paused/busy) instead of hiding the action in the bottom sheet.

### Verification

- `assembleFossDebug` + `assembleGplayDebug` pass; new unit tests (`SyncAddVMTest`, `SyncSetupIntentVMTest`) cover mode routing, the link-mode filter (including the null-destination regression guard), and the real contributions' destinations.
- Full emulator walkthrough (API 35): intent screen → link path lands on QR scan (not create), GDrive link mode shows the warning, create path unchanged, card button opens the link-host QR screen. No crashes.
- Note: `lintFossRelease` fails on pre-existing issues (MissingTranslation on older strings, NewApi in `RecorderActivityVM`) unrelated to this change; new strings are base-English only per the Crowdin workflow.
