### PR TITLE
Polish first-run guidance placement and sync setup picker

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -496,24 +496,6 @@ fun DashboardScreen(
                 }
             }
 
-            // First-run guidance cards (full-span, mutually exclusive by construction)
-            if (state.showSyncSetup) {
-                item(key = "sync_setup", span = { GridItemSpan(maxLineSpan) }) {
-                    SyncSetupCard(
-                        onLater = onSnoozeSyncSetup,
-                        onSetup = onSetupSync,
-                    )
-                }
-            }
-            if (state.showSyncedAlone) {
-                item(key = "synced_alone", span = { GridItemSpan(maxLineSpan) }) {
-                    SyncedAloneCard(
-                        onLater = onSnoozeSyncedAlone,
-                        onAddDevice = onSetupSync,
-                    )
-                }
-            }
-
             // Action chips row (permissions + upgrade + issue counts)
             val errorCount = state.issues.count { it.severity == IssueSeverity.ERROR }
             val warningCount = state.issues.count { it.severity == IssueSeverity.WARNING }
@@ -602,6 +584,25 @@ fun DashboardScreen(
                     onMoveDown = onMoveDeviceDown,
                     onRemoveDevice = onRemoveDevice,
                 )
+            }
+
+            // First-run guidance cards below the device content (full-span,
+            // mutually exclusive by construction)
+            if (state.showSyncSetup) {
+                item(key = "sync_setup", span = { GridItemSpan(maxLineSpan) }) {
+                    SyncSetupCard(
+                        onLater = onSnoozeSyncSetup,
+                        onSetup = onSetupSync,
+                    )
+                }
+            }
+            if (state.showSyncedAlone) {
+                item(key = "synced_alone", span = { GridItemSpan(maxLineSpan) }) {
+                    SyncedAloneCard(
+                        onLater = onSnoozeSyncedAlone,
+                        onAddDevice = onSetupSync,
+                    )
+                }
             }
 
             // Device limit card (full-span)

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncAddScreen.kt
@@ -1,6 +1,5 @@
 package eu.darken.octi.sync.ui.add
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -23,7 +22,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -85,8 +83,8 @@ fun SyncAddScreen(
                     Text(
                         text = stringResource(
                             when (mode) {
-                                Nav.Sync.AddPicker.Mode.CREATE -> R.string.sync_add_pick_create_title
-                                Nav.Sync.AddPicker.Mode.LINK -> R.string.sync_add_pick_link_title
+                                Nav.Sync.AddPicker.Mode.CREATE -> R.string.sync_setup_intent_new_title
+                                Nav.Sync.AddPicker.Mode.LINK -> R.string.sync_setup_intent_link_title
                             }
                         )
                     )
@@ -104,28 +102,39 @@ fun SyncAddScreen(
             )
         },
     ) { innerPadding ->
-        if (items.isEmpty() && mode == Nav.Sync.AddPicker.Mode.LINK) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
-                contentAlignment = Alignment.Center,
-            ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+        ) {
+            item(key = "header") {
                 Text(
-                    text = stringResource(R.string.sync_add_link_none_available),
+                    text = stringResource(
+                        when (mode) {
+                            Nav.Sync.AddPicker.Mode.CREATE -> R.string.sync_add_pick_create_header
+                            Nav.Sync.AddPicker.Mode.LINK -> R.string.sync_add_pick_link_header
+                        }
+                    ),
                     style = MaterialTheme.typography.bodyMedium,
-                    textAlign = TextAlign.Center,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(32.dp),
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
                 )
             }
-        } else {
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding),
-            ) {
+
+            if (items.isEmpty() && mode == Nav.Sync.AddPicker.Mode.LINK) {
+                item(key = "empty") {
+                    Text(
+                        text = stringResource(R.string.sync_add_link_none_available),
+                        style = MaterialTheme.typography.bodyMedium,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                    )
+                }
+            } else {
                 items(items, key = { it.type.name }) { contribution ->
                     SyncSetupRow(
                         icon = { modifier -> contribution.Icon(modifier = modifier) },

--- a/app/src/main/java/eu/darken/octi/sync/ui/add/SyncSetupRow.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/add/SyncSetupRow.kt
@@ -30,11 +30,11 @@ internal fun SyncSetupRow(
             .fillMaxWidth()
             .clickable(onClick = onClick)
             .padding(16.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        icon(Modifier.size(20.dp))
+        icon(Modifier.size(24.dp))
 
-        Spacer(modifier = Modifier.width(4.dp))
+        Spacer(modifier = Modifier.width(16.dp))
 
         Column {
             Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,8 +122,8 @@
     <string name="sync_setup_intent_new_desc">Create a new account. Choose this on your first device.</string>
     <string name="sync_setup_intent_link_title">Add this device</string>
     <string name="sync_setup_intent_link_desc">Link to an Octi setup you already use on another device.</string>
-    <string name="sync_add_pick_create_title">Choose a sync service</string>
-    <string name="sync_add_pick_link_title">Which service does your other device use?</string>
+    <string name="sync_add_pick_create_header">These are the sync services Octi currently supports. Pick one to start — you can add more or switch later.</string>
+    <string name="sync_add_pick_link_header">Which sync service does your other device use? Devices can only see each other on a shared service.</string>
     <string name="sync_add_link_none_available">None of your sync services support linking a device yet.</string>
     <string name="sync_add_help_desc">A synchronization service is required for information exchange between Octi installs.\n\nDevices can only see each other if they have a common sync service!</string>
 


### PR DESCRIPTION
Design polish on the first-run guidance from #330 and the sync setup flow from #327, based on review of the shipped screens:

- **Guidance cards moved below the device cards.** The dashboard now leads with content; "Set up synchronization" / "Now add your second device" render as the next step under the device the user is looking at, instead of pushing content down.
- **Setup rows use proper list-item alignment.** Icons are vertically centered against the full text block and sized 24dp with standard spacing (previously 20dp, top-aligned, cramped gap).
- **Backend picker restructured.** The question no longer lives in the app bar (where "Which service does your other device use?" wrapped to two oversized lines). The app bar now carries the short intent ("Add this device" / "Set up a new sync"), and a muted header line above the list carries the question plus an explanation the title never had room for:
  - LINK: "Which sync service does your other device use? Devices can only see each other on a shared service."
  - CREATE: "These are the sync services Octi currently supports. Pick one to start — you can add more or switch later."
- The `sync_add_pick_*_title` strings were replaced by `*_header` keys since their meaning changed (clean re-translation via Crowdin).

Verified on emulator (fresh install walkthrough of dashboard, intent screen, both picker modes); both flavors build and the sync/dashboard/onboarding unit tests pass.
