### PR TITLE
General: Fix grace re-stamping and handle async already-owned purchases

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -1,11 +1,14 @@
 package eu.darken.octi.common.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.value
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
@@ -26,12 +29,16 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
@@ -50,6 +57,46 @@ class UpgradeRepoGplay @Inject constructor(
 ) : UpgradeRepo {
 
     override val mainWebsite: String = SITE
+
+    init {
+        // Fresh-provenance grace stamping: this collector subscribes once at construction (eager,
+        // process start) and never re-subscribes, so every value it sees was produced in this
+        // process moments before — unlike the reactive upgradeInfo map, which re-runs on replayed
+        // shared-flow data every time the UI resubscribes and therefore writes nothing anymore.
+        // This is what keeps a purchase completion stamping the grace cache.
+        billingManager.billingData
+            .distinctUntilChanged()
+            .onEach { data ->
+                try {
+                    recordProState(data)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // A failed DataStore write must not kill this process-lifetime collector.
+                    log(TAG, WARN) { "Failed to record pro state: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "proStateRecorder" }
+            .launchIn(scope)
+
+        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that the
+        // user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
+        // failures, so no app-side dialog here.
+        billingManager.purchaseFailures
+            .filter { it.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED }
+            .onEach {
+                log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
+                try {
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT) { restorePurchaseNow() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
+            .launchIn(scope)
+    }
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
         .map<BillingData, BillingData?> { it }
@@ -74,7 +121,9 @@ class UpgradeRepoGplay @Inject constructor(
 
     // True once we've ever confirmed a (known) pro purchase on this install; drives the proactive
     // restore banner. Local signal only — a fresh install or a switched Google account starts false.
-    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
+        .map { it > 0 }
+        .distinctUntilChanged()
 
     fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
@@ -97,7 +146,8 @@ class UpgradeRepoGplay @Inject constructor(
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
         try {
-            withTimeout(REFRESH_TIMEOUT) { billingManager.refresh() }
+            val fresh = withTimeout(REFRESH_TIMEOUT) { billingManager.refresh() }
+            recordProState(fresh)
         } catch (e: TimeoutCancellationException) {
             log(TAG, ERROR) { "Background refresh timed out" }
         } catch (e: CancellationException) {
@@ -115,7 +165,9 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun restorePurchaseNow(): Info {
         log(TAG) { "restorePurchaseNow()" }
         return try {
-            billingManager.refresh().toUpgradeInfo()
+            val fresh = billingManager.refresh()
+            recordProState(fresh)
+            fresh.toUpgradeInfo()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -134,22 +186,16 @@ class UpgradeRepoGplay @Inject constructor(
     }
 
     // Shared pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
-    // Only relinquishes pro state if we haven't had it for a while (grace period).
+    // Only relinquishes pro state if we haven't had it for a while (grace period). READ-ONLY: this
+    // runs on replayed shared-flow data too, so it must never stamp the grace cache — see
+    // recordProState(). An unrecognized purchase neither counts as pro nor suppresses active grace.
     private suspend fun BillingData?.toUpgradeInfo(): Info {
         val now = Clock.System.now().toEpochMilliseconds()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         val info = Info(billingData = this)
-        // Only a *known* pro SKU counts as "last pro state" — an unrecognized purchase must not
-        // refresh the grace timestamp (and must not suppress an active grace window either).
-        // Prefer the permanent IAP so it drives the window.
-        val preferred = preferredProSku(info.upgrades)
         return when {
-            preferred != null -> {
-                billingCache.lastProStateAt.value(now)
-                updateLastProSku(preferred, iapQueryOk = this?.iapQueryOk ?: true)
-                info
-            }
+            preferredProSku(info.upgrades) != null -> info
 
             (now - lastProStateAt).milliseconds < graceWindow() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
@@ -158,6 +204,28 @@ class UpgradeRepoGplay @Inject constructor(
 
             else -> info
         }
+    }
+
+    // Persists "we saw a known pro purchase" for the grace machinery. Callers must only pass FRESH
+    // data (returned query results, or new emissions seen by the init collector) — never replayed
+    // flow data, so a refunded purchase can't keep re-stamping its grace window. Only a *known* pro
+    // SKU counts; the permanent IAP is preferred so it drives the window length.
+    private suspend fun recordProState(data: BillingData) {
+        // A failed product-type query keeps previously cached purchases in billingData (ACK must not
+        // starve), but those aren't fresh ownership proof — only purchases whose product type was
+        // verified by this data may renew grace. Query-returned data is inherently verified; this
+        // only bites for the combined reactive emissions.
+        val verified = Info(billingData = data).upgrades.filter {
+            when (it.sku.type) {
+                Sku.Type.IAP -> data.iapQueryOk
+                Sku.Type.SUBSCRIPTION -> data.subQueryOk
+            }
+        }
+        val preferred = preferredProSku(verified) ?: return
+        // SKU before timestamp: the timestamp gates grace, the SKU only modifies its length — this
+        // order can't leave a fresh gate pointing at a stale modifier if we die between the writes.
+        updateLastProSku(preferred, iapQueryOk = data.iapQueryOk)
+        billingCache.lastProStateAt.value(Clock.System.now().toEpochMilliseconds())
     }
 
     // A stored permanent-IAP sku is only replaced by a subscription sku when the IAP query actually
@@ -226,6 +294,7 @@ class UpgradeRepoGplay @Inject constructor(
         internal val PRO_GRACE_PERIOD = 7.days
         internal val PRO_GRACE_PERIOD_IAP = 30.days
         private val REFRESH_TIMEOUT = 15.seconds
+        private val RESTORE_ON_OWNED_TIMEOUT = 15.seconds
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 
         // The SKU whose grace window applies when several are owned: the permanent one-time purchase

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.common.upgrade.core.billing
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.Bugs
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
@@ -95,6 +96,11 @@ class BillingManager @Inject constructor(
         .distinctUntilChanged()
         .setupCommonEventHandlers(TAG) { "billingData" }
         .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
+
+    val purchaseFailures: Flow<BillingResult> = connection
+        .mapNotNull { it.getOrNull() }
+        .flatMapLatest { it.purchaseFailures }
+        .setupCommonEventHandlers(TAG) { "purchaseFailures" }
 
     init {
         billingData

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -34,6 +34,7 @@ import kotlin.coroutines.suspendCoroutine
 data class BillingConnection(
     private val client: BillingClient,
     val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
+    private val purchaseFailureEvents: Flow<BillingResult?>,
 ) {
 
     private val queryCacheIaps = MutableStateFlow<QueryCache?>(null)
@@ -65,6 +66,10 @@ data class BillingConnection(
         val purchases: Collection<Purchase>,
         val querySucceeded: Boolean,
     )
+
+    // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
+    // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
+    val purchaseFailures: Flow<BillingResult> = purchaseFailureEvents.filterNotNull()
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -34,6 +34,7 @@ class BillingConnectionProvider @Inject constructor(
 
     private val provider: Flow<BillingConnection> = callbackFlow {
         val purchaseEvents = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
+        val purchaseFailureEvents = MutableStateFlow<BillingResult?>(null)
 
         val pendingPurchasesParams = PendingPurchasesParams.newBuilder().apply {
             enableOneTimeProducts()
@@ -52,6 +53,11 @@ class BillingConnectionProvider @Inject constructor(
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
+                    // Failures go to their own slot: async ITEM_ALREADY_OWNED drives the auto-restore
+                    // in UpgradeRepoGplay. They must NOT overwrite the success slot — a purchase event
+                    // not yet reflected in the query caches would vanish from billingData (and could
+                    // starve acknowledgement) if a later cancel/error replaced it.
+                    purchaseFailureEvents.value = result
                 }
             }
         }.build()
@@ -65,7 +71,7 @@ class BillingConnectionProvider @Inject constructor(
 
                 when (result.responseCode) {
                     BillingResponseCode.OK -> {
-                        val connection = BillingConnection(client, purchaseEvents)
+                        val connection = BillingConnection(client, purchaseEvents, purchaseFailureEvents)
                         trySendBlocking(connection)
                     }
 

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,5 +1,7 @@
 package eu.darken.octi.common.upgrade.core
 
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.common.upgrade.core.billing.BillingData
@@ -9,11 +11,14 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -31,10 +36,17 @@ class UpgradeRepoGplayTest : BaseTest() {
     private lateinit var lastProSkuValue: DataStoreValue<String>
 
     // Builds a repo whose stored last-pro timestamp is `lastProAt` and last-owned sku is `lastSku`.
-    // billingData is stubbed only because the upgradeInfo flow references it at construction; it is
-    // never collected here.
-    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
-        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
+    // The Unconfined scope runs the init collectors (grace stamping, async already-owned) eagerly
+    // against the stubbed flows.
+    private fun repo(
+        lastProAt: Long,
+        lastSku: String = "",
+        billingData: BillingData = BillingData(emptySet()),
+        purchaseFailures: List<BillingResult> = emptyList(),
+    ): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.purchaseFailures } returns
+            if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
         lastProAtValue = mockk<DataStoreValue<Long>>(relaxed = true).apply {
             every { flow } returns flowOf(lastProAt)
         }
@@ -45,6 +57,8 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { billingCache.lastProStateSku } returns lastProSkuValue
         return UpgradeRepoGplay(scope, TestDispatcherProvider(), billingManager, billingCache)
     }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
     private fun now() = Clock.System.now().toEpochMilliseconds()
 
@@ -193,5 +207,82 @@ class UpgradeRepoGplayTest : BaseTest() {
             .restorePurchaseNow().isPro shouldBe true
 
         coVerify(exactly = 1) { lastProSkuValue.update(match { it("") == OurSku.Sub.PRO_UPGRADE.id }) }
+    }
+
+    @Test fun `explicit restore stamps the grace cache, sku before timestamp`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
+
+        coVerifyOrder {
+            lastProSkuValue.update(any())
+            lastProAtValue.update(any())
+        }
+    }
+
+    @Test fun `background refresh stamps the grace cache from the fresh result`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).refresh()
+
+        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    }
+
+    @Test fun `reactive emissions stamp once via the init collector, the map never stamps`() = runTest2 {
+        // billingData carries a pro purchase: the persistent init collector stamps exactly once.
+        // Collecting upgradeInfo runs the map at least twice (onStart-null + pro data) — the map is
+        // read-only now, so if it still stamped the count would exceed one.
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+
+        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
+
+        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    }
+
+    @Test fun `stale cached purchases behind a failed query do not renew grace`() = runTest2 {
+        // A failed IAP query keeps the previously cached IAP purchase in billingData (so ACKs can't
+        // starve) — but that's not fresh ownership proof and must not re-stamp the grace window.
+        repo(
+            lastProAt = 0L,
+            billingData = BillingData(
+                purchases = setOf(purchaseOf(OurSku.Iap.PRO_UPGRADE.id)),
+                iapQueryOk = false,
+            ),
+        )
+
+        coVerify(exactly = 0) { lastProAtValue.update(any()) }
+    }
+
+    @Test fun `a verified subscription renews grace even while the IAP query fails`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            billingData = BillingData(
+                purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
+                iapQueryOk = false,
+                subQueryOk = true,
+            ),
+        )
+
+        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    }
+
+    @Test fun `async already-owned purchase event triggers a silent restore`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = listOf(result(BillingResponseCode.ITEM_ALREADY_OWNED)),
+        )
+
+        coVerify(exactly = 1) { billingManager.refresh() }
+    }
+
+    @Test fun `other async purchase failures do not trigger a restore`() = runTest2 {
+        repo(
+            lastProAt = 0L,
+            purchaseFailures = listOf(result(BillingResponseCode.DEVELOPER_ERROR)),
+        )
+
+        coVerify(exactly = 0) { billingManager.refresh() }
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -98,7 +98,7 @@ class BillingConnectionTest : BaseTest() {
                     )
                 }
             }
-            val connection = BillingConnection(client, flowOf(null))
+            val connection = BillingConnection(client, flowOf(null), flowOf(null))
 
             connection.refreshPurchases().purchases shouldBe listOf(owned)
             // The failed type's cache is seeded empty, so the combined flow must still emit —


### PR DESCRIPTION
## What changed

Two billing reliability fixes:

- A refund now reliably ends the Pro grace period on schedule — the grace timer can no longer be extended by stale or replayed billing data.
- If Google Play reports mid-purchase that you already own the upgrade, Octi now restores it automatically (same behavior that already existed when Play reports it immediately at launch, #333).

Port of fixes 2+3 from d4rken-org/sdmaid-se#2561 (fix 1, connection recovery, was already implemented here in #328 via the Result-carrying connection flow with retry loop).

## Technical Context

- **Grace provenance:** `toUpgradeInfo()` stamped the grace cache inside the reactive map, which also runs on **replayed** shared-flow data — `billingData` is pinned alive for the process lifetime (ACK loop + `UpgradeEntitlementObserver`), so every `upgradeInfo` resubscription re-stamped `lastProStateAt` from possibly days-old data, letting a refunded user extend their own grace window indefinitely. The map is now read-only; `recordProState()` stamps only from fresh-provenance sites: the `BillingData` **returned** by `refresh()`/`restorePurchaseNow()` (covers steady owners — StateFlow dedupe means unchanged query results never re-emit through the flows) plus one persistent `billingData` collector subscribed at construction. SKU is written before the timestamp (a crash between the writes can't pair a fresh grace gate with a stale window length).
- **Beyond the upstream port** (found in review, applies to sdmaid-se#2561 too — will report upstream):
  - `recordProState` only counts purchases whose product type was **freshly verified** (`iapQueryOk`/`subQueryOk` from #328): a failed query keeps previously cached purchases in `billingData` so ACKs can't starve, but those aren't ownership proof and must not renew grace.
  - Async purchase failures get their **own event slot** instead of sharing the success `StateFlow`: upstream's shape lets a later `USER_CANCELED`/error overwrite a fresh success event before the query caches contain that purchase, making it vanish from `billingData` (and potentially delaying acknowledgement).
- **Async ITEM_ALREADY_OWNED:** `onPurchasesUpdated` failures were dropped; now exposed as `purchaseFailures` and consumed by one persistent repo collector that silently runs the hardened `restorePurchaseNow()` (15s bound). Only this one code is handled — Play shows its own UI for other purchase-sheet failures, so no app-side dialogs.
- `wasEverPro` gains `distinctUntilChanged`. The `iapQueryOk` downgrade guard from #329 is preserved inside `recordProState`.
- **Tests:** stamp order (sku before timestamp), refresh/restore stamping, map-never-stamps (exact update count), stale-cache-behind-failed-query doesn't renew grace, verified-sub-renews-while-IAP-query-fails, async already-owned → restore, other async codes ignored.