### PR TITLE
General: Show returning Pro buyers a restore prompt, not a paywall

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -71,6 +71,10 @@ class UpgradeRepoGplay @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
         .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
+    // True once we've ever confirmed a (known) pro purchase on this install; drives the proactive
+    // restore banner. Local signal only — a fresh install or a switched Google account starts false.
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+
     fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
         scope.launch {

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -1,6 +1,11 @@
 package eu.darken.octi.common.upgrade.ui
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -122,7 +127,7 @@ private fun RestoreFailedDialog(onDismiss: () -> Unit) {
 
 @Composable
 fun UpgradeScreen(
-    state: UpgradeViewModel.Pricing?,
+    state: UpgradeViewModel.State?,
     onNavigateUp: () -> Unit,
     onIap: () -> Unit,
     onSubscription: () -> Unit,
@@ -177,6 +182,11 @@ fun UpgradeScreen(
                 )
             }
 
+            if (state?.wasPreviouslyPro == true) {
+                Spacer(modifier = Modifier.height(16.dp))
+                RestoreBanner(onRestore = onRestore)
+            }
+
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
@@ -207,7 +217,7 @@ fun UpgradeScreen(
                     .padding(bottom = 24.dp),
             )
 
-            if (state == null) {
+            if (state == null || state.pricingLoading) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -216,14 +226,28 @@ fun UpgradeScreen(
                 ) {
                     CircularProgressIndicator()
                 }
-            } else {
+            } else if (state.pricing != null) {
                 PricingContent(
-                    state = state,
+                    pricing = state.pricing,
                     onIap = onIap,
                     onSubscription = onSubscription,
                     onSubscriptionTrial = onSubscriptionTrial,
-                    onRestore = onRestore,
                 )
+            } else {
+                PricingUnavailable()
+            }
+
+            if (state != null) {
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // Restore is available regardless of whether pricing could be loaded — a returning
+                // buyer with a flaky Play connection is exactly who needs it.
+                TextButton(
+                    onClick = onRestore,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+                }
             }
 
             Spacer(modifier = Modifier.height(32.dp))
@@ -232,26 +256,102 @@ fun UpgradeScreen(
 }
 
 @Composable
+private fun RestoreBanner(
+    onRestore: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = onRestore,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PricingUnavailable() {
+    val context = LocalContext.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.upgrades_gplay_unavailable_error_title),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.upgrades_gplay_unavailable_error_description),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // Same fix action the GplayServiceUnavailableException error dialog offers.
+        OutlinedButton(
+            onClick = {
+                try {
+                    val intent = Intent().apply {
+                        action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                        data = Uri.fromParts("package", "com.android.vending", null)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                    context.startActivity(intent)
+                } catch (e: ActivityNotFoundException) {
+                    Toast.makeText(context, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+                }
+            },
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = "Google Play")
+        }
+    }
+}
+
+@Composable
 private fun PricingContent(
-    state: UpgradeViewModel.Pricing,
+    pricing: UpgradeViewModel.Pricing,
     onIap: () -> Unit,
     onSubscription: () -> Unit,
     onSubscriptionTrial: () -> Unit,
-    onRestore: () -> Unit,
 ) {
-    val subOffer = state.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
+    val subOffer = pricing.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
         OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(offer)
     }
-    val subOfferTrial = state.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
+    val subOfferTrial = pricing.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
         OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(offer)
     }
-    val iapOffer = state.iap?.details?.oneTimePurchaseOfferDetails
+    val iapOffer = pricing.iap?.details?.oneTimePurchaseOfferDetails
     val canSub = subOffer != null || subOfferTrial != null
 
     if (canSub) {
         Button(
             onClick = if (subOfferTrial != null) onSubscriptionTrial else onSubscription,
-            enabled = !state.hasSub,
+            enabled = !pricing.hasSub,
             modifier = Modifier.fillMaxWidth(),
         ) {
             Text(
@@ -277,7 +377,7 @@ private fun PricingContent(
 
     OutlinedButton(
         onClick = onIap,
-        enabled = iapOffer != null && !state.hasIap,
+        enabled = iapOffer != null && !pricing.hasIap,
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(text = stringResource(R.string.upgrade_screen_iap_action))
@@ -290,15 +390,6 @@ private fun PricingContent(
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth(),
         )
-    }
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    TextButton(
-        onClick = onRestore,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
     }
 }
 
@@ -319,11 +410,51 @@ private fun UpgradeScreenLoadingPreview() = PreviewWrapper {
 @Composable
 private fun UpgradeScreenLoadedPreview() = PreviewWrapper {
     UpgradeScreen(
-        state = UpgradeViewModel.Pricing(
-            iap = null,
-            sub = null,
-            hasIap = false,
-            hasSub = false,
+        state = UpgradeViewModel.State(
+            pricing = UpgradeViewModel.Pricing(
+                iap = null,
+                sub = null,
+                hasIap = false,
+                hasSub = false,
+            ),
+        ),
+        onNavigateUp = {},
+        onIap = {},
+        onSubscription = {},
+        onSubscriptionTrial = {},
+        onRestore = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenReturningBuyerPreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeViewModel.State(
+            pricing = UpgradeViewModel.Pricing(
+                iap = null,
+                sub = null,
+                hasIap = false,
+                hasSub = false,
+            ),
+            wasPreviouslyPro = true,
+        ),
+        onNavigateUp = {},
+        onIap = {},
+        onSubscription = {},
+        onSubscriptionTrial = {},
+        onRestore = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenPricingUnavailablePreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeViewModel.State(
+            pricing = null,
+            pricingUnavailable = true,
+            wasPreviouslyPro = true,
         ),
         onNavigateUp = {},
         onIap = {},

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -14,7 +14,7 @@ import eu.darken.octi.common.flow.SingleEventFlow
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
-import eu.darken.octi.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import eu.darken.octi.common.widget.WidgetManager
 import kotlinx.coroutines.CancellationException
@@ -57,41 +57,67 @@ class UpgradeViewModel @Inject constructor(
             .launchInViewModel()
     }
 
-    val state: Flow<Pricing> = combine(
-        flow {
-            val data = withTimeoutOrNull(5.seconds) {
-                try {
-                    upgradeRepo.querySkus(OurSku.Iap.PRO_UPGRADE)
-                } catch (e: Exception) {
-                    errorEvents.emitBlocking(e)
-                    null
-                }
-            }
-            emit(data)
-        },
-        flow {
-            val data = withTimeoutOrNull(5.seconds) {
-                try {
-                    upgradeRepo.querySkus(OurSku.Sub.PRO_UPGRADE)
-                } catch (e: Exception) {
-                    errorEvents.emitBlocking(e)
-                    null
-                }
-            }
-            emit(data)
-        },
+    val state: Flow<State> = combine(
+        querySkuDetails(OurSku.Iap.PRO_UPGRADE),
+        querySkuDetails(OurSku.Sub.PRO_UPGRADE),
         upgradeRepo.upgradeInfo,
-    ) { iap, sub, current ->
-        if (iap == null && sub == null) {
-            throw GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
+        upgradeRepo.wasEverPro,
+    ) { iap, sub, current, wasEverPro ->
+        // Pricing is deliberately decoupled from entitlement: a returning buyer must see the
+        // restore banner and the restore action immediately, even while Google Play is still
+        // resolving (or failing to resolve) pricing.
+        val pricingLoading = iap is SkuQuery.Loading || sub is SkuQuery.Loading
+        val iapDetails = (iap as? SkuQuery.Done)?.details
+        val subDetails = (sub as? SkuQuery.Done)?.details
+        val pricing = when {
+            pricingLoading -> null
+
+            iapDetails == null && subDetails == null -> {
+                log(TAG, WARN) { "Pricing unavailable, IAP and SUB queries failed or timed out." }
+                null
+            }
+
+            else -> Pricing(
+                iap = iapDetails?.firstOrNull(),
+                sub = subDetails?.firstOrNull(),
+                hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
+                hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
+            )
         }
-        Pricing(
-            iap = iap?.first(),
-            sub = sub?.first(),
-            hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
-            hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
+        State(
+            pricing = pricing,
+            pricingLoading = pricingLoading,
+            pricingUnavailable = !pricingLoading && pricing == null,
+            wasPreviouslyPro = wasEverPro && !current.isPro,
         )
     }.asStateFlow()
+
+    private sealed interface SkuQuery {
+        data object Loading : SkuQuery
+        data class Done(val details: Collection<SkuDetails>?) : SkuQuery
+    }
+
+    private fun querySkuDetails(sku: Sku): Flow<SkuQuery> = flow {
+        emit(SkuQuery.Loading)
+        val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT) {
+            try {
+                upgradeRepo.querySkus(sku)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "SKU query failed for $sku: ${e.asLog()}" }
+                null
+            }
+        }
+        emit(SkuQuery.Done(data))
+    }
+
+    data class State(
+        val pricing: Pricing?,
+        val pricingLoading: Boolean = false,
+        val pricingUnavailable: Boolean = false,
+        val wasPreviouslyPro: Boolean = false,
+    )
 
     data class Pricing(
         val iap: SkuDetails?,
@@ -184,6 +210,7 @@ class UpgradeViewModel @Inject constructor(
     }
 
     companion object {
+        private val SKU_QUERY_TIMEOUT = 5.seconds
         private val RESTORE_TIMEOUT = 15.seconds
         private val TAG = logTag("Upgrade", "Gplay", "ViewModel")
     }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
+    <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. If you still own the upgrade, restoring will unlock it again.</string>
     <string name="upgrade_screen_restore_purchase_message">Your upgrade is valid across devices on the same Google account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
@@ -24,10 +25,15 @@ class UpgradeViewModelTest : BaseTest() {
 
     private val testDispatcher = StandardTestDispatcher()
 
-    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+    private fun mockRepo(
+        isProViaGrace: Boolean = false,
+        wasEverPro: Boolean = false,
+    ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(
-            UpgradeRepoGplay.Info(gracePeriod = false, billingData = null)
+            UpgradeRepoGplay.Info(gracePeriod = isProViaGrace, billingData = null)
         )
+        every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
+        coEvery { querySkus(any()) } returns emptyList()
     }
 
     private fun buildVm(
@@ -81,6 +87,61 @@ class UpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         forwardedError.await() shouldBe boom
+    }
+
+    @Test fun `previously-pro on this device flows into the banner flag`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(mockRepo(wasEverPro = true))
+
+        val state = async { vm.state.first { !it.pricingLoading } }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe true
+    }
+
+    @Test fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
+        // gracePeriod = true => Info.isPro is true even without a current raw purchase.
+        val vm = buildVm(mockRepo(isProViaGrace = true, wasEverPro = true))
+
+        val state = async { vm.state.first { !it.pricingLoading } }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe false
+    }
+
+    @Test fun `banner and restore stay available when pricing is unavailable`() = runTest2(context = testDispatcher) {
+        // A returning buyer with a flaky Play connection is exactly who needs restore — pricing
+        // failures must not take the banner down with them.
+        val repo = mockRepo(wasEverPro = true)
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.first { !it.pricingLoading } }
+        advanceUntilIdle()
+
+        state.await().apply {
+            pricingUnavailable shouldBe true
+            pricing shouldBe null
+            wasPreviouslyPro shouldBe true
+        }
+    }
+
+    @Test fun `banner is already available while pricing is still loading`() = runTest2(context = testDispatcher) {
+        // The banner must not wait for the SKU queries — a hanging Play pricing request (up to the
+        // 5s timeout) must not delay the restore affordance for a returning buyer.
+        val repo = mockRepo(wasEverPro = true)
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // never resolves within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.first() }
+        runCurrent()
+
+        state.await().apply {
+            pricingLoading shouldBe true
+            wasPreviouslyPro shouldBe true
+        }
     }
 
     @Test fun `successful restore refreshes widgets`() = runTest2(context = testDispatcher) {


### PR DESCRIPTION
## What changed

When you open the upgrade screen and this device remembers that you bought Pro before — but Google Play isn't currently showing you as Pro — Octi now shows a friendly **"Already bought Pro? → Restore purchase"** banner near the top, instead of leading you straight to the paywall. The restore affordances also no longer depend on Play pricing: even while pricing is loading or unavailable, the banner and the restore button are usable.

Port of d4rken-org/sdmaid-se#2556, plus a decoupling of entitlement/restore state from the pricing queries. Stacked on #329.

## Technical Context

- New reactive `wasEverPro` signal in `UpgradeRepoGplay` (`lastProStateAt > 0`) — a **local** signal, set only on a confirmed *known* Pro purchase.
- The ViewModel folds it into the state as `wasPreviouslyPro = wasEverPro && !isPro`, so the banner hides while a grace period or an actual purchase keeps the user Pro.
- **Decoupled state model** (beyond the SD Maid port): `State(pricing, pricingLoading, pricingUnavailable, wasPreviouslyPro)` with the SKU queries modeled tri-state (loading → done/failed). The state — and thus the banner — emits immediately instead of waiting up to 5s for hanging pricing queries. When both SKU queries fail, the screen shows an inline "Google Play is unavailable" section (with the same Play-settings fix action the error dialog offered) instead of throwing `GplayServiceUnavailableException` and being stuck on a spinner; restore keeps working.
- The banner reuses the hardened `restorePurchase()` path from #328; the small bottom "Restore purchase" link stays for everyone and moved out of the pricing section.
- **Scope / limit:** local-only signal — a fresh install or a switched Google account has no prior-Pro record and won't see the banner. The copy is deliberately hedged ("If you still own the upgrade, restoring will unlock it again") since an expired subscription can't be restored.
- **Tests:** VM plumbing (previously-Pro → banner flag on; grace keeps it off; banner + restore available when pricing fails; banner already available while pricing is still loading). Rendering covered via `@Preview2` previews (no Compose/Robolectric test infra in this repo).