### PR TITLE
General: Fix 'Restore purchase' failing when you already own Pro

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -17,7 +17,9 @@ import eu.darken.octi.common.upgrade.core.billing.BillingManager
 import eu.darken.octi.common.upgrade.core.billing.PurchasedSku
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
@@ -28,6 +30,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
@@ -51,28 +54,7 @@ class UpgradeRepoGplay @Inject constructor(
         .map<BillingData, BillingData?> { it }
         .onStart { emit(null) }
         .setupCommonEventHandlers(TAG) { "upgradeInfo1" }
-        .map { data: BillingData? -> // Only relinquish pro state if we haven't had it for a while
-            val now = Clock.System.now().toEpochMilliseconds()
-            val lastProStateAt = billingCache.lastProStateAt.value()
-            log(TAG) { "Map: now=$now, lastProStateAt=$lastProStateAt, data=${data}" }
-
-            when {
-                data?.purchases?.isNotEmpty() == true -> {
-                    // If we are pro refresh timestamp
-                    billingCache.lastProStateAt.value(now)
-                    Info(billingData = data)
-                }
-
-                (now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD -> {
-                    log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                    Info(gracePeriod = true, billingData = null)
-                }
-
-                else -> {
-                    Info(billingData = data)
-                }
-            }
-        }
+        .map { data: BillingData? -> data.toUpgradeInfo() }
         .distinctUntilChanged()
         .catch {
             // Ignore Google Play errors if the last pro state was recent
@@ -107,7 +89,63 @@ class UpgradeRepoGplay @Inject constructor(
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
-        billingManager.refresh()
+        try {
+            withTimeout(REFRESH_TIMEOUT) { billingManager.refresh() }
+        } catch (e: TimeoutCancellationException) {
+            log(TAG, ERROR) { "Background refresh timed out" }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Background refresh: swallow-and-log so callers like the widget config screens aren't
+            // affected. The explicit restore path uses restorePurchaseNow(), which surfaces errors.
+            log(TAG, ERROR) { "Background refresh failed: ${e.asLog()}" }
+        }
+    }
+
+    // Explicit "Restore purchase": query Play now and evaluate pro from the returned data in the same
+    // coroutine (real happens-before), so we never read a stale upgradeInfo replay. Billing errors
+    // propagate so the caller can distinguish "not owned" from "Play unavailable".
+    suspend fun restorePurchaseNow(): Info {
+        log(TAG) { "restorePurchaseNow()" }
+        return try {
+            billingManager.refresh().toUpgradeInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Mirror the reactive flow's catch: a transient Play error while we were pro recently
+            // keeps us pro via the grace period; otherwise surface the error so the caller can show
+            // the proper "Play unavailable" message instead of a generic restore failure.
+            val now = Clock.System.now().toEpochMilliseconds()
+            val lastProStateAt = billingCache.lastProStateAt.value()
+            if ((now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD) {
+                log(TAG, VERBOSE) { "Restore hit a Play error but we were pro recently -> grace" }
+                Info(gracePeriod = true, billingData = null)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    // Shared pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
+    // Only relinquishes pro state if we haven't had it for a while (grace period).
+    private suspend fun BillingData?.toUpgradeInfo(): Info {
+        val now = Clock.System.now().toEpochMilliseconds()
+        val lastProStateAt = billingCache.lastProStateAt.value()
+        log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
+        return when {
+            this?.purchases?.isNotEmpty() == true -> {
+                // If we are pro refresh timestamp
+                billingCache.lastProStateAt.value(now)
+                Info(billingData = this)
+            }
+
+            (now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD -> {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
+                Info(gracePeriod = true, billingData = null)
+            }
+
+            else -> Info(billingData = this)
+        }
     }
 
     data class Info(
@@ -143,7 +181,10 @@ class UpgradeRepoGplay @Inject constructor(
 
     companion object {
         private const val SITE = "https://play.google.com/store/apps/details?id=eu.darken.octi"
-        private val PRO_GRACE_PERIOD = 7.days
+
+        // Keep paying users pro through transient empty/failed Play Billing responses.
+        internal val PRO_GRACE_PERIOD = 7.days
+        private val REFRESH_TIMEOUT = 15.seconds
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
     }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingData.kt
@@ -3,5 +3,10 @@ package eu.darken.octi.common.upgrade.core.billing
 import com.android.billingclient.api.Purchase
 
 data class BillingData(
-    val purchases: Collection<Purchase>
+    val purchases: Collection<Purchase>,
+    // Per-product-type query status: false means the last INAPP/SUBS query failed and `purchases`
+    // may be missing entries of that type. Lets consumers distinguish "confirmed not owned" from
+    // "couldn't verify this product type".
+    val iapQueryOk: Boolean = true,
+    val subQueryOk: Boolean = true,
 )

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -22,18 +22,20 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.single
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 @Singleton
@@ -42,32 +44,62 @@ class BillingManager @Inject constructor(
     connectionProvider: BillingConnectionProvider,
 ) {
 
-    private val connection = connectionProvider.connection
-        .onEach {
-            try {
-                it.refreshPurchases()
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
+    // Carries connection failures as values instead of swallowing them: useConnection callers
+    // (purchase, restore) get an immediate, mappable error (e.g. BILLING_UNAVAILABLE) instead of
+    // hanging on a flow that never emits until some timeout fires. After a failure a fresh
+    // connection attempt is made once the retry delay elapses — permanent subscribers (the ACK
+    // loop) keep this flow active, so without the loop a single failure would stick in the replay
+    // cache and break billing until process restart.
+    private val connection: Flow<Result<BillingConnection>> = flow {
+        while (true) {
+            var failure: Throwable? = null
+            connectionProvider.connection
+                .onEach {
+                    try {
+                        it.refreshPurchases()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
+                    }
+                }
+                .map<BillingConnection, Result<BillingConnection>> { Result.success(it) }
+                .catch {
+                    log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" }
+                    failure = it
+                    emit(Result.failure(it))
+                }
+                .collect { emit(it) }
+
+            // The provider flow only completes after a connection failure — a healthy connection
+            // stays open indefinitely. Pause, then attempt a fresh connection so billing recovers
+            // without a process restart. A device without Play (BILLING_UNAVAILABLE) gets a much
+            // longer pause since that state rarely changes.
+            val cause = failure
+            val retryDelay = when {
+                cause is BillingClientException &&
+                    cause.result.responseCode == BillingResponseCode.BILLING_UNAVAILABLE -> CONNECTION_RETRY_DELAY_UNAVAILABLE
+
+                else -> CONNECTION_RETRY_DELAY
             }
+            log(TAG) { "Retrying billing connection in $retryDelay" }
+            delay(retryDelay)
         }
-        .catch { log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" } }
+    }
         .setupCommonEventHandlers(TAG) { "connection" }
         .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
-    private val purchases = connection
-        .flatMapLatest { it.purchases }
+    val billingData: Flow<BillingData> = connection
+        .mapNotNull { it.getOrNull() }
+        .flatMapLatest { it.billingData }
         .distinctUntilChanged()
-        .setupCommonEventHandlers(TAG) { "purchases" }
-        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
-
-    val billingData: Flow<BillingData> = purchases
-        .map { BillingData(purchases = it) }
+        .setupCommonEventHandlers(TAG) { "billingData" }
         .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
     init {
-        purchases
-            .onEach { purchases ->
-                purchases
+        billingData
+            .onEach { data ->
+                data.purchases
                     .filter {
                         val needsAck = !it.isAcknowledged
 
@@ -117,10 +149,9 @@ class BillingManager @Inject constructor(
             .launchIn(scope)
     }
 
-    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T = connection
-        .map { action(it) }
-        .take(1)
-        .single()
+    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T = connection.first()
+        .getOrElse { throw it.tryMapUserFriendly() }
+        .action()
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection {
         log(TAG) { "querySkus(): $skus..." }
@@ -151,20 +182,18 @@ class BillingManager @Inject constructor(
         }
     }
 
-    suspend fun refresh() {
+    // Query in the caller's context and return the result directly, so callers get the fresh
+    // purchases (and any billing error) with a real happens-before instead of racing the shared
+    // billingData replay cache.
+    suspend fun refresh(): BillingData {
         log(TAG) { "refresh()" }
-        scope.launch {
-            useConnection {
-                try {
-                    refreshPurchases()
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Manual purchase data refresh failed: ${e.asLog()}" }
-                }
-            }
-        }.join()
+        return useConnection { refreshPurchases() }
     }
 
     companion object {
+        private val CONNECTION_RETRY_DELAY = 1.minutes
+        private val CONNECTION_RETRY_DELAY_UNAVAILABLE = 1.hours
+
         internal fun Throwable.tryMapUserFriendly(): Throwable {
             if (this !is BillingClientException) return this
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -15,11 +15,12 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,26 +34,35 @@ data class BillingConnection(
     val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
 ) {
 
-    private val queryCacheIaps = MutableStateFlow<Collection<Purchase>?>(null)
-    private val queryCacheSubs = MutableStateFlow<Collection<Purchase>?>(null)
+    private val queryCacheIaps = MutableStateFlow<QueryCache?>(null)
+    private val queryCacheSubs = MutableStateFlow<QueryCache?>(null)
 
-    val purchases: Flow<Collection<Purchase>> = combine(
+    val billingData: Flow<BillingData> = combine(
         purchaseEvents,
         queryCacheIaps.filterNotNull(),
         queryCacheSubs.filterNotNull(),
     ) { purchaseEvent, iapCache, subCache ->
         val combined = mutableSetOf<Purchase>()
 
-        combined.addAll(iapCache)
-        combined.addAll(subCache)
+        combined.addAll(iapCache.purchases)
+        combined.addAll(subCache.purchases)
 
         purchaseEvent
             ?.takeIf { (result, _) -> result.isSuccess }
             ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
             ?.let { combined.addAll(it) }
 
-        combined.sortedByDescending { it.purchaseTime }
-    }.setupCommonEventHandlers(TAG) { "purchases" }
+        BillingData(
+            purchases = combined.sortedByDescending { it.purchaseTime },
+            iapQueryOk = iapCache.querySucceeded,
+            subQueryOk = subCache.querySucceeded,
+        )
+    }.setupCommonEventHandlers(TAG) { "billingData" }
+
+    private data class QueryCache(
+        val purchases: Collection<Purchase>,
+        val querySucceeded: Boolean,
+    )
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {
@@ -72,27 +82,41 @@ data class BillingConnection(
         return purchaseData
     }
 
-    suspend fun refreshPurchases() = coroutineScope {
+    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
+    // relation instead of racing the shared billingData replay caches after a refresh.
+    // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
+    // authoritative, and only propagate an error when nothing was found AND a query failed — so the
+    // caller can tell "not owned" apart from "couldn't verify".
+    suspend fun refreshPurchases(): BillingData = coroutineScope {
         log(TAG) { "refreshPurchases()" }
-        val iapJob = async {
-            try {
-                val iaps = queryPurchases(BillingClient.ProductType.INAPP)
-                log(TAG) { "Refreshed IAPs: $iaps" }
-                queryCacheIaps.value = iaps.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
-            }
-        }
-        val subJob = async {
-            try {
-                val subs = queryPurchases(BillingClient.ProductType.SUBS)
-                log(TAG) { "Refreshed SUBs: $subs" }
-                queryCacheSubs.value = subs.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
-            }
-        }
-        awaitAll(iapJob, subJob)
+        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP, queryCacheIaps) }
+        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS, queryCacheSubs) }
+        val iaps = iapJob.await()
+        val subs = subJob.await()
+        log(TAG) { "Refreshed IAPs=${iaps.getOrNull()}, SUBs=${subs.getOrNull()}" }
+        combinePurchaseResults(iaps, subs)
+    }
+
+    // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
+    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
+    // On failure the cache keeps its previous purchases (seeded empty if it had none) so the combined
+    // billingData flow still emits — a persistently failing product type must not block the other
+    // type's purchases or starve purchase acknowledgement.
+    private suspend fun queryPurchasedProducts(
+        @BillingClient.ProductType type: String,
+        cache: MutableStateFlow<QueryCache?>,
+    ): Result<Collection<Purchase>> = try {
+        val purchased = queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED }
+        cache.value = QueryCache(purchases = purchased, querySucceeded = true)
+        Result.success(purchased)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        cache.value = QueryCache(
+            purchases = cache.value?.purchases ?: emptyList(),
+            querySucceeded = false,
+        )
+        Result.failure(e.tryMapUserFriendly())
     }
 
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
@@ -184,5 +208,21 @@ data class BillingConnection(
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
+
+        // Combines the two product-type query results: a purchase found by either type is
+        // authoritative; an error is only propagated when nothing was found, so callers can tell
+        // "not owned" apart from "couldn't verify one product type". Pure and unit-tested.
+        internal fun combinePurchaseResults(
+            iaps: Result<Collection<Purchase>>,
+            subs: Result<Collection<Purchase>>,
+        ): BillingData {
+            val found = iaps.getOrNull().orEmpty() + subs.getOrNull().orEmpty()
+            if (found.isEmpty()) (iaps.exceptionOrNull() ?: subs.exceptionOrNull())?.let { throw it }
+            return BillingData(
+                purchases = found.sortedByDescending { it.purchaseTime },
+                iapQueryOk = iaps.isSuccess,
+                subQueryOk = subs.isSuccess,
+            )
+        }
     }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -6,7 +6,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
-import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
@@ -22,7 +21,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -138,18 +136,35 @@ class UpgradeViewModel @Inject constructor(
     fun restorePurchase() = launch {
         log(TAG) { "restorePurchase()" }
 
-        log(TAG, VERBOSE) { "Refreshing" }
-        upgradeRepo.refresh()
+        val restored = try {
+            withTimeoutOrNull(RESTORE_TIMEOUT) { upgradeRepo.restorePurchaseNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
+            // of the generic "restore failed" message, so the user can tell the two cases apart.
+            log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
+            errorEvents.emit(e)
+            return@launch
+        }
 
-        val refreshedState = upgradeRepo.upgradeInfo.first()
-        log(TAG) { "Refreshed purchase state: $refreshedState" }
+        when {
+            restored == null -> {
+                // Play never answered in time; the restore-failed dialog already suggests waiting /
+                // clearing the Play cache, which fits a timeout too.
+                log(TAG, WARN) { "Restore purchase timed out" }
+                events.emit(UpgradeEvents.RestoreFailed)
+            }
 
-        if (refreshedState.isPro) {
-            log(TAG, INFO) { "Restored purchase :))" }
-            refreshWidgetsForUpgrade()
-        } else {
-            log(TAG, WARN) { "Restore purchase failed" }
-            events.emit(UpgradeEvents.RestoreFailed)
+            restored.isPro -> {
+                log(TAG, INFO) { "Restored purchase :))" }
+                refreshWidgetsForUpgrade()
+            }
+
+            else -> {
+                log(TAG, WARN) { "Restore purchase failed" }
+                events.emit(UpgradeEvents.RestoreFailed)
+            }
         }
     }
 
@@ -169,6 +184,7 @@ class UpgradeViewModel @Inject constructor(
     }
 
     companion object {
+        private val RESTORE_TIMEOUT = 15.seconds
         private val TAG = logTag("Upgrade", "Gplay", "ViewModel")
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,0 +1,109 @@
+package eu.darken.octi.common.upgrade.core
+
+import com.android.billingclient.api.Purchase
+import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.common.upgrade.core.billing.BillingData
+import eu.darken.octi.common.upgrade.core.billing.BillingManager
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+
+class UpgradeRepoGplayTest : BaseTest() {
+
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val billingManager = mockk<BillingManager>()
+    private val billingCache = mockk<BillingCache>()
+
+    // Builds a repo whose stored last-pro timestamp is `lastProAt`. billingData is stubbed only
+    // because the upgradeInfo flow references it at construction; it is never collected here.
+    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
+        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastProAt)
+        }
+        every { billingCache.lastProStateAt } returns lastPro
+        return UpgradeRepoGplay(scope, TestDispatcherProvider(), billingManager, billingCache)
+    }
+
+    private fun now() = Clock.System.now().toEpochMilliseconds()
+
+    private fun proPurchase() = mockk<Purchase>().apply {
+        every { products } returns OurSku.PRO_SKUS.map { it.id }
+        every { purchaseTime } returns 1704067200000L // 2024-01-01T00:00:00Z
+    }
+
+    @Test fun `upgrade info pro status mapping`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = null,
+        ).isPro shouldBe false
+
+        UpgradeRepoGplay.Info(
+            gracePeriod = true,
+            billingData = null,
+        ).isPro shouldBe true
+
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(setOf(proPurchase())),
+        ).isPro shouldBe true
+    }
+
+    @Test fun `grace period spans a week`() {
+        // Keeps paying users pro through transient empty/failed Play Billing responses.
+        UpgradeRepoGplay.PRO_GRACE_PERIOD shouldBe 7.days
+    }
+
+    @Test fun `restore returns pro when a purchase is found`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val expired = now() - UpgradeRepoGplay.PRO_GRACE_PERIOD.inWholeMilliseconds - 1_000
+        repo(lastProAt = expired).restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        shouldThrow<RuntimeException> {
+            repo(lastProAt = 0L).restorePurchaseNow()
+        }
+    }
+
+    @Test fun `restore cancellation is not converted into grace pro state`() = runTest2 {
+        coEvery { billingManager.refresh() } throws CancellationException("cancelled")
+
+        shouldThrow<CancellationException> {
+            repo(lastProAt = now() - 1_000).restorePurchaseNow()
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.octi.common.upgrade.core.billing
+
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import eu.darken.octi.common.upgrade.core.billing.client.BillingClientException
+import eu.darken.octi.common.upgrade.core.billing.client.BillingConnection
+import eu.darken.octi.common.upgrade.core.billing.client.BillingConnectionProvider
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.advanceTimeBy
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class BillingManagerTest : BaseTest() {
+
+    @Test fun `connection failure surfaces to refresh callers instead of hanging`() = runTest2 {
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { connection } returns flow { throw BillingException("Google Play unavailable") }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+
+        shouldThrow<BillingException> {
+            manager.refresh()
+        }
+    }
+
+    @Test fun `connection setup failure maps to the user-friendly Play error`() = runTest2 {
+        val unavailable = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.BILLING_UNAVAILABLE)
+            .build()
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { connection } returns flow { throw BillingClientException(unavailable) }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+
+        shouldThrow<GplayServiceUnavailableException> {
+            manager.refresh()
+        }
+    }
+
+    @Test fun `connection recovers after an earlier failure without a process restart`() = runTest2 {
+        val healthyConnection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns BillingData(emptySet())
+            every { billingData } returns emptyFlow()
+        }
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { connection } returns flow {
+                if (attempts++ == 0) throw BillingException("Google Play hiccup")
+                emit(healthyConnection)
+                awaitCancellation() // a healthy connection stays open indefinitely
+            }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+
+        // The ACK loop keeps the shared connection flow subscribed for the process lifetime, so a
+        // failure Result must not stick in the replay cache forever.
+        shouldThrow<BillingException> { manager.refresh() }
+
+        advanceTimeBy(61_000) // past the connection retry delay
+
+        manager.refresh().purchases shouldBe emptySet()
+        attempts shouldBe 2
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,0 +1,111 @@
+package eu.darken.octi.common.upgrade.core.billing.client
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.PurchasesResult
+import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.queryPurchasesAsync
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class BillingConnectionTest : BaseTest() {
+
+    private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+
+    @Test fun `combines both product types, newest first`() {
+        val older = purchase(1_000)
+        val newer = purchase(2_000)
+
+        val data = BillingConnection.combinePurchaseResults(
+            iaps = Result.success(listOf(older)),
+            subs = Result.success(listOf(newer)),
+        )
+        data.purchases shouldBe listOf(newer, older)
+        data.iapQueryOk shouldBe true
+        data.subQueryOk shouldBe true
+    }
+
+    @Test fun `a single product-type failure does not mask a purchase found by the other`() {
+        val owned = purchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iaps = Result.success(listOf(owned)),
+            subs = Result.failure(RuntimeException("SUBS query failed")),
+        ).apply {
+            purchases shouldBe listOf(owned)
+            iapQueryOk shouldBe true
+            subQueryOk shouldBe false
+        }
+
+        BillingConnection.combinePurchaseResults(
+            iaps = Result.failure(RuntimeException("IAP query failed")),
+            subs = Result.success(listOf(owned)),
+        ).apply {
+            purchases shouldBe listOf(owned)
+            iapQueryOk shouldBe false
+            subQueryOk shouldBe true
+        }
+    }
+
+    @Test fun `both product types empty returns empty`() {
+        BillingConnection.combinePurchaseResults(
+            iaps = Result.success(emptyList()),
+            subs = Result.success(emptyList()),
+        ).purchases shouldBe emptyList<Purchase>()
+    }
+
+    @Test fun `nothing found but a query failed rethrows the error`() {
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iaps = Result.success(emptyList()),
+                subs = Result.failure(RuntimeException("SUBS query failed")),
+            )
+        }
+    }
+
+    @Test fun `a failing product type still lets billingData emit purchases from the other`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val client = mockk<BillingClient>()
+            val owned = purchase(1_000).apply {
+                every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+            }
+            // First query (whichever product type runs first) fails, the second finds a purchase.
+            // The behavior under test is symmetric, so call order doesn't matter.
+            var calls = 0
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } coAnswers {
+                if (calls++ == 0) {
+                    PurchasesResult(
+                        BillingResult.newBuilder().setResponseCode(BillingResponseCode.ERROR).build(),
+                        emptyList(),
+                    )
+                } else {
+                    PurchasesResult(
+                        BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build(),
+                        listOf(owned),
+                    )
+                }
+            }
+            val connection = BillingConnection(client, flowOf(null))
+
+            connection.refreshPurchases().purchases shouldBe listOf(owned)
+            // The failed type's cache is seeded empty, so the combined flow must still emit —
+            // otherwise purchase acknowledgement would be starved by one broken product type.
+            connection.billingData.first().purchases shouldBe listOf(owned)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,0 +1,100 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.octi.common.widget.WidgetManager
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class UpgradeViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(
+            UpgradeRepoGplay.Info(gracePeriod = false, billingData = null)
+        )
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoGplay,
+        widgetManagers: Set<WidgetManager> = emptySet(),
+    ): UpgradeViewModel = UpgradeViewModel(
+        handle = SavedStateHandle(),
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        upgradeRepo = repo,
+        widgetManagers = widgetManagers,
+    )
+
+    @Test fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = null,
+        )
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(30_000) // longer than the 15s restore timeout
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test fun `restore that errors forwards the error instead of RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val boom = IllegalStateException("Play unavailable")
+        coEvery { repo.restorePurchaseNow() } throws boom
+        val vm = buildVm(repo)
+
+        val forwardedError = async { vm.errorEvents.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        forwardedError.await() shouldBe boom
+    }
+
+    @Test fun `successful restore refreshes widgets`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(
+            gracePeriod = true,
+            billingData = null,
+        )
+        val widgetManager = mockk<WidgetManager>().apply { coJustRun { refreshWidgets() } }
+        val vm = buildVm(repo, widgetManagers = setOf(widgetManager))
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { widgetManager.refreshWidgets() }
+    }
+}


### PR DESCRIPTION
## What changed

Fixed the **"Restore purchase"** button sometimes reporting failure even when you already own Pro on your Google account. Restoring is now more resilient when Google Play is slow, briefly unreachable, or returns an incomplete answer, and it shows a clearer "Google Play unavailable" message when the store itself is the problem (instead of the generic restore-failed dialog).

Port of the restore-reliability work from SD Maid: d4rken-org/sdmaid-se#2554, with extra hardening found during review.

## Technical Context

- **Root cause:** the restore flow triggered a Play refresh and then read Pro state from the shared `upgradeInfo` flow's replay cache. The refresh only awaited the query-cache writes — not their propagation through the `shareIn(WhileSubscribed, replay=1)` hops on `AppScope` — so the read could return the stale pre-refresh (non-Pro) value and report "restore failed" for someone who actually owns Pro.
- **Fix:** `BillingManager.refresh()` now returns the freshly queried purchases and `UpgradeRepoGplay.restorePurchaseNow()` evaluates Pro from that result in the same coroutine (a real happens-before), so no shared-flow replay is read.
- **Added robustness on the restore path:**
  - a transient Play error while still within the grace period keeps Pro, mirroring the reactive flow's grace logic;
  - a single INAPP/SUBS query failure no longer masks a purchase found by the other product type (error only surfaces when nothing was found) — and no longer cancels the sibling query;
  - a failed product-type query seeds its cache empty instead of leaving it `null`, so the combined `billingData` flow still emits and purchase **acknowledgement can't be starved** by one broken product type;
  - a 15s timeout stops the button hanging on an unresponsive connection;
  - billing errors route to the proper "Play unavailable" dialog rather than the generic restore-failed message.
- **Beyond the SD Maid port** (candidates for upstreaming):
  - the shared connection flow now carries `Result<BillingConnection>` instead of swallowing failures in `catch { log }` — `useConnection` callers fail fast with a user-friendly-mapped error (e.g. `BILLING_UNAVAILABLE`) instead of hanging into a timeout;
  - after a connection failure a **retry loop** attempts a fresh connection (60s delay; 1h for `BILLING_UNAVAILABLE`), so billing recovers without a process restart — previously (and in SD Maid today) one exhausted connection attempt left billing dead for the process lifetime, since the permanently-subscribed ACK loop keeps `WhileSubscribed` active forever;
  - `BillingData` gained per-product-type query-status flags (`iapQueryOk`/`subQueryOk`), used by the follow-up grace-window PR.
- **Unchanged:** the background `refresh()` override still swallows errors (now bounded by a 15s timeout), so the widget-config retry callers are unaffected.
- **Tests:** new `testGplay` source set with `UpgradeRepoGplayTest` (restore outcomes incl. cancellation-doesn't-grant-grace), `BillingConnectionTest` (`combinePurchaseResults` + partial-query emission), `BillingManagerTest` (connection failure surfaces / maps user-friendly / recovers after failure), `UpgradeViewModelTest` (RestoreFailed / timeout / error forwarding / widget refresh).