### PR TITLE
General: Show an error when Google Play can't start a purchase

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -17,6 +17,7 @@ import eu.darken.octi.common.upgrade.core.billing.BillingManager
 import eu.darken.octi.common.upgrade.core.billing.PurchasedSku
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
+import eu.darken.octi.common.upgrade.core.billing.UserCanceledBillingException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
@@ -80,6 +81,8 @@ class UpgradeRepoGplay @Inject constructor(
         scope.launch {
             try {
                 billingManager.startIapFlow(activity, sku, offer)
+            } catch (e: UserCanceledBillingException) {
+                log(TAG) { "User canceled the billing flow." }
             } catch (e: Exception) {
                 log(TAG) { "startIapFlow failed:${e.asLog()}" }
                 withContext(dispatcherProvider.Main) {

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -167,7 +167,12 @@ class BillingManager @Inject constructor(
             }
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to start IAP flow:\n${e.asLog()}" }
-            val ignoredCodes = listOf(3, 6)
+            // Expected environmental/user situations — user-facing handling only, no bug report.
+            val ignoredCodes = listOf(
+                BillingResponseCode.USER_CANCELED,
+                BillingResponseCode.BILLING_UNAVAILABLE,
+                BillingResponseCode.ERROR,
+            )
             when {
                 e !is BillingException -> {
                     Bugs.report(RuntimeException("State exception for $sku, U", e))
@@ -198,6 +203,10 @@ class BillingManager @Inject constructor(
             if (this !is BillingClientException) return this
 
             return when (result.responseCode) {
+                BillingResponseCode.USER_CANCELED -> UserCanceledBillingException(this)
+
+                BillingResponseCode.ITEM_ALREADY_OWNED -> ItemAlreadyOwnedBillingException(this)
+
                 BillingResponseCode.BILLING_UNAVAILABLE,
                 BillingResponseCode.SERVICE_UNAVAILABLE,
                 BillingResponseCode.SERVICE_DISCONNECTED,

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
@@ -1,0 +1,18 @@
+package eu.darken.octi.common.upgrade.core.billing
+
+import eu.darken.octi.R
+import eu.darken.octi.common.ca.toCaString
+import eu.darken.octi.common.error.HasLocalizedError
+import eu.darken.octi.common.error.LocalizedError
+
+// Play reports the upgrade as already owned when the buy flow is launched — the stale-state
+// returning buyer. Points the user at "Restore purchase" instead of a generic error.
+class ItemAlreadyOwnedBillingException(cause: Throwable? = null) :
+    BillingException("Purchase is reported as already owned.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_already_owned_error_title.toCaString(),
+        description = R.string.upgrades_already_owned_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/UserCanceledBillingException.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/UserCanceledBillingException.kt
@@ -1,0 +1,5 @@
+package eu.darken.octi.common.upgrade.core.billing
+
+// The user backed out of the billing flow — expected behavior, callers swallow this silently.
+class UserCanceledBillingException(cause: Throwable? = null) :
+    BillingException("User canceled the billing flow.", cause)

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -20,8 +20,10 @@ import eu.darken.octi.common.upgrade.core.billing.BillingManager.Companion.tryMa
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -203,7 +205,19 @@ data class BillingConnection(
             setProductDetailsParamsList(listOf(productDetail))
         }.build()
 
-        return client.launchBillingFlow(activity, params)
+        // launchBillingFlow must run on the main thread (documented BillingClient contract), and its
+        // RETURNED result reports whether the flow could be launched at all (DEVELOPER_ERROR,
+        // ITEM_ALREADY_OWNED, BILLING_UNAVAILABLE, ...) — failures arrive here, not as exceptions.
+        // Throw like the other client calls do, so callers can surface them instead of silence.
+        val result = withContext(Dispatchers.Main) {
+            client.launchBillingFlow(activity, params)
+        }
+        log(TAG) {
+            "launchBillingFlow(sku=$sku): code=${result.responseCode}, message=${result.debugMessage}"
+        }
+        if (!result.isSuccess) throw BillingClientException(result)
+
+        return result
     }
 
     companion object {

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -7,6 +7,9 @@
 
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
 
+    <string name="upgrades_already_owned_error_title">Already purchased</string>
+    <string name="upgrades_already_owned_error_description">Google Play reports that you already own this upgrade. Use \'Restore purchase\' to unlock it.</string>
+
     <string name="upgrades_dashcard_title">Get Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade to unlock additional features and support development!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
@@ -1,7 +1,10 @@
 package eu.darken.octi.common.upgrade.core.billing
 
+import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import eu.darken.octi.common.debug.Bugs
+import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.octi.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.octi.common.upgrade.core.billing.client.BillingConnectionProvider
@@ -9,16 +12,89 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 
 class BillingManagerTest : BaseTest() {
+
+    private val activity = mockk<Activity>()
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(Bugs)
+        justRun { Bugs.report(any()) }
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(Bugs)
+    }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
+
+    // A manager whose connection fails launchBillingFlow with the given launch-result code —
+    // the path Play uses for immediate "buy" failures (returned result, not an exception).
+    private fun TestScope.manager(launchFailureCode: Int): BillingManager {
+        val connection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns BillingData(emptySet())
+            every { billingData } returns emptyFlow()
+            coEvery { launchBillingFlow(any(), any(), null) } throws BillingClientException(result(launchFailureCode))
+        }
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flowOf(connection)
+        }
+        return BillingManager(backgroundScope, provider)
+    }
+
+    @Test fun `failed launch surfaces as the already-owned user error and is reported`() = runTest2 {
+        val manager = manager(BillingResponseCode.ITEM_ALREADY_OWNED)
+
+        shouldThrow<ItemAlreadyOwnedBillingException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 1) { Bugs.report(any()) }
+    }
+
+    @Test fun `user cancel from the launch result stays silent bug-report-wise`() = runTest2 {
+        val manager = manager(BillingResponseCode.USER_CANCELED)
+
+        shouldThrow<UserCanceledBillingException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test fun `billing-unavailable maps to the service error without a bug report`() = runTest2 {
+        val manager = manager(BillingResponseCode.BILLING_UNAVAILABLE)
+
+        shouldThrow<GplayServiceUnavailableException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test fun `developer errors are rethrown and reported`() = runTest2 {
+        val manager = manager(BillingResponseCode.DEVELOPER_ERROR)
+
+        shouldThrow<BillingClientException> {
+            manager.startIapFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        }
+        verify(exactly = 1) { Bugs.report(any()) }
+    }
 
     @Test fun `connection failure surfaces to refresh callers instead of hanging`() = runTest2 {
         val provider = mockk<BillingConnectionProvider>().apply {


### PR DESCRIPTION
## What changed

If Google Play can't start the purchase flow when you tap a buy button, Octi now shows the matching error message instead of silently doing nothing. If Play says you already own the upgrade, you get an "Already purchased" dialog pointing you at "Restore purchase".

Mirror of d4rken-org/sdmaid-se#2559 (which itself originated from the cross-review of this shared billing code lineage). Stacked on #332.

## Technical Context

- Root cause: `client.launchBillingFlow()` reports immediate launch failures through its **returned** `BillingResult` (not exceptions) — and that result was discarded. Non-OK meant the buy tap failed with no dialog, no log, no bug report.
- `BillingConnection.launchBillingFlow` now throws `BillingClientException` on a non-OK result, consistent with its sibling methods (`queryPurchases` / `acknowledgePurchase` / `querySkus`), and logs the result.
- The launch call now runs on `Dispatchers.Main` per the documented BillingClient contract (it previously ran on `AppScope`/Default) — a plausible contributor to sporadic silent buy failures.
- New `UserCanceledBillingException` (swallowed by `UpgradeRepoGplay.launchBillingFlow` — the API reference lists `USER_CANCELED` as a possible synchronous launch result, and once we throw it must stay silent) and `ItemAlreadyOwnedBillingException` (localized "Already purchased → use Restore purchase" dialog).
- Bug-report gating: the magic `listOf(3, 6)` became named constants (`USER_CANCELED`, `BILLING_UNAVAILABLE`, `ERROR`). Already-owned and developer-error launches stay reported.
- Behavior change to be aware of: launch-time failures that used to be silent now show dialogs — that's the fix, but it means e.g. launch-time `BILLING_UNAVAILABLE` now surfaces the Play-unavailable message.
- **Tests:** `BillingManagerTest` covers the mapped user-facing exceptions and the report-vs-silent gating (already-owned → reported, user-cancel/unavailable → silent, developer-error → reported).