### PR TITLE
Fix devices stuck 'Synchronizing' and blocked device linking

### DIFF
--- a/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/ForegroundSyncControl.kt
@@ -22,7 +22,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -177,9 +179,7 @@ class ForegroundSyncControl @Inject constructor(
                             }
                         }
 
-                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT) {
-                            syncPendingModules(pending)
-                        } ?: log(TAG, WARN) { "In-flight sync timed out after $SYNC_COMPLETION_TIMEOUT" }
+                        syncPendingModules(pending)
                     }
                 }
             } finally {
@@ -196,9 +196,7 @@ class ForegroundSyncControl @Inject constructor(
                     }
                     if (remaining.isNotEmpty()) {
                         log(TAG, INFO) { "Flushing ${remaining.values.sumOf { it.modules.size }} pending events on shutdown" }
-                        withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT) {
-                            syncPendingModules(remaining)
-                        } ?: log(TAG, WARN) { "Flush sync timed out after $SYNC_COMPLETION_TIMEOUT" }
+                        syncPendingModules(remaining)
                     }
                 }
             }
@@ -218,21 +216,39 @@ class ForegroundSyncControl @Inject constructor(
     private suspend fun syncPendingModules(pending: Map<ConnectorId, PendingSync>) {
         pending.forEach { (connectorId, sync) ->
             log(TAG) { "Batched sync: ${sync.modules.size} modules, ${sync.devices.size} devices on ${connectorId.logLabel}" }
-            try {
-                syncManager.sync(
-                    connectorId,
-                    SyncOptions(
-                        stats = false,
-                        readData = true,
-                        writeData = false,
-                        moduleFilter = sync.modules.toSet(),
-                        deviceFilter = sync.devices.toSet(),
-                    ),
-                )
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Batched sync failed: ${e.asLog()}" }
+            // Per-connector timeout: this loop is serial, so a single whole-batch timeout would give a
+            // later connector only whatever time the earlier one left over. Bound each connector on its
+            // own instead. The op keeps running to completion on the connector's scope after a timeout
+            // (bounded by the HTTP client timeouts); we just stop waiting on it here.
+            val completed = withTimeoutOrNull(SYNC_COMPLETION_TIMEOUT) {
+                try {
+                    syncManager.sync(
+                        connectorId,
+                        SyncOptions(
+                            stats = false,
+                            readData = true,
+                            writeData = false,
+                            moduleFilter = sync.modules.toSet(),
+                            deviceFilter = sync.devices.toSet(),
+                        ),
+                    )
+                    true
+                } catch (e: CancellationException) {
+                    // ensureActive() rethrows only if WE are cancelled — our own timeout (converted to
+                    // null above) or the collector being torn down, both of which must propagate. A
+                    // stopped connector fails ops with ConnectorStoppedException (not a cancellation),
+                    // but if some other in-connector cancellation bubbles up while this loop is still
+                    // active, swallow it so it can't abort the remaining connectors in this serial batch.
+                    currentCoroutineContext().ensureActive()
+                    log(TAG, WARN) { "Sync cancelled by connector on ${connectorId.logLabel}, continuing batch" }
+                    true
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Batched sync failed on ${connectorId.logLabel}: ${e.asLog()}" }
+                    true
+                }
+            }
+            if (completed == null) {
+                log(TAG, WARN) { "In-flight sync timed out after $SYNC_COMPLETION_TIMEOUT on ${connectorId.logLabel}" }
             }
         }
     }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoEquivalence.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoEquivalence.kt
@@ -1,0 +1,72 @@
+package eu.darken.octi.modules.power.core
+
+import kotlin.math.abs
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+/**
+ * Sync-oriented equivalence for [PowerInfo] with per-field tolerances.
+ *
+ * The battery broadcast (`ACTION_BATTERY_CHANGED`) fires roughly once per second while (dis)charging,
+ * and several [PowerInfo] fields jitter on every read: the raw current registers ([ChargeIO.currentNow]
+ * / [ChargeIO.currenAvg]), the temperature (0.1 °C steps), and the `now()`-based charge ETA
+ * ([ChargeIO.fullAt] / [ChargeIO.fullSince]). Plain data-class equality therefore treats every sample as
+ * "changed", defeating the `distinctUntilChanged()` in `BaseModuleRepo` and pushing a module sync every
+ * second.
+ *
+ * Used with [kotlinx.coroutines.flow.distinctUntilChanged], where the comparison is against the last
+ * EMITTED value (hysteresis): sub-tolerance drift accumulates against that anchor rather than the
+ * previous sample, so a slow ramp still eventually emits, and values that oscillate just under a
+ * tolerance boundary don't flap. The emitted value is always the real sample — nothing is rounded — so
+ * derived data (e.g. [ChargeIO.speed]) and the wire payload keep full precision; we simply emit less
+ * often.
+ */
+internal fun PowerInfo.isEquivalentForSync(other: PowerInfo): Boolean {
+    if (status != other.status) return false
+    if (!battery.isEquivalentForSync(other.battery)) return false
+    if (!chargeIO.isEquivalentForSync(other.chargeIO)) return false
+    return true
+}
+
+private fun PowerInfo.Battery.isEquivalentForSync(other: PowerInfo.Battery): Boolean {
+    if (level != other.level) return false
+    if (scale != other.scale) return false
+    if (health != other.health) return false
+    if (!floatsEquivalent(temp, other.temp, TEMP_TOLERANCE_C)) return false
+    return true
+}
+
+private fun PowerInfo.ChargeIO.isEquivalentForSync(other: PowerInfo.ChargeIO): Boolean {
+    // The current tolerance must not swallow a change that flips the semantic charge-speed category
+    // (e.g. 980 mA → 1020 mA is <50 mA apart but crosses SLOW→NORMAL), or the UI would show a stale
+    // "charging slowly/normally/fast" indefinitely.
+    if (speed != other.speed) return false
+    if (!intsEquivalent(currentNow, other.currentNow, CURRENT_TOLERANCE_UA)) return false
+    if (!intsEquivalent(currenAvg, other.currenAvg, CURRENT_TOLERANCE_UA)) return false
+    if (!instantsEquivalent(fullSince, other.fullSince, ETA_TOLERANCE)) return false
+    if (!instantsEquivalent(fullAt, other.fullAt, ETA_TOLERANCE)) return false
+    if (!instantsEquivalent(emptyAt, other.emptyAt, ETA_TOLERANCE)) return false
+    return true
+}
+
+// A null↔non-null transition is always significant; two non-null values within tolerance are equivalent.
+private fun intsEquivalent(a: Int?, b: Int?, toleranceUa: Int): Boolean {
+    if (a == null || b == null) return a == b
+    return abs(a.toLong() - b.toLong()) < toleranceUa
+}
+
+private fun floatsEquivalent(a: Float?, b: Float?, tolerance: Float): Boolean {
+    if (a == null || b == null) return a == b
+    return abs(a - b) < tolerance
+}
+
+private fun instantsEquivalent(a: Instant?, b: Instant?, tolerance: Duration): Boolean {
+    if (a == null || b == null) return a == b
+    return (a - b).absoluteValue < tolerance
+}
+
+// Below these, a delta is treated as noise and does not trigger a sync.
+internal const val CURRENT_TOLERANCE_UA = 50_000 // 50 mA
+internal const val TEMP_TOLERANCE_C = 1.0f // 1 °C
+internal val ETA_TOLERANCE = 1.minutes

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoSource.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/PowerInfoSource.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
@@ -172,6 +173,10 @@ class PowerInfoSource @Inject constructor(
             chargeIO = chargeIO,
         )
     }
+        // The battery broadcast fires ~1/sec while (dis)charging and current/temp/ETA jitter every
+        // read, so plain equality would push a module sync every second. Suppress sub-tolerance drift
+        // (hysteresis vs. the last emitted sample) — emitted values keep full precision.
+        .distinctUntilChanged { old, new -> old.isEquivalentForSync(new) }
         .setupCommonEventHandlers(TAG) { "info" }
         .shareLatest(appScope, SharingStarted.Lazily, TAG)
 

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/core/PowerInfoEquivalenceTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/core/PowerInfoEquivalenceTest.kt
@@ -1,0 +1,143 @@
+package eu.darken.octi.modules.power.core
+
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Instant
+
+class PowerInfoEquivalenceTest : BaseTest() {
+
+    private val t0 = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    private fun info(
+        status: PowerInfo.Status = PowerInfo.Status.CHARGING,
+        level: Int = 80,
+        scale: Int = 100,
+        health: Int? = 2,
+        temp: Float? = 30.0f,
+        currentNow: Int? = -500_000,
+        currenAvg: Int? = -500_000,
+        fullSince: Instant? = t0,
+        fullAt: Instant? = t0,
+        emptyAt: Instant? = null,
+    ) = PowerInfo(
+        status = status,
+        battery = PowerInfo.Battery(level = level, scale = scale, health = health, temp = temp),
+        chargeIO = PowerInfo.ChargeIO(
+            currentNow = currentNow,
+            currenAvg = currenAvg,
+            fullSince = fullSince,
+            fullAt = fullAt,
+            emptyAt = emptyAt,
+        ),
+    )
+
+    @Test fun `identical infos are equivalent`() {
+        info().isEquivalentForSync(info()) shouldBe true
+    }
+
+    @Test fun `status change is significant`() {
+        info(status = PowerInfo.Status.CHARGING)
+            .isEquivalentForSync(info(status = PowerInfo.Status.DISCHARGING)) shouldBe false
+    }
+
+    @Test fun `battery level or health change is significant`() {
+        info(level = 80).isEquivalentForSync(info(level = 81)) shouldBe false
+        info(health = 2).isEquivalentForSync(info(health = 3)) shouldBe false
+    }
+
+    @Test fun `temperature within tolerance is noise`() {
+        info(temp = 30.0f).isEquivalentForSync(info(temp = 30.5f)) shouldBe true
+        info(temp = 30.0f).isEquivalentForSync(info(temp = 31.0f)) shouldBe false
+    }
+
+    @Test fun `current within tolerance is noise`() {
+        info(currentNow = -500_000).isEquivalentForSync(info(currentNow = -520_000)) shouldBe true
+        info(currentNow = -500_000).isEquivalentForSync(info(currentNow = -560_000)) shouldBe false
+    }
+
+    @Test fun `current avg within tolerance is noise`() {
+        info(currenAvg = -500_000).isEquivalentForSync(info(currenAvg = -540_000)) shouldBe true
+        info(currenAvg = -500_000).isEquivalentForSync(info(currenAvg = -600_000)) shouldBe false
+    }
+
+    @Test fun `charge ETA within a minute is noise`() {
+        info(fullAt = t0).isEquivalentForSync(info(fullAt = t0.plusSeconds(45))) shouldBe true
+        info(fullAt = t0).isEquivalentForSync(info(fullAt = t0.plusSeconds(90))) shouldBe false
+    }
+
+    @Test fun `crossing a charge-speed threshold is significant even within current tolerance`() {
+        // 980 mA (SLOW) vs 1020 mA (NORMAL): 40 mA apart (under tolerance) but different speed category.
+        info(currentNow = 980_000).isEquivalentForSync(info(currentNow = 1_020_000)) shouldBe false
+        // Same side of the threshold, within tolerance -> still noise.
+        info(currentNow = 1_020_000).isEquivalentForSync(info(currentNow = 1_040_000)) shouldBe true
+    }
+
+    @Test fun `crossing the NORMAL to FAST threshold is significant even within current tolerance`() {
+        // 2480 mA (NORMAL) vs 2520 mA (FAST): 40 mA apart (under tolerance) but crosses the 2.5 A line.
+        info(currentNow = 2_480_000).isEquivalentForSync(info(currentNow = 2_520_000)) shouldBe false
+        // Both FAST, within tolerance -> noise.
+        info(currentNow = 2_520_000).isEquivalentForSync(info(currentNow = 2_540_000)) shouldBe true
+    }
+
+    @Test fun `battery scale change is significant`() {
+        info(scale = 100).isEquivalentForSync(info(scale = 200)) shouldBe false
+    }
+
+    @Test fun `fullSince within tolerance is noise, beyond is significant`() {
+        info(fullSince = t0).isEquivalentForSync(info(fullSince = t0.plusSeconds(45))) shouldBe true
+        info(fullSince = t0).isEquivalentForSync(info(fullSince = t0.plusSeconds(90))) shouldBe false
+    }
+
+    @Test fun `emptyAt within tolerance is noise, beyond is significant`() {
+        info(emptyAt = t0).isEquivalentForSync(info(emptyAt = t0.plusSeconds(45))) shouldBe true
+        info(emptyAt = t0).isEquivalentForSync(info(emptyAt = t0.plusSeconds(90))) shouldBe false
+    }
+
+    @Test fun `null transitions are always significant`() {
+        info(currentNow = -500_000).isEquivalentForSync(info(currentNow = null)) shouldBe false
+        info(currentNow = null).isEquivalentForSync(info(currentNow = null)) shouldBe true
+        info(temp = null).isEquivalentForSync(info(temp = 30.0f)) shouldBe false
+        info(fullAt = null).isEquivalentForSync(info(fullAt = null)) shouldBe true
+    }
+
+    @Test fun `distinctUntilChanged collapses sub-tolerance jitter but not real change`() = runTest2 {
+        // Current jitters within ±50 mA and ETA drifts a few seconds — all noise — then a real jump.
+        val samples = listOf(
+            info(currentNow = -500_000, fullAt = t0),
+            info(currentNow = -515_000, fullAt = t0.plusSeconds(5)),
+            info(currentNow = -488_000, fullAt = t0.plusSeconds(10)),
+            info(currentNow = -502_000, fullAt = t0.plusSeconds(15)),
+            info(currentNow = -900_000, fullAt = t0.plusSeconds(15)), // real change (>50 mA)
+        )
+
+        val emitted = flowOf(*samples.toTypedArray())
+            .distinctUntilChanged { old, new -> old.isEquivalentForSync(new) }
+            .toList()
+
+        // First sample + the real change only — the three noisy samples in between are suppressed.
+        emitted.size shouldBe 2
+        emitted.first().chargeIO.currentNow shouldBe -500_000
+        emitted.last().chargeIO.currentNow shouldBe -900_000
+    }
+
+    @Test fun `slow ramp still eventually emits (hysteresis vs last emitted)`() = runTest2 {
+        // Each step is <50 mA but they accumulate; compared against the last EMITTED value, the ramp
+        // must emit again once cumulative drift crosses the tolerance — not stay suppressed forever.
+        val samples = (0..5).map { info(currentNow = -500_000 - it * 20_000) } // -500k, -520k, ... -600k
+
+        val emitted = flowOf(*samples.toTypedArray())
+            .distinctUntilChanged { old, new -> old.isEquivalentForSync(new) }
+            .toList()
+
+        // -500k emits; -520k noise; -540k is 40k from -500k -> still noise; -560k is 60k -> emits;
+        // -580k noise; -600k is 40k from -560k -> noise. => 2 emissions.
+        emitted.map { it.chargeIO.currentNow } shouldBe listOf(-500_000, -560_000)
+    }
+
+    private fun Instant.plusSeconds(s: Long) = Instant.fromEpochMilliseconds(toEpochMilliseconds() + s * 1000)
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
@@ -7,9 +7,12 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.sync.core.errors.ConnectorPausedException
+import eu.darken.octi.sync.core.errors.ConnectorStoppedException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -58,6 +61,12 @@ class ConnectorProcessor(
     private val inbox = Channel<Pending>(capacity = Channel.UNLIMITED)
     private val pending = ConcurrentHashMap<OperationId, Pending>()
 
+    // Serializes the submit/shutdown ownership decision: a submit either registers in [pending] before
+    // shutdown claims it, or is rejected once [stopped] is set — never both, and never onto a closed
+    // inbox with no consumer.
+    private val lifecycleLock = Any()
+    private var stopped = false
+
     private val _operations = MutableStateFlow<List<ConnectorOperation>>(emptyList())
     val operations: StateFlow<List<ConnectorOperation>> = _operations.asStateFlow()
 
@@ -67,27 +76,52 @@ class ConnectorProcessor(
     )
     val completions: SharedFlow<ConnectorOperation.Terminal> = _completions.asSharedFlow()
 
-    fun start(scope: CoroutineScope): Job = scope.launch {
+    // ATOMIC start so the body — and therefore the shutdown `finally` — always runs, even if `scope`
+    // is cancelled before the coroutine is first dispatched. With the default start, that pre-dispatch
+    // cancellation would skip the body entirely, leaving `stopped` false, the inbox open, and any op
+    // that raced in stuck forever (its await() would never resolve). The "delicate" property (the body
+    // is guaranteed to begin regardless of cancellation) is exactly what we rely on to run cleanup.
+    @OptIn(DelicateCoroutinesApi::class)
+    fun start(scope: CoroutineScope): Job = scope.launch(start = CoroutineStart.ATOMIC) {
         log(TAG, VERBOSE) { "processor($connectorId): started" }
         try {
             for (entry in inbox) processOne(entry)
         } finally {
-            log(TAG, VERBOSE) { "processor($connectorId): stopping, failing ${pending.size} pending" }
-            val now = Clock.System.now()
-            pending.values.forEach { entry ->
-                if (!entry.result.isCompleted) {
-                    val failed = ConnectorOperation.Failed(
-                        id = entry.queued.id,
-                        command = entry.queued.command,
-                        submittedAt = entry.queued.submittedAt,
-                        startedAt = now,
-                        finishedAt = now,
-                        error = CancellationException("Connector shutting down"),
-                    )
-                    entry.result.complete(failed)
-                }
+            // Under the lock: mark stopped and close the inbox so any racing submit() is rejected up
+            // front (submit registers everything under this same lock, so an op either became fully
+            // visible before this snapshot or is rejected after — never a half-registered op), then
+            // snapshot the still-pending ops. We deliberately do NOT clear `pending`: leaving the
+            // (about-to-be-completed) entries in place lets a late await(id) resolve from its deferred
+            // regardless of `operations` retention trimming. The map dies with the processor anyway.
+            val snapshot = synchronized(lifecycleLock) {
+                stopped = true
+                inbox.close()
+                pending.values.toList()
             }
-            pending.clear()
+            log(TAG, VERBOSE) { "processor($connectorId): stopping, failing ${snapshot.size} pending" }
+            val now = Clock.System.now()
+            val failures = snapshot.mapNotNull { entry ->
+                if (entry.result.isCompleted) return@mapNotNull null
+                val failed = ConnectorOperation.Failed(
+                    id = entry.queued.id,
+                    command = entry.queued.command,
+                    submittedAt = entry.queued.submittedAt,
+                    startedAt = now,
+                    finishedAt = now,
+                    error = ConnectorStoppedException(connectorId),
+                )
+                entry.result.complete(failed)
+                failed
+            }
+            // Move the UI operations to terminal and emit their completions too — otherwise a shutdown
+            // leaves Queued/Processing entries in `operations`, keeping `isBusy` true (and gated actions
+            // disabled) until the connector is fully reconstructed. `operations` is the authoritative
+            // isBusy source (lossless StateFlow); the completions emit is best-effort observational.
+            if (failures.isNotEmpty()) {
+                val failedById = failures.associateBy { it.id }
+                _operations.update { ops -> ops.map { failedById[it.id] ?: it }.trim() }
+                failures.forEach { _completions.tryEmit(it) }
+            }
         }
     }
 
@@ -96,24 +130,48 @@ class ConnectorProcessor(
         val queued = ConnectorOperation.Queued(id, command, Clock.System.now())
         val deferred = CompletableDeferred<ConnectorOperation.Terminal>()
         val entry = Pending(queued, deferred)
-        pending[id] = entry
-        _operations.update { (it + queued).trim() }
-        val sendResult = inbox.trySend(entry)
-        if (sendResult.isFailure) {
-            val now = Clock.System.now()
-            val failed = ConnectorOperation.Failed(
-                id = id,
-                command = command,
-                submittedAt = queued.submittedAt,
-                startedAt = now,
-                finishedAt = now,
-                error = IllegalStateException("Connector inbox closed"),
-            )
-            pending.remove(id)?.result?.complete(failed)
-            _operations.update { ops -> ops.map { if (it.id == id) failed else it }.trim() }
-            _completions.tryEmit(failed)
+
+        // Register the pending entry, publish the Queued op, and enqueue — all under the lock. The
+        // shutdown path runs under the same lock, so it sees an all-or-nothing submit: either the op is
+        // fully visible before shutdown snapshots (and gets failed there), or `stopped` is already set
+        // and we reject here. Because the inbox is only closed under this lock once `stopped` is true, a
+        // trySend while `stopped` is false is guaranteed to land in the UNLIMITED buffer — there is no
+        // "enqueued onto a closed inbox" case to recover from.
+        val accepted = synchronized(lifecycleLock) {
+            if (stopped) {
+                false
+            } else {
+                pending[id] = entry
+                _operations.update { (it + queued).trim() }
+                check(inbox.trySend(entry).isSuccess) { "inbox closed while not stopped" }
+                true
+            }
+        }
+        if (!accepted) {
+            // Processor already stopped — fail fast so the caller's await() never hangs. Keep the entry
+            // in `pending` (completed) so a late await(id) still resolves from its deferred instead of
+            // racing retention trimming of `_operations`. The processor is dead; this map dies with it.
+            pending[id] = entry
+            failEntry(entry, ConnectorStoppedException(connectorId))
         }
         return id
+    }
+
+    // Completes an unaccepted [entry] as Failed and publishes it. Only reachable from the submit-after-
+    // shutdown reject path, so the op was never listed in [_operations] — append it.
+    private fun failEntry(entry: Pending, error: Throwable) {
+        val now = Clock.System.now()
+        val failed = ConnectorOperation.Failed(
+            id = entry.queued.id,
+            command = entry.queued.command,
+            submittedAt = entry.queued.submittedAt,
+            startedAt = now,
+            finishedAt = now,
+            error = error,
+        )
+        entry.result.complete(failed)
+        _operations.update { (it + failed).trim() }
+        _completions.tryEmit(failed)
     }
 
     suspend fun await(id: OperationId): ConnectorOperation.Terminal {
@@ -175,14 +233,15 @@ class ConnectorProcessor(
             )
         }
 
-        publishTerminal(entry, terminal)
-
-        // After a successful Resume, enqueue a Sync on our own queue. Submitting here (inside
-        // the processing of Resume) guarantees Sync lands in the inbox before any subsequent
-        // user Pause, so the post-resume sync is deterministic.
+        // After a successful Resume, enqueue a Sync on our own queue BEFORE publishing Resume's terminal.
+        // Completing the Resume deferred can wake a waiter that immediately submits (e.g. Pause) on
+        // another thread; enqueuing the Sync first guarantees it lands in the inbox ahead of that
+        // command, so the post-resume sync is ordered deterministically (Resume → Sync → …).
         if (terminal is ConnectorOperation.Succeeded && entry.queued.command == ConnectorCommand.Resume) {
             submit(ConnectorCommand.Sync())
         }
+
+        publishTerminal(entry, terminal)
     }
 
     private fun publishTerminal(entry: Pending, terminal: ConnectorOperation.Terminal) {

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorStoppedException.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorStoppedException.kt
@@ -1,0 +1,14 @@
+package eu.darken.octi.sync.core.errors
+
+import eu.darken.octi.sync.core.ConnectorId
+
+/**
+ * Terminal error for operations that were still pending when a connector's processor shut down (its
+ * scope was cancelled). Deliberately NOT a [kotlinx.coroutines.CancellationException]: a shutdown must
+ * fail waiters, but callers that catch cancellation to honor structured concurrency (e.g. the
+ * per-connector loop in `ForegroundSyncControl`) must treat this as an ordinary connector failure and
+ * carry on, not as their own coroutine being cancelled.
+ */
+class ConnectorStoppedException(
+    val connectorId: ConnectorId,
+) : IllegalStateException("Connector ${connectorId.logLabel} stopped")

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.sync.core
 
 import eu.darken.octi.common.sync.ConnectorType
 import eu.darken.octi.sync.core.errors.ConnectorPausedException
+import eu.darken.octi.sync.core.errors.ConnectorStoppedException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -13,6 +14,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -273,5 +275,94 @@ class ConnectorProcessorTest : BaseTest() {
 
         // The processor teardown should have completed the pending deferred as Failed.
         proc.await(id).shouldBeInstanceOf<ConnectorOperation.Failed>()
+    }
+
+    @Test
+    fun `processor scope cancellation clears busy operations, not just waiters`() = runTest2 {
+        val gate = CompletableDeferred<Unit>()
+        val (proc, job) = buildProcessor(executor = { gate.await() })
+
+        proc.submit(ConnectorCommand.Sync()) // becomes Processing (awaits gate)
+        proc.submit(ConnectorCommand.Sync()) // stays Queued behind it
+        advanceUntilIdle()
+
+        // Busy: at least one Queued/Processing entry.
+        proc.operations.first()
+            .any { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing } shouldBe true
+
+        job.cancel()
+        advanceUntilIdle()
+
+        // After shutdown no non-terminal op remains, so isBusy would report false — the connector card
+        // and its gated actions recover instead of staying stuck "busy".
+        val ops = proc.operations.first()
+        ops.none { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing } shouldBe true
+        ops.filterIsInstance<ConnectorOperation.Failed>().shouldHaveSize(2)
+    }
+
+    @Test
+    fun `scope cancelled before the actor is dispatched still terminates submitted ops`() = runTest2 {
+        val (proc, job) = buildProcessor(executor = { })
+        // Cancel BEFORE advancing: the actor coroutine has been launched but not yet dispatched. With
+        // CoroutineStart.DEFAULT the body (and its shutdown finally) would be skipped entirely, leaving
+        // this op queued forever and await() hanging. ATOMIC start guarantees the finally runs.
+        job.cancel()
+        val id = proc.submit(ConnectorCommand.Sync())
+        advanceUntilIdle()
+
+        proc.await(id).shouldBeInstanceOf<ConnectorOperation.Terminal>()
+    }
+
+    @Test
+    fun `submitting after shutdown fails fast instead of hanging`() = runTest2 {
+        val (proc, job) = buildProcessor()
+        advanceUntilIdle() // let the actor start and reach inbox.receive() before we tear it down
+        job.cancel()
+        advanceUntilIdle() // run cancellation + finally, which closes the inbox
+
+        // A stale reference submitting after teardown must not enqueue onto a consumer-less channel;
+        // with the inbox closed, submit completes the op as Failed instead of leaving it Queued forever.
+        val id = proc.submit(ConnectorCommand.Sync())
+        proc.await(id).shouldBeInstanceOf<ConnectorOperation.Failed>()
+    }
+
+    @Test
+    fun `active waiters on more ops than retention all resolve at shutdown`() = runTest2 {
+        val gate = CompletableDeferred<Unit>()
+        // Retention smaller than the op count: after shutdown, `operations` keeps only 2 terminals. Real
+        // callers (SyncConnector.execute) await immediately after submit, so model suspended waiters —
+        // they resolve from their deferred and must never hang, independent of retention trimming.
+        val (proc, job) = buildProcessor(retention = 2, executor = { gate.await() })
+
+        val ids = (1..5).map { proc.submit(ConnectorCommand.Sync()) }
+        val waiters = ids.map { id -> async { proc.await(id) } }
+        advanceUntilIdle() // first becomes Processing on the gate, rest stay Queued; all waiters suspend
+
+        job.cancel()
+        advanceUntilIdle()
+
+        proc.operations.first().filterIsInstance<ConnectorOperation.Terminal>().shouldHaveSize(2)
+        waiters.forEach { it.await().shouldBeInstanceOf<ConnectorOperation.Failed>() }
+    }
+
+    @Test
+    fun `shutdown fails still-queued ops with ConnectorStoppedException, not a CancellationException`() = runTest2 {
+        val gate = CompletableDeferred<Unit>()
+        val (proc, job) = buildProcessor(executor = { gate.await() })
+
+        proc.submit(ConnectorCommand.Sync()) // becomes Processing, blocks on the gate
+        val queuedId = proc.submit(ConnectorCommand.Sync()) // never pulled — stays Queued behind it
+        advanceUntilIdle()
+
+        job.cancel()
+        advanceUntilIdle()
+
+        // The still-queued op is failed by the shutdown path, whose error must NOT be a
+        // CancellationException: ForegroundSyncControl's serial loop catches cancellation to honor
+        // structured concurrency and would otherwise abort the remaining connectors in the batch.
+        val terminal = proc.await(queuedId)
+        terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+        // ConnectorStoppedException is an IllegalStateException, not a CancellationException.
+        terminal.error.shouldBeInstanceOf<ConnectorStoppedException>()
     }
 }

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/ui/GDriveUiContribution.kt
@@ -134,10 +134,12 @@ class GDriveUiContribution @Inject constructor() : ConnectorUiContribution {
                     Text(text = stringResource(CommonR.string.general_sync_action))
                 }
 
+                // Reading the device list doesn't go through the sync command queue, so don't block it
+                // while a sync is in flight.
                 FilledTonalButton(
                     onClick = onViewDevices,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused && !isBusy,
+                    enabled = !isPaused,
                 ) {
                     Text(text = stringResource(SyncR.string.sync_synced_devices_label))
                 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/OctiServerUiContribution.kt
@@ -164,10 +164,13 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                     Text(text = stringResource(CommonR.string.general_sync_action))
                 }
 
+                // Not gated on isBusy: reading the device list and generating a link code do not go
+                // through the sync command queue, so an in-flight sync never conflicts with them —
+                // gating them on busy just needlessly blocks the user while a sync churns.
                 FilledTonalButton(
                     onClick = onViewDevices,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused && !isBusy,
+                    enabled = !isPaused,
                 ) {
                     Text(text = stringResource(SyncR.string.sync_synced_devices_label))
                 }
@@ -175,7 +178,7 @@ class OctiServerUiContribution @Inject constructor() : ConnectorUiContribution {
                 FilledTonalButton(
                     onClick = onLinkNewDevice,
                     modifier = Modifier.fillMaxWidth(),
-                    enabled = !isPaused && !isBusy,
+                    enabled = !isPaused,
                 ) {
                     Text(text = stringResource(R.string.sync_octiserver_link_device_action))
                 }


### PR DESCRIPTION
## Problem

On accounts with several devices, the sync connector could sit on **"Synchronizing"** more or less permanently, and while it showed busy you **couldn't link a new device**.

Root cause was the power module. `PowerInfo` carries `now()`-based charge ETAs and raw-µA current registers that change on essentially every `ACTION_BATTERY_CHANGED` broadcast (~1/sec while charging or discharging). Plain equality therefore saw every reading as a change and defeated the existing `distinctUntilChanged`, so each device pushed a battery sync every second. Multiplied across devices, that kept every connector busy — and the "busy" state was gating the Link/View buttons.

## Changes

**Debounce power updates**
- New `PowerInfoEquivalence` with per-field sync tolerances — current 50 mA, temperature 1 °C, charge ETA 1 min — applied via `distinctUntilChanged` compared against the *last emitted* sample (hysteresis), so oscillation near a boundary doesn't flap but a slow ramp still eventually emits.
- A sub-tolerance current delta that crosses a charge-speed boundary (SLOW/NORMAL/FAST) still emits, so the "charging slowly/normally/fast" indicator can't go stale.
- Emitted samples are the real values — nothing is rounded — so the wire payload and UI keep full precision; we simply emit less often.

**Unblock device linking**
- "Link device" and "View devices" are no longer disabled while a sync is in flight. Neither action goes through the sync command queue (link-code creation and device-list reads bypass it), so gating them on busy only blocked the user needlessly.

**Sync controller robustness**
- Each connector's batched sync now has its own timeout instead of one shared whole-batch timeout, so a slow connector can't starve the next one in the serial loop.
- The connector processor's shutdown now clears its in-flight operations (not just waiters) and is race-safe against a `submit()` that arrives during/after shutdown, so a connector restart can't leave the card stuck "busy". Pending ops are failed with a dedicated `ConnectorStoppedException` (not a `CancellationException`) so the foreground sync loop treats it as an ordinary connector failure rather than aborting the remaining connectors.

## Testing

- `./gradlew :sync-core:testDebugUnitTest :modules-power:testDebugUnitTest` — green.
- New `PowerInfoEquivalenceTest` covers each tolerance, null transitions, speed-threshold crossings, flow-level jitter collapse, and slow-ramp hysteresis.
- New `ConnectorProcessorTest` cases cover shutdown clearing busy ops, retention-independent waiters at shutdown, fail-fast on post-shutdown submit, pre-dispatch cancellation cleanup, and the `ConnectorStoppedException` contract.
- FOSS + gplay debug variants compile.

## Notes

- The battery-alert freshness gate is intentionally left on the existing `modifiedAt` + 24h window. With the debounce, a device sitting in a byte-identical power state for over a day would have its power alerts suppressed until anything changes — a narrow, self-healing case that was previously masked by per-second µA jitter. Deliberately accepted over adding a separate liveness signal (which GDrive can't provide).
