### PR TITLE
General: Show progress while restoring a purchase

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
@@ -184,7 +185,10 @@ fun UpgradeScreen(
 
             if (state?.wasPreviouslyPro == true) {
                 Spacer(modifier = Modifier.height(16.dp))
-                RestoreBanner(onRestore = onRestore)
+                RestoreBanner(
+                    onRestore = onRestore,
+                    restoreInProgress = state.restoreInProgress,
+                )
             }
 
             Spacer(modifier = Modifier.height(24.dp))
@@ -244,6 +248,7 @@ fun UpgradeScreen(
                 // buyer with a flaky Play connection is exactly who needs it.
                 TextButton(
                     onClick = onRestore,
+                    enabled = !state.restoreInProgress,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
@@ -258,6 +263,7 @@ fun UpgradeScreen(
 @Composable
 private fun RestoreBanner(
     onRestore: () -> Unit,
+    restoreInProgress: Boolean = false,
 ) {
     ElevatedCard(
         modifier = Modifier.fillMaxWidth(),
@@ -282,8 +288,16 @@ private fun RestoreBanner(
 
             Button(
                 onClick = onRestore,
+                enabled = !restoreInProgress,
                 modifier = Modifier.fillMaxWidth(),
             ) {
+                if (restoreInProgress) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
                 Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
         }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -19,6 +19,7 @@ import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import eu.darken.octi.common.widget.WidgetManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
@@ -57,12 +58,15 @@ class UpgradeViewModel @Inject constructor(
             .launchInViewModel()
     }
 
+    private val restoring = MutableStateFlow(false)
+
     val state: Flow<State> = combine(
         querySkuDetails(OurSku.Iap.PRO_UPGRADE),
         querySkuDetails(OurSku.Sub.PRO_UPGRADE),
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
-    ) { iap, sub, current, wasEverPro ->
+        restoring,
+    ) { iap, sub, current, wasEverPro, isRestoring ->
         // Pricing is deliberately decoupled from entitlement: a returning buyer must see the
         // restore banner and the restore action immediately, even while Google Play is still
         // resolving (or failing to resolve) pricing.
@@ -89,6 +93,7 @@ class UpgradeViewModel @Inject constructor(
             pricingLoading = pricingLoading,
             pricingUnavailable = !pricingLoading && pricing == null,
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            restoreInProgress = isRestoring,
         )
     }.asStateFlow()
 
@@ -117,6 +122,7 @@ class UpgradeViewModel @Inject constructor(
         val pricingLoading: Boolean = false,
         val pricingUnavailable: Boolean = false,
         val wasPreviouslyPro: Boolean = false,
+        val restoreInProgress: Boolean = false,
     )
 
     data class Pricing(
@@ -159,37 +165,49 @@ class UpgradeViewModel @Inject constructor(
         upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER)
     }
 
-    fun restorePurchase() = launch {
-        log(TAG) { "restorePurchase()" }
-
-        val restored = try {
-            withTimeoutOrNull(RESTORE_TIMEOUT) { upgradeRepo.restorePurchaseNow() }
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
-            // of the generic "restore failed" message, so the user can tell the two cases apart.
-            log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
-            errorEvents.emit(e)
-            return@launch
+    fun restorePurchase() {
+        // Single-flight: repeated taps while a restore is running (worst case bounded by
+        // RESTORE_TIMEOUT) must not stack concurrent restores and duplicate result dialogs.
+        if (!restoring.compareAndSet(expect = false, update = true)) {
+            log(TAG) { "restorePurchase() ignored, already in progress" }
+            return
         }
 
-        when {
-            restored == null -> {
-                // Play never answered in time; the restore-failed dialog already suggests waiting /
-                // clearing the Play cache, which fits a timeout too.
-                log(TAG, WARN) { "Restore purchase timed out" }
-                events.emit(UpgradeEvents.RestoreFailed)
-            }
+        launch {
+            log(TAG) { "restorePurchase()" }
+            try {
+                val restored = withTimeoutOrNull(RESTORE_TIMEOUT) { upgradeRepo.restorePurchaseNow() }
 
-            restored.isPro -> {
-                log(TAG, INFO) { "Restored purchase :))" }
-                refreshWidgetsForUpgrade()
-            }
+                when {
+                    restored == null -> {
+                        // Play never answered in time; the restore-failed dialog already suggests
+                        // waiting / clearing the Play cache, which fits a timeout too.
+                        log(TAG, WARN) { "Restore purchase timed out" }
+                        events.emit(UpgradeEvents.RestoreFailed)
+                    }
 
-            else -> {
-                log(TAG, WARN) { "Restore purchase failed" }
-                events.emit(UpgradeEvents.RestoreFailed)
+                    restored.isPro -> {
+                        log(TAG, INFO) { "Restored purchase :))" }
+                        refreshWidgetsForUpgrade()
+                    }
+
+                    else -> {
+                        log(TAG, WARN) { "Restore purchase failed" }
+                        events.emit(UpgradeEvents.RestoreFailed)
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Play/billing error (e.g. service unavailable): surface the proper error dialog
+                // instead of the generic "restore failed" message, so the user can tell the two
+                // cases apart.
+                log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
+                errorEvents.emit(e)
+            } finally {
+                // Reset only after result handling, so the single-flight guard covers the whole
+                // user-visible action, including dialog emission.
+                restoring.value = false
             }
         }
     }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
@@ -142,6 +143,68 @@ class UpgradeViewModelTest : BaseTest() {
             pricingLoading shouldBe true
             wasPreviouslyPro shouldBe true
         }
+    }
+
+    @Test fun `restore is single-flight, taps during a running restore are ignored`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        vm.restorePurchase()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `a failed restore also allows a new attempt`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `restore progress flows into the ui state`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(wasEverPro = true)
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        val inProgress = async { vm.state.first { it.restoreInProgress } }
+        advanceTimeBy(1_000)
+
+        inProgress.await().restoreInProgress shouldBe true
+
+        val done = async { vm.state.first { !it.restoreInProgress } }
+        advanceUntilIdle()
+
+        done.await().restoreInProgress shouldBe false
     }
 
     @Test fun `successful restore refreshes widgets`() = runTest2(context = testDispatcher) {


### PR DESCRIPTION
## What changed

Tapping "Restore purchase" now shows a spinner and disables the restore buttons while the check is running, instead of appearing to do nothing (the check can take several seconds if Google Play is slow). Tapping repeatedly no longer starts multiple overlapping restore attempts that could each pop their own result dialog.

Port of d4rken-org/sdmaid-se#2558. Stacked on #331.

## Technical Context

- Follow-up to the restore-reliability work (#328, #329, #331): the restore banner made restore prominent, which made the missing in-flight feedback user-visible (worst case is the 15s restore timeout).
- A `restoring` flag in the ViewModel makes `restorePurchase()` single-flight. The `MutableStateFlow.compareAndSet` guard runs **synchronously before the coroutine launches**, so rapid taps can't enqueue overlapping restores even before Compose disables the buttons; the flag resets in `finally` *after* result handling so the guard covers the whole user-visible action, including dialog emission.
- The flag flows into the UI state as `restoreInProgress`; both restore affordances disable and the banner button shows a spinner.
- **Tests:** single-flight (3 taps → 1 call), re-enable after successful *and* failed restores, and `restoreInProgress` flowing into (and out of) the state.