### PR TITLE
General: Faster billing recovery and accurate trial copy

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -17,8 +17,12 @@ import eu.darken.octi.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.octi.common.upgrade.core.billing.client.BillingConnectionProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
@@ -32,10 +36,10 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -44,6 +48,10 @@ class BillingManager @Inject constructor(
     @AppScope private val scope: CoroutineScope,
     connectionProvider: BillingConnectionProvider,
 ) {
+
+    // Declared before `connection`: the init-block collectors can drive the retry loop on the
+    // app scope while this class is still initializing.
+    private val retryNow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     // Carries connection failures as values instead of swallowing them: useConnection callers
     // (purchase, restore) get an immediate, mappable error (e.g. BILLING_UNAVAILABLE) instead of
@@ -74,8 +82,8 @@ class BillingManager @Inject constructor(
 
             // The provider flow only completes after a connection failure — a healthy connection
             // stays open indefinitely. Pause, then attempt a fresh connection so billing recovers
-            // without a process restart. A device without Play (BILLING_UNAVAILABLE) gets a much
-            // longer pause since that state rarely changes.
+            // without a process restart. A device without Play (BILLING_UNAVAILABLE) gets a longer
+            // pause — but not too long: the user may just have signed into their Google account.
             val cause = failure
             val retryDelay = when {
                 cause is BillingClientException &&
@@ -83,8 +91,10 @@ class BillingManager @Inject constructor(
 
                 else -> CONNECTION_RETRY_DELAY
             }
-            log(TAG) { "Retrying billing connection in $retryDelay" }
-            delay(retryDelay)
+            log(TAG) { "Retrying billing connection in $retryDelay (sooner on demand)" }
+            // User-facing billing actions can skip the wait via retryNow — e.g. tapping "Restore
+            // purchase" right after fixing the Play/account state shouldn't fail on a stale error.
+            withTimeoutOrNull(retryDelay) { retryNow.first() }
         }
     }
         .setupCommonEventHandlers(TAG) { "connection" }
@@ -155,11 +165,36 @@ class BillingManager @Inject constructor(
             .launchIn(scope)
     }
 
-    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T = connection.first()
-        .getOrElse { throw it.tryMapUserFriendly() }
-        .action()
+    private suspend fun <T> useConnection(
+        retryOnFailure: Boolean = false,
+        action: suspend BillingConnection.() -> T,
+    ): T {
+        var current = connection.first()
+        if (current.isFailure && retryOnFailure) {
+            // A user-facing action must not keep failing on a stale error until the retry delay
+            // elapses — the user may just have fixed the cause (signed in, updated Play). Poke the
+            // retry loop and wait (bounded — not every caller has its own timeout, e.g. buy taps)
+            // for the fresh attempt's outcome. Subscribe before poking so the fresh result can't
+            // be missed, and filter on the stale value in case the loop retried on its own in the
+            // meantime. If the fresh attempt doesn't resolve in time, fail with the known error.
+            log(TAG) { "Connection has a stale failure, requesting an immediate retry" }
+            val stale = current
+            current = withTimeoutOrNull(RETRY_WAIT_TIMEOUT) {
+                coroutineScope {
+                    val fresh = async(start = CoroutineStart.UNDISPATCHED) {
+                        connection.first { it != stale }
+                    }
+                    retryNow.tryEmit(Unit)
+                    fresh.await()
+                }
+            } ?: stale
+        }
+        return current
+            .getOrElse { throw it.tryMapUserFriendly() }
+            .action()
+    }
 
-    suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection {
+    suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection(retryOnFailure = true) {
         log(TAG) { "querySkus(): $skus..." }
         querySkus(*skus).also {
             log(TAG) { "querySkus(): $it" }
@@ -168,7 +203,7 @@ class BillingManager @Inject constructor(
 
     suspend fun startIapFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         try {
-            useConnection {
+            useConnection(retryOnFailure = true) {
                 launchBillingFlow(activity, sku, offer)
             }
         } catch (e: Exception) {
@@ -198,12 +233,13 @@ class BillingManager @Inject constructor(
     // billingData replay cache.
     suspend fun refresh(): BillingData {
         log(TAG) { "refresh()" }
-        return useConnection { refreshPurchases() }
+        return useConnection(retryOnFailure = true) { refreshPurchases() }
     }
 
     companion object {
         private val CONNECTION_RETRY_DELAY = 1.minutes
-        private val CONNECTION_RETRY_DELAY_UNAVAILABLE = 1.hours
+        internal val CONNECTION_RETRY_DELAY_UNAVAILABLE = 5.minutes
+        private val RETRY_WAIT_TIMEOUT = 10.seconds
 
         internal fun Throwable.tryMapUserFriendly(): Throwable {
             if (this !is BillingClientException) return this

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -171,6 +171,12 @@ data class BillingConnection(
         log(TAG) {
             "querySkus(skus=${skus.joinToString { it.print() }}): code=${result.responseCode}, debug=${result.debugMessage}), skuDetails=$details"
         }
+        // Make "Play withheld an offer" vs "we failed to match it" diagnosable from debug logs.
+        details?.forEach { detail ->
+            log(TAG) {
+                "querySkus(): ${detail.productId} offers=${detail.subscriptionOfferDetails?.map { "${it.basePlanId}:${it.offerId}" }}"
+            }
+        }
 
         if (!result.isSuccess) throw BillingClientException(result)
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -214,12 +214,22 @@ fun UpgradeScreen(
             )
 
             Text(
-                text = stringResource(R.string.upgrade_screen_how_body),
+                text = stringResource(R.string.upgrade_screen_how_body2),
                 style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 24.dp),
+                modifier = Modifier.fillMaxWidth(),
             )
+
+            // Trial copy is promise-accurate: only shown when Play actually offers the trial to
+            // this account, matching the button below.
+            if (state?.trialAvailable == true) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_how_trial_hint),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
 
             if (state == null || state.pricingLoading) {
                 Box(

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -92,6 +92,10 @@ class UpgradeViewModel @Inject constructor(
             pricing = pricing,
             pricingLoading = pricingLoading,
             pricingUnavailable = !pricingLoading && pricing == null,
+            // Only advertise the free trial when Play actually returned the trial offer — accounts
+            // that already used their trial (or regions without it) get plain subscription copy.
+            trialAvailable = pricing?.sub?.details?.subscriptionOfferDetails
+                ?.any { OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(it) } == true,
             wasPreviouslyPro = wasEverPro && !current.isPro,
             restoreInProgress = isRestoring,
         )
@@ -121,6 +125,7 @@ class UpgradeViewModel @Inject constructor(
         val pricing: Pricing?,
         val pricingLoading: Boolean = false,
         val pricingUnavailable: Boolean = false,
+        val trialAvailable: Boolean = false,
         val wasPreviouslyPro: Boolean = false,
         val restoreInProgress: Boolean = false,
     )

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Voordele</string>
     <string name="upgrade_screen_benefits_body">• Meer as 3 toestelle 💯\n• Verskillende temas 🎨\n• Meer opsies ⚙️\n• Ekstra sinkroniseer-bedieners🖥️️\n• Voortgesette ontwikkeling ☕\n• \'n Gemotiveerde ontwikkelaar 🧙</string>
     <string name="upgrade_screen_how_title">Opsies</string>
-    <string name="upgrade_screen_how_body">Jy kan kies tussen \'n eenmalige aankoop en \'n goedkoper jaarlikse inskrywing.\nDie inskrywing begin met \'n gratis 14-dae proeflopie, waarna jy jaarliks gehef sal word. Proeflopie en inskrywing kan enige tyd gekanselleer word.\nDieselfde funksies, net ander prysmodelle.</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis 14-dae proef</string>
     <string name="upgrade_screen_subscription_action">Inskryf</string>
     <string name="upgrade_screen_subscription_action_hint">Die inskrywing kos %s per jaar.</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -20,7 +20,6 @@
     <string name="upgrade_screen_benefits_title">المزايا</string>
     <string name="upgrade_screen_benefits_body">• أكثر من 3 أجهزة 💯\n• سمات مختلفة 🎨\n• المزيد من الخيارات ⚙️\n• خوادم مزامنة إضافية🖥️️\n• تطوير مستمر ☕\n• مطور متحمس 🧙</string>
     <string name="upgrade_screen_how_title">الخيارات</string>
-    <string name="upgrade_screen_how_body">يمكنك الاختيار بين عملية شراء لمرة واحدة واشتراك سنوي أرخص.\nيبدأ الاشتراك بفترة تجريبية مجانية لمدة 14 يومًا، وبعدها سيتم محاسبتك مرة واحدة سنويًا. يمكن إلغاء الفترة التجريبية والاشتراك في أي وقت.\nنفس الميزات، فقط نماذج تسعير مختلفة.</string>
     <string name="upgrade_screen_subscription_trial_action">ابدأ فترة تجريبية مجانية لمدة 14 يومًا</string>
     <string name="upgrade_screen_subscription_action">اشتراك</string>
     <string name="upgrade_screen_subscription_action_hint">تبلغ تكلفة الاشتراك %s سنوياً.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Предимства</string>
     <string name="upgrade_screen_benefits_body">• Повече от 3 устройства 💯\n• Различни теми 🎨\n• Повече опции ⚙️\n• Допълнителни сървъри за синхронизация 🖥️️\n• Продължаващо развитие ☕\n• Мотивиран разработчик 🧙</string>
     <string name="upgrade_screen_how_title">Опции</string>
-    <string name="upgrade_screen_how_body">Можете да изберете между еднокупна покупка и по-евтин годишен абонамент.\nАбонаментът започва с 14-дневен безплатен пробен период, след което ще бъдете таксувани веднъж годишно. Пробният период и абонаментът могат да бъдат анулирани по всяко време.\nСъщите функции, просто различни модели на ценообразуване.</string>
     <string name="upgrade_screen_subscription_trial_action">Стартирайте безплатен 14-дневен пробен период</string>
     <string name="upgrade_screen_subscription_action">Абонирайте се</string>
     <string name="upgrade_screen_subscription_action_hint">Абонаментът струва %s на година.</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Avantatges</string>
     <string name="upgrade_screen_benefits_body">• Més de 3 dispositius 💯\n• Temes diferents 🎨\n• Més opcions ⚙️\n• Servidors de sincronització addicionals🖥️️\n• Desenvolupament continu ☕\n• Un desenvolupador motivat 🧙</string>
     <string name="upgrade_screen_how_title">Opcions</string>
-    <string name="upgrade_screen_how_body">Podeu triar entre una compra única i una subscripció anual més barata.\nLa subscripció comença amb una prova gratuïta de 14 dies, després de la qual se li cobrarà un cop l\'any. La prova i la subscripció es poden cancel·lar en qualsevol moment.\nLes mateixes funcions, només models de preus diferents.</string>
     <string name="upgrade_screen_subscription_trial_action">Comença la prova gratuïta de 14 dies</string>
     <string name="upgrade_screen_subscription_action">Subscriure’s</string>
     <string name="upgrade_screen_subscription_action_hint">La subscripció costa %s a l\'any.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -18,7 +18,6 @@
     <string name="upgrade_screen_benefits_title">Výhody</string>
     <string name="upgrade_screen_benefits_body">• Více než 3 zařízení 💯\n• Různé motivy 🎨\n• Více možností ⚙️\n• Extra synchronizace serverů🖥️\n• Pokračování ve vývoji ☕\n• Motivovaný vývojář 🧙</string>
     <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Můžete si vybrat mezi jednorázovým nákupem a levnějším ročním předplatným.\nPředplatné začíná 14denní bezplatnou zkušební dobou, po které budete jednou ročně účtováni. Zkušební dobu a předplatné je možné kdykoliv zrušit.\nStejné funkce, jen různé cenové modely.</string>
     <string name="upgrade_screen_subscription_trial_action">Zahájit bezplatnou 14denní zkušební dobu</string>
     <string name="upgrade_screen_subscription_action">Předplatit</string>
     <string name="upgrade_screen_subscription_action_hint">Předplatné stojí %s ročně.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Fordele</string>
     <string name="upgrade_screen_benefits_body">• Mere end 3 enheder 💯\n• Forskellige temaer 🎨\n• Flere muligheder ⚙️\n• Ekstra synkroniseringsservere🖥️️\n• Fortsat udvikling ☕\n• En motiveret udvikler 🧙</string>
     <string name="upgrade_screen_how_title">Muligheder</string>
-    <string name="upgrade_screen_how_body">Du kan vælge mellem et engangskøb og et billigere årligt abonnement.\nAbonnementet starter med en gratis 14-dages prøveperiode, hvorefter du opkræves én gang om året. Prøve og abonnement kan til enhver tid opsiges.\nSamme funktioner, bare forskellige prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis 14-dages prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s om året.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Vorteile</string>
     <string name="upgrade_screen_benefits_body">• Mehr als 3 Geräte 💯\n• Verschiedene Skins</string>
     <string name="upgrade_screen_how_title">Optionen</string>
-    <string name="upgrade_screen_how_body">Sie können zwischen einem einmaligen Kauf und einem günstigeren Jahresabonnement wählen.\nDas Abonnement beginnt mit einer kostenlosen 14-Tage-Testversion. Danach wird Ihnen einmal pro Jahr eine Gebühr berechnet. Testversion und Abonnement sind jederzeit kündbar.\nGleiche Funktionen, nur unterschiedliche Preismodelle.</string>
     <string name="upgrade_screen_subscription_trial_action">Starte eine 14 Tage Testversion</string>
     <string name="upgrade_screen_subscription_action">Abonnement</string>
     <string name="upgrade_screen_subscription_action_hint">Das Abonnement kostet %s im Jahr.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Πλεονεκτήματα</string>
     <string name="upgrade_screen_benefits_body">• Πάνω από 3 συσκευές 💯\n• Διαφορετικά θέματα 🎨\n• Περισσότερες επιλογές ⚙️\n• Πρόσθετοι servers συγχρονισμού🖥️️\n• Συνεχής ανάπτυξη ☕\n• Ένας αφοσιωμένος προγραμματιστής 🧙</string>
     <string name="upgrade_screen_how_title">Επιλογές</string>
-    <string name="upgrade_screen_how_body">Μπορείτε να επιλέξετε μεταξύ μιας εφάπαξ αγοράς και μιας φθηνότερης ετήσιας συνδρομής.\nΗ συνδρομή ξεκινά με μια δωρεάν δοκιμή 14 ημερών, μετά την οποία θα χρεώνεστε ετησίως. Η δοκιμή και η συνδρομή ακυρώνονται ανά πάσα στιγμή.\nΊδια χαρακτηριστικά, απλά διαφορετικά μοντέλα τιμολόγησης.</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής 14 ημερών</string>
     <string name="upgrade_screen_subscription_action">Συνδρομή</string>
     <string name="upgrade_screen_subscription_action_hint">Η συνδρομή κοστίζει %s ετησίως.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Beneficios</string>
     <string name="upgrade_screen_benefits_body">• Más de 3 dispositivos 💯\n• Diferentes temas 🎨\n• Más opciones ⚙️\n• Servidores de sincronización extra🖥️️\n• Desarrollo continuo ☕\n• Un desarrollador motivado 🧙</string>
     <string name="upgrade_screen_how_title">Opciones</string>
-    <string name="upgrade_screen_how_body">Puedes elegir entre una compra única y una suscripción anual más económica.\nLa suscripción comienza con una prueba gratuita de 14 días, después serás cobrado una vez al año. La prueba y suscripción pueden cancelarse en cualquier momento.\nLas mismas funciones, solo diferentes modelos de precios.</string>
     <string name="upgrade_screen_subscription_trial_action">Comenzar prueba gratuita de 14 días</string>
     <string name="upgrade_screen_subscription_action">Suscribirse</string>
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s al año.</string>

--- a/app/src/gplay/res/values-et/strings.xml
+++ b/app/src/gplay/res/values-et/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Eelised</string>
     <string name="upgrade_screen_benefits_body">• Rohkem kui 3 seadet 💯\n• Erinevad teemad 🎨\n• Rohkem valikuid ⚙️\n• Lisanduvad sünkroonimisserverid🖥️️\n• Jätkuv arendus ☕\n• Motiveeritud arendaja 🧙</string>
     <string name="upgrade_screen_how_title">Valikud</string>
-    <string name="upgrade_screen_how_body">Saad valida ühekordse ostu ja odavama aastase tellimuse vahel.\nTellige alustuseks tasuta 14-päevane prooviperiood, mille järel arvestatakse tasu kord aastas. Prooviperioodi ja tellimust saab igal ajal tühistada.\nSama funktsionaalsus, lihtsalt erinevad hinnamudelid.</string>
     <string name="upgrade_screen_subscription_trial_action">Alusta tasuta 14-päevast prooviperioodi</string>
     <string name="upgrade_screen_subscription_action">Telli</string>
     <string name="upgrade_screen_subscription_action_hint">Tellimus maksab %s aastas.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Hyödyt</string>
     <string name="upgrade_screen_benefits_body">• Yli 3 laitetta 💯\n• Erilaiset teemat 🎨\n• Lisää vaihtoehtoja ⚙️\n• Lisäsynkronointipalvelimet🖥️️\n• Jatkuva kehitys ☕\n• Motivoitunut kehittäjä 🧙</string>
     <string name="upgrade_screen_how_title">Vaihtoehdot</string>
-    <string name="upgrade_screen_how_body">Voit valita kertamaksun ja halvemman vuositilauksen välillä.\nTilaus alkaa ilmaisella 14 päivän kokeilulla, jonka jälkeen maksu veloitetaan vuosittain. Kokeilu ja tilaus ovat peruttavissa milloin tahansa.\nSamat ominaisuudet, vain eri hinnoittelumallit.</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen 14 päivän kokeilu</string>
     <string name="upgrade_screen_subscription_action">Tilaa</string>
     <string name="upgrade_screen_subscription_action_hint">Tilauksen hinta on %s vuodessa.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Avantages</string>
     <string name="upgrade_screen_benefits_body">• Plus de 3 appareils 💯;\n• Plusieurs thèmes 🎨;\n• Plus d’options ⚙️;\n• Des serveurs de synchronisation supplémentaires ; 🖥️\n• Un développement permanent ; ☕\nUn développeur motivé 🧙.</string>
     <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">Vous pouvez soit choisir un achat unique soit un abonnement annuel moins coûteux.\nL\'abonnement commence par un essai gratuit de 14 jours suivi d’une facture annuelle. L’essai et l’abonnement peuvent être annulés n’importe quand.\nMême fonctions, juste différents modes tarifaires.</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit de 14 jours</string>
     <string name="upgrade_screen_subscription_action">M’abonner</string>
     <string name="upgrade_screen_subscription_action_hint">L’abonnement coûte %s par an.</string>

--- a/app/src/gplay/res/values-ga/strings.xml
+++ b/app/src/gplay/res/values-ga/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Buntáistí</string>
     <string name="upgrade_screen_benefits_body">• Níos mó ná 3 ghléas 💯\n• Téamaí éagsúla 🎨\n• Tuilleadh roghanna ⚙️\n• Freastalaithe sioncrónaithe breise🖥️️\n• Forbairt leanúnach ☕\n• Forbróir spreagtha 🧙</string>
     <string name="upgrade_screen_how_title">Roghanna</string>
-    <string name="upgrade_screen_how_body">Is féidir leat rogha a dhéanamh idir ceannach aonuaire agus síntiús bliantúil níos saoire.\nTosaíonn an síntiús le triail saor in aisce ar feadh 14 lá, ansin gearrfar ort uair sa bhliain. Is féidir an triail agus an síntiús a chur ar ceal am ar bith.\nNa gnéithe céanna, ach samhlacha praghsála éagsúla.</string>
     <string name="upgrade_screen_subscription_trial_action">Cuir tús le triail saor in aisce 14 lá</string>
     <string name="upgrade_screen_subscription_action">Liostáil</string>
     <string name="upgrade_screen_subscription_action_hint">Cosnaíonn an síntiús %s sa bhliain.</string>

--- a/app/src/gplay/res/values-he/strings.xml
+++ b/app/src/gplay/res/values-he/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">יתרונות</string>
     <string name="upgrade_screen_benefits_body">• יותר מ-3 מכשירים 💯\n• ערכות נושא מגוונות 🎨\n• אפשרויות נוספות ⚙️\n• שרתי סנכרון נוספים 🖥️️\n• המשך פיתוח ☕\n• מפתח חדור מוטיבציה 🧙</string>
     <string name="upgrade_screen_how_title">אפשרויות</string>
-    <string name="upgrade_screen_how_body">באפשרותך לבחור בין רכישה חד פעמית למנוי שנתי מוזל.\nהמנוי מתחיל בניסיון חינם ל-14 ימים, ואחריו תחויב פעם בשנה. ניתן לבטל את הניסיון ואת המנוי בכל עת.\nאותן תכונות, מודלי תמחור שונים בלבד.</string>
     <string name="upgrade_screen_subscription_trial_action">התחל ניסיון חינם ל-14 ימים</string>
     <string name="upgrade_screen_subscription_action">הירשם כמנוי</string>
     <string name="upgrade_screen_subscription_action_hint">עלות המנוי היא %s לשנה.</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Prednosti</string>
     <string name="upgrade_screen_benefits_body">• Više od 3 uređaja 💯\n• Različite teme 🎨\n• Više opcija ⚙️\n• Dodatni serveri za sinkronizaciju🖥️️\n• Kontinuirani razvoj ☕\n• Motivirani programer 🧙</string>
     <string name="upgrade_screen_how_title">Mogućnosti</string>
-    <string name="upgrade_screen_how_body">Možete birati između jednokratne kupnje i jeftinije godišnje pretplate.\nPretplata započinje besplatnim probnim razdobljem od 14 dana, nakon čega se naplaćuje jednom godišnje. Probno razdoblje i pretplatu moguće je otkazati u bilo kojem trenutku.\nIste značajke, samo različiti modeli cijena.</string>
     <string name="upgrade_screen_subscription_trial_action">Pokreni besplatno probno razdoblje od 14 dana</string>
     <string name="upgrade_screen_subscription_action">Pretplati se</string>
     <string name="upgrade_screen_subscription_action_hint">Pretplata košta %s godišnje.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Előnyök</string>
     <string name="upgrade_screen_benefits_body">• Több mint 3 eszköz 💯\n• Különböző témák 🎨\n• Több lehetőség ⚙️\n• Extra szinkronizáló szerverek🖥️️\n• Folyamatos fejlesztés ☕\n• Elkötelezett fejlesztő 🧙</string>
     <string name="upgrade_screen_how_title">Lehetőségek</string>
-    <string name="upgrade_screen_how_body">Választhatsz egyszeri vásárlás és olcsóbb éves előfizetés között.\nAz előfizetés 14 napos ingyenes próbaidőszakkal indul, utána évente egyszer kerül számlázásra. A próbaidő és az előfizetés bármikor lemondható.\nUgyanazok a funkciók, csak eltérő árazási modellek.</string>
     <string name="upgrade_screen_subscription_trial_action">14 napos ingyenes próba indítása</string>
     <string name="upgrade_screen_subscription_action">Előfizetés</string>
     <string name="upgrade_screen_subscription_action_hint">Az előfizetés ára: %s évente.</string>

--- a/app/src/gplay/res/values-id/strings.xml
+++ b/app/src/gplay/res/values-id/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Keuntungan</string>
     <string name="upgrade_screen_benefits_body">• Lebih dari 3 perangkat 💯\n• Tema berbeda 🎨\n• Lebih banyak opsi ⚙️\n• Server sinkronisasi tambahan 🖥️️\n• Pengembangan berkelanjutan ☕\n• Pengembang yang termotivasi 🧙</string>
     <string name="upgrade_screen_how_title">Pilihan</string>
-    <string name="upgrade_screen_how_body">Anda dapat memilih antara pembelian satu kali atau langganan tahunan yang lebih murah.\nLangganan dimulai dengan uji coba gratis 14 hari, setelah itu akan dikenakan biaya satu kali per tahun. Uji coba dan langganan dapat dibatalkan kapan saja.\nFitur sama, hanya model harga berbeda.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulai uji coba gratis 14 hari</string>
     <string name="upgrade_screen_subscription_action">Langganan</string>
     <string name="upgrade_screen_subscription_action_hint">Biaya langganan %s per tahun.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Kostir</string>
     <string name="upgrade_screen_benefits_body">• Meira en 3 tæki 💯\n• Mismunandi þemu 🎨\n• Fleiri stillingar ⚙️\n• Aukalegir samstillingarþjónar 🖥️️\n• Samfelld þróun ☕\n• Áhugasamur hugbúnaðarþróari 🧙</string>
     <string name="upgrade_screen_how_title">Valkostir</string>
-    <string name="upgrade_screen_how_body">Þú getur valið milli einskiptiskaupa eða hagstæðrar árstillaga.\nÁskrift byrjar með 14 daga fría prufu, og verður rukkað árlega eftir það. Hægt er að hætta bæði áskrift og prufu hvenær sem er.\nSömu eiginleikar, bara mismunandi verðmódel.</string>
     <string name="upgrade_screen_subscription_trial_action">Byrja 14 daga fría prufu</string>
     <string name="upgrade_screen_subscription_action">Gerast áskrifandi</string>
     <string name="upgrade_screen_subscription_action_hint">Áskrift kostar %s á ári.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Vantaggi</string>
     <string name="upgrade_screen_benefits_body">• Più di 3 dispositivi 💯\n• Temi diversi 🎨\n• Più opzioni ⚙️\n• Server di sincronizzazione extra 🖥️️\n• Sviluppo continuo ☕\n• Uno sviluppatore motivato 🧙</string>
     <string name="upgrade_screen_how_title">Opzioni</string>
-    <string name="upgrade_screen_how_body">Puoi scegliere tra un acquisto una tantum e un abbonamento annuale più economico. L\'abbonamento inizia con una prova gratuita di 14 giorni, dopo la quale verrà addebitato una volta all\'anno. La prova e l\'abbonamento possono essere annullati in qualsiasi momento.\nStesse funzionalità, solo modelli di prezzo diversi.</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita di 14 giorni</string>
     <string name="upgrade_screen_subscription_action">Iscriviti</string>
     <string name="upgrade_screen_subscription_action_hint">L\'abbonamento costa %s all\'anno.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">יתרונות</string>
     <string name="upgrade_screen_benefits_body">• יותר מ- 3 מכשירים 💯\n• ערכות נושא שונות 🎨\n• אפשרויות נוספות ⚙️\n• שרתי סנכרון נוספים🖥️️\n• המשך פיתוח ☕\n• מוטיבציה להמשך הפיתוח 🧙</string>
     <string name="upgrade_screen_how_title">אפשרויות</string>
-    <string name="upgrade_screen_how_body">אתה יכול לבחור בין רכישה חד פעמית לבין מנוי שנתי זול יותר.\nהמינוי מתחיל בניסיון חינם של 14 יום, ולאחר מכן תחויב פעם בשנה. גרסת ניסיון ומנוי ניתנים לביטול בכל עת.\nאותן תכונות, רק דגמי תמחור שונים.</string>
     <string name="upgrade_screen_subscription_trial_action">התחל ניסיון חינם למשך 14 יום</string>
     <string name="upgrade_screen_subscription_action">הרשמה</string>
     <string name="upgrade_screen_subscription_action_hint">המנוי עולה %s לשנה.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_benefits_title">特典</string>
     <string name="upgrade_screen_benefits_body">• 3 台以上のデバイスを同期 💯\n• 様々なテーマ 🎨\n• より多くのオプション ⚙️\n• 追加の同期サーバー 🖥️\n• 開発の継続 ☕\n• 開発者のやる気 🧙</string>
     <string name="upgrade_screen_how_title">オプション</string>
-    <string name="upgrade_screen_how_body">1 回限りの購入か、より安価な年間の定期購入のどちらかを選択できます。\n定期購入は 14 日間の無料試用期間から開始され、その後に 1 年に 1 回の課金がされます。試用と定期購入はいつでもキャンセルが可能です。\n価格モデルは異なりますが、機能は同じです。</string>
     <string name="upgrade_screen_subscription_trial_action">14 日間の試用期間を開始</string>
     <string name="upgrade_screen_subscription_action">定期購入</string>
     <string name="upgrade_screen_subscription_action_hint">定期購入は年間で %s が必要です。</string>

--- a/app/src/gplay/res/values-ka/strings.xml
+++ b/app/src/gplay/res/values-ka/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">უპირატესობები</string>
     <string name="upgrade_screen_benefits_body">• 3-ზე მეტი მოწყობილობა 💯\n• სხვადასხვა თემები 🎨\n• მეტი პარამეტრი ⚙️\n• დამატებითი სინქრონიზაციის სერვერები 🖥️️\n• გამუდმებული ახალი შესაძლებლობების წარმოება ☕\n• მოტივირებული დეველოპერი 🧙</string>
     <string name="upgrade_screen_how_title">არჩევანი</string>
-    <string name="upgrade_screen_how_body">შეგიძლიათ აირჩიოთ ერთჯერადი შეძენა ან იაფი წლიური გამოწერა.\nგამოწერა იწყება 14-დღიანი უფასო საცდელი პერიოდით, რის შემდეგაც თანხა ჩამოგეჭრებათ წელიწადში ერთხელ. საცდელი პერიოდი და გამოწერა ნებისმიერ დროს შეიძლება გაუქმდეს.\nიგივე შესაძლებლობები, უბრალოდ განსხვავებული ფასების მოდელები.</string>
     <string name="upgrade_screen_subscription_trial_action">დაიწყეთ 14-დღიანი უფასო საცდელი პერიოდი</string>
     <string name="upgrade_screen_subscription_action">გამოწერა</string>
     <string name="upgrade_screen_subscription_action_hint">გამოწერის ღირებულებაა %s წელიწადში.</string>

--- a/app/src/gplay/res/values-kk/strings.xml
+++ b/app/src/gplay/res/values-kk/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Артықшылықтар</string>
     <string name="upgrade_screen_benefits_body">• 3-тен көп құрылғы 💯\n• Әртүрлі тақырыптар 🎨\n• Көптеген параметрлер ⚙️\n• Қосымша синхрондау серверлері🖥️️\n• Үздіксіз дамыту ☕\n• Мотивацияланған әзірлеуші 🧙</string>
     <string name="upgrade_screen_how_title">Таңдау мүмкіндіктері</string>
-    <string name="upgrade_screen_how_body">Бір реттік сатып алу немесе арзанырақ жылдық жазылымды таңдай аласыз.\nЖазылым 14 күндік тегін сынақ мерзімінен басталады, содан кейін жылына бір рет ақы алынады. Сынақ мерзімі мен жазылымды кез келген уақытта тоқтатуға болады.\nБірдей функциялар, тек баға үлгілері әртүрлі.</string>
     <string name="upgrade_screen_subscription_trial_action">14 күндік тегін сынақты бастаңыз</string>
     <string name="upgrade_screen_subscription_action">Жазылу</string>
     <string name="upgrade_screen_subscription_action_hint">Жазылым құны жылына %s.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_benefits_title">혜택</string>
     <string name="upgrade_screen_benefits_body">• 3대 이상의 기기 💯\n• 다양한 테마 🎨\n• 더 많은 옵션 ⚙️\n• 추가 동기화 서버 🖥️️\n• 지속적인 개발 ☕\n• 동기부여된 개발자 🧙</string>
     <string name="upgrade_screen_how_title">옵션</string>
-    <string name="upgrade_screen_how_body">일회성 구매와 더 저렴한 연간 구독 중에서 선택할 수 있습니다.\n구독은 14일 무료 체험으로 시작하며 이후에는 매년 1회 결제됩니다. 체험과 구독은 언제든지 취소할 수 있습니다.\n동일한 기능, 단지 가격 모델만 다릅니다.</string>
     <string name="upgrade_screen_subscription_trial_action">14일 무료 체험 시작</string>
     <string name="upgrade_screen_subscription_action">구독</string>
     <string name="upgrade_screen_subscription_action_hint">구독료는 연 %s입니다.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Privalumai</string>
     <string name="upgrade_screen_benefits_body">• Daugiau nei 3 įrenginiai 💯\n• Skirtingos temos 🎨\n• Daugiau parinkčių ⚙️\n• Papildomi sinchronizavimo serveriai 🖥️️\n• Nuolatinė plėtra ☕\n• Motyvuotas kūrėjas 🧙</string>
     <string name="upgrade_screen_how_title">Pasirinkimai</string>
-    <string name="upgrade_screen_how_body">Galite pasirinkti vienkartinį pirkimą arba pigesnį metinį prenumeratą.\nPrenumerata prasideda nuo 14 dienų nemokamo bandomojo laikotarpio, po kurio būsite apmokestinti kartą per metus. Bandomasis laikotarpis ir prenumerata gali būti bet kada atšaukti.\nTie patys funkcionalumai, tik skirtingi kainodaros modeliai.</string>
     <string name="upgrade_screen_subscription_trial_action">Pradėti nemokamą 14 dienų bandomąją versiją</string>
     <string name="upgrade_screen_subscription_action">Prenumeruoti</string>
     <string name="upgrade_screen_subscription_action_hint">Prenumerata kainuoja %s per metus.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Priekšrocības</string>
     <string name="upgrade_screen_benefits_body">• Vairāk nekā 3 ierīces 💯\n• Dažādas tēmas 🎨\n• Vairāk opciju ⚙️\n• Papildu sinhronizācijas serveri 🖥️️\n• Pastāvīga izstrāde ☕\n• Motivēts izstrādātājs 🧙</string>
     <string name="upgrade_screen_how_title">Iespējas</string>
-    <string name="upgrade_screen_how_body">Jūs varat izvēlēties vienreizēju pirkumu vai lētāku gada abonementu.\nAbonements sākas ar 14 dienu bezmaksas izmēģinājumu, pēc kura jums tiks iekasēta maksa reizi gadā. Izmēģinājumu un abonementu var jebkurā laikā atcelt.\nVienas un tās pašas funkcijas, tikai atšķirīgi cenu modeļi.</string>
     <string name="upgrade_screen_subscription_trial_action">Sākt bezmaksas 14 dienu izmēģinājumu</string>
     <string name="upgrade_screen_subscription_action">Abonēt</string>
     <string name="upgrade_screen_subscription_action_hint">Abonements maksā %s gadā.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Kelebihan</string>
     <string name="upgrade_screen_benefits_body">• Lebih daripada 3 peranti 💯\n• Tema yang berbeza 🎨\n• Pilihan tambahan ⚙️\n• Pelayan segerak tambahan 🖥️️\n• Pembangunan berterusan ☕\n• Pembangun bermotivasi 🧙</string>
     <string name="upgrade_screen_how_title">Pilihan</string>
-    <string name="upgrade_screen_how_body">Anda boleh memilih antara pembelian sekali dan langganan tahunan yang lebih murah.\nLangganan bermula dengan percubaan percuma selama 14 hari, selepas itu anda akan dikenakan caj setahun sekali. Percubaan dan langganan boleh dibatalkan pada bila-bila masa.\nFungsi yang sama, cuma model harga berbeza.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulakan percubaan percuma 14 hari</string>
     <string name="upgrade_screen_subscription_action">Langgan</string>
     <string name="upgrade_screen_subscription_action_hint">Langganan berharga %s setahun.</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Fordeler</string>
     <string name="upgrade_screen_benefits_body">• Mer enn 3 enheter 💯\n• Ulike temaer 🎨\n• Flere alternativer ⚙️\n• Ekstra synkroniseringsservere 🖥️️\n• Fortsatt utvikling ☕\n• En motivert utvikler 🧙</string>
     <string name="upgrade_screen_how_title">Alternativer</string>
-    <string name="upgrade_screen_how_body">Du kan velge mellom et engangskjøp og et billigere årlig abonnement.\nAbonnementet starter med en gratis 14-dagers prøveperiode, deretter blir du belastet én gang i året. Prøveperioden og abonnementet kan når som helst avbestilles.\nSamme funksjoner, bare ulike prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis 14-dagers prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s per år.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Voordelen</string>
     <string name="upgrade_screen_benefits_body">• Meer dan 3 apparaten 💯\n• Verschillende thema\'s 🎨\n• Meer opties ⚙️\n• Extra synchronisatie-servers🖥️️\n• Voortgezette ontwikkeling ☕\n• Een gemotiveerde ontwikkelaar 🧙</string>
     <string name="upgrade_screen_how_title">Opties</string>
-    <string name="upgrade_screen_how_body">Je kunt kiezen tussen een eenmalige aankoop en een goedkoper jaarabonnement.\nHet abonnement begint met een gratis proefperiode van 14 dagen, waarna je jaarlijks wordt gefactureerd. De proefperiode en het abonnement zijn op elk moment opzegbaar.\nDezelfde functies, alleen andere prijsmodellen.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode van 14 dagen</string>
     <string name="upgrade_screen_subscription_action">Abonneren</string>
     <string name="upgrade_screen_subscription_action_hint">Het abonnement kost %s per jaar.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -18,7 +18,6 @@
     <string name="upgrade_screen_benefits_title">Korzyści</string>
     <string name="upgrade_screen_benefits_body">• Ponad 3 urządzenia 💯\n• Różne motywy 🎨\n• Więcej opcji ⚙️\n• Dodatkowe serwery synchronizacji 🖥️️\n• Ciągły rozwój ☕\n• Motywacja programisty 🧙</string>
     <string name="upgrade_screen_how_title">Opcje</string>
-    <string name="upgrade_screen_how_body">Możesz wybrać pomiędzy jednorazowym zakupem a tańszą roczną subskrypcją.\nSubskrypcja zaczyna się od 14-dniowego bezpłatnego okresu próbnego, po którym opłata jest pobierana raz w roku. Okres próbny oraz subskrypcja mogą zostać anulowane w każdej chwili.\nTe same funkcje, tylko inne modele cenowe.</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij bezpłatny 14-dniowy okres próbny</string>
     <string name="upgrade_screen_subscription_action">Subskrybuj</string>
     <string name="upgrade_screen_subscription_action_hint">Subskrypcja kosztuje %s rocznie.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Benefícios</string>
     <string name="upgrade_screen_benefits_body">• Mais de 3 dispositivos 💯\n• Temas diferentes 🎨\n• Mais opções ⚙️\n• Servidores de sincronização extras🖥️️\n• Desenvolvimento contínuo ☕\n• Um desenvolvedor motivado 🧙</string>
     <string name="upgrade_screen_how_title">Opções</string>
-    <string name="upgrade_screen_how_body">Você pode escolher entre uma compra única e uma assinatura anual mais barata.\nA assinatura começa com um teste gratuito de 14 dias, após o qual você será cobrado uma vez por ano. O teste e a assinatura podem ser cancelados a qualquer momento.\nMesmas funcionalidades, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
     <string name="upgrade_screen_subscription_action">Assinar</string>
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Benefícios</string>
     <string name="upgrade_screen_benefits_body">• Mais de 3 dispositivos 💯\n• Temas diferentes 🎨\n• Mais opções ⚙️\n• Servidores de sincronização extra🖥️️\n• Desenvolvimento contínuo ☕\n• Um desenvolvedor motivado 🧙</string>
     <string name="upgrade_screen_how_title">Opções</string>
-    <string name="upgrade_screen_how_body">Você pode escolher entre uma compra única e uma assinatura anual mais barata.\nA assinatura começa com um teste gratuito de 14 dias, após o qual você será cobrado uma vez por ano. O teste e a assinatura podem ser cancelados a qualquer momento.\nMesmas funcionalidades, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
     <string name="upgrade_screen_subscription_action">Assinar</string>
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrade_screen_benefits_title">Beneficii</string>
     <string name="upgrade_screen_benefits_body">• Mai mult de 3 dispozitive 💯\n• Teme diferite 🎨\n• Mai multe opțiuni ⚙️\n• Servere suplimentare de sincronizare🖥️️\n• Dezvoltare continuă ☕\n• Un dezvoltator motivat 🧙</string>
     <string name="upgrade_screen_how_title">Opțiuni</string>
-    <string name="upgrade_screen_how_body">Poți alege între o achiziție unică și un abonament anual mai ieftin.\nAbonamentul începe cu o perioadă de probă gratuită de 14 zile, după care vei fi taxat o dată pe an. Perioada de probă și abonamentul pot fi anulate oricând.\nAceleași funcții, doar modele de preț diferite.</string>
     <string name="upgrade_screen_subscription_trial_action">Începe perioada de probă gratuită de 14 zile</string>
     <string name="upgrade_screen_subscription_action">Abonare</string>
     <string name="upgrade_screen_subscription_action_hint">Abonamentul costă %s pe an.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -18,7 +18,6 @@
     <string name="upgrade_screen_benefits_title">Преимущества</string>
     <string name="upgrade_screen_benefits_body">• Более 3 устройств 💯\n• Различные темы оформления 🎨\n• Больше опций ⚙️\n• Дополнительные серверы синхронизации🖥️️\n• Поддержка разработки ☕\n• Мотивированный разработчик 🧙</string>
     <string name="upgrade_screen_how_title">Варианты</string>
-    <string name="upgrade_screen_how_body">Вы можете выбрать между разовой покупкой или более выгодной годовой подпиской.\nПодписка начинается с бесплатного 14-дневного пробного периода, после чего списание происходит раз в год. Пробный период и подписку можно отменить в любой момент.\nТе же функции, просто разные модели оплаты.</string>
     <string name="upgrade_screen_subscription_trial_action">Начать 14-дневный бесплатный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться</string>
     <string name="upgrade_screen_subscription_action_hint">Подписка стоит %s в год.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Výhody</string>
     <string name="upgrade_screen_benefits_body">• Viac ako 3 zariadenia 💯\n• Rôzne témy 🎨\n• Viac možností ⚙️\n• Extra servery na synchronizáciu🖥️️\n• Pokračujúci vývoj ☕\n• Motivovaný vývojár 🧙</string>
     <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Môžete si vybrať medzi jednorazovým nákupom a lacnejším ročným predplatným.\nPredplatné začína bezplatnou 14-dňovou skúšobnou dobou, po ktorej vás budeme raz ročne účtovať. Skúšobnú dobu a predplatné možno kedykoľvek zrušiť.\nRovnaké funkcie, len iné cenové modely.</string>
     <string name="upgrade_screen_subscription_trial_action">Začať bezplatnú 14-dňovú skúšku</string>
     <string name="upgrade_screen_subscription_action">Predplatiť</string>
     <string name="upgrade_screen_subscription_action_hint">Predplatné stojí %s ročne.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">Prednosti</string>
     <string name="upgrade_screen_benefits_body">• Več kot 3 naprave 💯\n• Različne teme 🎨\n• Več možnosti ⚙️\n• Dodatni strežniki za sinhronizacijo 🖥️️\n• Neprekinjen razvoj ☕\n• Motiviran razvijalec 🧙</string>
     <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Izbirate lahko med enkratnim nakupom in cenejšo letno naročnino.\nNaročnina se začne z brezplačnim 14-dnevnim preizkusom, nato boste zaračunani enkrat letno. Preizkus in naročnino lahko kadarkoli prekličete.\nEnake funkcije, le drugačni modeli cen.</string>
     <string name="upgrade_screen_subscription_trial_action">Začni brezplačni 14-dnevni preizkus</string>
     <string name="upgrade_screen_subscription_action">Naroči se</string>
     <string name="upgrade_screen_subscription_action_hint">Naročnina stane %s letno.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrade_screen_benefits_title">Предности</string>
     <string name="upgrade_screen_benefits_body">• Више од 3 уређаја 💯\n• Различите теме 🎨\n• Више опција ⚙️\n• Додатни сервери за синхронизацију 🖥️️\n• Континуиран развој ☕\n• Мотивациони програмер 🧙</string>
     <string name="upgrade_screen_how_title">Опције</string>
-    <string name="upgrade_screen_how_body">Можете да бирате између једнократне куповине и јефтиније годишње претплате.\nПретплата почиње бесплатним пробним периодом од 14 дана, након чега се наплаћује једном годишње. Пробни период и претплату можете отказати у било ком тренутку.\nИсте функције, само различити модели цена.</string>
     <string name="upgrade_screen_subscription_trial_action">Почните бесплатни пробни период од 14 дана</string>
     <string name="upgrade_screen_subscription_action">Претплатите се</string>
     <string name="upgrade_screen_subscription_action_hint">Претплата кошта %s годишње.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Fördelar</string>
     <string name="upgrade_screen_benefits_body">• Mer än 3 enheter 💯\n• Olika teman 🎨\n• Fler alternativ ⚙️\n• Extra synkroniseringsservrar🖥️️\n• Fortsatt utveckling ☕\n• En motiverad utvecklare 🧙</string>
     <string name="upgrade_screen_how_title">Alternativ</string>
-    <string name="upgrade_screen_how_body">Du kan välja mellan ett engångsköp och en billigare årlig prenumeration.\nPrenumerationen börjar med en gratis 14-dagars provperiod, därefter debiteras du en gång per år. Provet och prenumerationen kan när som helst avbrytas.\nSamma funktioner, bara olika prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Börja gratis 14-dagars provperiod</string>
     <string name="upgrade_screen_subscription_action">Prenumerera</string>
     <string name="upgrade_screen_subscription_action_hint">Prenumerationen kostar %s per år.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -12,7 +12,6 @@
     <string name="upgrade_screen_benefits_title">ข้อดี</string>
     <string name="upgrade_screen_benefits_body">• มากกว่า 3 อุปกรณ์ 💯\n• ธีมที่แตกต่างกัน 🎨\n• ตัวเลือกเพิ่มเติม ⚙️\n• เซิร์ฟเวอร์ซิงค์เพิ่มเติม 🖥️️\n• การพัฒนาอย่างต่อเนื่อง ☕\n• นักพัฒนาที่มีแรงบันดาลใจ 🧙</string>
     <string name="upgrade_screen_how_title">ตัวเลือก</string>
-    <string name="upgrade_screen_how_body">คุณสามารถเลือกการซื้อเพียงครั้งเดียวหรือสมัครสมาชิกรายปีในราคาถูกกว่า\nการสมัครสมาชิกเริ่มต้นด้วยการทดลองใช้ฟรี 14 วัน หลังจากนั้นจะมีการเรียกเก็บเงินปีละครั้ง คุณสามารถยกเลิกการทดลองใช้ฟรีและการสมัครสมาชิกได้ทุกเมื่อ\nคุณสมบัติเหมือนกัน แค่รูปแบบราคาแตกต่างกัน</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้งานฟรี 14 วัน</string>
     <string name="upgrade_screen_subscription_action">สมัครสมาชิก</string>
     <string name="upgrade_screen_subscription_action_hint">ค่าสมัครสมาชิก %s ต่อปี</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -16,7 +16,6 @@
     <string name="upgrade_screen_benefits_title">Avantajlar</string>
     <string name="upgrade_screen_benefits_body">- 3\'ten fazla cihaz 💯\n- Farklı temalar 🎨\n- Daha fazla seçenek ⚙️\n- Ekstra senkronizasyon sunucuları🖥️️\n- Sürekli devam eden geliştirme ☕\n- Motive olmuş bir geliştirici 🧙</string>
     <string name="upgrade_screen_how_title">Şeçenekler</string>
-    <string name="upgrade_screen_how_body">Tek seferlik satın alma ile daha ucuz olan yıllık abonelik arasında seçim yapabilirsiniz.\nAbonelik 14 günlük ücretsiz deneme ile başlar ve sonrasında yılda bir kez ücretlendirilirsiniz. Deneme sürümü ve abonelik istenildiği zaman iptal edilebilir.\nAynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_subscription_trial_action">14 günlük ücretsiz denemeyi başlatın</string>
     <string name="upgrade_screen_subscription_action">Abone ol</string>
     <string name="upgrade_screen_subscription_action_hint">Abonelik ücreti yıllık %s\'dir.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -18,7 +18,6 @@
     <string name="upgrade_screen_benefits_title">Переваги</string>
     <string name="upgrade_screen_benefits_body">• Більше ніж 3 пристрої 💯\n• Різні теми 🎨\n• Більше опцій ⚙️\n• Додаткові сервери синхронізації🖥️️\n• Безперервна розробка ☕\n• Мотивований розробник 🧙</string>
     <string name="upgrade_screen_how_title">Варіанти</string>
-    <string name="upgrade_screen_how_body">Ви можете обрати між одноразовою покупкою та дешевшою річною підпискою.\nПідписка починається з безкоштовного 14-денного пробного періоду, після чого буде здійснюватися річна оплата. Пробний період і підписку можна скасувати будь-коли.\nТі ж функції, лише різні моделі оплати.</string>
     <string name="upgrade_screen_subscription_trial_action">Почати безкоштовний 14-денний пробний період</string>
     <string name="upgrade_screen_subscription_action">Оформити підписку</string>
     <string name="upgrade_screen_subscription_action_hint">Підписка коштує %s на рік.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_benefits_title">Lợi ích</string>
     <string name="upgrade_screen_benefits_body">• Hơn 3 thiết bị 💯\n• Chủ đề khác nhau 🎨\n• Nhiều tùy chọn hơn ⚙️\n• Máy chủ đồng bộ hóa bổ sung 🖥️️\n• Tiếp tục phát triển ☕\n• Nhà phát triển đầy nhiệt huyết 🧙</string>
     <string name="upgrade_screen_how_title">Tùy chọn</string>
-    <string name="upgrade_screen_how_body">Bạn có thể chọn giữa mua một lần và đăng ký hàng năm rẻ hơn.\nĐăng ký bắt đầu với 14 ngày dùng thử miễn phí, sau đó bạn sẽ bị tính phí một lần mỗi năm. Có thể hủy dùng thử và đăng ký bất cứ lúc nào.\nCùng các chức năng, chỉ khác mô hình giá.</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử miễn phí 14 ngày</string>
     <string name="upgrade_screen_subscription_action">Đăng ký</string>
     <string name="upgrade_screen_subscription_action_hint">Đăng ký có giá %s một năm.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_benefits_title">优势</string>
     <string name="upgrade_screen_benefits_body">• 超过 3 台设备 💯\n• 不同主题 🎨\n• 更多选项 ⚙️\n• 额外的同步服务器🖥️️\n• 持续开发 ☕\n• 积极进取的开发者 🧙</string>
     <string name="upgrade_screen_how_title">选项</string>
-    <string name="upgrade_screen_how_body">您可以选择一次性购买或更便宜的年度订阅。\n订阅从 14 天免费试用开始，之后每年收费一次。试用和订阅可随时取消。\n功能相同，只是定价模式不同。</string>
     <string name="upgrade_screen_subscription_trial_action">开始14天免费试用</string>
     <string name="upgrade_screen_subscription_action">订阅</string>
     <string name="upgrade_screen_subscription_action_hint">每年的订阅费用为 %s。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_benefits_title">優勢</string>
     <string name="upgrade_screen_benefits_body">• 超過 3 台裝置 💯\n• 不同主題 🎨\n• 更多選項 ⚙️\n• 額外同步伺服器🖥️️\n• 持續開發 ☕\n• 積極進取的開發者 🧙</string>
     <string name="upgrade_screen_how_title">選項</string>
-    <string name="upgrade_screen_how_body">您可以選擇一次性購買或更便宜的年度訂閱。\n訂閱從 14 天免費試用開始，之後每年收費一次。試用與訂閱可隨時取消。\n功能相同，只是價格模式不同。</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>
     <string name="upgrade_screen_subscription_action">訂閱</string>
     <string name="upgrade_screen_subscription_action_hint">訂閱費用為 %s/年。</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -23,7 +23,11 @@
     <string name="upgrade_screen_benefits_title">Benefits</string>
     <string name="upgrade_screen_benefits_body">• More than 3 devices 💯\n• Different themes 🎨\n• More options ⚙️\n• Extra sync servers🖥️️\n• Continued development ☕\n• A motivated developer 🧙</string>
     <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription starts with a free 14-day trial, after which you\'ll be charged once per year. Trial and subscription are cancellable at any time.\nSame features, just different pricing models.</string>
+    <!-- Replaces upgrade_screen_how_body: the trial promise moved to the conditional
+         upgrade_screen_how_trial_hint. New key so stale translations of the old string (which
+         promise the trial unconditionally) can't be picked up. -->
+    <string name="upgrade_screen_how_body2">You can choose between a one-time purchase and a cheaper yearly subscription. Both are cancellable at any time.\nSame features, just different pricing models.</string>
+    <string name="upgrade_screen_how_trial_hint">The subscription starts with a free 14-day trial, after which you\'ll be charged once per year.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
     <string name="upgrade_screen_subscription_action_hint">The subscription costs %s per year.</string>

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -121,7 +123,12 @@ class BillingManagerTest : BaseTest() {
         }
     }
 
-    @Test fun `connection recovers after an earlier failure without a process restart`() = runTest2 {
+    // A manager whose provider fails `failuresBeforeSuccess` times before providing a healthy
+    // connection. `attempts()` reports how many connection attempts the provider has seen.
+    private fun TestScope.recoveringManager(
+        failuresBeforeSuccess: Int = 1,
+        failure: () -> Throwable = { BillingException("Google Play hiccup") },
+    ): Pair<BillingManager, () -> Int> {
         val healthyConnection = mockk<BillingConnection>().apply {
             coEvery { refreshPurchases() } returns BillingData(emptySet())
             every { billingData } returns emptyFlow()
@@ -129,20 +136,77 @@ class BillingManagerTest : BaseTest() {
         var attempts = 0
         val provider = mockk<BillingConnectionProvider>().apply {
             every { connection } returns flow {
-                if (attempts++ == 0) throw BillingException("Google Play hiccup")
+                if (attempts++ < failuresBeforeSuccess) throw failure()
                 emit(healthyConnection)
                 awaitCancellation() // a healthy connection stays open indefinitely
             }
         }
+        return BillingManager(backgroundScope, provider) to { attempts }
+    }
+
+    @Test fun `an explicit action retries a failed connection immediately`() = runTest2 {
+        val (manager, attempts) = recoveringManager()
+
+        // A user action (restore/buy/pricing) right after the user fixed the Play/account state
+        // must not keep failing on the stale cached error until the retry delay elapses.
+        val timeBefore = currentTime
+        manager.refresh().purchases shouldBe emptySet()
+
+        attempts() shouldBe 2
+        // On-demand retry, not the virtual clock skipping the retry delay.
+        (currentTime - timeBefore) shouldBe 0L
+    }
+
+    @Test fun `connection self-heals over time without any user action`() = runTest2 {
+        val (manager, attempts) = recoveringManager()
+
+        // The ACK loop keeps the shared connection flow subscribed for the process lifetime; the
+        // retry loop alone must recover the connection without anyone calling billing APIs.
+        runCurrent()
+        attempts() shouldBe 1
+
+        advanceTimeBy(61_000) // past the default retry delay
+        runCurrent()
+
+        attempts() shouldBe 2
+        manager.refresh().purchases shouldBe emptySet()
+    }
+
+    @Test fun `the on-demand retry wait is bounded, a wedged attempt fails with the known error`() = runTest2 {
+        // First attempt fails, second attempt hangs forever (Play wedged): a user action must not
+        // hang with it — after the bounded wait it fails with the stale, mapped error. This matters
+        // for buy taps, which have no caller-side timeout.
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { connection } returns flow {
+                if (attempts++ == 0) throw BillingException("Google Play hiccup")
+                awaitCancellation() // attempt never resolves
+            }
+        }
         val manager = BillingManager(backgroundScope, provider)
 
-        // The ACK loop keeps the shared connection flow subscribed for the process lifetime, so a
-        // failure Result must not stick in the replay cache forever.
+        val timeBefore = currentTime
         shouldThrow<BillingException> { manager.refresh() }
+        (currentTime - timeBefore) shouldBe 10_000L
+    }
 
-        advanceTimeBy(61_000) // past the connection retry delay
+    @Test fun `billing-unavailable retries within minutes, not hours`() = runTest2 {
+        val unavailable = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.BILLING_UNAVAILABLE)
+            .build()
+        val (_, attempts) = recoveringManager(failure = { BillingClientException(unavailable) })
 
-        manager.refresh().purchases shouldBe emptySet()
-        attempts shouldBe 2
+        runCurrent()
+        attempts() shouldBe 1
+
+        // Longer than the default delay, but a user signing into their Google account must not
+        // stay locked out for an hour.
+        advanceTimeBy(250_000)
+        runCurrent()
+        attempts() shouldBe 1
+
+        advanceTimeBy(51_000) // past the 5min BILLING_UNAVAILABLE delay
+        runCurrent()
+        attempts() shouldBe 2
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,7 +1,10 @@
 package eu.darken.octi.common.upgrade.ui
 
 import androidx.lifecycle.SavedStateHandle
+import com.android.billingclient.api.ProductDetails
+import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import eu.darken.octi.common.widget.WidgetManager
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -46,6 +49,45 @@ class UpgradeViewModelTest : BaseTest() {
         upgradeRepo = repo,
         widgetManagers = widgetManagers,
     )
+
+    private fun subDetailsWithOffers(vararg offerIds: String?): SkuDetails {
+        val offers = offerIds.map { id ->
+            mockk<ProductDetails.SubscriptionOfferDetails>().apply {
+                every { basePlanId } returns OurSku.Sub.PRO_UPGRADE.BASE_OFFER.basePlanId
+                every { offerId } returns id
+            }
+        }
+        val details = mockk<ProductDetails>().apply {
+            every { subscriptionOfferDetails } returns offers
+        }
+        return SkuDetails(OurSku.Sub.PRO_UPGRADE, details)
+    }
+
+    @Test fun `trial copy is advertised when Play returns the trial offer`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns listOf(
+            subDetailsWithOffers(null, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.offerId)
+        )
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.first { !it.pricingLoading } }
+        advanceUntilIdle()
+
+        state.await().trialAvailable shouldBe true
+    }
+
+    @Test fun `no trial copy when Play only returns the base offer`() = runTest2(context = testDispatcher) {
+        // An account that already used its trial (or a region without one) only gets the base
+        // offer back — the UI must not promise a 14-day trial it can't deliver.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns listOf(subDetailsWithOffers(null))
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.first { !it.pricingLoading } }
+        advanceUntilIdle()
+
+        state.await().trialAvailable shouldBe false
+    }
 
     @Test fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()


### PR DESCRIPTION
## What changed

Two follow-ups from the billing smoke-test session (emulator testing of #328–#334):

- If billing failed because Google Play or the Google account wasn't ready, fixing the cause now takes effect immediately: tapping **Restore purchase**, a buy button, or reopening the upgrade screen retries the connection on the spot instead of failing on the cached error. The background retry for "Play unavailable" also dropped from 1 hour to 5 minutes.
- The upgrade screen only advertises the **free 14-day trial** when Google Play actually offers it to that account — accounts that already used their trial (or regions without one) no longer see a trial promise next to a plain "Subscribe" button.

## Technical Context

- **On-demand connection retry:** the retry loop's `delay` became `withTimeoutOrNull(retryDelay) { retryNow.first() }`; `useConnection(retryOnFailure = true)` (used by `querySkus`/`startIapFlow`/`refresh`) pokes `retryNow` when it sees a stale failure Result and waits for the fresh attempt's outcome. The waiter subscribes **before** poking (`async(start = UNDISPATCHED)`) and filters on the stale value, so a concurrent loop-driven retry can't be missed; concurrent user actions coalesce onto the same fresh result. The wait is **bounded (10s)** — a wedged connection attempt fails with the known mapped error instead of hanging (buy taps have no caller-side timeout). The background ACK path keeps fail-fast behavior. `retryNow` is declared before `connection` because the init-block collectors can drive the loop during construction (found in review).
- **Smoke-test origin:** on a fresh no-account emulator, `BILLING_UNAVAILABLE` stuck in the replay cache — process-lifetime collectors pin the `shareIn`, so after signing in, billing stayed failed until process restart or the 1h retry.
- **Trial copy:** `State.trialAvailable` = Play returned an offer matching `TRIAL_OFFER`; the trial sentence moved out of the static "Options" body into a conditional `upgrade_screen_how_trial_hint`. The body uses a **new key** (`upgrade_screen_how_body2`) so stale translations of the old string (which promise the trial unconditionally) can't be picked up — Crowdin cleans up the old translations. `querySkus` now logs returned `basePlanId:offerId` pairs so "Play withheld the offer" vs "we failed to match it" is diagnosable from debug logs.
- **Tests:** explicit-action retry is immediate (asserts virtual time didn't advance), time-based self-heal without user action, `BILLING_UNAVAILABLE` retries at 5min not 1h, bounded retry wait (wedged attempt → known error after 10s), trial flag on/off from returned offers.
- Play Console side (not code): worth checking why a brand-new account wasn't offered the trial for `upgrade-pro-baseplan-trial`.