### PR TITLE
General: See your Pro status and switch to a one-time purchase

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/navigation/Nav.kt
@@ -18,7 +18,10 @@ object Nav {
         data object Connect : Main
 
         @Serializable
-        data class Upgrade(val forced: Boolean = false) : Main
+        data class Upgrade(
+            val forced: Boolean = false,
+            val manage: Boolean = false,
+        ) : Main
 
         @Serializable
         data class AppsList(val deviceId: String) : Main

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(forced = key.forced) }
+        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(forced = key.forced, manage = key.manage) }
     }
 
     @Module

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -9,20 +9,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,21 +34,26 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import eu.darken.octi.R
 import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import kotlin.time.Instant
 
 @Composable
 fun UpgradeScreenHost(
-    forced: Boolean,
+    forced: Boolean = false,
+    manage: Boolean = false,
     vm: UpgradeViewModel = hiltViewModel(),
 ) {
-    vm.initialize(forced)
+    vm.initialize(forced = forced, manage = manage)
 
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
@@ -58,18 +67,25 @@ fun UpgradeScreenHost(
         vm.snackbarEvents.collect { snackbarHostState.showSnackbar(tooFastMsg) }
     }
 
+    val state by vm.state.collectAsState()
     UpgradeScreen(
+        state = state,
         snackbarHostState = snackbarHostState,
         onNavigateUp = { vm.navUp() },
         onSponsor = { vm.goGithubSponsors() },
+        onOpenSponsors = { vm.openSponsors() },
+        onSeeUpgradeOptions = { vm.onSeeUpgradeOptions() },
     )
 }
 
 @Composable
 fun UpgradeScreen(
+    state: UpgradeViewModel.State?,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onNavigateUp: () -> Unit,
     onSponsor: () -> Unit,
+    onOpenSponsors: () -> Unit,
+    onSeeUpgradeOptions: () -> Unit,
 ) {
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -102,75 +118,170 @@ fun UpgradeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.height(8.dp))
-
             OctiMascot(modifier = Modifier.size(96.dp))
-
             Spacer(modifier = Modifier.height(8.dp))
 
-            ElevatedCard(
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_preamble),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(16.dp),
+            when {
+                // DataStore hasn't answered yet — render nothing rather than flashing the sales
+                // pitch (with its armable unlock heuristic) at an existing supporter.
+                state == null -> Unit
+
+                state.isPro -> SupporterStatus(
+                    upgradedAt = state.upgradedAt,
+                    onOpenSponsors = onOpenSponsors,
                 )
+
+                state.showFreeStatus -> FreeStatus(onSeeUpgradeOptions = onSeeUpgradeOptions)
+
+                else -> SponsorPitch(onSponsor = onSponsor)
             }
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_how_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_how_body),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_why_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_benefits_body),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = onSponsor,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                Text(text = stringResource(R.string.upgrade_screen_sponsor_action))
-            }
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_sponsor_action_hint),
-                style = MaterialTheme.typography.labelSmall,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
 
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
 }
 
+@Composable
+private fun SupporterStatus(
+    upgradedAt: Instant?,
+    onOpenSponsors: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_supporter_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_supporter_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            upgradedAt?.let { instant ->
+                Spacer(modifier = Modifier.height(4.dp))
+                val formatted = remember(instant) {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+                        .withZone(ZoneId.systemDefault())
+                        .format(java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds()))
+                }
+                Text(
+                    text = stringResource(R.string.upgrade_screen_supporter_since, formatted),
+                    style = MaterialTheme.typography.labelMedium,
+                )
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    OutlinedButton(onClick = onOpenSponsors, modifier = Modifier.fillMaxWidth()) {
+        Text(text = stringResource(R.string.upgrade_screen_open_sponsors_action))
+    }
+}
+
+@Composable
+private fun FreeStatus(onSeeUpgradeOptions: () -> Unit) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_free_status_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_free_status_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(onClick = onSeeUpgradeOptions, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.upgrade_screen_see_options_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SponsorPitch(onSponsor: () -> Unit) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    Text(
+        text = stringResource(R.string.upgrade_screen_how_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Text(
+        text = stringResource(R.string.upgrade_screen_how_body),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    Text(
+        text = stringResource(R.string.upgrade_screen_why_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Text(
+        text = stringResource(R.string.upgrade_screen_benefits_body),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    Button(onClick = onSponsor, modifier = Modifier.fillMaxWidth()) {
+        Text(text = stringResource(R.string.upgrade_screen_sponsor_action))
+    }
+    Text(
+        text = stringResource(R.string.upgrade_screen_sponsor_action_hint),
+        style = MaterialTheme.typography.labelSmall,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
 @Preview2
 @Composable
-private fun UpgradeScreenPreview() = PreviewWrapper {
+private fun UpgradeScreenSponsorPreview() = PreviewWrapper {
     UpgradeScreen(
-        onNavigateUp = {},
-        onSponsor = {},
+        state = UpgradeViewModel.State(isPro = false),
+        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenSupporterPreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeViewModel.State(isPro = true, upgradedAt = Instant.fromEpochMilliseconds(1704067200000L)),
+        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenFreeStatusPreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeViewModel.State(isPro = false, manageMode = true, viewingOffers = false),
+        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
     )
 }

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -9,17 +9,25 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.SingleEventFlow
 import eu.darken.octi.common.uix.ViewModel4
+import eu.darken.octi.common.upgrade.core.FossUpgrade
 import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
 import eu.darken.octi.common.widget.WidgetManager
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
@@ -32,25 +40,77 @@ class UpgradeViewModel @Inject constructor(
     val snackbarEvents = SingleEventFlow<Unit>()
 
     private var initialized = false
+    private var forced = false
+    private var manage = false
     private val widgetsRefreshedForUpgrade = AtomicBoolean(false)
 
-    fun initialize(forced: Boolean) {
+    private val manageRoute = MutableStateFlow<Boolean?>(null)
+    private val viewingOffers = MutableStateFlow(handle.get<Boolean>(KEY_SHOW_OFFERS) ?: false)
+
+    data class State(
+        val isPro: Boolean = false,
+        val upgradedAt: Instant? = null,
+        val upgradeType: FossUpgrade.Type? = null,
+        val manageMode: Boolean = false,
+        val viewingOffers: Boolean = false,
+    ) {
+        // Free user opening the status row: show the calm status page first, revealing the sponsor
+        // pitch only when asked.
+        val showFreeStatus: Boolean get() = !isPro && manageMode && !viewingOffers
+    }
+
+    // Null until DataStore answered: a defaulted isPro=false would flash the sales pitch (and its
+    // armable unlock heuristic) at an existing supporter opening their status.
+    val state: StateFlow<State?> = combine(
+        upgradeRepo.upgradeInfo,
+        manageRoute.filterNotNull(),
+        viewingOffers,
+    ) { info, isManage, offers ->
+        val fossInfo = info as? UpgradeRepoFoss.Info
+        State(
+            isPro = info.isPro,
+            upgradedAt = info.upgradedAt,
+            upgradeType = fossInfo?.fossUpgradeType,
+            manageMode = isManage,
+            viewingOffers = offers,
+        )
+    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    fun initialize(forced: Boolean, manage: Boolean) {
         if (initialized) return
         initialized = true
+        this.forced = forced
+        this.manage = manage
+        manageRoute.value = manage
 
+        // Sales route: close once the user is Pro. Manage/forced route: never auto-close.
+        if (forced || manage) return
         upgradeRepo.upgradeInfo
             .filter { it.isPro }
             .take(1)
             .onEach {
                 refreshWidgetsForUpgrade()
-                if (!forced) navUp()
+                navUp()
             }
             .launchInViewModel()
+    }
+
+    fun onSeeUpgradeOptions() {
+        log(TAG) { "onSeeUpgradeOptions()" }
+        handle[KEY_SHOW_OFFERS] = true
+        viewingOffers.value = true
     }
 
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
         handle["browserOpenedAt"] = Clock.System.now().toEpochMilliseconds()
+        upgradeRepo.openSponsorsPage()
+    }
+
+    // Plain sponsor link for existing supporters: must NOT arm the unlock heuristic — re-running it
+    // would rewrite the "supporter since" date and navigate away from the status view.
+    fun openSponsors() {
+        log(TAG) { "openSponsors()" }
         upgradeRepo.openSponsorsPage()
     }
 
@@ -69,7 +129,8 @@ class UpgradeViewModel @Inject constructor(
             launch {
                 upgradeRepo.unlockUpgrade()
                 refreshWidgetsForUpgrade()
-                navUp()
+                // Sales route closes; manage/forced route stays to show the new supporter status.
+                if (!forced && !manage) navUp()
             }
         }
     }
@@ -91,6 +152,7 @@ class UpgradeViewModel @Inject constructor(
 
     companion object {
         private val MIN_SPONSOR_TIME = 5.seconds
-        private val TAG = logTag("Upgrade", "ViewModel")
+        private const val KEY_SHOW_OFFERS = "upgrade.manage.showOffers"
+        private val TAG = logTag("Upgrade", "Foss", "ViewModel")
     }
 }

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -23,4 +23,15 @@
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast_msg">Back already? Your support keeps Octi alive!</string>
+    <!-- Supporter / status (manage entry) -->
+    <string name="upgrade_screen_supporter_title">You are a supporter ❤️</string>
+    <string name="upgrade_screen_supporter_body">Thank you for supporting open-source development of Octi!</string>
+    <string name="upgrade_screen_supporter_since">Supporter since %1$s</string>
+    <string name="upgrade_screen_open_sponsors_action">Open GitHub Sponsors</string>
+    <string name="upgrade_screen_free_status_title">You are on the free version</string>
+    <string name="upgrade_screen_free_status_body">Become a supporter to unlock extra features and sponsor continued development.</string>
+    <string name="upgrade_screen_see_options_action">See upgrade options</string>
+    <!-- Settings status row (foss) -->
+    <string name="settings_upgrade_status_title">Octi FOSS</string>
+    <string name="settings_upgrade_status_desc">See your supporter status</string>
 </resources>

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/UpgradeModule.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/UpgradeModule.kt
@@ -2,10 +2,12 @@ package eu.darken.octi.common.upgrade
 
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
 import javax.inject.Singleton
+import kotlin.time.Clock
 
 @InstallIn(SingletonComponent::class)
 @Module
@@ -14,4 +16,8 @@ abstract class UpgradeModule {
     @Singleton
     abstract fun control(gplay: UpgradeRepoGplay): UpgradeRepo
 
+    companion object {
+        @Provides
+        fun clock(): Clock = Clock.System
+    }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
@@ -3,24 +3,65 @@ package eu.darken.octi.common.upgrade.core
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.datastore.createValue
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.gplayDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings_gplay")
+
 @Singleton
-class BillingCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class BillingCache internal constructor(
+    private val dataStore: DataStore<Preferences>,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_gplay")
+    @Inject constructor(@ApplicationContext context: Context) : this(context.gplayDataStore)
 
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
-
-    val lastProStateAt = dataStore.createValue("gplay.cache.lastProAt", 0L)
+    val lastProStateAt = dataStore.createValue(KEY_LAST_PRO_AT.name, 0L)
 
     // Product id of the last known-owned pro SKU; determines which grace window applies.
-    val lastProStateSku = dataStore.createValue("gplay.cache.lastProSku", "")
+    val lastProStateSku = dataStore.createValue(KEY_LAST_PRO_SKU.name, "")
+
+    // Start of the current "fresh data can't confirm Pro" episode, 0 = no open episode. Drives
+    // the two-stage grace UI (calm confirmation phase first, diagnostics once the episode ages).
+    val proUnconfirmedAt = dataStore.createValue(KEY_PRO_UNCONFIRMED_AT.name, 0L)
+
+    // One transaction: a confirmed Pro purchase stamps the anchor (SKU only when the caller wants
+    // to move it) and atomically closes any unconfirmed episode. Observers and crash recovery must
+    // never see the anchor updated but the episode still open, or vice versa.
+    suspend fun stampLastProState(skuId: String?, at: Long) {
+        dataStore.edit { prefs ->
+            skuId?.let { prefs[KEY_LAST_PRO_SKU] = it }
+            prefs[KEY_LAST_PRO_AT] = at
+            prefs[KEY_PRO_UNCONFIRMED_AT] = 0L
+        }
+    }
+
+    // Starts the unconfirmed-episode clock. Set-if-unset: follow-up failures must not push the
+    // diagnostics threshold out. An episode only exists relative to a previous confirmation, and a
+    // stored stamp from before that confirmation or from the future is corrupt state that gets
+    // repaired instead of trusted.
+    suspend fun recordProUnconfirmed(at: Long) {
+        dataStore.edit { prefs ->
+            val lastProAt = prefs[KEY_LAST_PRO_AT] ?: 0L
+            // Also rejects failures arriving moments after a confirmation: a confirmation and a
+            // conflicting empty snapshot within the same minute is emission reordering around a
+            // racing purchase event, not a real unconfirmed state.
+            if (lastProAt <= 0L || at - lastProAt < MIN_CONFIRMATION_AGE_MS) return@edit
+            val current = prefs[KEY_PRO_UNCONFIRMED_AT] ?: 0L
+            val corrupt = current != 0L && (current <= lastProAt || current > at)
+            if (current == 0L || corrupt) prefs[KEY_PRO_UNCONFIRMED_AT] = at
+        }
+    }
+
+    companion object {
+        private val KEY_LAST_PRO_AT = longPreferencesKey("gplay.cache.lastProAt")
+        private val KEY_LAST_PRO_SKU = stringPreferencesKey("gplay.cache.lastProSku")
+        private val KEY_PRO_UNCONFIRMED_AT = longPreferencesKey("gplay.cache.proUnconfirmedAt")
+        internal const val MIN_CONFIRMATION_AGE_MS = 60_000L
+    }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.common.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.Purchase
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.datastore.value
@@ -17,6 +18,7 @@ import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.BillingManager
+import eu.darken.octi.common.upgrade.core.billing.FreshBillingData
 import eu.darken.octi.common.upgrade.core.billing.PurchasedSku
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
@@ -24,18 +26,25 @@ import eu.darken.octi.common.upgrade.core.billing.UserCanceledBillingException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.withTimeoutOrNull
@@ -44,7 +53,6 @@ import javax.inject.Singleton
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -54,21 +62,30 @@ class UpgradeRepoGplay @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val billingManager: BillingManager,
     private val billingCache: BillingCache,
+    private val clock: Clock,
 ) : UpgradeRepo {
 
     override val mainWebsite: String = SITE
 
+    private fun nowMs(): Long = clock.now().toEpochMilliseconds()
+
+    // Serializes the check-then-write anchor/episode logic: concurrent fresh observations (init
+    // collector, failure events, direct restores) must not interleave between reading the current
+    // anchor and stamping the new one.
+    private val proStateLock = Mutex()
+
+    // Declared before init: the init collector below flips it, and under an eager (Unconfined)
+    // subscriber it can run during construction before a later-declared field would initialize.
+    private val _autoRestoreInProgress = MutableStateFlow(false)
+
     init {
-        // Fresh-provenance grace stamping: this collector subscribes once at construction (eager,
-        // process start) and never re-subscribes, so every value it sees was produced in this
-        // process moments before — unlike the reactive upgradeInfo map, which re-runs on replayed
-        // shared-flow data every time the UI resubscribes and therefore writes nothing anymore.
-        // This is what keeps a purchase completion stamping the grace cache.
-        billingManager.billingData
-            .distinctUntilChanged()
-            .onEach { data ->
+        // Fresh-provenance grace stamping: freshBillingData carries every conclusive observation
+        // (successful queries + push payloads) with provenance, unlike the reactive upgradeInfo map
+        // which re-runs on replayed shared-flow data and therefore writes nothing.
+        billingManager.freshBillingData
+            .onEach { fresh ->
                 try {
-                    recordProState(data)
+                    recordProState(fresh)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -79,6 +96,23 @@ class UpgradeRepoGplay @Inject constructor(
             .setupCommonEventHandlers(TAG) { "proStateRecorder" }
             .launchIn(scope)
 
+        // Failed fresh-data attempts (query errors) start the unconfirmed-episode clock. Most of
+        // these failures are swallowed by their pipelines (logged, retried later), so without this
+        // collector a sustained Play outage would never age the grace presentation from
+        // "confirming…" into its diagnostics stage.
+        billingManager.refreshFailures
+            .onEach {
+                try {
+                    proStateLock.withLock { billingCache.recordProUnconfirmed(nowMs()) }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Failed to record unconfirmed state: ${e.asLog()}" }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "unconfirmedRecorder" }
+            .launchIn(scope)
+
         // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that the
         // user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
         // failures, so no app-side dialog here.
@@ -86,31 +120,60 @@ class UpgradeRepoGplay @Inject constructor(
             .filter { it.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED }
             .onEach {
                 log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
+                _autoRestoreInProgress.value = true
                 try {
                     withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT) { restorePurchaseNow() }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
+                } finally {
+                    _autoRestoreInProgress.value = false
                 }
             }
             .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
             .launchIn(scope)
     }
 
-    override val upgradeInfo: Flow<Info> = billingManager.billingData
-        .map<BillingData, BillingData?> { it }
-        .onStart { emit(null) }
+    // True while the invisible already-owned reconciliation runs. Exposed so the UI can hold its buy
+    // buttons disabled during it — that restore is off the VM's operation guard, so without this a
+    // second purchase could be launched on top of the one being reconciled.
+    val autoRestoreInProgress: Flow<Boolean> = _autoRestoreInProgress
+
+    // Grace is time-based, but billingData is equality-deduped state kept hot by a process-lifetime
+    // subscriber — without this deadline tick, a lapsed grace window would keep isPro=true until the
+    // next distinct billing emission or a process restart, and every non-screen consumer
+    // (UpgradeEntitlementObserver, widgets) would keep seeing an expired entitlement.
+    private val graceDeadlineTick: Flow<Unit> = billingCache.lastProStateAt.flow
+        .flatMapLatest { lastProAt ->
+            flow {
+                emit(Unit)
+                if (lastProAt > 0L) {
+                    val remaining = lastProAt + graceWindow().inWholeMilliseconds - nowMs()
+                    if (remaining > 0) {
+                        delay(remaining)
+                        emit(Unit)
+                    }
+                }
+            }
+        }
+
+    override val upgradeInfo: Flow<Info> = combine(
+        billingManager.billingData
+            .map<BillingData, BillingData?> { it }
+            .onStart { emit(null) },
+        graceDeadlineTick,
+    ) { data, _ -> data }
         .setupCommonEventHandlers(TAG) { "upgradeInfo1" }
         .map { data: BillingData? -> data.toUpgradeInfo() }
         .distinctUntilChanged()
         .catch {
             // Ignore Google Play errors if the last pro state was recent
-            val now = Clock.System.now().toEpochMilliseconds()
+            val now = nowMs()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, error=$it" }
-            if ((now - lastProStateAt).milliseconds < graceWindow()) {
-                log(TAG, VERBOSE) { "We are not pro, but were recently, and just and an error, what is GPlay doing???" }
+            if ((now - lastProStateAt).let { d -> d in 0..<graceWindow().inWholeMilliseconds }) {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, and just an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
                 throw it
@@ -125,20 +188,44 @@ class UpgradeRepoGplay @Inject constructor(
         .map { it > 0 }
         .distinctUntilChanged()
 
+    // Start of the current "fresh data can't confirm Pro" episode (0 = none open). Drives the
+    // two-stage grace UI: calm confirmation phase first, diagnostics once the episode has aged.
+    val proUnconfirmedSince: Flow<Long> = billingCache.proUnconfirmedAt.flow
+
+    // True once any fresh billing observation arrived this process. The pre-reconciliation empty
+    // purchase state must not enable purchase actions — an owner on a fresh install would briefly
+    // look free and could buy the other product on top of what they already own.
+    val isSettled: Flow<Boolean> = billingManager.freshBillingData
+        .map { true }
+        .onStart { emit(false) }
+        .distinctUntilChanged()
+
+    // Strict SUBS-only ownership check for the switch-to-IAP gate. Errors propagate — a subscriber
+    // whose renewal state can't be verified must not be allowed to double-buy.
+    suspend fun queryCurrentSubscriptions(): Collection<Purchase> = billingManager.querySubscriptions()
+
     fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
         scope.launch {
             try {
-                billingManager.startIapFlow(activity, sku, offer)
+                launchBillingFlowNow(activity, sku, offer)
             } catch (e: UserCanceledBillingException) {
                 log(TAG) { "User canceled the billing flow." }
             } catch (e: Exception) {
-                log(TAG) { "startIapFlow failed:${e.asLog()}" }
+                log(TAG) { "launchBillingFlowNow failed:${e.asLog()}" }
                 withContext(dispatcherProvider.Main) {
                     e.asErrorDialogBuilder(activity).show()
                 }
             }
         }
+    }
+
+    // Suspending launch: the caller's coroutine stays alive until the Play sheet has been launched
+    // (or failed), so a single-flight operation guard can cover the whole window instead of racing a
+    // fire-and-forget launch.
+    suspend fun launchBillingFlowNow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
+        log(TAG) { "launchBillingFlowNow($activity,$sku)" }
+        billingManager.startIapFlow(activity, sku, offer)
     }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
@@ -150,12 +237,28 @@ class UpgradeRepoGplay @Inject constructor(
             recordProState(fresh)
         } catch (e: TimeoutCancellationException) {
             log(TAG, ERROR) { "Background refresh timed out" }
+            recordUnconfirmedSafely()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             // Background refresh: swallow-and-log so callers like the widget config screens aren't
             // affected. The explicit restore path uses restorePurchaseNow(), which surfaces errors.
             log(TAG, ERROR) { "Background refresh failed: ${e.asLog()}" }
+            recordUnconfirmedSafely()
+        }
+    }
+
+    // A refresh/restore that failed or timed out is a conclusive "couldn't confirm Pro" — start the
+    // unconfirmed-episode clock so the grace UI can escalate to diagnostics after 24h even when the
+    // failure never reaches the connection-level freshFailures signal (e.g. connection setup failed,
+    // or the query hung until timeout). No-op unless we were previously Pro (guarded in the cache).
+    private suspend fun recordUnconfirmedSafely() {
+        try {
+            proStateLock.withLock { billingCache.recordProUnconfirmed(nowMs()) }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to record unconfirmed state: ${e.asLog()}" }
         }
     }
 
@@ -167,17 +270,20 @@ class UpgradeRepoGplay @Inject constructor(
         return try {
             val fresh = billingManager.refresh()
             recordProState(fresh)
-            fresh.toUpgradeInfo()
+            fresh.data.toUpgradeInfo()
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             // Mirror the reactive flow's catch: a transient Play error while we were pro recently
             // keeps us pro via the grace period; otherwise surface the error so the caller can show
             // the proper "Play unavailable" message instead of a generic restore failure.
-            val now = Clock.System.now().toEpochMilliseconds()
+            val now = nowMs()
             val lastProStateAt = billingCache.lastProStateAt.value()
-            if ((now - lastProStateAt).milliseconds < graceWindow()) {
+            if ((now - lastProStateAt).let { d -> d in 0..<graceWindow().inWholeMilliseconds }) {
                 log(TAG, VERBOSE) { "Restore hit a Play error but we were pro recently -> grace" }
+                // The failed restore is a conclusive "couldn't confirm" — open the episode so the
+                // grace UI escalates to diagnostics after 24h.
+                recordUnconfirmedSafely()
                 Info(gracePeriod = true, billingData = null)
             } else {
                 throw e
@@ -190,14 +296,14 @@ class UpgradeRepoGplay @Inject constructor(
     // runs on replayed shared-flow data too, so it must never stamp the grace cache — see
     // recordProState(). An unrecognized purchase neither counts as pro nor suppresses active grace.
     private suspend fun BillingData?.toUpgradeInfo(): Info {
-        val now = Clock.System.now().toEpochMilliseconds()
+        val now = nowMs()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         val info = Info(billingData = this)
         return when {
             preferredProSku(info.upgrades) != null -> info
 
-            (now - lastProStateAt).milliseconds < graceWindow() -> {
+            (now - lastProStateAt).let { d -> d in 0..<graceWindow().inWholeMilliseconds } -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                 Info(gracePeriod = true, billingData = null)
             }
@@ -206,41 +312,34 @@ class UpgradeRepoGplay @Inject constructor(
         }
     }
 
-    // Persists "we saw a known pro purchase" for the grace machinery. Callers must only pass FRESH
-    // data (returned query results, or new emissions seen by the init collector) — never replayed
-    // flow data, so a refunded purchase can't keep re-stamping its grace window. Only a *known* pro
-    // SKU counts; the permanent IAP is preferred so it drives the window length.
-    private suspend fun recordProState(data: BillingData) {
-        // A failed product-type query keeps previously cached purchases in billingData (ACK must not
-        // starve), but those aren't fresh ownership proof — only purchases whose product type was
-        // verified by this data may renew grace. Query-returned data is inherently verified; this
-        // only bites for the combined reactive emissions.
-        val verified = Info(billingData = data).upgrades.filter {
-            when (it.sku.type) {
-                Sku.Type.IAP -> data.iapQueryOk
-                Sku.Type.SUBSCRIPTION -> data.subQueryOk
-            }
-        }
-        val preferred = preferredProSku(verified) ?: return
-        // SKU before timestamp: the timestamp gates grace, the SKU only modifies its length — this
-        // order can't leave a fresh gate pointing at a stale modifier if we die between the writes.
-        updateLastProSku(preferred, iapQueryOk = data.iapQueryOk)
-        billingCache.lastProStateAt.value(Clock.System.now().toEpochMilliseconds())
-    }
+    // Persists what fresh data told us about Pro ownership. Callers must only pass FRESH data
+    // (returned query results, or new emissions seen by the init collector) — never replayed flow
+    // data. A confirmed purchase stamps the anchor and atomically closes any unconfirmed episode; a
+    // full snapshot WITHOUT a pro purchase conclusively failed to confirm and starts the episode
+    // clock; presence-only data without a purchase proves nothing either way. The permanent IAP wins
+    // as anchor when both are owned, and an IAP anchor is sticky: purchase data may lack the IAP
+    // because that query failed or was out of scope (SUBS-only verification), and a subscription seen
+    // in the meantime must not shrink the 30d window of an owner whose IAP was never disproven.
+    private suspend fun recordProState(fresh: FreshBillingData) {
+        val upgrades = Info(billingData = fresh.data).upgrades
+        val preferred = preferredProSku(upgrades)
+        proStateLock.withLock {
+            when {
+                preferred != null -> {
+                    val anchorIsIap = OurSku.PRO_SKUS.singleOrNull {
+                        it.id == billingCache.lastProStateSku.value()
+                    }?.type == Sku.Type.IAP
+                    val anchorSku = preferred
+                        .takeIf { it.type == Sku.Type.IAP || !anchorIsIap }
+                        ?.id
+                    billingCache.stampLastProState(anchorSku, nowMs())
+                }
 
-    // A stored permanent-IAP sku is only replaced by a subscription sku when the IAP query actually
-    // succeeded and confirmed no IAP is owned — a transient IAP query failure must not silently
-    // shrink the 30d grace window down to the 7d subscription one.
-    private suspend fun updateLastProSku(preferred: Sku, iapQueryOk: Boolean) {
-        if (preferred.type != Sku.Type.IAP) {
-            val storedSku = billingCache.lastProStateSku.value()
-            val storedIsIap = OurSku.PRO_SKUS.singleOrNull { it.id == storedSku }?.type == Sku.Type.IAP
-            if (storedIsIap && !iapQueryOk) {
-                log(TAG) { "Keeping stored IAP sku, the IAP query failed and can't confirm it's gone" }
-                return
+                fresh.isFullSnapshot -> {
+                    billingCache.recordProUnconfirmed(nowMs())
+                }
             }
         }
-        billingCache.lastProStateSku.value(preferred.id)
     }
 
     // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
@@ -248,13 +347,11 @@ class UpgradeRepoGplay @Inject constructor(
     private suspend fun graceWindow(): Duration {
         val lastSku = billingCache.lastProStateSku.value()
         val type = OurSku.PRO_SKUS.singleOrNull { it.id == lastSku }?.type
-        val window = if (type == Sku.Type.IAP) PRO_GRACE_PERIOD_IAP else PRO_GRACE_PERIOD
-        log(TAG) { "graceWindow(): lastSku=$lastSku, type=$type -> $window" }
-        return window
+        return if (type == Sku.Type.IAP) PRO_GRACE_PERIOD_IAP else PRO_GRACE_PERIOD
     }
 
     data class Info(
-        private val gracePeriod: Boolean = false,
+        val gracePeriod: Boolean = false,
         private val billingData: BillingData?,
     ) : UpgradeRepo.Info {
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingData.kt
@@ -10,3 +10,11 @@ data class BillingData(
     val iapQueryOk: Boolean = true,
     val subQueryOk: Boolean = true,
 )
+
+// Provenance-tagged fresh billing data: only a full snapshot (both product types queried
+// conclusively, no racing purchase event) proves absence — anything else proves presence only.
+// The grace machinery relies on this to never start an unconfirmed episode from partial data.
+data class FreshBillingData(
+    val data: BillingData,
+    val isFullSnapshot: Boolean,
+)

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManager.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.common.upgrade.core.billing
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.Bugs
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
@@ -19,6 +20,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +28,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -34,8 +37,10 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -107,62 +112,122 @@ class BillingManager @Inject constructor(
         .setupCommonEventHandlers(TAG) { "billingData" }
         .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
 
+    // Provenance-tagged conclusive fresh looks (successful queries + push payloads). Grace stamping
+    // must use THIS, not the equality-deduped billingData which can mix in stale listener data.
+    val freshBillingData: Flow<FreshBillingData> = connection
+        .mapNotNull { it.getOrNull() }
+        .flatMapLatest { it.freshPurchases }
+        .map { FreshBillingData(BillingData(it.purchases), it.isFullSnapshot) }
+        .setupCommonEventHandlers(TAG) { "freshBillingData" }
+        .shareIn(scope, SharingStarted.WhileSubscribed(stopTimeout = 3.seconds, replayExpiration = Duration.ZERO), replay = 1)
+
+    // Failed attempts at a fresh conclusive look (query errors) — start the unconfirmed-episode
+    // clock so a sustained Play outage eventually escalates the grace UI to its diagnostics stage.
+    val refreshFailures: Flow<Unit> = connection
+        .mapNotNull { it.getOrNull() }
+        .flatMapLatest { it.freshFailures }
+        .setupCommonEventHandlers(TAG) { "refreshFailures" }
+
     val purchaseFailures: Flow<BillingResult> = connection
         .mapNotNull { it.getOrNull() }
         .flatMapLatest { it.purchaseFailures }
         .setupCommonEventHandlers(TAG) { "purchaseFailures" }
 
-    init {
-        billingData
-            .onEach { data ->
-                data.purchases
-                    .filter {
-                        val needsAck = !it.isAcknowledged
+    // Purchase tokens acknowledged this process. An immutable Purchase snapshot keeps reporting
+    // isAcknowledged=false until a fresh query replaces it, so without this guard every billingData
+    // re-emission would re-ACK. Recorded only on ACK success. Accessed only from the single ack
+    // collector below.
+    private val ackedTokens = mutableSetOf<String>()
 
-                        if (needsAck) log(TAG, INFO) { "Needs ACK: $it" }
-                        else log(TAG) { "Already ACK'ed: $it" }
+    // Re-runs the ACK pass independently of distinct billing-state changes: a re-query returning the
+    // same still-unacknowledged Purchase is deduped away by billingData's distinctUntilChanged, so a
+    // purchase stuck behind a transient Play outage would otherwise never get another ACK attempt
+    // before Play's ~3-day auto-refund of unacknowledged purchases.
+    private val ackRetryTrigger = MutableSharedFlow<Unit>(extraBufferCapacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+
+    init {
+        combine(billingData, ackRetryTrigger.onStart { emit(Unit) }) { data, _ -> data }
+            .onEach { data ->
+                var anyFailed = false
+                data.purchases
+                    .filter { purchase ->
+                        val needsAck = !purchase.isAcknowledged && purchase.purchaseToken !in ackedTokens
+
+                        if (needsAck) log(TAG, INFO) { "Needs ACK: $purchase" }
+                        else log(TAG) { "Already ACK'ed (or in-flight): $purchase" }
 
                         needsAck
                     }
-                    .forEach {
-                        log(TAG, INFO) { "Acknowledging purchase: $it" }
-
-                        try {
-                            useConnection {
-                                acknowledgePurchase(it)
-                            }
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Failed to ancknowledge purchase: $it\n${e.asLog()}" }
+                    .forEach { purchase ->
+                        log(TAG, INFO) { "Acknowledging purchase: $purchase" }
+                        if (acknowledgeWithRetry(purchase)) {
+                            ackedTokens.add(purchase.purchaseToken)
+                        } else {
+                            anyFailed = true
                         }
                     }
+                if (anyFailed) {
+                    // Schedule a retry that re-reads the latest billingData via the trigger, so a
+                    // failed ACK is re-attempted even if the purchase state never changes again.
+                    scope.launch {
+                        delay(ACK_RESCHEDULE_DELAY)
+                        ackRetryTrigger.tryEmit(Unit)
+                    }
+                }
             }
             .setupCommonEventHandlers(TAG) { "connection-acks" }
             .retryWhen { cause, attempt ->
+                // acknowledgeWithRetry swallows its own billing errors, so this only fires on an
+                // unexpected collector crash; bounded so it can't spin.
                 if (cause is CancellationException) {
-                    log(TAG) { "Ack was cancelled (appScope?) cancelled." }
+                    log(TAG) { "Ack collector cancelled (appScope?)." }
                     return@retryWhen false
                 }
                 if (attempt > 5) {
-                    log(TAG, WARN) { "Reached attempt limit: $attempt due to $cause" }
+                    log(TAG, WARN) { "Ack collector reached attempt limit: $attempt due to $cause" }
                     return@retryWhen false
                 }
-                if (cause !is BillingException) {
-                    log(TAG, WARN) { "Unknown BillingClient exception type: $cause" }
-                    return@retryWhen false
-                } else {
-                    log(TAG) { "BillingClient exception: $cause" }
-                }
-
-                if (cause is BillingClientException && cause.result.responseCode == BillingResponseCode.BILLING_UNAVAILABLE) {
-                    log(TAG) { "Got BILLING_UNAVAILABLE while trying to ACK purchase." }
-                    return@retryWhen false
-                }
-
-                log(TAG) { "Will retry ACK" }
+                log(TAG, WARN) { "Ack collector crashed unexpectedly (attempt $attempt): $cause" }
                 delay((3 * attempt).seconds)
                 true
             }
             .launchIn(scope)
+    }
+
+    // Bounded inline ACK retry with linear backoff. Gives up immediately when billing is
+    // unavailable (retrying is pointless until reconnect), and after ACK_MAX_ATTEMPTS otherwise.
+    // Returns true only on a confirmed acknowledgement. Never throws (except cancellation) — a
+    // failed ACK is left for a later emission/reconnect to retry.
+    private suspend fun acknowledgeWithRetry(purchase: Purchase): Boolean {
+        var attempt = 0
+        while (true) {
+            attempt++
+            try {
+                useConnection { acknowledgePurchase(purchase) }
+                return true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                if (e.isBillingUnavailable()) {
+                    log(TAG, WARN) { "ACK giving up (billing unavailable) for $purchase" }
+                    return false
+                }
+                if (attempt >= ACK_MAX_ATTEMPTS) {
+                    log(TAG, ERROR) { "ACK failed after $attempt attempts for $purchase:\n${e.asLog()}" }
+                    return false
+                }
+                log(TAG, WARN) { "ACK attempt $attempt failed for $purchase, retrying: ${e.asLog()}" }
+                delay(ACK_RETRY_BASE * attempt)
+            }
+        }
+    }
+
+    // BILLING_UNAVAILABLE both as the raw client code (acknowledgePurchase throws it unmapped) and
+    // as the user-friendly mapped type (a failed connection acquisition inside useConnection).
+    private fun Throwable.isBillingUnavailable(): Boolean = when {
+        this is BillingClientException && result.responseCode == BillingResponseCode.BILLING_UNAVAILABLE -> true
+        this is GplayServiceUnavailableException -> true
+        else -> false
     }
 
     private suspend fun <T> useConnection(
@@ -231,15 +296,28 @@ class BillingManager @Inject constructor(
     // Query in the caller's context and return the result directly, so callers get the fresh
     // purchases (and any billing error) with a real happens-before instead of racing the shared
     // billingData replay cache.
-    suspend fun refresh(): BillingData {
+    suspend fun refresh(): FreshBillingData {
         log(TAG) { "refresh()" }
-        return useConnection(retryOnFailure = true) { refreshPurchases() }
+        val fresh = useConnection(retryOnFailure = true) { refreshPurchases() }
+        return FreshBillingData(BillingData(fresh.purchases), fresh.isFullSnapshot)
+    }
+
+    // Strict SUBS-only ownership query for the switch-to-IAP gate. Errors propagate so the caller
+    // fails closed. Returns the currently-owned subscription purchases (each carries isAutoRenewing).
+    suspend fun querySubscriptions(): Collection<Purchase> = useConnection(retryOnFailure = true) {
+        log(TAG) { "querySubscriptions()" }
+        querySubscriptions()
     }
 
     companion object {
         private val CONNECTION_RETRY_DELAY = 1.minutes
         internal val CONNECTION_RETRY_DELAY_UNAVAILABLE = 5.minutes
         private val RETRY_WAIT_TIMEOUT = 10.seconds
+        private const val ACK_MAX_ATTEMPTS = 3
+        private val ACK_RETRY_BASE = 3.seconds
+        // Between inline-retry bursts: long enough not to hammer a downed Play, short enough to
+        // comfortably beat Play's ~3-day auto-refund of unacknowledged purchases.
+        private val ACK_RESCHEDULE_DELAY = 5.minutes
 
         internal fun Throwable.tryMapUserFriendly(): Throwable {
             if (this !is BillingClientException) return this

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -15,6 +15,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
 import eu.darken.octi.common.upgrade.core.billing.Sku
@@ -25,35 +26,41 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 data class BillingConnection(
     private val client: BillingClient,
-    val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
+    // Listener overlay from onPurchasesUpdated. Mutable + reconcilable: a stale record (e.g. an
+    // isAutoRenewing=true event) must be prunable by a later conclusive query, or it would union
+    // into billingData forever and keep the switch-to-IAP gate locked after the user cancelled.
+    private val purchasesGlobal: MutableStateFlow<Collection<Purchase>>,
+    private val freshObservations: MutableSharedFlow<FreshPurchases>,
+    private val freshFailuresGlobal: MutableSharedFlow<Unit>,
     private val purchaseFailureEvents: Flow<BillingResult?>,
+    private val listenerGeneration: () -> Long,
 ) {
 
     private val queryCacheIaps = MutableStateFlow<QueryCache?>(null)
     private val queryCacheSubs = MutableStateFlow<QueryCache?>(null)
 
     val billingData: Flow<BillingData> = combine(
-        purchaseEvents,
+        purchasesGlobal,
         queryCacheIaps.filterNotNull(),
         queryCacheSubs.filterNotNull(),
-    ) { purchaseEvent, iapCache, subCache ->
+    ) { overlay, iapCache, subCache ->
         val combined = mutableSetOf<Purchase>()
 
         combined.addAll(iapCache.purchases)
         combined.addAll(subCache.purchases)
-
-        purchaseEvent
-            ?.takeIf { (result, _) -> result.isSuccess }
-            ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
-            ?.let { combined.addAll(it) }
+        combined.addAll(overlay.filter { it.purchaseState == PurchaseState.PURCHASED })
 
         BillingData(
             purchases = combined.sortedByDescending { it.purchaseTime },
@@ -61,6 +68,16 @@ data class BillingConnection(
             subQueryOk = subCache.querySucceeded,
         )
     }.setupCommonEventHandlers(TAG) { "billingData" }
+
+    // Every conclusive fresh look at PURCHASED purchases (successful queries and push payloads),
+    // tagged with provenance: only a full snapshot proves absence. The combined billingData state
+    // is equality-deduped and can mix in stale listener data, so grace stamping must use THIS.
+    val freshPurchases: Flow<FreshPurchases> = freshObservations
+
+    // Failed attempts to get a fresh conclusive look (query errors). Consumed by UpgradeRepoGplay
+    // to start the unconfirmed-episode clock — without this, a sustained Play outage would never
+    // escalate the grace UI to its diagnostics stage.
+    val freshFailures: Flow<Unit> = freshFailuresGlobal
 
     private data class QueryCache(
         val purchases: Collection<Purchase>,
@@ -70,6 +87,11 @@ data class BillingConnection(
     // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
     // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
     val purchaseFailures: Flow<BillingResult> = purchaseFailureEvents.filterNotNull()
+
+    // Serializes refreshes on this connection: the initial query, foreground refreshes, manual
+    // restores, switch-gate verifications and already-owned recoveries may overlap, and an older
+    // query completing late must not overwrite the cache with stale purchases.
+    private val refreshLock = Mutex()
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {
@@ -89,24 +111,123 @@ data class BillingConnection(
         return purchaseData
     }
 
-    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
-    // relation instead of racing the shared billingData replay caches after a refresh.
-    // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
-    // authoritative, and only propagate an error when nothing was found AND a query failed — so the
-    // caller can tell "not owned" apart from "couldn't verify".
-    suspend fun refreshPurchases(): BillingData = coroutineScope {
+    // Returns the freshly queried PURCHASED purchases (with provenance) so callers get a guaranteed
+    // happens-before relation instead of racing the shared billingData replay caches after a
+    // refresh. Tolerant of a single product-type failure: if either query finds a purchase we treat
+    // that as authoritative, and only propagate an error when nothing was found AND a query failed —
+    // so the caller can tell "not owned" apart from "couldn't verify".
+    suspend fun refreshPurchases(): FreshPurchases = refreshLock.withLock {
+        refreshPurchasesLocked()
+    }
+
+    private suspend fun refreshPurchasesLocked(): FreshPurchases = coroutineScope {
         log(TAG) { "refreshPurchases()" }
+        val generationBefore = listenerGeneration()
+
         val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP, queryCacheIaps) }
         val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS, queryCacheSubs) }
         val iaps = iapJob.await()
         val subs = subJob.await()
         log(TAG) { "Refreshed IAPs=${iaps.getOrNull()}, SUBs=${subs.getOrNull()}" }
-        combinePurchaseResults(iaps, subs)
+
+        val combined = try {
+            combinePurchaseResults(iaps, subs)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            freshFailuresGlobal.tryEmit(Unit)
+            throw e
+        }
+
+        val bothOk = iaps.isSuccess && subs.isSuccess
+        reconcileListenerRecords(
+            fresh = combined.purchases,
+            generationBefore = generationBefore,
+            // A conclusive both-type query proves absence for every product: listener records it
+            // didn't return are stale (refunded, expired) and must not linger until restart.
+            absenceProven = bothOk,
+            absenceScope = { true },
+        )
+
+        // Absence is only proven when both type queries succeeded AND no purchase event raced the
+        // queries: a racing event either flips the generation (downgrading this to presence-only),
+        // or its own fresh emission follows ours and immediately re-stamps the confirmation.
+        val isFullSnapshot = bothOk && listenerGeneration() == generationBefore
+        val fresh = FreshPurchases(combined.purchases, isFullSnapshot)
+
+        // A conclusive refresh is a fresh observation for the grace stamping, even when the result
+        // equals the previous one and the state flows dedupe it away.
+        freshObservations.tryEmit(fresh)
+
+        fresh
+    }
+
+    // Strict SUBS-only verification query for the switch-to-IAP gate: errors propagate (the caller
+    // fails closed), and the result is committed to the caches so the ownership UI heals from stale
+    // renewal state (e.g. after the user cancelled the subscription in Play).
+    suspend fun querySubscriptions(): Collection<Purchase> = refreshLock.withLock {
+        log(TAG) { "querySubscriptions()" }
+        val generationBefore = listenerGeneration()
+        val subs = try {
+            queryPurchases(BillingClient.ProductType.SUBS).filter { it.purchaseState == PurchaseState.PURCHASED }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            freshFailuresGlobal.tryEmit(Unit)
+            throw e.tryMapUserFriendly()
+        }
+
+        queryCacheSubs.value = QueryCache(purchases = subs, querySucceeded = true)
+        reconcileListenerRecords(
+            fresh = subs,
+            generationBefore = generationBefore,
+            // A conclusive SUBS query proves absence for subscriptions only.
+            absenceProven = true,
+            absenceScope = { it.isKnownSub() },
+        )
+
+        // Presence-only provenance: a SUBS query proves nothing about the IAP.
+        freshObservations.tryEmit(FreshPurchases(subs, isFullSnapshot = false))
+
+        // Surviving listener records for known subs — empty after a non-racing conclusive query
+        // (reconciliation pruned them). After a RACE the overlay keeps the NEWER record, which must
+        // WIN over the older query row for its token: a just-arrived renewing subscription must not
+        // be hidden by a stale no-longer-renewing query result and slip past the switch gate.
+        val listenerSubs = purchasesGlobal.value.filter {
+            it.purchaseState == PurchaseState.PURCHASED && it.isKnownSub()
+        }
+        val listenerTokens = listenerSubs.mapTo(mutableSetOf()) { it.purchaseToken }
+
+        subs.filter { it.purchaseToken !in listenerTokens } + listenerSubs
+    }
+
+    private fun Purchase.isKnownSub(): Boolean = products.any { it == OurSku.Sub.PRO_UPGRADE.id }
+
+    // Reconciles the listener overlay against a fresh query result — but ONLY when no purchase event
+    // raced the query (generation unchanged, re-checked inside the update): a listener record
+    // published mid-query is NEWER than the query result and must survive, or a just-renewed
+    // subscription could be deleted by an older query and slip past the IAP gate. Without a race:
+    // fresh records supersede same-token listener records (a stale in-session isAutoRenewing=true
+    // must not coexist with newer query state forever), and when absence was proven, in-scope
+    // listener records the query didn't return are dropped entirely (refunded/expired purchases
+    // must not keep resurrecting until process restart).
+    private fun reconcileListenerRecords(
+        fresh: Collection<Purchase>,
+        generationBefore: Long,
+        absenceProven: Boolean,
+        absenceScope: (Purchase) -> Boolean,
+    ) {
+        purchasesGlobal.update { current ->
+            if (listenerGeneration() != generationBefore) return@update current
+            current.filterNot { old ->
+                fresh.any { it.purchaseToken == old.purchaseToken } || (absenceProven && absenceScope(old))
+            }
+        }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
-    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    // On failure the cache keeps its previous purchases (seeded empty if it had none) so the combined
+    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped. On
+    // failure the cache keeps its previous purchases (seeded empty if it had none) so the combined
     // billingData flow still emits — a persistently failing product type must not block the other
     // type's purchases or starve purchase acknowledgement.
     private suspend fun queryPurchasedProducts(

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -16,13 +16,16 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.upgrade.core.billing.BillingException
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.retryWhen
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -33,8 +36,28 @@ class BillingConnectionProvider @Inject constructor(
 ) {
 
     private val provider: Flow<BillingConnection> = callbackFlow {
-        val purchaseEvents = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
+        // Reconcilable listener overlay: onPurchasesUpdated writes here, fresh queries prune it.
+        val purchasesGlobal = MutableStateFlow<Collection<Purchase>>(emptyList())
         val purchaseFailureEvents = MutableStateFlow<BillingResult?>(null)
+        // replay=1: a fresh observation can arrive before UpgradeRepoGplay's grace collector
+        // subscribes (construction-order race) — the latest fresh look must not be lost.
+        val freshObservations = MutableSharedFlow<FreshPurchases>(
+            replay = 1,
+            extraBufferCapacity = 16,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+        // replay=1: the initial refresh can fail before the failure collector subscribes — that
+        // first failure must still be able to start the unconfirmed-episode clock. A stale replayed
+        // failure is harmless (episode recording is set-if-unset and guarded).
+        val freshFailures = MutableSharedFlow<Unit>(
+            replay = 1,
+            extraBufferCapacity = 8,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
+        // Bumped on every successful onPurchasesUpdated BEFORE its data is published: a refresh
+        // compares the generation around its queries to detect a racing purchase event, which
+        // downgrades that refresh's snapshot from "proves absence" to "presence only".
+        val listenerGeneration = AtomicLong(0)
 
         val pendingPurchasesParams = PendingPurchasesParams.newBuilder().apply {
             enableOneTimeProducts()
@@ -48,7 +71,16 @@ class BillingConnectionProvider @Inject constructor(
                     log(TAG) {
                         "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
-                    purchaseEvents.value = result to purchases
+                    listenerGeneration.incrementAndGet()
+                    purchasesGlobal.value = purchases.orEmpty()
+                    freshObservations.tryEmit(
+                        FreshPurchases(
+                            purchases = purchases.orEmpty().filter { it.purchaseState == Purchase.PurchaseState.PURCHASED },
+                            // Push payloads only carry this session's purchases — they prove
+                            // presence, never absence.
+                            isFullSnapshot = false,
+                        )
+                    )
                 } else {
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
@@ -71,7 +103,14 @@ class BillingConnectionProvider @Inject constructor(
 
                 when (result.responseCode) {
                     BillingResponseCode.OK -> {
-                        val connection = BillingConnection(client, purchaseEvents, purchaseFailureEvents)
+                        val connection = BillingConnection(
+                            client = client,
+                            purchasesGlobal = purchasesGlobal,
+                            freshObservations = freshObservations,
+                            freshFailuresGlobal = freshFailures,
+                            purchaseFailureEvents = purchaseFailureEvents,
+                            listenerGeneration = { listenerGeneration.get() },
+                        )
                         trySendBlocking(connection)
                     }
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/FreshPurchases.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/FreshPurchases.kt
@@ -1,0 +1,11 @@
+package eu.darken.octi.common.upgrade.core.billing.client
+
+import com.android.billingclient.api.Purchase
+
+// Provenance-tagged fresh purchase observation: a full snapshot (both product types queried
+// conclusively, with no purchase event racing the queries) proves absence; anything else — push
+// payloads, single-type queries, partial or raced refreshes — proves presence only.
+data class FreshPurchases(
+    val purchases: Collection<Purchase>,
+    val isFullSnapshot: Boolean,
+)

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeEvents.kt
@@ -2,4 +2,7 @@ package eu.darken.octi.common.upgrade.ui
 
 sealed class UpgradeEvents {
     data object RestoreFailed : UpgradeEvents()
+    data object RestoreSucceeded : UpgradeEvents()
+    data object SubscriptionStillRenewing : UpgradeEvents()
+    data object SubscriptionCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(forced = key.forced) }
+        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(forced = key.forced, manage = key.manage) }
     }
 
     @Module

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -17,13 +17,13 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,107 +33,117 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import eu.darken.octi.R
 import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
-import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.R as CommonR
 
 @Composable
 fun UpgradeScreenHost(
-    forced: Boolean,
+    forced: Boolean = false,
+    manage: Boolean = false,
     vm: UpgradeViewModel = hiltViewModel(),
 ) {
-    vm.initialize(forced)
-
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
+
+    // Bind the route BEFORE anything else can race the auto-close collector.
+    LaunchedEffect(forced, manage) { vm.initialize(forced = forced, manage = manage) }
 
     val context = LocalContext.current
     val activity = context as? Activity
 
-    LaunchedEffect(vm.billingEvents) {
-        vm.billingEvents.collect { event ->
-            if (activity == null) return@collect
-            when (event) {
-                UpgradeViewModel.BillingEvent.LaunchIap -> vm.launchBillingIap(activity)
-                UpgradeViewModel.BillingEvent.LaunchSubscription -> vm.launchBillingSubscription(activity)
-                UpgradeViewModel.BillingEvent.LaunchSubscriptionTrial -> vm.launchBillingSubscriptionTrial(activity)
-            }
-        }
-    }
-
+    var showStillRenewingDialog by remember { mutableStateOf(false) }
+    var showCheckFailedDialog by remember { mutableStateOf(false) }
     var showRestoreFailedDialog by remember { mutableStateOf(false) }
+
+    val restoreSuccessMessage = stringResource(R.string.upgrade_screen_restore_success_message)
 
     LaunchedEffect(vm.events) {
         vm.events.collect { event ->
             when (event) {
                 UpgradeEvents.RestoreFailed -> showRestoreFailedDialog = true
+                UpgradeEvents.RestoreSucceeded ->
+                    Toast.makeText(context, restoreSuccessMessage, Toast.LENGTH_LONG).show()
+
+                UpgradeEvents.SubscriptionStillRenewing -> showStillRenewingDialog = true
+                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailedDialog = true
             }
         }
     }
 
-    if (showRestoreFailedDialog) {
-        RestoreFailedDialog(onDismiss = { showRestoreFailedDialog = false })
+    // Returning from Play's subscription-management page must refresh the renewal state promptly.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) vm.onResume()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    val state by vm.state.collectAsState(initial = null)
+    val state by vm.state.collectAsState()
     UpgradeScreen(
         state = state,
         onNavigateUp = { vm.navUp() },
-        onIap = { vm.onGoIap() },
-        onSubscription = { vm.onGoSubscription() },
-        onSubscriptionTrial = { vm.onGoSubscriptionTrial() },
+        onIap = { activity?.let { vm.onGoIap(it) } },
+        onSubscription = { activity?.let { vm.onGoSubscription(it) } },
+        onSubscriptionTrial = { activity?.let { vm.onGoSubscriptionTrial(it) } },
         onRestore = { vm.restorePurchase() },
+        onManageSubscription = { vm.onManageSubscription() },
+        onSeeUpgradeOptions = { vm.onSeeUpgradeOptions() },
+        onContactSupport = { vm.onContactSupport() },
     )
-}
 
-@Composable
-private fun RestoreFailedDialog(onDismiss: () -> Unit) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        text = {
-            Text(
-                text = listOf(
-                    stringResource(R.string.upgrade_screen_restore_purchase_message),
-                    stringResource(R.string.upgrade_screen_restore_troubleshooting_msg),
-                    stringResource(R.string.upgrade_screen_restore_sync_patience_hint),
-                    stringResource(R.string.upgrade_screen_restore_multiaccount_hint),
-                ).joinToString("\n\n"),
-            )
-        },
-        confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(text = stringResource(CommonR.string.general_dismiss_action))
-            }
-        },
-    )
+    if (showStillRenewingDialog) {
+        StillRenewingDialog(
+            onManage = {
+                showStillRenewingDialog = false
+                vm.onManageSubscription()
+            },
+            onDismiss = { showStillRenewingDialog = false },
+        )
+    }
+    if (showCheckFailedDialog) {
+        CheckFailedDialog(onDismiss = { showCheckFailedDialog = false })
+    }
+    if (showRestoreFailedDialog) {
+        RestoreFailedDialog(onDismiss = { showRestoreFailedDialog = false })
+    }
 }
 
 @Composable
 fun UpgradeScreen(
-    state: UpgradeViewModel.State?,
+    state: UpgradeUiState?,
     onNavigateUp: () -> Unit,
     onIap: () -> Unit,
     onSubscription: () -> Unit,
     onSubscriptionTrial: () -> Unit,
     onRestore: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onSeeUpgradeOptions: () -> Unit,
+    onContactSupport: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -165,108 +175,376 @@ fun UpgradeScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Spacer(modifier = Modifier.height(8.dp))
-
             OctiMascot(modifier = Modifier.size(72.dp))
-
             Spacer(modifier = Modifier.height(8.dp))
 
-            ElevatedCard(
-                modifier = Modifier.fillMaxWidth(),
-                colors = CardDefaults.elevatedCardColors(
-                    containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-                ),
-            ) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_preamble),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(16.dp),
-                )
-            }
+            when (state) {
+                null, is UpgradeUiState.Loading -> LoadingContent()
+                is UpgradeUiState.Loaded -> when {
+                    state.ownership.ownsAnything -> OwnedContent(
+                        state = state,
+                        onIap = onIap,
+                        onManageSubscription = onManageSubscription,
+                    )
 
-            if (state?.wasPreviouslyPro == true) {
-                Spacer(modifier = Modifier.height(16.dp))
-                RestoreBanner(
-                    onRestore = onRestore,
-                    restoreInProgress = state.restoreInProgress,
-                )
-            }
+                    state.grace != null -> GraceContent(
+                        grace = state.grace,
+                        restoreInProgress = state.restoreInProgress,
+                        onRestore = onRestore,
+                        onContactSupport = onContactSupport,
+                    )
 
-            Spacer(modifier = Modifier.height(24.dp))
+                    state.showFreeStatus -> FreeStatusContent(onSeeUpgradeOptions = onSeeUpgradeOptions)
 
-            Text(
-                text = stringResource(R.string.upgrade_screen_benefits_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_benefits_body),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_how_title),
-                style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            Text(
-                text = stringResource(R.string.upgrade_screen_how_body2),
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier.fillMaxWidth(),
-            )
-
-            // Trial copy is promise-accurate: only shown when Play actually offers the trial to
-            // this account, matching the button below.
-            if (state?.trialAvailable == true) {
-                Text(
-                    text = stringResource(R.string.upgrade_screen_how_trial_hint),
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            if (state == null || state.pricingLoading) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(32.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CircularProgressIndicator()
-                }
-            } else if (state.pricing != null) {
-                PricingContent(
-                    pricing = state.pricing,
-                    onIap = onIap,
-                    onSubscription = onSubscription,
-                    onSubscriptionTrial = onSubscriptionTrial,
-                )
-            } else {
-                PricingUnavailable()
-            }
-
-            if (state != null) {
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Restore is available regardless of whether pricing could be loaded — a returning
-                // buyer with a flaky Play connection is exactly who needs it.
-                TextButton(
-                    onClick = onRestore,
-                    enabled = !state.restoreInProgress,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+                    else -> OffersContent(
+                        state = state,
+                        onIap = onIap,
+                        onSubscription = onSubscription,
+                        onSubscriptionTrial = onSubscriptionTrial,
+                        onRestore = onRestore,
+                    )
                 }
             }
 
             Spacer(modifier = Modifier.height(32.dp))
         }
+    }
+}
+
+@Composable
+private fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(32.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun StatusCard(
+    title: String,
+    body: String,
+    container: Color = MaterialTheme.colorScheme.tertiaryContainer,
+    content: @Composable (() -> Unit)? = null,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(containerColor = container),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = title, style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(text = body, style = MaterialTheme.typography.bodyMedium)
+            content?.let {
+                Spacer(modifier = Modifier.height(12.dp))
+                it()
+            }
+        }
+    }
+}
+
+@Composable
+private fun OwnedContent(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onManageSubscription: () -> Unit,
+) {
+    val subscription = state.ownership.subscription
+
+    StatusCard(
+        title = stringResource(R.string.upgrade_screen_owned_title),
+        body = stringResource(R.string.upgrade_screen_owned_body),
+    )
+
+    if (state.ownership.hasIap) {
+        Spacer(modifier = Modifier.height(16.dp))
+        StatusCard(
+            title = stringResource(R.string.upgrade_screen_owned_iap_title),
+            body = stringResource(R.string.upgrade_screen_owned_iap_body),
+        )
+    }
+
+    if (subscription != null) {
+        Spacer(modifier = Modifier.height(16.dp))
+        StatusCard(
+            title = stringResource(R.string.upgrade_screen_owned_sub_title),
+            body = stringResource(
+                if (subscription.isAutoRenewing) R.string.upgrade_screen_owned_sub_renewing_body
+                else R.string.upgrade_screen_owned_sub_not_renewing_body
+            ),
+        ) {
+            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        }
+    }
+
+    // Own both: warn so the user can cancel the (redundant) subscription in Play.
+    if (state.ownership.hasIap && subscription != null) {
+        Spacer(modifier = Modifier.height(16.dp))
+        StatusCard(
+            title = stringResource(R.string.upgrade_screen_owned_both_title),
+            body = stringResource(R.string.upgrade_screen_owned_both_warning),
+            container = MaterialTheme.colorScheme.errorContainer,
+        ) {
+            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        }
+    }
+
+    // Switch offer: a subscriber without the lifetime purchase can move over. Locked while the
+    // subscription still auto-renews (cancel in Play first); the purchase gate re-verifies anyway.
+    if (subscription != null && !state.ownership.hasIap) {
+        Spacer(modifier = Modifier.height(16.dp))
+        SwitchCard(
+            renewing = subscription.isAutoRenewing,
+            iapPrice = state.iapPrice,
+            iapEnabled = state.iapEnabled,
+            onIap = onIap,
+            onManageSubscription = onManageSubscription,
+        )
+    }
+}
+
+@Composable
+private fun SwitchCard(
+    renewing: Boolean,
+    iapPrice: String?,
+    iapEnabled: Boolean,
+    onIap: () -> Unit,
+    onManageSubscription: () -> Unit,
+) {
+    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_switch_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_switch_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            if (renewing) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.upgrade_screen_switch_locked_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
+                    Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
+                }
+            } else {
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onIap,
+                    enabled = iapEnabled,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = if (iapPrice != null) {
+                            stringResource(R.string.upgrade_screen_switch_action, iapPrice)
+                        } else {
+                            stringResource(R.string.upgrade_screen_iap_action)
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GraceContent(
+    grace: GraceHint,
+    restoreInProgress: Boolean,
+    onRestore: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    StatusCard(
+        title = stringResource(R.string.upgrade_screen_grace_title),
+        body = stringResource(
+            if (grace.showDiagnostics) R.string.upgrade_screen_grace_diagnostics_body
+            else R.string.upgrade_screen_grace_body
+        ),
+    ) {
+        if (grace.showDiagnostics) {
+            Button(
+                onClick = onRestore,
+                enabled = !restoreInProgress,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (restoreInProgress) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(onClick = onContactSupport, modifier = Modifier.fillMaxWidth()) {
+                Text(text = stringResource(R.string.upgrade_screen_contact_support_action))
+            }
+        } else {
+            Box(
+                modifier = Modifier.fillMaxWidth(),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FreeStatusContent(onSeeUpgradeOptions: () -> Unit) {
+    StatusCard(
+        title = stringResource(R.string.upgrade_screen_free_status_title),
+        body = stringResource(R.string.upgrade_screen_free_status_body),
+    ) {
+        Button(onClick = onSeeUpgradeOptions, modifier = Modifier.fillMaxWidth()) {
+            Text(text = stringResource(R.string.upgrade_screen_see_options_action))
+        }
+    }
+}
+
+@Composable
+private fun OffersContent(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onSubscription: () -> Unit,
+    onSubscriptionTrial: () -> Unit,
+    onRestore: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+
+    if (state.showRestoreBanner) {
+        Spacer(modifier = Modifier.height(16.dp))
+        RestoreBanner(onRestore = onRestore, restoreInProgress = state.restoreInProgress)
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Text(
+        text = stringResource(R.string.upgrade_screen_benefits_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Text(
+        text = stringResource(R.string.upgrade_screen_benefits_body),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    Text(
+        text = stringResource(R.string.upgrade_screen_how_title),
+        style = MaterialTheme.typography.titleMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Text(
+        text = stringResource(R.string.upgrade_screen_how_body2),
+        style = MaterialTheme.typography.bodyMedium,
+        modifier = Modifier.fillMaxWidth(),
+    )
+    if (state.subscriptionAction == SubscriptionAction.TRIAL) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_how_trial_hint),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+
+    Spacer(modifier = Modifier.height(24.dp))
+
+    if (!state.subAvailable && !state.iapAvailable) {
+        PricingUnavailable()
+    } else {
+        PricingContent(
+            state = state,
+            onIap = onIap,
+            onSubscription = onSubscription,
+            onSubscriptionTrial = onSubscriptionTrial,
+        )
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    // Restore is available regardless of whether pricing could be loaded — a returning buyer with a
+    // flaky Play connection is exactly who needs it.
+    TextButton(
+        onClick = onRestore,
+        enabled = !state.restoreInProgress,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+    }
+}
+
+@Composable
+private fun PricingContent(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onSubscription: () -> Unit,
+    onSubscriptionTrial: () -> Unit,
+) {
+    if (state.subAvailable) {
+        Button(
+            onClick = if (state.subscriptionAction == SubscriptionAction.TRIAL) onSubscriptionTrial else onSubscription,
+            enabled = state.subscriptionEnabled,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(
+                    if (state.subscriptionAction == SubscriptionAction.TRIAL) R.string.upgrade_screen_subscription_trial_action
+                    else R.string.upgrade_screen_subscription_action
+                ),
+            )
+        }
+        state.subscriptionPrice?.let { price ->
+            Text(
+                text = stringResource(R.string.upgrade_screen_subscription_action_hint, price),
+                style = MaterialTheme.typography.labelSmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    OutlinedButton(
+        onClick = onIap,
+        enabled = state.iapEnabled && state.iapAvailable,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(text = stringResource(R.string.upgrade_screen_iap_action))
+    }
+    state.iapPrice?.let { price ->
+        Text(
+            text = stringResource(R.string.upgrade_screen_iap_action_hint, price),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -286,26 +564,19 @@ private fun RestoreBanner(
                 text = stringResource(R.string.upgrade_screen_restore_banner_title),
                 style = MaterialTheme.typography.titleMedium,
             )
-
             Spacer(modifier = Modifier.height(4.dp))
-
             Text(
                 text = stringResource(R.string.upgrade_screen_restore_banner_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
-
             Spacer(modifier = Modifier.height(12.dp))
-
             Button(
                 onClick = onRestore,
                 enabled = !restoreInProgress,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 if (restoreInProgress) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
                     Spacer(modifier = Modifier.width(8.dp))
                 }
                 Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
@@ -324,18 +595,13 @@ private fun PricingUnavailable() {
             textAlign = TextAlign.Center,
             modifier = Modifier.fillMaxWidth(),
         )
-
         Spacer(modifier = Modifier.height(8.dp))
-
         Text(
             text = stringResource(R.string.upgrades_gplay_unavailable_error_description),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.fillMaxWidth(),
         )
-
         Spacer(modifier = Modifier.height(8.dp))
-
-        // Same fix action the GplayServiceUnavailableException error dialog offers.
         OutlinedButton(
             onClick = {
                 try {
@@ -357,133 +623,151 @@ private fun PricingUnavailable() {
 }
 
 @Composable
-private fun PricingContent(
-    pricing: UpgradeViewModel.Pricing,
-    onIap: () -> Unit,
-    onSubscription: () -> Unit,
-    onSubscriptionTrial: () -> Unit,
-) {
-    val subOffer = pricing.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
-        OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(offer)
-    }
-    val subOfferTrial = pricing.sub?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
-        OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(offer)
-    }
-    val iapOffer = pricing.iap?.details?.oneTimePurchaseOfferDetails
-    val canSub = subOffer != null || subOfferTrial != null
+private fun StillRenewingDialog(onManage: () -> Unit, onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.upgrade_screen_sub_still_renewing_title)) },
+        text = { Text(text = stringResource(R.string.upgrade_screen_sub_still_renewing_message)) },
+        confirmButton = {
+            TextButton(onClick = onManage) {
+                Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(CommonR.string.general_dismiss_action))
+            }
+        },
+    )
+}
 
-    if (canSub) {
-        Button(
-            onClick = if (subOfferTrial != null) onSubscriptionTrial else onSubscription,
-            enabled = !pricing.hasSub,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
+@Composable
+private fun CheckFailedDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(R.string.upgrade_screen_sub_check_failed_title)) },
+        text = { Text(text = stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(CommonR.string.general_dismiss_action))
+            }
+        },
+    )
+}
+
+@Composable
+private fun RestoreFailedDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = {
             Text(
-                text = stringResource(
-                    if (subOfferTrial != null) R.string.upgrade_screen_subscription_trial_action
-                    else R.string.upgrade_screen_subscription_action
-                ),
+                text = listOf(
+                    stringResource(R.string.upgrade_screen_restore_purchase_message),
+                    stringResource(R.string.upgrade_screen_restore_troubleshooting_msg),
+                    stringResource(R.string.upgrade_screen_restore_sync_patience_hint),
+                    stringResource(R.string.upgrade_screen_restore_multiaccount_hint),
+                ).joinToString("\n\n"),
             )
-        }
-
-        val subPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice
-        if (subPrice != null) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint, subPrice),
-                style = MaterialTheme.typography.labelSmall,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    OutlinedButton(
-        onClick = onIap,
-        enabled = iapOffer != null && !pricing.hasIap,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(text = stringResource(R.string.upgrade_screen_iap_action))
-    }
-
-    if (iapOffer != null) {
-        Text(
-            text = stringResource(R.string.upgrade_screen_iap_action_hint, "${iapOffer.formattedPrice}"),
-            style = MaterialTheme.typography.labelSmall,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(CommonR.string.general_dismiss_action))
+            }
+        },
+    )
 }
 
 @Preview2
 @Composable
 private fun UpgradeScreenLoadingPreview() = PreviewWrapper {
     UpgradeScreen(
-        state = null,
-        onNavigateUp = {},
-        onIap = {},
-        onSubscription = {},
-        onSubscriptionTrial = {},
-        onRestore = {},
+        state = UpgradeUiState.Loading,
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
-private fun UpgradeScreenLoadedPreview() = PreviewWrapper {
+private fun UpgradeScreenOffersPreview() = PreviewWrapper {
     UpgradeScreen(
-        state = UpgradeViewModel.State(
-            pricing = UpgradeViewModel.Pricing(
-                iap = null,
-                sub = null,
-                hasIap = false,
-                hasSub = false,
-            ),
+        state = UpgradeUiState.Loaded(
+            subscriptionAction = SubscriptionAction.STANDARD,
+            subscriptionEnabled = true,
+            subscriptionPrice = "€1.99",
+            iapEnabled = true,
+            iapPrice = "€9.99",
         ),
-        onNavigateUp = {},
-        onIap = {},
-        onSubscription = {},
-        onSubscriptionTrial = {},
-        onRestore = {},
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
-private fun UpgradeScreenReturningBuyerPreview() = PreviewWrapper {
+private fun UpgradeScreenOwnedSubRenewingPreview() = PreviewWrapper {
     UpgradeScreen(
-        state = UpgradeViewModel.State(
-            pricing = UpgradeViewModel.Pricing(
-                iap = null,
-                sub = null,
-                hasIap = false,
-                hasSub = false,
-            ),
-            wasPreviouslyPro = true,
+        state = UpgradeUiState.Loaded(
+            subscriptionAction = SubscriptionAction.UNAVAILABLE,
+            subscriptionEnabled = false,
+            subscriptionPrice = null,
+            iapEnabled = false,
+            iapPrice = "€9.99",
+            ownership = Ownership(hasIap = false, subscription = SubscriptionOwnership(isAutoRenewing = true)),
         ),
-        onNavigateUp = {},
-        onIap = {},
-        onSubscription = {},
-        onSubscriptionTrial = {},
-        onRestore = {},
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
-private fun UpgradeScreenPricingUnavailablePreview() = PreviewWrapper {
+private fun UpgradeScreenSwitchAvailablePreview() = PreviewWrapper {
     UpgradeScreen(
-        state = UpgradeViewModel.State(
-            pricing = null,
-            pricingUnavailable = true,
-            wasPreviouslyPro = true,
+        state = UpgradeUiState.Loaded(
+            subscriptionAction = SubscriptionAction.UNAVAILABLE,
+            subscriptionEnabled = false,
+            subscriptionPrice = null,
+            iapEnabled = true,
+            iapPrice = "€9.99",
+            ownership = Ownership(hasIap = false, subscription = SubscriptionOwnership(isAutoRenewing = false)),
         ),
-        onNavigateUp = {},
-        onIap = {},
-        onSubscription = {},
-        onSubscriptionTrial = {},
-        onRestore = {},
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenGraceDiagnosticsPreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeUiState.Loaded(
+            subscriptionAction = SubscriptionAction.UNAVAILABLE,
+            subscriptionEnabled = false,
+            subscriptionPrice = null,
+            iapEnabled = false,
+            iapPrice = null,
+            grace = GraceHint(showDiagnostics = true),
+        ),
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenFreeStatusPreview() = PreviewWrapper {
+    UpgradeScreen(
+        state = UpgradeUiState.Loaded(
+            subscriptionAction = SubscriptionAction.STANDARD,
+            subscriptionEnabled = true,
+            subscriptionPrice = "€1.99",
+            iapEnabled = true,
+            iapPrice = "€9.99",
+            manageMode = true,
+            viewingOffers = false,
+        ),
+        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeUiState.kt
@@ -1,0 +1,109 @@
+package eu.darken.octi.common.upgrade.ui
+
+import eu.darken.octi.common.upgrade.core.OurSku
+import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.octi.common.upgrade.core.billing.SkuDetails
+
+sealed interface UpgradeUiState {
+
+    data object Loading : UpgradeUiState
+
+    data class Loaded(
+        val subscriptionAction: SubscriptionAction,
+        val subscriptionEnabled: Boolean,
+        val subscriptionPrice: String?,
+        val iapEnabled: Boolean,
+        val iapPrice: String?,
+        val ownership: Ownership = Ownership(),
+        val grace: GraceHint? = null,
+        val showRestoreBanner: Boolean = false,
+        val settled: Boolean = true,
+        val restoreInProgress: Boolean = false,
+        val verificationInProgress: Boolean = false,
+        // Manage route + free user: show the calm status page first, revealing the offers only when
+        // the user asks. Sales route or an existing owner/grace user always sees the relevant view.
+        val manageMode: Boolean = false,
+        val viewingOffers: Boolean = false,
+    ) : UpgradeUiState {
+        val subAvailable: Boolean get() = subscriptionAction != SubscriptionAction.UNAVAILABLE
+        val iapAvailable: Boolean get() = iapPrice != null
+        val isFree: Boolean get() = !ownership.ownsAnything && grace == null
+        // Free user on the manage route who hasn't asked to see the offers yet.
+        val showFreeStatus: Boolean get() = isFree && manageMode && !viewingOffers
+    }
+}
+
+// Pro but no owned purchase in the current data — the grace period is carrying the entitlement.
+// Quiet at first (a Play hiccup usually resolves itself), diagnostics once the unconfirmed episode
+// has aged past the threshold.
+data class GraceHint(val showDiagnostics: Boolean)
+
+data class Ownership(
+    val hasIap: Boolean = false,
+    val subscription: SubscriptionOwnership? = null,
+) {
+    val ownsAnything: Boolean get() = hasIap || subscription != null
+}
+
+data class SubscriptionOwnership(val isAutoRenewing: Boolean)
+
+enum class SubscriptionAction { TRIAL, STANDARD, UNAVAILABLE }
+
+// Conservative: if ANY record for the sub SKU still claims auto-renew, treat it as renewing — that
+// can only under-offer the switch to the one-time purchase, and the purchase gate re-verifies
+// against a fresh SUBS query before any billing flow starts anyway.
+fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
+    hasIap = upgrades.any { it.sku.id == OurSku.Iap.PRO_UPGRADE.id },
+    subscription = upgrades
+        .filter { it.sku.id == OurSku.Sub.PRO_UPGRADE.id }
+        .takeIf { it.isNotEmpty() }
+        ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
+)
+
+// Aggregate result of the one-shot SKU detail queries. `done` distinguishes "queries still running"
+// from "queries finished but found nothing" — owners render without waiting either way.
+data class SkuQueryState(
+    val done: Boolean = false,
+    val iap: SkuDetails? = null,
+    val sub: SkuDetails? = null,
+)
+
+fun toLoadedState(
+    skus: SkuQueryState,
+    ownership: Ownership,
+    grace: GraceHint?,
+    showRestoreBanner: Boolean,
+    settled: Boolean,
+    restoreInProgress: Boolean,
+    verificationInProgress: Boolean,
+    manageMode: Boolean,
+    viewingOffers: Boolean,
+): UpgradeUiState.Loaded {
+    val iapOffer = skus.iap?.details?.oneTimePurchaseOfferDetails
+    val subOffers = skus.sub?.details?.subscriptionOfferDetails
+    val baseOffer = subOffers?.firstOrNull { OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(it) }
+    val trialOffer = subOffers?.firstOrNull { OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(it) }
+
+    return UpgradeUiState.Loaded(
+        subscriptionAction = when {
+            trialOffer != null -> SubscriptionAction.TRIAL
+            baseOffer != null -> SubscriptionAction.STANDARD
+            else -> SubscriptionAction.UNAVAILABLE
+        },
+        // `settled` gates all purchase actions until the first billing reconciliation (or its
+        // bounded fallback): the initially-empty purchase state must not let an owner on a fresh
+        // install buy the other product before their existing purchase has been seen.
+        subscriptionEnabled = settled && ownership.subscription == null && !restoreInProgress && !verificationInProgress,
+        subscriptionPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
+        iapEnabled = settled && !ownership.hasIap && !restoreInProgress && !verificationInProgress,
+        iapPrice = iapOffer?.formattedPrice,
+        ownership = ownership,
+        grace = grace,
+        showRestoreBanner = showRestoreBanner,
+        settled = settled,
+        restoreInProgress = restoreInProgress,
+        verificationInProgress = verificationInProgress,
+        manageMode = manageMode,
+        viewingOffers = viewingOffers,
+    )
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -3,6 +3,8 @@ package eu.darken.octi.common.upgrade.ui
 import android.app.Activity
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.common.BuildConfigWrap
+import eu.darken.octi.common.WebpageTool
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
@@ -11,208 +13,407 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.SingleEventFlow
+import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.octi.common.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import eu.darken.octi.common.widget.WidgetManager
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.hours
 
 @HiltViewModel
 class UpgradeViewModel @Inject constructor(
-    @Suppress("unused") private val handle: SavedStateHandle,
+    private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoGplay,
     private val widgetManagers: Set<@JvmSuppressWildcards WidgetManager>,
+    private val webpageTool: WebpageTool,
+    private val clock: Clock,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
-    private var initialized = false
+    val events = SingleEventFlow<UpgradeEvents>()
+
     private val widgetsRefreshedForUpgrade = AtomicBoolean(false)
 
-    val events = SingleEventFlow<UpgradeEvents>()
-    val billingEvents = SingleEventFlow<BillingEvent>()
+    private fun nowMs(): Long = clock.now().toEpochMilliseconds()
 
-    fun initialize(forced: Boolean) {
-        if (initialized) return
-        initialized = true
+    // ONE authoritative admission guard for all mutually-exclusive billing actions. A single CAS
+    // from null closes the TOCTOU race that two independent "check the other flag, then set mine"
+    // flags have when the coroutines run on different threads (Dispatchers.Default).
+    private enum class Operation { RESTORE, PURCHASE }
 
-        upgradeRepo.upgradeInfo
+    private val activeOperation = MutableStateFlow<Operation?>(null)
+
+    // null until the host reports whether this is the manage route. The auto-close collector waits
+    // for it, so a manage visit can never race a premature navUp().
+    private val manageRoute = MutableStateFlow<Boolean?>(null)
+    private val autoClose = MutableStateFlow<Boolean?>(null)
+
+    // Free user on the manage route: reveal the offers only when asked. Persisted so a process
+    // recreation while looking at the offers doesn't bounce back to the status page.
+    private val viewingOffers = MutableStateFlow(handle.get<Boolean>(KEY_SHOW_OFFERS) ?: false)
+
+    fun initialize(forced: Boolean, manage: Boolean) {
+        if (manageRoute.value != null) return
+        log(TAG) { "initialize(forced=$forced, manage=$manage)" }
+        manageRoute.value = manage
+        // Sales route auto-closes on first Pro; a forced or manage visit stays open on purpose.
+        autoClose.value = !forced && !manage
+    }
+
+    // Purchase actions stay disabled until the first billing reconciliation of this process (or a
+    // bounded fallback so a Play outage can't brick the buttons): the initially-empty purchase state
+    // must not let an owner on a fresh install double-buy.
+    private val settled: StateFlow<Boolean> = merge(
+        upgradeRepo.isSettled.filter { it },
+        flow {
+            delay(SETTLE_FALLBACK_MS)
+            emit(true)
+        },
+    ).stateIn(vmScope, SharingStarted.Eagerly, false)
+
+    // One aggregate SKU-detail query per ViewModel lifetime, both types concurrently. Failures
+    // resolve to null details — owners/grace render price-independently, acquisition users get the
+    // fallback purchase UI.
+    private val skuQueries = flow {
+        emit(SkuQueryState())
+        val result = coroutineScope {
+            val iap = async { querySkuDetailsSafe(OurSku.Iap.PRO_UPGRADE) }
+            val sub = async { querySkuDetailsSafe(OurSku.Sub.PRO_UPGRADE) }
+            SkuQueryState(done = true, iap = iap.await(), sub = sub.await())
+        }
+        emit(result)
+    }.shareIn(vmScope, SharingStarted.Lazily, replay = 1)
+
+    private suspend fun querySkuDetailsSafe(sku: Sku): SkuDetails? = try {
+        withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
+            upgradeRepo.querySkus(sku).firstOrNull()
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Failed to query SKU ${sku.id}: ${e.asLog()}" }
+        null
+    }
+
+    // Re-evaluates the grace presentation when the open episode crosses the diagnostics threshold —
+    // every other combined flow is distinct-until-changed and would never re-fire.
+    private val graceTick = upgradeRepo.proUnconfirmedSince
+        .flatMapLatest { stamp ->
+            flow {
+                emit(Unit)
+                if (stamp > 0L) {
+                    val remaining = stamp + GRACE_DIAGNOSTICS_AFTER_MS - nowMs()
+                    if (remaining > 0) {
+                        delay(remaining)
+                        emit(Unit)
+                    }
+                }
+            }
+        }
+
+    private data class BillingState(
+        val info: UpgradeRepoGplay.Info?,
+        val wasEverPro: Boolean,
+        val proUnconfirmedSince: Long,
+    )
+
+    private val billingState = combine(
+        upgradeRepo.upgradeInfo,
+        upgradeRepo.wasEverPro,
+        upgradeRepo.proUnconfirmedSince,
+        graceTick,
+    ) { info, wasEverPro, unconfirmedSince, _ ->
+        BillingState(
+            info = info,
+            wasEverPro = wasEverPro,
+            proUnconfirmedSince = unconfirmedSince,
+        )
+    }
+
+    private data class UiInputs(
+        val settled: Boolean,
+        val restoring: Boolean,
+        val busy: Boolean,
+        val manage: Boolean,
+        val viewingOffers: Boolean,
+    )
+
+    private val uiInputs = combine(
+        settled,
+        activeOperation,
+        upgradeRepo.autoRestoreInProgress,
+        manageRoute.filterNotNull(),
+        viewingOffers,
+    ) { isSettled, operation, autoRestoring, manage, offers ->
+        UiInputs(
+            settled = isSettled,
+            restoring = operation == Operation.RESTORE,
+            // The invisible already-owned reconciliation runs off the VM's guard — treat it as busy
+            // so the buy buttons stay disabled while it resolves.
+            busy = operation == Operation.PURCHASE || autoRestoring,
+            manage = manage,
+            viewingOffers = offers,
+        )
+    }
+
+    val state: StateFlow<UpgradeUiState> = combine(
+        billingState,
+        skuQueries,
+        uiInputs,
+    ) { billing, skus, inputs ->
+        val info = billing.info
+        val ownership = info?.toOwnership() ?: Ownership()
+        val grace = if (info?.isPro == true && !ownership.ownsAnything) {
+            GraceHint(
+                showDiagnostics = billing.proUnconfirmedSince > 0L &&
+                    nowMs() - billing.proUnconfirmedSince >= GRACE_DIAGNOSTICS_AFTER_MS,
+            )
+        } else {
+            null
+        }
+
+        // Owners and grace users render price-independently: their status view must not degrade to a
+        // spinner (or an error) just because the SKU pricing queries failed or are slow.
+        val priceIndependent = ownership.ownsAnything || grace != null
+        if (!priceIndependent && !skus.done) {
+            UpgradeUiState.Loading
+        } else {
+            toLoadedState(
+                skus = skus,
+                ownership = ownership,
+                grace = grace,
+                // Hidden while a grace period or an actual purchase keeps the user Pro.
+                showRestoreBanner = billing.wasEverPro && info?.isPro != true,
+                settled = inputs.settled,
+                restoreInProgress = inputs.restoring,
+                verificationInProgress = inputs.busy,
+                manageMode = inputs.manage,
+                viewingOffers = inputs.viewingOffers,
+            )
+        }
+    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), UpgradeUiState.Loading)
+
+    init {
+        // Sales route: close once the user is Pro (purchase completed, or they were Pro all along).
+        // Manage/forced route: never auto-close — it exists to LOOK at the status.
+        autoClose
+            .filterNotNull()
+            .flatMapLatest { shouldClose ->
+                if (shouldClose) upgradeRepo.upgradeInfo else emptyFlow()
+            }
             .filter { it.isPro }
             .take(1)
             .onEach {
+                log(TAG) { "User is pro on the sales route, navigating back" }
                 refreshWidgetsForUpgrade()
-                if (!forced) navUp()
+                navUp()
             }
             .launchInViewModel()
     }
 
-    private val restoring = MutableStateFlow(false)
-
-    val state: Flow<State> = combine(
-        querySkuDetails(OurSku.Iap.PRO_UPGRADE),
-        querySkuDetails(OurSku.Sub.PRO_UPGRADE),
-        upgradeRepo.upgradeInfo,
-        upgradeRepo.wasEverPro,
-        restoring,
-    ) { iap, sub, current, wasEverPro, isRestoring ->
-        // Pricing is deliberately decoupled from entitlement: a returning buyer must see the
-        // restore banner and the restore action immediately, even while Google Play is still
-        // resolving (or failing to resolve) pricing.
-        val pricingLoading = iap is SkuQuery.Loading || sub is SkuQuery.Loading
-        val iapDetails = (iap as? SkuQuery.Done)?.details
-        val subDetails = (sub as? SkuQuery.Done)?.details
-        val pricing = when {
-            pricingLoading -> null
-
-            iapDetails == null && subDetails == null -> {
-                log(TAG, WARN) { "Pricing unavailable, IAP and SUB queries failed or timed out." }
-                null
-            }
-
-            else -> Pricing(
-                iap = iapDetails?.firstOrNull(),
-                sub = subDetails?.firstOrNull(),
-                hasIap = current.upgrades.any { it.sku == OurSku.Iap.PRO_UPGRADE },
-                hasSub = current.upgrades.any { it.sku == OurSku.Sub.PRO_UPGRADE },
-            )
-        }
-        State(
-            pricing = pricing,
-            pricingLoading = pricingLoading,
-            pricingUnavailable = !pricingLoading && pricing == null,
-            // Only advertise the free trial when Play actually returned the trial offer — accounts
-            // that already used their trial (or regions without it) get plain subscription copy.
-            trialAvailable = pricing?.sub?.details?.subscriptionOfferDetails
-                ?.any { OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(it) } == true,
-            wasPreviouslyPro = wasEverPro && !current.isPro,
-            restoreInProgress = isRestoring,
-        )
-    }.asStateFlow()
-
-    private sealed interface SkuQuery {
-        data object Loading : SkuQuery
-        data class Done(val details: Collection<SkuDetails>?) : SkuQuery
+    fun onSeeUpgradeOptions() {
+        log(TAG) { "onSeeUpgradeOptions()" }
+        handle[KEY_SHOW_OFFERS] = true
+        viewingOffers.value = true
     }
 
-    private fun querySkuDetails(sku: Sku): Flow<SkuQuery> = flow {
-        emit(SkuQuery.Loading)
-        val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT) {
-            try {
-                upgradeRepo.querySkus(sku)
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log(TAG, WARN) { "SKU query failed for $sku: ${e.asLog()}" }
-                null
+    fun onGoIap(activity: Activity) {
+        log(TAG, INFO) { "onGoIap()" }
+        launch {
+            runExclusive {
+                // ALWAYS verify against a fresh SUBS-only query, not just for known subscribers: the
+                // replayed ownership state can be stale or still empty right after process start, and
+                // a renewing subscriber must never double-buy. Fails closed.
+                val subscriptions = try {
+                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Subscription verification failed: ${e.asLog()}" }
+                    errorEvents.emit(e)
+                    return@runExclusive
+                }
+                when {
+                    subscriptions == null -> {
+                        log(TAG, WARN) { "Subscription verification timed out" }
+                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
+                    }
+
+                    subscriptions.any { it.isAutoRenewing } -> {
+                        log(TAG, INFO) { "Subscription still set to renew -> blocking IAP purchase" }
+                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    }
+
+                    else -> launchBillingFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+                }
             }
         }
-        emit(SkuQuery.Done(data))
     }
 
-    data class State(
-        val pricing: Pricing?,
-        val pricingLoading: Boolean = false,
-        val pricingUnavailable: Boolean = false,
-        val trialAvailable: Boolean = false,
-        val wasPreviouslyPro: Boolean = false,
-        val restoreInProgress: Boolean = false,
-    )
-
-    data class Pricing(
-        val iap: SkuDetails?,
-        val sub: SkuDetails?,
-        val hasSub: Boolean,
-        val hasIap: Boolean,
-    )
-
-    sealed class BillingEvent {
-        data object LaunchIap : BillingEvent()
-        data object LaunchSubscription : BillingEvent()
-        data object LaunchSubscriptionTrial : BillingEvent()
+    fun onGoSubscription(activity: Activity) {
+        log(TAG, INFO) { "onGoSubscription()" }
+        launch {
+            runExclusive { launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.BASE_OFFER) }
+        }
     }
 
-    fun onGoIap() {
-        log(TAG) { "onGoIap()" }
-        billingEvents.tryEmit(BillingEvent.LaunchIap)
+    fun onGoSubscriptionTrial(activity: Activity) {
+        log(TAG, INFO) { "onGoSubscriptionTrial()" }
+        launch {
+            runExclusive { launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER) }
+        }
     }
 
-    fun onGoSubscription() {
-        log(TAG) { "onGoSubscription()" }
-        billingEvents.tryEmit(BillingEvent.LaunchSubscription)
-    }
-
-    fun onGoSubscriptionTrial() {
-        log(TAG) { "onGoSubscriptionTrial()" }
-        billingEvents.tryEmit(BillingEvent.LaunchSubscriptionTrial)
-    }
-
-    fun launchBillingIap(activity: Activity) {
-        upgradeRepo.launchBillingFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
-    }
-
-    fun launchBillingSubscription(activity: Activity) {
-        upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.BASE_OFFER)
-    }
-
-    fun launchBillingSubscriptionTrial(activity: Activity) {
-        upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER)
-    }
-
-    fun restorePurchase() {
-        // Single-flight: repeated taps while a restore is running (worst case bounded by
-        // RESTORE_TIMEOUT) must not stack concurrent restores and duplicate result dialogs.
-        if (!restoring.compareAndSet(expect = false, update = true)) {
-            log(TAG) { "restorePurchase() ignored, already in progress" }
+    // Single-flight for purchase actions: the guard is held from the tap until the Play sheet launch
+    // has resolved, so repeated taps can't stack verification queries or billing flows, and a
+    // restore can't overlap either. Atomic single CAS from null — no check-then-set race.
+    private suspend fun runExclusive(block: suspend () -> Unit) {
+        if (!activeOperation.compareAndSet(expect = null, update = Operation.PURCHASE)) {
+            log(TAG) { "Purchase action ignored, another operation is in flight" }
             return
         }
+        try {
+            block()
+        } finally {
+            activeOperation.value = null
+        }
+    }
 
-        launch {
-            log(TAG) { "restorePurchase()" }
-            try {
-                val restored = withTimeoutOrNull(RESTORE_TIMEOUT) { upgradeRepo.restorePurchaseNow() }
+    private suspend fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
+        try {
+            upgradeRepo.launchBillingFlowNow(activity, sku, offer)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ItemAlreadyOwnedBillingException) {
+            // Play returned "already owned" as the immediate launch result (not an async event, so
+            // the purchaseFailures auto-restore never sees it). Reconcile by restoring now, and only
+            // surface the error if the EXACT launched SKU still doesn't show up — a grace-only isPro
+            // or a different owned SKU doesn't explain this failure.
+            log(TAG, INFO) { "Already owned on launch, reconciling ${sku.id}" }
+            val restored = try {
+                withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            } catch (c: CancellationException) {
+                throw c
+            } catch (re: Exception) {
+                log(TAG, WARN) { "Reconcile restore failed: ${re.asLog()}" }
+                null
+            }
+            if (restored?.upgrades?.any { it.sku.id == sku.id } == true) {
+                log(TAG, INFO) { "Reconciled already-owned ${sku.id}" }
+                refreshWidgetsForUpgrade()
+                events.tryEmit(UpgradeEvents.RestoreSucceeded)
+            } else {
+                errorEvents.emit(e)
+            }
+        } catch (e: Exception) {
+            log(TAG, WARN) { "launchBillingFlow(${sku.id}) failed: ${e.asLog()}" }
+            errorEvents.emit(e)
+        }
+    }
 
-                when {
-                    restored == null -> {
-                        // Play never answered in time; the restore-failed dialog already suggests
-                        // waiting / clearing the Play cache, which fits a timeout too.
-                        log(TAG, WARN) { "Restore purchase timed out" }
-                        events.emit(UpgradeEvents.RestoreFailed)
-                    }
+    fun restorePurchase() = launch {
+        // Same authoritative guard as purchases: a single CAS from null admits at most one operation,
+        // so a restore can't overlap an in-flight verification/launch and vice versa (no stacked
+        // result dialogs), and repeated restore taps collapse to one.
+        if (!activeOperation.compareAndSet(expect = null, update = Operation.RESTORE)) {
+            log(TAG) { "restorePurchase() ignored, another operation is in flight" }
+            return@launch
+        }
+        log(TAG, INFO) { "restorePurchase()" }
 
-                    restored.isPro -> {
-                        log(TAG, INFO) { "Restored purchase :))" }
-                        refreshWidgetsForUpgrade()
-                    }
-
-                    else -> {
-                        log(TAG, WARN) { "Restore purchase failed" }
-                        events.emit(UpgradeEvents.RestoreFailed)
-                    }
+        try {
+            // Pad the round-trip to a minimum visible duration, CONCURRENTLY with the real query (a
+            // pad, not an add-on): warm caches can answer instantly, and a spinner that flashes for a
+            // single frame leaves the user unsure whether anything actually happened.
+            val restored = coroutineScope {
+                val minVisible = async { delay(RESTORE_MIN_VISIBLE_MS) }
+                val result = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+                minVisible.await()
+                result
+            }
+            when {
+                restored == null -> {
+                    // Play never answered in time; the restore-failed message already suggests
+                    // waiting / clearing the Play cache, which fits a timeout too.
+                    log(TAG, WARN) { "Restore purchase timed out" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
                 }
+
+                // An actual returned purchase is required — a grace-only isPro means Play still
+                // couldn't confirm anything, which is not a successful restore.
+                restored.upgrades.isNotEmpty() -> {
+                    log(TAG, INFO) { "Restored purchase :))" }
+                    refreshWidgetsForUpgrade()
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
+
+                else -> {
+                    log(TAG, WARN) { "Restore purchase found no purchase" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
+            // of the generic "restore failed" message, so the user can tell the two cases apart.
+            log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
+            errorEvents.emit(e)
+        } finally {
+            activeOperation.value = null
+        }
+    }
+
+    fun onManageSubscription() {
+        log(TAG, INFO) { "onManageSubscription()" }
+        webpageTool.open(PLAY_SUBSCRIPTION_URL)
+    }
+
+    fun onContactSupport() {
+        log(TAG, INFO) { "onContactSupport()" }
+        navTo(Nav.Settings.ContactSupport)
+    }
+
+    fun onResume() {
+        // Returning from Play (e.g. after cancelling renewal on the Manage page) must reflect the new
+        // renewal state promptly — a disabled switch button can't re-run the gate itself, so refresh
+        // the SUBS state here to heal the ownership UI and unlock the switch.
+        val current = state.value
+        val hasSub = (current as? UpgradeUiState.Loaded)?.ownership?.subscription != null
+        if (!hasSub) return
+        launch {
+            try {
+                withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                // Play/billing error (e.g. service unavailable): surface the proper error dialog
-                // instead of the generic "restore failed" message, so the user can tell the two
-                // cases apart.
-                log(TAG, WARN) { "Restore purchase errored: ${e.asLog()}" }
-                errorEvents.emit(e)
-            } finally {
-                // Reset only after result handling, so the single-flight guard covers the whole
-                // user-visible action, including dialog emission.
-                restoring.value = false
+                log(TAG, WARN) { "Resume subscription refresh failed: ${e.asLog()}" }
             }
         }
     }
@@ -233,8 +434,18 @@ class UpgradeViewModel @Inject constructor(
     }
 
     companion object {
-        private val SKU_QUERY_TIMEOUT = 5.seconds
-        private val RESTORE_TIMEOUT = 15.seconds
+        internal const val RESTORE_TIMEOUT_MS = 15_000L
+        // Long enough that the user believes a round-trip to Play happened, short enough not to drag.
+        internal const val RESTORE_MIN_VISIBLE_MS = 1_500L
+        internal const val VERIFY_TIMEOUT_MS = 10_000L
+        // The first SKU query after a Play sign-in has been observed to take >8s.
+        internal const val SKU_QUERY_TIMEOUT_MS = 15_000L
+        internal const val SETTLE_FALLBACK_MS = 10_000L
+        internal val GRACE_DIAGNOSTICS_AFTER_MS = 24.hours.inWholeMilliseconds
+        internal val PLAY_SUBSCRIPTION_URL =
+            "https://play.google.com/store/account/subscriptions" +
+                "?sku=${OurSku.Sub.PRO_UPGRADE.id}&package=${BuildConfigWrap.APPLICATION_ID}"
+        private const val KEY_SHOW_OFFERS = "upgrade.manage.showOffers"
         private val TAG = logTag("Upgrade", "Gplay", "ViewModel")
     }
 }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -41,4 +41,37 @@
     <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
+    <string name="upgrade_screen_restore_success_message">Purchase restored — thank you!</string>
+    <!-- Pro status / ownership -->
+    <string name="upgrade_screen_owned_title">You are Octi Pro 🎉</string>
+    <string name="upgrade_screen_owned_body">Thanks for supporting Octi! Your Pro features are unlocked.</string>
+    <string name="upgrade_screen_owned_iap_title">Lifetime purchase</string>
+    <string name="upgrade_screen_owned_iap_body">You own the one-time Pro purchase. It never expires.</string>
+    <string name="upgrade_screen_owned_sub_title">Subscription</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Your Pro subscription is active and renews automatically.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Your Pro subscription is active but set to not renew. It stays active until the end of the current period.</string>
+    <string name="upgrade_screen_owned_both_title">You own both</string>
+    <string name="upgrade_screen_owned_both_warning">You own both the subscription and the one-time purchase. To avoid paying twice, cancel the subscription in Google Play — you keep Pro through the lifetime purchase.</string>
+    <string name="upgrade_screen_manage_subscription_action">Manage subscription</string>
+    <!-- Switch subscription → one-time purchase -->
+    <string name="upgrade_screen_switch_title">Switch to a one-time purchase</string>
+    <string name="upgrade_screen_switch_body">Prefer to pay once instead of subscribing? You can buy the one-time Pro purchase and stop the subscription.</string>
+    <string name="upgrade_screen_switch_locked_note">Your subscription still renews automatically. Cancel it in Google Play first, then come back to buy the one-time purchase. Buying it here does not cancel or refund the subscription — use the same Google account.</string>
+    <string name="upgrade_screen_switch_action">Buy one-time purchase (%1$s)</string>
+    <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still set to renew. Cancel it in Google Play first so you are not charged twice, then buy the one-time purchase. This does not refund the subscription.</string>
+    <string name="upgrade_screen_sub_check_failed_title">Couldn\'t verify subscription</string>
+    <string name="upgrade_screen_sub_check_failed_message">Google Play didn\'t respond in time, so we can\'t safely confirm your subscription state. Please try again in a moment.</string>
+    <!-- Grace period -->
+    <string name="upgrade_screen_grace_title">Pro is still active</string>
+    <string name="upgrade_screen_grace_body">We\'re confirming your purchase with Google Play. Your Pro features stay unlocked in the meantime.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">We still can\'t confirm your purchase with Google Play. Your Pro features remain unlocked for now. Try restoring, or contact support if this persists.</string>
+    <string name="upgrade_screen_contact_support_action">Contact support</string>
+    <!-- Free status page (manage entry) -->
+    <string name="upgrade_screen_free_status_title">You are on the free version</string>
+    <string name="upgrade_screen_free_status_body">Upgrade to Octi Pro to unlock extra features and support development.</string>
+    <string name="upgrade_screen_see_options_action">See upgrade options</string>
+    <!-- Settings status row (gplay) -->
+    <string name="settings_upgrade_status_title">Octi Pro</string>
+    <string name="settings_upgrade_status_desc">See your Pro status and manage your upgrade</string>
 </resources>

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.twotone.Devices
 import androidx.compose.material.icons.twotone.Extension
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Settings
+import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.SupportAgent
 import androidx.compose.material.icons.twotone.Sync
 import androidx.compose.material.icons.twotone.Translate
@@ -54,6 +55,7 @@ fun SettingsIndexScreenHost(vm: SettingsIndexVM = hiltViewModel()) {
             onHelpTranslate = { vm.openUrl("https://crowdin.com/project/octi") },
             onAcknowledgements = { vm.navTo(Nav.Settings.Acknowledgements) },
             onPrivacyPolicy = { vm.openUrl(PrivacyPolicy.URL) },
+            onUpgradeStatus = { vm.navTo(Nav.Main.Upgrade(manage = true)) },
         )
     }
 }
@@ -71,6 +73,7 @@ fun SettingsIndexScreen(
     onHelpTranslate: () -> Unit,
     onAcknowledgements: () -> Unit,
     onPrivacyPolicy: () -> Unit,
+    onUpgradeStatus: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -116,6 +119,14 @@ fun SettingsIndexScreen(
             }
             item {
                 SettingsCategoryHeader(text = stringResource(R.string.settings_category_other_label))
+            }
+            item {
+                SettingsBaseItem(
+                    title = stringResource(R.string.settings_upgrade_status_title),
+                    subtitle = stringResource(R.string.settings_upgrade_status_desc),
+                    icon = Icons.TwoTone.Stars,
+                    onClick = onUpgradeStatus,
+                )
             }
             item {
                 SettingsBaseItem(
@@ -184,5 +195,6 @@ private fun SettingsIndexScreenPreview() = PreviewWrapper {
         onHelpTranslate = {},
         onAcknowledgements = {},
         onPrivacyPolicy = {},
+        onUpgradeStatus = {},
     )
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
@@ -1,0 +1,102 @@
+package eu.darken.octi.common.upgrade.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import eu.darken.octi.common.datastore.value
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+
+class BillingCacheTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private fun cache(scope: TestScope): BillingCache = BillingCache(
+        PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { File(tempDir, "billing.preferences_pb") },
+        )
+    )
+
+    @Test
+    fun `stamp sets anchor and clears any open episode`() = runTest {
+        val cache = cache(this)
+
+        cache.recordProUnconfirmed(0L) // no-op: no prior confirmation
+        cache.proUnconfirmedAt.value() shouldBe 0L
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1_000_000L)
+        cache.lastProStateAt.value() shouldBe 1_000_000L
+        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+        cache.proUnconfirmedAt.value() shouldBe 0L
+    }
+
+    @Test
+    fun `stamp with null sku keeps the previous sku`() = runTest {
+        val cache = cache(this)
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1_000_000L)
+
+        cache.stampLastProState(null, 2_000_000L)
+
+        cache.lastProStateAt.value() shouldBe 2_000_000L
+        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+    }
+
+    @Test
+    fun `unconfirmed is a no-op without a prior confirmation`() = runTest {
+        val cache = cache(this)
+        cache.recordProUnconfirmed(5_000_000L)
+        cache.proUnconfirmedAt.value() shouldBe 0L
+    }
+
+    @Test
+    fun `unconfirmed is rejected within the confirmation-age guard`() = runTest {
+        val cache = cache(this)
+        cache.stampLastProState("sku", 1_000_000L)
+
+        // 30s after confirmation < MIN_CONFIRMATION_AGE_MS (60s): treated as emission reordering.
+        cache.recordProUnconfirmed(1_000_000L + 30_000L)
+        cache.proUnconfirmedAt.value() shouldBe 0L
+    }
+
+    @Test
+    fun `unconfirmed opens the episode once and does not push it out`() = runTest {
+        val cache = cache(this)
+        cache.stampLastProState("sku", 1_000_000L)
+
+        val first = 1_000_000L + 120_000L
+        cache.recordProUnconfirmed(first)
+        cache.proUnconfirmedAt.value() shouldBe first
+
+        // A follow-up failure must NOT move the diagnostics threshold.
+        cache.recordProUnconfirmed(first + 500_000L)
+        cache.proUnconfirmedAt.value() shouldBe first
+    }
+
+    @Test
+    fun `stamp closes an open episode atomically`() = runTest {
+        val cache = cache(this)
+        cache.stampLastProState("sku", 1_000_000L)
+        cache.recordProUnconfirmed(1_000_000L + 120_000L)
+        cache.proUnconfirmedAt.value() shouldBe 1_120_000L
+
+        cache.stampLastProState("sku", 2_000_000L)
+        cache.proUnconfirmedAt.value() shouldBe 0L
+    }
+
+    @Test
+    fun `unconfirmed repairs a corrupt episode stamp`() = runTest {
+        val cache = cache(this)
+        cache.stampLastProState("sku", 5_000_000L)
+
+        // Corrupt: an episode start at/older than the last confirmation can't be real.
+        cache.proUnconfirmedAt.value(4_000_000L)
+
+        cache.recordProUnconfirmed(5_200_000L)
+        cache.proUnconfirmedAt.value() shouldBe 5_200_000L
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -6,19 +6,20 @@ import com.android.billingclient.api.Purchase
 import eu.darken.octi.common.datastore.DataStoreValue
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.BillingManager
+import eu.darken.octi.common.upgrade.core.billing.FreshBillingData
 import eu.darken.octi.common.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.coVerifyOrder
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -26,41 +27,48 @@ import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
 
 class UpgradeRepoGplayTest : BaseTest() {
 
     private val scope = CoroutineScope(Dispatchers.Unconfined)
     private val billingManager = mockk<BillingManager>()
     private val billingCache = mockk<BillingCache>()
-    private lateinit var lastProAtValue: DataStoreValue<Long>
-    private lateinit var lastProSkuValue: DataStoreValue<String>
+    private val clock = FakeClock(BASE_MS)
 
-    // Builds a repo whose stored last-pro timestamp is `lastProAt` and last-owned sku is `lastSku`.
-    // The Unconfined scope runs the init collectors (grace stamping, async already-owned) eagerly
-    // against the stubbed flows.
+    private class FakeClock(var nowMs: Long) : Clock {
+        override fun now(): Instant = Instant.fromEpochMilliseconds(nowMs)
+    }
+
     private fun repo(
-        lastProAt: Long,
+        lastProAt: Long = 0L,
         lastSku: String = "",
         billingData: BillingData = BillingData(emptySet()),
+        fresh: FreshBillingData? = null,
+        refreshFailures: Int = 0,
         purchaseFailures: List<BillingResult> = emptyList(),
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.freshBillingData } returns (fresh?.let { flowOf(it) } ?: emptyFlow())
+        every { billingManager.refreshFailures } returns
+            if (refreshFailures == 0) emptyFlow() else flowOf(*Array(refreshFailures) { Unit })
         every { billingManager.purchaseFailures } returns
             if (purchaseFailures.isEmpty()) emptyFlow() else flowOf(*purchaseFailures.toTypedArray())
-        lastProAtValue = mockk<DataStoreValue<Long>>(relaxed = true).apply {
-            every { flow } returns flowOf(lastProAt)
-        }
-        every { billingCache.lastProStateAt } returns lastProAtValue
-        lastProSkuValue = mockk<DataStoreValue<String>>(relaxed = true).apply {
-            every { flow } returns flowOf(lastSku)
-        }
-        every { billingCache.lastProStateSku } returns lastProSkuValue
-        return UpgradeRepoGplay(scope, TestDispatcherProvider(), billingManager, billingCache)
+
+        every { billingCache.lastProStateAt } returns dataStoreValue(lastProAt)
+        every { billingCache.lastProStateSku } returns dataStoreValue(lastSku)
+        every { billingCache.proUnconfirmedAt } returns dataStoreValue(0L)
+        coEvery { billingCache.stampLastProState(any(), any()) } just Runs
+        coEvery { billingCache.recordProUnconfirmed(any()) } just Runs
+
+        return UpgradeRepoGplay(scope, TestDispatcherProvider(), billingManager, billingCache, clock)
+    }
+
+    private fun <T> dataStoreValue(value: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(value)
     }
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
-
-    private fun now() = Clock.System.now().toEpochMilliseconds()
 
     private fun purchaseOf(vararg skuIds: String) = mockk<Purchase>().apply {
         every { products } returns skuIds.toList()
@@ -69,220 +77,129 @@ class UpgradeRepoGplayTest : BaseTest() {
 
     private fun proPurchase() = purchaseOf(*OurSku.PRO_SKUS.map { it.id }.toTypedArray())
 
+    private fun freshOf(data: BillingData, full: Boolean = true) = FreshBillingData(data, full)
+
     @Test fun `upgrade info pro status mapping`() {
-        UpgradeRepoGplay.Info(
-            gracePeriod = false,
-            billingData = null,
-        ).isPro shouldBe false
-
-        UpgradeRepoGplay.Info(
-            gracePeriod = true,
-            billingData = null,
-        ).isPro shouldBe true
-
-        UpgradeRepoGplay.Info(
-            gracePeriod = false,
-            billingData = BillingData(setOf(proPurchase())),
-        ).isPro shouldBe true
+        UpgradeRepoGplay.Info(gracePeriod = false, billingData = null).isPro shouldBe false
+        UpgradeRepoGplay.Info(gracePeriod = true, billingData = null).isPro shouldBe true
+        UpgradeRepoGplay.Info(gracePeriod = false, billingData = BillingData(setOf(proPurchase()))).isPro shouldBe true
     }
 
-    @Test fun `grace period spans a week`() {
-        // Keeps paying users pro through transient empty/failed Play Billing responses.
+    @Test fun `grace windows`() {
         UpgradeRepoGplay.PRO_GRACE_PERIOD shouldBe 7.days
+        UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP shouldBe 30.days
+        (UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP > UpgradeRepoGplay.PRO_GRACE_PERIOD) shouldBe true
     }
 
     @Test fun `restore returns pro when a purchase is found`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
-
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(setOf(proPurchase())))
         repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
     }
 
     @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(emptySet())
-
-        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(emptySet()))
+        repo(lastProAt = BASE_MS - 1_000).restorePurchaseNow().isPro shouldBe true
     }
 
-    @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(emptySet())
-
-        val expired = now() - UpgradeRepoGplay.PRO_GRACE_PERIOD.inWholeMilliseconds - 1_000
+    @Test fun `restore is not pro when empty and grace expired`() = runTest2 {
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(emptySet()))
+        val expired = BASE_MS - UpgradeRepoGplay.PRO_GRACE_PERIOD.inWholeMilliseconds - 1_000
         repo(lastProAt = expired).restorePurchaseNow().isPro shouldBe false
     }
 
     @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
         coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
-
-        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+        repo(lastProAt = BASE_MS - 1_000).restorePurchaseNow().isPro shouldBe true
     }
 
     @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
         coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
-
-        shouldThrow<RuntimeException> {
-            repo(lastProAt = 0L).restorePurchaseNow()
-        }
+        shouldThrow<RuntimeException> { repo(lastProAt = 0L).restorePurchaseNow() }
     }
 
     @Test fun `restore cancellation is not converted into grace pro state`() = runTest2 {
         coEvery { billingManager.refresh() } throws CancellationException("cancelled")
-
-        shouldThrow<CancellationException> {
-            repo(lastProAt = now() - 1_000).restorePurchaseNow()
-        }
+        shouldThrow<CancellationException> { repo(lastProAt = BASE_MS - 1_000).restorePurchaseNow() }
     }
 
-    @Test fun `permanent IAP keeps grace well beyond the subscription window`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(emptySet())
-        // 20 days ago: past the 7-day subscription window, but within the 30-day IAP window.
-        val twentyDaysAgo = now() - 20.days.inWholeMilliseconds
-
-        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+    @Test fun `permanent IAP keeps grace beyond the subscription window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(emptySet()))
+        repo(lastProAt = BASE_MS - 20.days.inWholeMilliseconds, lastSku = OurSku.Iap.PRO_UPGRADE.id)
             .restorePurchaseNow().isPro shouldBe true
     }
 
     @Test fun `subscription grace expires after the short window`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(emptySet())
-        val twentyDaysAgo = now() - 20.days.inWholeMilliseconds
-
-        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Sub.PRO_UPGRADE.id)
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(emptySet()))
+        repo(lastProAt = BASE_MS - 20.days.inWholeMilliseconds, lastSku = OurSku.Sub.PRO_UPGRADE.id)
             .restorePurchaseNow().isPro shouldBe false
-    }
-
-    @Test fun `IAP grace window is longer than the subscription window`() {
-        (UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP > UpgradeRepoGplay.PRO_GRACE_PERIOD) shouldBe true
-        UpgradeRepoGplay.PRO_GRACE_PERIOD_IAP shouldBe 30.days
     }
 
     @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {
         val iap = PurchasedSku(OurSku.Iap.PRO_UPGRADE, mockk<Purchase>())
         val sub = PurchasedSku(OurSku.Sub.PRO_UPGRADE, mockk<Purchase>())
-
         UpgradeRepoGplay.preferredProSku(listOf(sub, iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
-        UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
     }
 
-    @Test fun `unknown purchases do not refresh the grace timestamp`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(purchaseOf("some.unknown.product")))
-
-        val info = repo(lastProAt = 0L).restorePurchaseNow()
-
-        info.isPro shouldBe false
-        coVerify(exactly = 0) { lastProAtValue.update(any()) }
-        coVerify(exactly = 0) { lastProSkuValue.update(any()) }
+    @Test fun `a fresh full snapshot with a pro purchase stamps the anchor`() = runTest2 {
+        repo(lastProAt = 0L, fresh = freshOf(BillingData(setOf(proPurchase())), full = true))
+        coVerify(exactly = 1) { billingCache.stampLastProState(any(), any()) }
+        coVerify(exactly = 0) { billingCache.recordProUnconfirmed(any()) }
     }
 
-    @Test fun `unknown purchases do not suppress an active grace window`() = runTest2 {
-        // An unrecognized purchase must be treated like an empty response, not like a confirmed
-        // "not owned" — a user within grace stays pro.
-        coEvery { billingManager.refresh() } returns BillingData(setOf(purchaseOf("some.unknown.product")))
-
-        repo(lastProAt = now() - 1_000).restorePurchaseNow().isPro shouldBe true
+    @Test fun `a fresh full snapshot without a pro purchase opens the episode`() = runTest2 {
+        repo(lastProAt = BASE_MS - 120_000, fresh = freshOf(BillingData(emptySet()), full = true))
+        coVerify(exactly = 1) { billingCache.recordProUnconfirmed(any()) }
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
     }
 
-    @Test fun `a failed IAP query does not downgrade the stored IAP sku`() = runTest2 {
-        // Only a subscription came back, but the IAP query failed — the stored permanent-IAP sku
-        // must survive, otherwise the grace window silently shrinks from 30d to 7d.
-        coEvery { billingManager.refresh() } returns BillingData(
-            purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
-            iapQueryOk = false,
-        )
-
-        repo(lastProAt = now() - 1_000, lastSku = OurSku.Iap.PRO_UPGRADE.id)
-            .restorePurchaseNow().isPro shouldBe true
-
-        coVerify(exactly = 1) { lastProAtValue.update(any()) }
-        coVerify(exactly = 0) { lastProSkuValue.update(any()) }
+    @Test fun `presence-only fresh data without a pro purchase records nothing`() = runTest2 {
+        repo(lastProAt = BASE_MS - 120_000, fresh = freshOf(BillingData(emptySet()), full = false))
+        coVerify(exactly = 0) { billingCache.recordProUnconfirmed(any()) }
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
     }
 
-    @Test fun `a confirmed missing IAP lets the subscription take over the sku`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(
-            purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
-            iapQueryOk = true,
-        )
-
-        repo(lastProAt = now() - 1_000, lastSku = OurSku.Iap.PRO_UPGRADE.id)
-            .restorePurchaseNow().isPro shouldBe true
-
-        coVerify(exactly = 1) { lastProSkuValue.update(match { it("") == OurSku.Sub.PRO_UPGRADE.id }) }
+    @Test fun `a failed fresh attempt opens the episode`() = runTest2 {
+        repo(lastProAt = BASE_MS - 120_000, refreshFailures = 1)
+        coVerify(exactly = 1) { billingCache.recordProUnconfirmed(any()) }
     }
 
-    @Test fun `explicit restore stamps the grace cache, sku before timestamp`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
-
-        repo(lastProAt = 0L).restorePurchaseNow().isPro shouldBe true
-
-        coVerifyOrder {
-            lastProSkuValue.update(any())
-            lastProAtValue.update(any())
-        }
+    @Test fun `a background refresh failure opens the unconfirmed episode`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+        repo(lastProAt = BASE_MS - 1_000).refresh()
+        coVerify(atLeast = 1) { billingCache.recordProUnconfirmed(any()) }
     }
 
-    @Test fun `background refresh stamps the grace cache from the fresh result`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
-
-        repo(lastProAt = 0L).refresh()
-
-        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    @Test fun `a restore error within grace opens the unconfirmed episode`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+        repo(lastProAt = BASE_MS - 1_000).restorePurchaseNow().isPro shouldBe true
+        coVerify(atLeast = 1) { billingCache.recordProUnconfirmed(any()) }
     }
 
-    @Test fun `reactive emissions stamp once via the init collector, the map never stamps`() = runTest2 {
-        // billingData carries a pro purchase: the persistent init collector stamps exactly once.
-        // Collecting upgradeInfo runs the map at least twice (onStart-null + pro data) — the map is
-        // read-only now, so if it still stamped the count would exceed one.
-        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
-
-        repo.upgradeInfo.first { it.isPro }.isPro shouldBe true
-
-        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    @Test fun `an IAP anchor is kept sticky when only a subscription is seen`() = runTest2 {
+        repo(lastSku = OurSku.Iap.PRO_UPGRADE.id, fresh = freshOf(BillingData(setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)))))
+        coVerify(exactly = 1) { billingCache.stampLastProState(null, any()) }
     }
 
-    @Test fun `stale cached purchases behind a failed query do not renew grace`() = runTest2 {
-        // A failed IAP query keeps the previously cached IAP purchase in billingData (so ACKs can't
-        // starve) — but that's not fresh ownership proof and must not re-stamp the grace window.
-        repo(
-            lastProAt = 0L,
-            billingData = BillingData(
-                purchases = setOf(purchaseOf(OurSku.Iap.PRO_UPGRADE.id)),
-                iapQueryOk = false,
-            ),
-        )
-
-        coVerify(exactly = 0) { lastProAtValue.update(any()) }
-    }
-
-    @Test fun `a verified subscription renews grace even while the IAP query fails`() = runTest2 {
-        repo(
-            lastProAt = 0L,
-            billingData = BillingData(
-                purchases = setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)),
-                iapQueryOk = false,
-                subQueryOk = true,
-            ),
-        )
-
-        coVerify(exactly = 1) { lastProAtValue.update(any()) }
+    @Test fun `a subscription takes over the sku when there is no IAP anchor`() = runTest2 {
+        repo(lastSku = "", fresh = freshOf(BillingData(setOf(purchaseOf(OurSku.Sub.PRO_UPGRADE.id)))))
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, any()) }
     }
 
     @Test fun `async already-owned purchase event triggers a silent restore`() = runTest2 {
-        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
-
-        repo(
-            lastProAt = 0L,
-            purchaseFailures = listOf(result(BillingResponseCode.ITEM_ALREADY_OWNED)),
-        )
-
+        coEvery { billingManager.refresh() } returns freshOf(BillingData(setOf(proPurchase())))
+        repo(lastProAt = 0L, purchaseFailures = listOf(result(BillingResponseCode.ITEM_ALREADY_OWNED)))
         coVerify(exactly = 1) { billingManager.refresh() }
     }
 
     @Test fun `other async purchase failures do not trigger a restore`() = runTest2 {
-        repo(
-            lastProAt = 0L,
-            purchaseFailures = listOf(result(BillingResponseCode.DEVELOPER_ERROR)),
-        )
-
+        repo(lastProAt = 0L, purchaseFailures = listOf(result(BillingResponseCode.DEVELOPER_ERROR)))
         coVerify(exactly = 0) { billingManager.refresh() }
+    }
+
+    companion object {
+        // Fixed "now" well past the grace windows so relative timestamps stay positive.
+        private const val BASE_MS = 40L * 365 * 24 * 60 * 60 * 1000
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/BillingManagerTest.kt
@@ -8,6 +8,7 @@ import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.billing.client.BillingClientException
 import eu.darken.octi.common.upgrade.core.billing.client.BillingConnection
 import eu.darken.octi.common.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.octi.common.upgrade.core.billing.client.FreshPurchases
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -52,7 +53,7 @@ class BillingManagerTest : BaseTest() {
     // the path Play uses for immediate "buy" failures (returned result, not an exception).
     private fun TestScope.manager(launchFailureCode: Int): BillingManager {
         val connection = mockk<BillingConnection>().apply {
-            coEvery { refreshPurchases() } returns BillingData(emptySet())
+            coEvery { refreshPurchases() } returns FreshPurchases(emptySet(), isFullSnapshot = false)
             every { billingData } returns emptyFlow()
             coEvery { launchBillingFlow(any(), any(), null) } throws BillingClientException(result(launchFailureCode))
         }
@@ -130,7 +131,7 @@ class BillingManagerTest : BaseTest() {
         failure: () -> Throwable = { BillingException("Google Play hiccup") },
     ): Pair<BillingManager, () -> Int> {
         val healthyConnection = mockk<BillingConnection>().apply {
-            coEvery { refreshPurchases() } returns BillingData(emptySet())
+            coEvery { refreshPurchases() } returns FreshPurchases(emptySet(), isFullSnapshot = false)
             every { billingData } returns emptyFlow()
         }
         var attempts = 0
@@ -150,7 +151,7 @@ class BillingManagerTest : BaseTest() {
         // A user action (restore/buy/pricing) right after the user fixed the Play/account state
         // must not keep failing on the stale cached error until the retry delay elapses.
         val timeBefore = currentTime
-        manager.refresh().purchases shouldBe emptySet()
+        manager.refresh().data.purchases shouldBe emptySet()
 
         attempts() shouldBe 2
         // On-demand retry, not the virtual clock skipping the retry delay.
@@ -169,7 +170,7 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         attempts() shouldBe 2
-        manager.refresh().purchases shouldBe emptySet()
+        manager.refresh().data.purchases shouldBe emptySet()
     }
 
     @Test fun `the on-demand retry wait is bounded, a wedged attempt fails with the known error`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -7,6 +7,7 @@ import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesResult
 import com.android.billingclient.api.QueryPurchasesParams
 import com.android.billingclient.api.queryPurchasesAsync
+import eu.darken.octi.common.upgrade.core.OurSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -14,15 +15,46 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.util.concurrent.atomic.AtomicLong
 
 class BillingConnectionTest : BaseTest() {
 
     private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+
+    private fun subPurchase(token: String, autoRenewing: Boolean) = mockk<Purchase>().apply {
+        every { purchaseTime } returns 1_000
+        every { purchaseToken } returns token
+        every { purchaseState } returns Purchase.PurchaseState.PURCHASED
+        every { products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
+        every { isAutoRenewing } returns autoRenewing
+    }
+
+    private fun connectionWith(
+        client: BillingClient,
+        overlay: Collection<Purchase> = emptyList(),
+        generation: AtomicLong = AtomicLong(0),
+    ): Pair<BillingConnection, MutableStateFlow<Collection<Purchase>>> {
+        val purchasesGlobal = MutableStateFlow(overlay)
+        val fresh = MutableSharedFlow<FreshPurchases>(replay = 1, extraBufferCapacity = 16, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+        val freshFail = MutableSharedFlow<Unit>(replay = 1, extraBufferCapacity = 8, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+        val connection = BillingConnection(
+            client = client,
+            purchasesGlobal = purchasesGlobal,
+            freshObservations = fresh,
+            freshFailuresGlobal = freshFail,
+            purchaseFailureEvents = flowOf(null),
+            listenerGeneration = { generation.get() },
+        )
+        return connection to purchasesGlobal
+    }
 
     @Test fun `combines both product types, newest first`() {
         val older = purchase(1_000)
@@ -98,12 +130,85 @@ class BillingConnectionTest : BaseTest() {
                     )
                 }
             }
-            val connection = BillingConnection(client, flowOf(null), flowOf(null))
+            val (connection, _) = connectionWith(client)
 
             connection.refreshPurchases().purchases shouldBe listOf(owned)
             // The failed type's cache is seeded empty, so the combined flow must still emit —
             // otherwise purchase acknowledgement would be starved by one broken product type.
             connection.billingData.first().purchases shouldBe listOf(owned)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySubscriptions prunes a stale renewing overlay when the sub is gone`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val client = mockk<BillingClient>()
+            // The user cancelled + the sub lapsed: a conclusive SUBS query returns nothing.
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } coAnswers {
+                PurchasesResult(
+                    BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build(),
+                    emptyList(),
+                )
+            }
+            // A stale listener record still claims the subscription auto-renews.
+            val stale = subPurchase(token = "sub1", autoRenewing = true)
+            val (connection, overlay) = connectionWith(client, overlay = listOf(stale))
+
+            // No renewing sub survives — the switch-to-IAP gate can unlock.
+            connection.querySubscriptions() shouldBe emptyList()
+            overlay.value shouldBe emptyList()
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySubscriptions keeps a renewing record when a purchase event races the query`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val client = mockk<BillingClient>()
+            val generation = AtomicLong(0)
+            val racing = subPurchase(token = "sub2", autoRenewing = true)
+            val (connection, overlay) = connectionWith(client, overlay = listOf(racing), generation = generation)
+
+            // A purchase event lands mid-query (generation bumps): the empty query result must NOT
+            // prune the newer listener record — over-blocking the switch is safe, missing it isn't.
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } coAnswers {
+                generation.incrementAndGet()
+                PurchasesResult(
+                    BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build(),
+                    emptyList(),
+                )
+            }
+
+            connection.querySubscriptions().map { it.purchaseToken } shouldBe listOf("sub2")
+            overlay.value shouldBe listOf(racing)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySubscriptions lets a racing renewing record win over an older query row for the same token`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val client = mockk<BillingClient>()
+            val generation = AtomicLong(0)
+            // The query row says the subscription no longer renews...
+            val queried = subPurchase(token = "sub1", autoRenewing = false)
+            // ...but a newer listener event for the SAME token says it does. It must win, or the gate
+            // would see only the stale non-renewing row and let a renewing subscriber double-buy.
+            val racing = subPurchase(token = "sub1", autoRenewing = true)
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } coAnswers {
+                generation.incrementAndGet() // a purchase event raced the query
+                PurchasesResult(
+                    BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build(),
+                    listOf(queried),
+                )
+            }
+            val (connection, _) = connectionWith(client, overlay = listOf(racing), generation = generation)
+
+            connection.querySubscriptions().any { it.isAutoRenewing } shouldBe true
         } finally {
             unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
         }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,10 +1,12 @@
 package eu.darken.octi.common.upgrade.ui
 
+import android.app.Activity
 import androidx.lifecycle.SavedStateHandle
-import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.Purchase
+import eu.darken.octi.common.WebpageTool
 import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
-import eu.darken.octi.common.upgrade.core.billing.SkuDetails
+import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.widget.WidgetManager
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -14,180 +16,200 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class UpgradeViewModelTest : BaseTest() {
 
     private val testDispatcher = StandardTestDispatcher()
+    private val webpageTool = mockk<WebpageTool>(relaxed = true)
+    private val clock = object : Clock {
+        override fun now(): Instant = Instant.fromEpochMilliseconds(BASE_MS)
+    }
+    private val activity = mockk<Activity>(relaxed = true)
+
+    private fun infoOf(vararg purchases: Purchase) = UpgradeRepoGplay.Info(
+        gracePeriod = false,
+        billingData = BillingData(purchases.toSet()),
+    )
 
     private fun mockRepo(
-        isProViaGrace: Boolean = false,
+        info: UpgradeRepoGplay.Info = UpgradeRepoGplay.Info(gracePeriod = false, billingData = null),
         wasEverPro: Boolean = false,
+        settled: Boolean = true,
     ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
-        every { upgradeInfo } returns MutableStateFlow(
-            UpgradeRepoGplay.Info(gracePeriod = isProViaGrace, billingData = null)
-        )
+        every { upgradeInfo } returns MutableStateFlow(info)
         every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
+        every { proUnconfirmedSince } returns MutableStateFlow(0L)
+        every { isSettled } returns MutableStateFlow(settled)
+        every { autoRestoreInProgress } returns MutableStateFlow(false)
         coEvery { querySkus(any()) } returns emptyList()
     }
 
     private fun buildVm(
         repo: UpgradeRepoGplay,
         widgetManagers: Set<WidgetManager> = emptySet(),
+        forced: Boolean = false,
+        manage: Boolean = false,
+        autoInit: Boolean = true,
     ): UpgradeViewModel = UpgradeViewModel(
         handle = SavedStateHandle(),
         dispatcherProvider = TestDispatcherProvider(testDispatcher),
         upgradeRepo = repo,
         widgetManagers = widgetManagers,
-    )
+        webpageTool = webpageTool,
+        clock = clock,
+    ).apply { if (autoInit) initialize(forced = forced, manage = manage) }
 
-    private fun subDetailsWithOffers(vararg offerIds: String?): SkuDetails {
-        val offers = offerIds.map { id ->
-            mockk<ProductDetails.SubscriptionOfferDetails>().apply {
-                every { basePlanId } returns OurSku.Sub.PRO_UPGRADE.BASE_OFFER.basePlanId
-                every { offerId } returns id
-            }
-        }
-        val details = mockk<ProductDetails>().apply {
-            every { subscriptionOfferDetails } returns offers
-        }
-        return SkuDetails(OurSku.Sub.PRO_UPGRADE, details)
+    private fun purchase(skuId: String, autoRenewing: Boolean) = mockk<Purchase>().apply {
+        every { products } returns listOf(skuId)
+        every { purchaseTime } returns 1704067200000L
+        every { isAutoRenewing } returns autoRenewing
     }
 
-    @Test fun `trial copy is advertised when Play returns the trial offer`() = runTest2(context = testDispatcher) {
+    @Test fun `iap gate blocks while the subscription still auto-renews`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns listOf(
-            subDetailsWithOffers(null, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.offerId)
-        )
+        coEvery { repo.queryCurrentSubscriptions() } returns listOf(purchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
         val vm = buildVm(repo)
 
-        val state = async { vm.state.first { !it.pricingLoading } }
+        val event = async { vm.events.first() }
+        vm.onGoIap(activity)
         advanceUntilIdle()
 
-        state.await().trialAvailable shouldBe true
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any()) }
     }
 
-    @Test fun `no trial copy when Play only returns the base offer`() = runTest2(context = testDispatcher) {
-        // An account that already used its trial (or a region without one) only gets the base
-        // offer back — the UI must not promise a 14-day trial it can't deliver.
+    @Test fun `iap gate reports check-failed on verification timeout`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } returns listOf(subDetailsWithOffers(null))
+        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+            delay(20_000) // longer than VERIFY_TIMEOUT_MS
+            emptyList()
+        }
         val vm = buildVm(repo)
 
-        val state = async { vm.state.first { !it.pricingLoading } }
+        val event = async { vm.events.first() }
+        vm.onGoIap(activity)
         advanceUntilIdle()
 
-        state.await().trialAvailable shouldBe false
+        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any()) }
     }
 
-    @Test fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
+    @Test fun `iap gate forwards a verification error`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(
-            gracePeriod = false,
-            billingData = null,
-        )
+        val boom = IllegalStateException("Play unavailable")
+        coEvery { repo.queryCurrentSubscriptions() } throws boom
         val vm = buildVm(repo)
+
+        val error = async { vm.errorEvents.first() }
+        vm.onGoIap(activity)
+        advanceUntilIdle()
+
+        error.await() shouldBe boom
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any()) }
+    }
+
+    @Test fun `iap gate launches when no subscription is renewing`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coJustRun { repo.launchBillingFlowNow(any(), any(), any()) }
+        val vm = buildVm(repo)
+
+        vm.onGoIap(activity)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.launchBillingFlowNow(activity, OurSku.Iap.PRO_UPGRADE, null) }
+    }
+
+    @Test fun `restore with only grace shows failed and does not refresh widgets`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        // Grace-only isPro: Play still couldn't confirm a real purchase.
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        val widget = mockk<WidgetManager>().apply { coJustRun { refreshWidgets() } }
+        val vm = buildVm(repo, widgetManagers = setOf(widget))
 
         val event = async { vm.events.first() }
         vm.restorePurchase()
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+        coVerify(exactly = 0) { widget.refreshWidgets() }
     }
 
-    @Test fun `restore that times out emits RestoreFailed`() = runTest2(context = testDispatcher) {
+    @Test fun `restore with a real purchase succeeds and refreshes widgets`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } coAnswers {
-            delay(30_000) // longer than the 15s restore timeout
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
-        }
-        val vm = buildVm(repo)
+        coEvery { repo.restorePurchaseNow() } returns infoOf(purchase(OurSku.Iap.PRO_UPGRADE.id, autoRenewing = false))
+        val widget = mockk<WidgetManager>().apply { coJustRun { refreshWidgets() } }
+        val vm = buildVm(repo, widgetManagers = setOf(widget))
 
         val event = async { vm.events.first() }
         vm.restorePurchase()
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.RestoreFailed
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+        coVerify(exactly = 1) { widget.refreshWidgets() }
     }
 
-    @Test fun `restore that errors forwards the error instead of RestoreFailed`() = runTest2(context = testDispatcher) {
+    @Test fun `restore that errors forwards the error`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
         coEvery { repo.restorePurchaseNow() } throws boom
         val vm = buildVm(repo)
 
-        val forwardedError = async { vm.errorEvents.first() }
+        val error = async { vm.errorEvents.first() }
         vm.restorePurchase()
         advanceUntilIdle()
 
-        forwardedError.await() shouldBe boom
+        error.await() shouldBe boom
     }
 
-    @Test fun `previously-pro on this device flows into the banner flag`() = runTest2(context = testDispatcher) {
-        val vm = buildVm(mockRepo(wasEverPro = true))
-
-        val state = async { vm.state.first { !it.pricingLoading } }
-        advanceUntilIdle()
-
-        state.await().wasPreviouslyPro shouldBe true
-    }
-
-    @Test fun `banner flag stays off while grace still keeps the user pro`() = runTest2(context = testDispatcher) {
-        // gracePeriod = true => Info.isPro is true even without a current raw purchase.
-        val vm = buildVm(mockRepo(isProViaGrace = true, wasEverPro = true))
-
-        val state = async { vm.state.first { !it.pricingLoading } }
-        advanceUntilIdle()
-
-        state.await().wasPreviouslyPro shouldBe false
-    }
-
-    @Test fun `banner and restore stay available when pricing is unavailable`() = runTest2(context = testDispatcher) {
-        // A returning buyer with a flaky Play connection is exactly who needs restore — pricing
-        // failures must not take the banner down with them.
-        val repo = mockRepo(wasEverPro = true)
-        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
-        val vm = buildVm(repo)
-
-        val state = async { vm.state.first { !it.pricingLoading } }
-        advanceUntilIdle()
-
-        state.await().apply {
-            pricingUnavailable shouldBe true
-            pricing shouldBe null
-            wasPreviouslyPro shouldBe true
-        }
-    }
-
-    @Test fun `banner is already available while pricing is still loading`() = runTest2(context = testDispatcher) {
-        // The banner must not wait for the SKU queries — a hanging Play pricing request (up to the
-        // 5s timeout) must not delay the restore affordance for a returning buyer.
-        val repo = mockRepo(wasEverPro = true)
-        coEvery { repo.querySkus(any()) } coAnswers {
-            delay(60_000) // never resolves within this test
-            emptyList()
+    @Test fun `an in-flight restore blocks the iap gate`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
         }
         val vm = buildVm(repo)
 
-        val state = async { vm.state.first() }
-        runCurrent()
+        vm.restorePurchase()
+        runCurrent() // restore admitted, holding the guard
+        vm.onGoIap(activity)
+        advanceUntilIdle()
 
-        state.await().apply {
-            pricingLoading shouldBe true
-            wasPreviouslyPro shouldBe true
-        }
+        // The gate never even queried subscriptions — the single guard rejected it.
+        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any()) }
     }
 
-    @Test fun `restore is single-flight, taps during a running restore are ignored`() = runTest2(context = testDispatcher) {
+    @Test fun `an immediate already-owned launch reconciles by restoring`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coEvery { repo.launchBillingFlowNow(any(), OurSku.Iap.PRO_UPGRADE, null) } throws
+            eu.darken.octi.common.upgrade.core.billing.ItemAlreadyOwnedBillingException()
+        coEvery { repo.restorePurchaseNow() } returns infoOf(purchase(OurSku.Iap.PRO_UPGRADE.id, autoRenewing = false))
+        val widget = mockk<WidgetManager>().apply { coJustRun { refreshWidgets() } }
+        val vm = buildVm(repo, widgetManagers = setOf(widget))
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(activity)
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+        coVerify(exactly = 1) { widget.refreshWidgets() }
+    }
+
+    @Test fun `restore is single-flight`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {
             delay(5_000)
@@ -203,64 +225,64 @@ class UpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
     }
 
-    @Test fun `a finished restore allows a new attempt`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+    @Test fun `owner sees the switch offer, subscription button disabled`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(info = infoOf(purchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false)))
         val vm = buildVm(repo)
 
-        vm.restorePurchase()
-        advanceUntilIdle()
-        vm.restorePurchase()
+        val loaded = async { vm.state.first { it is UpgradeUiState.Loaded } as UpgradeUiState.Loaded }
         advanceUntilIdle()
 
-        coVerify(exactly = 2) { repo.restorePurchaseNow() }
-    }
-
-    @Test fun `a failed restore also allows a new attempt`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } throws IllegalStateException("Play unavailable")
-        val vm = buildVm(repo)
-
-        vm.restorePurchase()
-        advanceUntilIdle()
-        vm.restorePurchase()
-        advanceUntilIdle()
-
-        coVerify(exactly = 2) { repo.restorePurchaseNow() }
-    }
-
-    @Test fun `restore progress flows into the ui state`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo(wasEverPro = true)
-        coEvery { repo.restorePurchaseNow() } coAnswers {
-            delay(5_000)
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        loaded.await().apply {
+            ownership.subscription?.isAutoRenewing shouldBe false
+            subscriptionEnabled shouldBe false
         }
-        val vm = buildVm(repo)
-
-        vm.restorePurchase()
-        val inProgress = async { vm.state.first { it.restoreInProgress } }
-        advanceTimeBy(1_000)
-
-        inProgress.await().restoreInProgress shouldBe true
-
-        val done = async { vm.state.first { !it.restoreInProgress } }
-        advanceUntilIdle()
-
-        done.await().restoreInProgress shouldBe false
     }
 
-    @Test fun `successful restore refreshes widgets`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(
-            gracePeriod = true,
-            billingData = null,
-        )
-        val widgetManager = mockk<WidgetManager>().apply { coJustRun { refreshWidgets() } }
-        val vm = buildVm(repo, widgetManagers = setOf(widgetManager))
+    @Test fun `purchase actions stay disabled until settled`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(settled = false)
+        val vm = buildVm(repo)
 
-        vm.restorePurchase()
+        // runCurrent only: advancing to idle would trip the bounded settle fallback timer.
+        val loaded = async { vm.state.first { it is UpgradeUiState.Loaded } as UpgradeUiState.Loaded }
+        runCurrent()
+
+        loaded.await().apply {
+            settled shouldBe false
+            iapEnabled shouldBe false
+            subscriptionEnabled shouldBe false
+        }
+    }
+
+    @Test fun `sales route auto-closes once the user is pro`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(info = infoOf(purchase(OurSku.Iap.PRO_UPGRADE.id, autoRenewing = false)))
+        val vm = buildVm(repo, forced = false, manage = false, autoInit = false)
+
+        // Subscribe before initializing so the navUp event can't be emitted before we collect.
+        val navs = mutableListOf<Any>()
+        val job = launch { vm.navEvents.collect { navs.add(it) } }
+        runCurrent()
+        vm.initialize(forced = false, manage = false)
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { widgetManager.refreshWidgets() }
+        navs.isNotEmpty() shouldBe true
+        job.cancel()
+    }
+
+    @Test fun `manage route does not auto-close when pro`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(info = infoOf(purchase(OurSku.Iap.PRO_UPGRADE.id, autoRenewing = false)))
+        val vm = buildVm(repo, forced = false, manage = true, autoInit = false)
+
+        val navs = mutableListOf<Any>()
+        val job = launch { vm.navEvents.collect { navs.add(it) } }
+        runCurrent()
+        vm.initialize(forced = false, manage = true)
+        advanceUntilIdle()
+
+        navs.isEmpty() shouldBe true
+        job.cancel()
+    }
+
+    companion object {
+        private const val BASE_MS = 40L * 365 * 24 * 60 * 60 * 1000
     }
 }


### PR DESCRIPTION
## What

Adds a "manage upgrade" experience so users can see their current Pro
status and, if they're subscribed, switch to the one-time purchase before
the subscription lapses.

- **Pro status view** — the upgrade screen now shows what you own
  (subscription vs. lifetime purchase) instead of only being a paywall.
- **Grace period, in two stages** — while Google Play can't confirm a
  purchase, Pro stays unlocked with a calm "confirming…" message; after
  24h it escalates to diagnostics with restore + contact-support.
- **Switch subscription → one-time purchase** — a subscriber can buy the
  lifetime purchase and stop renewing. Google Play has no native
  subscription→one-time replacement, so the flow is gated: the one-time
  purchase stays locked while the subscription still auto-renews; you
  cancel in Google Play, then buy it as a separate transaction (same
  Google account; it doesn't refund the subscription).
- **Settings** — an always-visible "Octi Pro" / "Octi FOSS" status row
  opens this screen. A free user first sees a status page with a
  "See upgrade options" button. FOSS gets a supporter-status view.

## Why

Ports the upgrade-ownership work from the sister apps
(d4rken-org/sdmaid-se#2563, d4rken-org/capod#638, d4rken-org/bluemusic#239)
that was left out of the earlier billing port, plus the follow-up
hardening those PRs added after live-subscription testing.

## Notable correctness changes (gplay billing)

- **Listener-generation reconciliation** in the billing connection: a
  stale `isAutoRenewing=true` push record can no longer coexist with a
  fresh cancelled record forever (which would keep the switch locked).
  A racing purchase event is preserved (fail-closed).
- **Unconfirmed-episode clock** (`BillingCache`, provenance-tagged): a
  full snapshot that can't confirm Pro — or a failed/timed-out
  query/refresh/restore — opens the episode; a confirmation closes it
  atomically. Drives the two-stage grace UI.
- **Repository-level grace-expiry tick** so entitlement drops for every
  consumer (widgets, entitlement observer), not just the screen.
- **Acknowledgement hardening**: token de-dup, bounded inline retry, and
  an independent reschedule so a purchase can't sit unacknowledged past
  Play's ~3-day auto-refund window.
- **Single authoritative operation guard** for restore / verify / launch
  (closes a two-flag TOCTOU race), plus immediate `ITEM_ALREADY_OWNED`
  reconciliation by exact SKU.

## Strings

Flavor-specific copy lives in the `gplay` / `foss` `strings.xml`; the
shared `manage` navigation flag is in `app-common`. English only —
translations flow through Crowdin as usual.

## Tests

New/updated unit tests cover the episode clock, the fail-closed IAP gate
(renewing / timeout / error all fail closed), the connection
reconciliation and same-token race, grace bookkeeping, ack behavior, and
the restore/verify mutual exclusion. `assembleFossDebug` +
`assembleGplayDebug` and both unit-test variants pass.

Draft while CI runs.
