### PR TITLE
General: Keep one-time Pro buyers Pro through longer Play outages

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
@@ -20,4 +20,7 @@ class BillingCache @Inject constructor(
         get() = context.dataStore
 
     val lastProStateAt = dataStore.createValue("gplay.cache.lastProAt", 0L)
+
+    // Product id of the last known-owned pro SKU; determines which grace window applies.
+    val lastProStateSku = dataStore.createValue("gplay.cache.lastProSku", "")
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -61,7 +61,7 @@ class UpgradeRepoGplay @Inject constructor(
             val now = Clock.System.now().toEpochMilliseconds()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, error=$it" }
-            if ((now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD) {
+            if ((now - lastProStateAt).milliseconds < graceWindow()) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just and an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
@@ -117,7 +117,7 @@ class UpgradeRepoGplay @Inject constructor(
             // the proper "Play unavailable" message instead of a generic restore failure.
             val now = Clock.System.now().toEpochMilliseconds()
             val lastProStateAt = billingCache.lastProStateAt.value()
-            if ((now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD) {
+            if ((now - lastProStateAt).milliseconds < graceWindow()) {
                 log(TAG, VERBOSE) { "Restore hit a Play error but we were pro recently -> grace" }
                 Info(gracePeriod = true, billingData = null)
             } else {
@@ -132,20 +132,50 @@ class UpgradeRepoGplay @Inject constructor(
         val now = Clock.System.now().toEpochMilliseconds()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
+        val info = Info(billingData = this)
+        // Only a *known* pro SKU counts as "last pro state" — an unrecognized purchase must not
+        // refresh the grace timestamp (and must not suppress an active grace window either).
+        // Prefer the permanent IAP so it drives the window.
+        val preferred = preferredProSku(info.upgrades)
         return when {
-            this?.purchases?.isNotEmpty() == true -> {
-                // If we are pro refresh timestamp
+            preferred != null -> {
                 billingCache.lastProStateAt.value(now)
-                Info(billingData = this)
+                updateLastProSku(preferred, iapQueryOk = this?.iapQueryOk ?: true)
+                info
             }
 
-            (now - lastProStateAt).milliseconds < PRO_GRACE_PERIOD -> {
+            (now - lastProStateAt).milliseconds < graceWindow() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                 Info(gracePeriod = true, billingData = null)
             }
 
-            else -> Info(billingData = this)
+            else -> info
         }
+    }
+
+    // A stored permanent-IAP sku is only replaced by a subscription sku when the IAP query actually
+    // succeeded and confirmed no IAP is owned — a transient IAP query failure must not silently
+    // shrink the 30d grace window down to the 7d subscription one.
+    private suspend fun updateLastProSku(preferred: Sku, iapQueryOk: Boolean) {
+        if (preferred.type != Sku.Type.IAP) {
+            val storedSku = billingCache.lastProStateSku.value()
+            val storedIsIap = OurSku.PRO_SKUS.singleOrNull { it.id == storedSku }?.type == Sku.Type.IAP
+            if (storedIsIap && !iapQueryOk) {
+                log(TAG) { "Keeping stored IAP sku, the IAP query failed and can't confirm it's gone" }
+                return
+            }
+        }
+        billingCache.lastProStateSku.value(preferred.id)
+    }
+
+    // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
+    // a subscription (or an unknown/legacy last SKU) gets the short default.
+    private suspend fun graceWindow(): Duration {
+        val lastSku = billingCache.lastProStateSku.value()
+        val type = OurSku.PRO_SKUS.singleOrNull { it.id == lastSku }?.type
+        val window = if (type == Sku.Type.IAP) PRO_GRACE_PERIOD_IAP else PRO_GRACE_PERIOD
+        log(TAG) { "graceWindow(): lastSku=$lastSku, type=$type -> $window" }
+        return window
     }
 
     data class Info(
@@ -182,9 +212,19 @@ class UpgradeRepoGplay @Inject constructor(
     companion object {
         private const val SITE = "https://play.google.com/store/apps/details?id=eu.darken.octi"
 
-        // Keep paying users pro through transient empty/failed Play Billing responses.
+        // Keep paying users pro through transient empty/failed Play Billing responses. A permanent
+        // one-time purchase should almost never be dropped on a hiccup, so it gets a long window; a
+        // subscription legitimately lapses, so it keeps the short one. PRO_GRACE_PERIOD is the
+        // subscription/default window (also used when the last-owned SKU is unknown/legacy).
         internal val PRO_GRACE_PERIOD = 7.days
+        internal val PRO_GRACE_PERIOD_IAP = 30.days
         private val REFRESH_TIMEOUT = 15.seconds
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
+
+        // The SKU whose grace window applies when several are owned: the permanent one-time purchase
+        // wins over a subscription (purchases are time-sorted, so firstOrNull alone isn't enough).
+        // null when no known pro SKU is owned.
+        internal fun preferredProSku(upgrades: Collection<PurchasedSku>): Sku? =
+            upgrades.firstOrNull { it.sku.type == Sku.Type.IAP }?.sku ?: upgrades.firstOrNull()?.sku
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -4,9 +4,11 @@ import com.android.billingclient.api.Purchase
 import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.BillingManager
+import eu.darken.octi.common.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
@@ -25,24 +27,33 @@ class UpgradeRepoGplayTest : BaseTest() {
     private val scope = CoroutineScope(Dispatchers.Unconfined)
     private val billingManager = mockk<BillingManager>()
     private val billingCache = mockk<BillingCache>()
+    private lateinit var lastProAtValue: DataStoreValue<Long>
+    private lateinit var lastProSkuValue: DataStoreValue<String>
 
-    // Builds a repo whose stored last-pro timestamp is `lastProAt`. billingData is stubbed only
-    // because the upgradeInfo flow references it at construction; it is never collected here.
-    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+    // Builds a repo whose stored last-pro timestamp is `lastProAt` and last-owned sku is `lastSku`.
+    // billingData is stubbed only because the upgradeInfo flow references it at construction; it is
+    // never collected here.
+    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
-        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
+        lastProAtValue = mockk<DataStoreValue<Long>>(relaxed = true).apply {
             every { flow } returns flowOf(lastProAt)
         }
-        every { billingCache.lastProStateAt } returns lastPro
+        every { billingCache.lastProStateAt } returns lastProAtValue
+        lastProSkuValue = mockk<DataStoreValue<String>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastSku)
+        }
+        every { billingCache.lastProStateSku } returns lastProSkuValue
         return UpgradeRepoGplay(scope, TestDispatcherProvider(), billingManager, billingCache)
     }
 
     private fun now() = Clock.System.now().toEpochMilliseconds()
 
-    private fun proPurchase() = mockk<Purchase>().apply {
-        every { products } returns OurSku.PRO_SKUS.map { it.id }
+    private fun purchaseOf(vararg skuIds: String) = mockk<Purchase>().apply {
+        every { products } returns skuIds.toList()
         every { purchaseTime } returns 1704067200000L // 2024-01-01T00:00:00Z
     }
+
+    private fun proPurchase() = purchaseOf(*OurSku.PRO_SKUS.map { it.id }.toTypedArray())
 
     @Test fun `upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
@@ -105,5 +116,82 @@ class UpgradeRepoGplayTest : BaseTest() {
         shouldThrow<CancellationException> {
             repo(lastProAt = now() - 1_000).restorePurchaseNow()
         }
+    }
+
+    @Test fun `permanent IAP keeps grace well beyond the subscription window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        // 20 days ago: past the 7-day subscription window, but within the 30-day IAP window.
+        val twentyDaysAgo = now() - 20.days.inWholeMilliseconds
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `subscription grace expires after the short window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = now() - 20.days.inWholeMilliseconds
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Sub.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe false
+    }
+
+    @Test fun `IAP grace window is longer than the subscription window`() {
+        (UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP > UpgradeRepoGplay.PRO_GRACE_PERIOD) shouldBe true
+        UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP shouldBe 30.days
+    }
+
+    @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {
+        val iap = PurchasedSku(OurSku.Iap.PRO_UPGRADE, mockk<Purchase>())
+        val sub = PurchasedSku(OurSku.Sub.PRO_UPGRADE, mockk<Purchase>())
+
+        UpgradeRepoGplay.preferredProSku(listOf(sub, iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
+    }
+
+    @Test fun `unknown purchases do not refresh the grace timestamp`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(purchaseOf("some.unknown.product")))
+
+        val info = repo(lastProAt = 0L).restorePurchaseNow()
+
+        info.isPro shouldBe false
+        coVerify(exactly = 0) { lastProAtValue.update(any()) }
+        coVerify(exactly = 0) { lastProSkuValue.update(any()) }
+    }
+
+    @Test fun `unknown purchases do not suppress an active grace window`() = runTest2 {
+        // An unrecognized purchase must be treated like an empty response, not like a confirmed
+        // "not owned" — a user within grace stays pro.
+        coEvery { billingManager.refresh() } returns BillingData(setOf(purchaseOf("some.unknown.product")))
+
+        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+    }
+
+    @Test fun `a failed IAP query does not downgrade the stored IAP sku`() = runTest2 {
+        // Only a subscription came back, but the IAP query failed — the stored permanent-IAP sku
+        // must survive, otherwise the grace window silently shrinks from 30d to 7d.
+        coEvery { billingManager.refresh() } returns BillingData(
+            purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
+            iapQueryOk = false,
+        )
+
+        repo(lastProAt = now() - 1_000, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe true
+
+        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+        coVerify(exactly = 0) { lastProSkuValue.update(any()) }
+    }
+
+    @Test fun `a confirmed missing IAP lets the subscription take over the sku`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(
+            purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
+            iapQueryOk = true,
+        )
+
+        repo(lastProAt = now() - 1_000, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isPro shouldBe true
+
+        coVerify(exactly = 1) { lastProSkuValue.update(match { it("") == OurSku.Sub.PRO_UPGRADE.id }) }
     }
 }


### PR DESCRIPTION
## What changed

People who bought the **one-time Pro upgrade** now stay Pro for up to **30 days** through Google Play billing hiccups (Play temporarily returning no/failed purchase info), up from 7 days. **Subscriptions keep the 7-day window** since they can genuinely lapse. This cuts down on the "it's asking me to pay again" cases for people who already own the permanent upgrade.

Port of d4rken-org/sdmaid-se#2555. Stacked on #328.

## Technical Context

- New `BillingCache.lastProStateSku` records the last-owned Pro SKU; `graceWindow()` resolves the window from that SKU's type — 30d for the permanent IAP, 7d for the subscription (or an unknown/legacy last SKU). Applied at all three grace sites: the shared `toUpgradeInfo()` mapping, the reactive flow's `catch`, and the explicit restore error path.
- Only a **known Pro SKU** refreshes the grace timestamp now — an unrecognized purchase no longer bumps it. It also no longer *suppresses* an active grace window (previously a purchases-list containing only unknown product ids resolved to non-Pro even inside grace; it now falls through to the grace check like an empty response).
- `preferredProSku()` picks the permanent IAP when both an IAP and a subscription are owned (purchases are time-sorted, so a plain `first()` could otherwise pick a newer subscription and shrink the window).
- **Downgrade guard** (beyond the SD Maid port): a stored IAP SKU is only overwritten by a subscription SKU when the IAP query actually **succeeded** and confirmed no IAP is owned (`BillingData.iapQueryOk` from #328) — a transient IAP query failure can't silently shrink the 30d window to 7d.
- **Fail-open cache caveat:** a refunded / charged-back / account-switched IAP keeps Pro for up to 30 days. Tunable via `PRO_GRACE_PERIOD_IAP`. Migrated existing IAP owners get the 7d default until their SKU is recorded on the next successful query (conservative).
- **Tests:** IAP → 30d, subscription → 7d, prefer-IAP-when-both-owned, unknown-purchase no-stamp + no-grace-suppression, failed-IAP-query no-downgrade, confirmed-missing-IAP downgrade, and the constant relationship.