### PR TITLE
Rework the gplay upgrade screen into a card dashboard

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeRepoGplay.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.WhileSubscribed
@@ -138,7 +139,7 @@ class UpgradeRepoGplay @Inject constructor(
     // True while the invisible already-owned reconciliation runs. Exposed so the UI can hold its buy
     // buttons disabled during it — that restore is off the VM's operation guard, so without this a
     // second purchase could be launched on top of the one being reconciled.
-    val autoRestoreInProgress: Flow<Boolean> = _autoRestoreInProgress
+    val autoRestoreInProgress: StateFlow<Boolean> = _autoRestoreInProgress
 
     // Grace is time-based, but billingData is equality-deduped state kept hot by a process-lifetime
     // subscriber — without this deadline tick, a lapsed grace window would keep isPro=true until the

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnection.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.resume
@@ -283,9 +284,15 @@ data class BillingConnection(
             setProductList(productList)
         }.build()
 
-        val (result, details) = suspendCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
+        // Cancellable bridge: queryProductDetailsAsync has no cancel API, so a withTimeout around this
+        // call could never interrupt a plain suspendCoroutine — if Play never called back, the caller
+        // hung forever. suspendCancellableCoroutine lets the timeout resume us; a late Play callback
+        // after that cancellation is dropped instead of resuming a dead continuation.
+        val (result, details) = suspendCancellableCoroutine<Pair<BillingResult, Collection<ProductDetails>?>> { continuation ->
             client.queryProductDetailsAsync(params) { billingResult, queryResult ->
-                continuation.resume(billingResult to queryResult.productDetailsList)
+                if (continuation.isActive) {
+                    continuation.resume(billingResult to queryResult.productDetailsList)
+                }
             }
         }
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
@@ -1,0 +1,396 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.CheckCircle
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.OctiMascot
+import eu.darken.octi.common.R as CommonR
+
+// "Octi" + a colored "Pro" postfix while Pro is active. The postfix is its own translatable string
+// (RTL/localized upgrade words reorder), so we never locate a substring inside a combined name.
+@Composable
+internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = buildAnnotatedString {
+    if (!upgraded) {
+        append(stringResource(R.string.upgrade_screen_title))
+        return@buildAnnotatedString
+    }
+    append(stringResource(CommonR.string.app_name))
+    append(" ")
+    pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
+    append(stringResource(R.string.app_name_upgrade_postfix))
+    pop()
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun UpgradeScreenScaffold(
+    title: AnnotatedString,
+    onNavigateUp: () -> Unit,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    val topAppBarState = rememberTopAppBarState()
+    val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
+
+    Scaffold(
+        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.TwoTone.ArrowBack,
+                            contentDescription = stringResource(R.string.upgrade_screen_navigate_up),
+                        )
+                    }
+                },
+                scrollBehavior = scrollBehavior,
+            )
+        },
+        content = content,
+    )
+}
+
+@Composable
+internal fun UpgradeScreenContent(
+    paddingValues: PaddingValues,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(horizontal = 24.dp, vertical = 24.dp),
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.TopCenter,
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 560.dp)
+                    .padding(contentPadding),
+                verticalArrangement = Arrangement.spacedBy(20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                content = content,
+            )
+        }
+    }
+}
+
+@Composable
+internal fun UpgradeMascot(
+    size: Dp,
+    modifier: Modifier = Modifier,
+) {
+    OctiMascot(modifier = modifier.size(size))
+}
+
+@Composable
+internal fun UpgradeHeader(
+    mascotSize: Dp,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Surface(
+            color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
+            shape = CircleShape,
+        ) {
+            UpgradeMascot(
+                size = mascotSize,
+                modifier = Modifier.padding(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun UpgradePreambleCard(
+    text: String,
+    modifier: Modifier = Modifier,
+    colors: CardColors = CardDefaults.elevatedCardColors(),
+) {
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = colors,
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+        )
+    }
+}
+
+@Composable
+internal fun UpgradeSectionCard(
+    title: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    iconTint: Color = Color.Unspecified,
+    colors: CardColors? = null,
+    leading: (@Composable () -> Unit)? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val cardColors = colors ?: CardDefaults.elevatedCardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+    )
+
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = cardColors,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            UpgradeSectionHeader(
+                title = title,
+                icon = icon,
+                iconTint = iconTint,
+                leading = leading,
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+internal fun UpgradeSectionHeader(
+    title: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    iconTint: Color = Color.Unspecified,
+    leading: (@Composable () -> Unit)? = null,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        if (leading != null) {
+            leading()
+        } else {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = if (iconTint == Color.Unspecified) MaterialTheme.colorScheme.primary else iconTint,
+            )
+        }
+        Text(
+            text = title,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+internal fun UpgradeSectionBody(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+// Renders a feature blurb: bullet lines (leading • or -, some translations use hyphens) become
+// checkmark rows, everything else stays plain paragraph text.
+@Composable
+internal fun UpgradeFeatureList(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        text.lineSequence()
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .forEach { line ->
+                val bullet = line.startsWith("•") || line.startsWith("-")
+                if (bullet) {
+                    UpgradeFeatureRow(text = line.drop(1).trim())
+                } else {
+                    Text(
+                        text = line,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+    }
+}
+
+@Composable
+private fun UpgradeFeatureRow(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Icon(
+            imageVector = Icons.TwoTone.CheckCircle,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .padding(top = 2.dp)
+                .size(18.dp),
+        )
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+    }
+}
+
+@Composable
+internal fun UpgradeHintText(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+@Composable
+internal fun UpgradeActionCard(
+    modifier: Modifier = Modifier,
+    colors: CardColors? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val cardColors = colors ?: CardDefaults.elevatedCardColors(
+        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+    )
+
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = cardColors,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(18.dp)
+                .animateContentSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            content = content,
+        )
+    }
+}
+
+@Composable
+internal fun UpgradeLoadingBlock(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 18.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator()
+        Text(
+            text = stringResource(R.string.upgrade_screen_progress_loading),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+internal fun UpgradeInlineStateCard(
+    title: String,
+    body: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit = {},
+) {
+    UpgradeSectionCard(
+        title = title,
+        icon = icon,
+        modifier = modifier,
+        iconTint = MaterialTheme.colorScheme.onErrorContainer,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Text(
+            text = body,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+        )
+        content()
+    }
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOffers.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOffers.kt
@@ -1,0 +1,151 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
+
+// The acquisition offers box: header, offer rows, "or" divider, parity footnote. A product whose
+// offer failed to load shows disabled with a "Refresh offers" action so the user isn't stuck.
+@Composable
+internal fun LoadedOffers(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onSubscription: () -> Unit,
+    onSubscriptionTrial: () -> Unit,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        UpgradeSectionHeader(
+            title = stringResource(R.string.upgrade_screen_offers_title),
+            icon = Icons.TwoTone.Stars,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        UpgradeOfferRow(
+            title = stringResource(R.string.upgrade_screen_subscription_offer_title),
+            price = state.subscriptionPrice,
+            // Only promise the trial when Play actually returned the trial offer.
+            hint = stringResource(
+                if (state.subscriptionAction == SubscriptionAction.TRIAL) {
+                    R.string.upgrade_screen_subscription_offer_body
+                } else {
+                    R.string.upgrade_screen_subscription_offer_body_no_trial
+                }
+            ),
+        ) {
+            Button(
+                onClick = if (state.subscriptionAction == SubscriptionAction.TRIAL) onSubscriptionTrial else onSubscription,
+                enabled = state.subscriptionEnabled,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = stringResource(
+                        if (state.subscriptionAction == SubscriptionAction.TRIAL) R.string.upgrade_screen_subscription_trial_action
+                        else R.string.upgrade_screen_subscription_action
+                    ),
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            HorizontalDivider(modifier = Modifier.weight(1f))
+            Text(
+                text = stringResource(R.string.upgrade_screen_offers_or),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            HorizontalDivider(modifier = Modifier.weight(1f))
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+
+        UpgradeOfferRow(
+            title = stringResource(R.string.upgrade_screen_iap_offer_title),
+            price = state.iapPrice,
+            hint = stringResource(R.string.upgrade_screen_iap_offer_body),
+        ) {
+            OutlinedButton(
+                onClick = onIap,
+                enabled = state.iapEnabled,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (state.verificationInProgress) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.upgrade_screen_iap_action))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        UpgradeHintText(text = stringResource(R.string.upgrade_screen_offers_body))
+
+        // One product's offer didn't load: keep the other actionable, but give a way to re-fetch the
+        // missing one without leaving the screen (retry re-runs both queries).
+        if (!state.subAvailable || !state.iapAvailable) {
+            TextButton(
+                onClick = onRetry,
+                enabled = !state.anyOperationInProgress,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(CommonR.string.general_refresh_action))
+            }
+        }
+    }
+}
+
+// Title and price share one line ("·"-joined in code: direction-neutral punctuation, not
+// translatable copy), terms follow as body text, then the action — the terms must not repeat the
+// button label.
+@Composable
+internal fun UpgradeOfferRow(
+    title: String,
+    price: String?,
+    modifier: Modifier = Modifier,
+    hint: String? = null,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = listOfNotNull(title, price).joinToString(" · "),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        hint?.let { UpgradeSectionBody(text = it) }
+        Spacer(modifier = Modifier.height(8.dp))
+        content()
+    }
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOwnership.kt
@@ -1,0 +1,213 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Autorenew
+import androidx.compose.material.icons.twotone.Verified
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.R
+import eu.darken.octi.common.R as CommonR
+
+// Ownership presentation for users who already own a Pro entitlement. Subscribers without the
+// one-time purchase see the switch offer — LOCKED while the subscription still renews, so buying it
+// can't stack with an upcoming renewal, and (Octi-specific) held until billing has settled.
+@Composable
+internal fun UpgradeOwnershipContent(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onRestore: () -> Unit,
+) {
+    val ownership = state.ownership
+    val subscription = ownership.subscription
+
+    UpgradeOwnedHero(ownership = ownership)
+
+    if (ownership.hasIap) {
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_owned_iap_title),
+            icon = Icons.TwoTone.Verified,
+        ) {
+            UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_owned_iap_body))
+        }
+    }
+
+    if (subscription != null) {
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_owned_sub_title),
+            icon = Icons.TwoTone.Autorenew,
+        ) {
+            UpgradeSectionBody(
+                text = stringResource(
+                    if (subscription.isAutoRenewing) R.string.upgrade_screen_owned_sub_renewing_body
+                    else R.string.upgrade_screen_owned_sub_not_renewing_body
+                ),
+            )
+            // Own both + still renewing: nudge to cancel the redundant subscription in Play.
+            if (subscription.isAutoRenewing && ownership.hasIap) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_owned_both_warning),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
+                Text(stringResource(R.string.upgrade_screen_manage_subscription_action))
+            }
+        }
+    }
+
+    if (subscription != null && !ownership.hasIap) {
+        // The switch path as a visible artifact, not just prose: while the subscription still renews
+        // the offer is shown LOCKED with the unlock condition. Kept gated on `settled` too — an
+        // unsettled fresh install must not let a renewing subscriber start the one-time purchase.
+        val switchUnlocked = !subscription.isAutoRenewing
+        UpgradeActionCard {
+            UpgradeOfferRow(
+                title = stringResource(R.string.upgrade_screen_iap_offer_title),
+                price = state.iapPrice,
+                hint = stringResource(
+                    if (switchUnlocked) R.string.upgrade_screen_switch_body
+                    else R.string.upgrade_screen_switch_locked_note
+                ),
+            ) {
+                Button(
+                    onClick = onIap,
+                    // Not gated on iapEnabled (prices may have failed while the purchase would still
+                    // work — the billing flow re-queries on launch), but still gated on `settled`.
+                    enabled = switchUnlocked && state.settled && !state.anyOperationInProgress,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.verificationInProgress) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.width(8.dp))
+                    }
+                    Text(stringResource(R.string.upgrade_screen_iap_action))
+                }
+            }
+        }
+    }
+
+    // Framed as a status re-check; support is offered by the failed-restore dialog only.
+    UpgradeRestoreSection(
+        title = stringResource(R.string.upgrade_screen_restore_status_title),
+        body = stringResource(R.string.upgrade_screen_restore_status_body),
+        onRestore = onRestore,
+        restoreInProgress = state.restoreInProgress,
+        busy = state.anyOperationInProgress,
+    )
+}
+
+// The "you have it" moment: mascot and congrats in one hero card at the top of the status screen,
+// with the variant (subscription vs one-time) spelled out.
+@Composable
+private fun UpgradeOwnedHero(
+    ownership: Ownership,
+    modifier: Modifier = Modifier,
+) {
+    val proName = "${stringResource(CommonR.string.app_name)} ${stringResource(R.string.app_name_upgrade_postfix)}"
+    ElevatedCard(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            UpgradeMascot(size = 56.dp)
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_owned_hero_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    // The permanent purchase is the meaningful one when both are owned.
+                    text = stringResource(
+                        if (ownership.hasIap) R.string.upgrade_screen_owned_hero_iap_body
+                        else R.string.upgrade_screen_owned_hero_sub_body,
+                        proName,
+                    ),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+// Shown on the acquisition view while Pro is active purely via the local grace window. Calm
+// reassurance, not a warning: the user has lost nothing (yet). Stage 1 confirms Pro is intact;
+// stage 2 (after the episode aged past the threshold) explains and offers restore. Support is NOT
+// offered here — escalation lives in the failed-restore dialog after an empty restore.
+@Composable
+internal fun UpgradeGraceCard(
+    showDiagnostics: Boolean,
+    onRestore: () -> Unit,
+    modifier: Modifier = Modifier,
+    restoreInProgress: Boolean = false,
+    busy: Boolean = false,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_grace_title),
+        icon = Icons.TwoTone.Verified,
+        modifier = modifier,
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+        // While the episode is young the title is "Confirming…", so the header shows motion. Once
+        // diagnostics appear the copy asks the user to act — a spinner would say "still working,
+        // wait" and undercut the restore button, so the static icon returns.
+        leading = if (showDiagnostics) null else {
+            {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.5.dp)
+            }
+        },
+    ) {
+        Text(
+            text = stringResource(
+                if (showDiagnostics) R.string.upgrade_screen_grace_diagnostics_body
+                else R.string.upgrade_screen_grace_body
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        if (showDiagnostics) {
+            Button(
+                onClick = onRestore,
+                enabled = !busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (restoreInProgress) {
+                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+                Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+        }
+    }
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeRestore.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeRestore.kt
@@ -1,0 +1,80 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Restore
+import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.octi.R
+
+// Described restore section, shared by all restore audiences (copy and emphasis differ, wiring
+// doesn't). Deliberately NO contact-support action here: escalation is offered only after a restore
+// came up empty (the failed-restore dialog), so self-service gets its chance first.
+@Composable
+internal fun UpgradeRestoreSection(
+    title: String,
+    body: String,
+    onRestore: () -> Unit,
+    modifier: Modifier = Modifier,
+    // Manual restore in flight -> spinner. `busy` disables the button for ANY in-flight operation
+    // (manual/auto restore, purchase) since the guard rejects a second one anyway.
+    restoreInProgress: Boolean = false,
+    busy: Boolean = false,
+    emphasized: Boolean = false,
+) {
+    UpgradeSectionCard(
+        title = title,
+        icon = Icons.TwoTone.Restore,
+        modifier = modifier,
+        colors = if (emphasized) {
+            CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        } else {
+            null
+        },
+    ) {
+        if (emphasized) {
+            // Plain Text: the tinted container brings its own content color, the muted
+            // UpgradeSectionBody tone is for neutral surface cards only.
+            Text(text = body, style = MaterialTheme.typography.bodyMedium)
+            Button(
+                onClick = onRestore,
+                enabled = !busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                RestoreButtonLabel(restoreInProgress = restoreInProgress)
+            }
+        } else {
+            UpgradeSectionBody(text = body)
+            OutlinedButton(
+                onClick = onRestore,
+                enabled = !busy,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                RestoreButtonLabel(restoreInProgress = restoreInProgress)
+            }
+        }
+    }
+}
+
+@Composable
+private fun RestoreButtonLabel(restoreInProgress: Boolean) {
+    if (restoreInProgress) {
+        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+        Spacer(modifier = Modifier.width(8.dp))
+    }
+    Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+}

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -1,58 +1,41 @@
 package eu.darken.octi.common.upgrade.ui
 
 import android.app.Activity
-import android.content.ActivityNotFoundException
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
 import android.widget.Toast
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.AutoAwesome
+import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.octi.R
-import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.error.ErrorEventHandler
@@ -74,9 +57,11 @@ fun UpgradeScreenHost(
     val context = LocalContext.current
     val activity = context as? Activity
 
-    var showStillRenewingDialog by remember { mutableStateOf(false) }
-    var showCheckFailedDialog by remember { mutableStateOf(false) }
-    var showRestoreFailedDialog by remember { mutableStateOf(false) }
+    // rememberSaveable so a config change (rotation) can't drop an in-flight dialog after it consumed
+    // its one-shot event.
+    var showStillRenewingDialog by rememberSaveable { mutableStateOf(false) }
+    var showCheckFailedDialog by rememberSaveable { mutableStateOf(false) }
+    var showRestoreFailedDialog by rememberSaveable { mutableStateOf(false) }
 
     val restoreSuccessMessage = stringResource(R.string.upgrade_screen_restore_success_message)
 
@@ -103,7 +88,7 @@ fun UpgradeScreenHost(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    val state by vm.state.collectAsState()
+    val state by vm.state.collectAsStateWithLifecycle()
     UpgradeScreen(
         state = state,
         onNavigateUp = { vm.navUp() },
@@ -113,7 +98,7 @@ fun UpgradeScreenHost(
         onRestore = { vm.restorePurchase() },
         onManageSubscription = { vm.onManageSubscription() },
         onSeeUpgradeOptions = { vm.onSeeUpgradeOptions() },
-        onContactSupport = { vm.onContactSupport() },
+        onRetry = { vm.retrySkuQuery() },
     )
 
     if (showStillRenewingDialog) {
@@ -129,12 +114,18 @@ fun UpgradeScreenHost(
         CheckFailedDialog(onDismiss = { showCheckFailedDialog = false })
     }
     if (showRestoreFailedDialog) {
-        RestoreFailedDialog(onDismiss = { showRestoreFailedDialog = false })
+        RestoreFailedDialog(
+            onContactSupport = {
+                showRestoreFailedDialog = false
+                vm.onContactSupport()
+            },
+            onDismiss = { showRestoreFailedDialog = false },
+        )
     }
 }
 
 @Composable
-fun UpgradeScreen(
+internal fun UpgradeScreen(
     state: UpgradeUiState?,
     onNavigateUp: () -> Unit,
     onIap: () -> Unit,
@@ -143,260 +134,171 @@ fun UpgradeScreen(
     onRestore: () -> Unit,
     onManageSubscription: () -> Unit,
     onSeeUpgradeOptions: () -> Unit,
-    onContactSupport: () -> Unit,
+    onRetry: () -> Unit,
 ) {
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.upgrade_screen_title),
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateUp) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = null,
-                        )
-                    }
-                },
-            )
+    val loaded = state as? UpgradeUiState.Loaded
+    val owned = loaded?.takeIf { it.ownership.ownsAnything }
+
+    UpgradeScreenScaffold(
+        // Grace users are still Pro: they get the "Octi Pro" status title too — "Get Octi Pro" would
+        // contradict the rest of the app, which behaves upgraded.
+        title = if (owned != null || loaded?.grace != null) {
+            upgradeScreenTitle(upgraded = true)
+        } else {
+            AnnotatedString(stringResource(R.string.upgrade_screen_title))
         },
+        onNavigateUp = onNavigateUp,
     ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 32.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
+        UpgradeScreenContent(
+            paddingValues = innerPadding,
+            contentPadding = PaddingValues(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 32.dp),
         ) {
-            Spacer(modifier = Modifier.height(8.dp))
-            OctiMascot(modifier = Modifier.size(72.dp))
-            Spacer(modifier = Modifier.height(8.dp))
+            // Owners get the mascot inside the congrats hero card instead of the standalone header.
+            if (owned == null) UpgradeHeader(mascotSize = 88.dp)
 
-            when (state) {
-                null, is UpgradeUiState.Loading -> LoadingContent()
-                is UpgradeUiState.Loaded -> when {
-                    state.ownership.ownsAnything -> OwnedContent(
-                        state = state,
-                        onIap = onIap,
-                        onManageSubscription = onManageSubscription,
-                    )
+            when {
+                owned != null -> UpgradeOwnershipContent(
+                    state = owned,
+                    onIap = onIap,
+                    onManageSubscription = onManageSubscription,
+                    onRestore = onRestore,
+                )
 
-                    state.grace != null -> GraceContent(
-                        grace = state.grace,
-                        restoreInProgress = state.restoreInProgress,
-                        onRestore = onRestore,
-                        onContactSupport = onContactSupport,
-                    )
+                loaded != null && loaded.showFreeStatus -> FreeStatusContent(onSeeUpgradeOptions = onSeeUpgradeOptions)
 
-                    state.showFreeStatus -> FreeStatusContent(onSeeUpgradeOptions = onSeeUpgradeOptions)
+                loaded != null -> UpgradeAcquisitionContent(
+                    state = loaded,
+                    onIap = onIap,
+                    onSubscription = onSubscription,
+                    onSubscriptionTrial = onSubscriptionTrial,
+                    onRestore = onRestore,
+                    onRetry = onRetry,
+                )
 
-                    else -> OffersContent(
-                        state = state,
-                        onIap = onIap,
-                        onSubscription = onSubscription,
-                        onSubscriptionTrial = onSubscriptionTrial,
-                        onRestore = onRestore,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
-        }
-    }
-}
-
-@Composable
-private fun LoadingContent() {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(32.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        CircularProgressIndicator()
-    }
-}
-
-@Composable
-private fun StatusCard(
-    title: String,
-    body: String,
-    container: Color = MaterialTheme.colorScheme.tertiaryContainer,
-    content: @Composable (() -> Unit)? = null,
-) {
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.elevatedCardColors(containerColor = container),
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = title, style = MaterialTheme.typography.titleMedium)
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(text = body, style = MaterialTheme.typography.bodyMedium)
-            content?.let {
-                Spacer(modifier = Modifier.height(12.dp))
-                it()
+                else -> UpgradeActionCard { UpgradeLoadingBlock() }
             }
         }
     }
 }
 
 @Composable
-private fun OwnedContent(
+private fun UpgradeAcquisitionContent(
     state: UpgradeUiState.Loaded,
     onIap: () -> Unit,
-    onManageSubscription: () -> Unit,
-) {
-    val subscription = state.ownership.subscription
-
-    StatusCard(
-        title = stringResource(R.string.upgrade_screen_owned_title),
-        body = stringResource(R.string.upgrade_screen_owned_body),
-    )
-
-    if (state.ownership.hasIap) {
-        Spacer(modifier = Modifier.height(16.dp))
-        StatusCard(
-            title = stringResource(R.string.upgrade_screen_owned_iap_title),
-            body = stringResource(R.string.upgrade_screen_owned_iap_body),
-        )
-    }
-
-    if (subscription != null) {
-        Spacer(modifier = Modifier.height(16.dp))
-        StatusCard(
-            title = stringResource(R.string.upgrade_screen_owned_sub_title),
-            body = stringResource(
-                if (subscription.isAutoRenewing) R.string.upgrade_screen_owned_sub_renewing_body
-                else R.string.upgrade_screen_owned_sub_not_renewing_body
-            ),
-        ) {
-            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
-            }
-        }
-    }
-
-    // Own both: warn so the user can cancel the (redundant) subscription in Play.
-    if (state.ownership.hasIap && subscription != null) {
-        Spacer(modifier = Modifier.height(16.dp))
-        StatusCard(
-            title = stringResource(R.string.upgrade_screen_owned_both_title),
-            body = stringResource(R.string.upgrade_screen_owned_both_warning),
-            container = MaterialTheme.colorScheme.errorContainer,
-        ) {
-            OutlinedButton(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
-            }
-        }
-    }
-
-    // Switch offer: a subscriber without the lifetime purchase can move over. Locked while the
-    // subscription still auto-renews (cancel in Play first); the purchase gate re-verifies anyway.
-    if (subscription != null && !state.ownership.hasIap) {
-        Spacer(modifier = Modifier.height(16.dp))
-        SwitchCard(
-            renewing = subscription.isAutoRenewing,
-            iapPrice = state.iapPrice,
-            iapEnabled = state.iapEnabled,
-            onIap = onIap,
-            onManageSubscription = onManageSubscription,
-        )
-    }
-}
-
-@Composable
-private fun SwitchCard(
-    renewing: Boolean,
-    iapPrice: String?,
-    iapEnabled: Boolean,
-    onIap: () -> Unit,
-    onManageSubscription: () -> Unit,
-) {
-    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_switch_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.upgrade_screen_switch_body),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-
-            if (renewing) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(R.string.upgrade_screen_switch_locked_note),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                Button(onClick = onManageSubscription, modifier = Modifier.fillMaxWidth()) {
-                    Text(text = stringResource(R.string.upgrade_screen_manage_subscription_action))
-                }
-            } else {
-                Spacer(modifier = Modifier.height(12.dp))
-                Button(
-                    onClick = onIap,
-                    enabled = iapEnabled,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        text = if (iapPrice != null) {
-                            stringResource(R.string.upgrade_screen_switch_action, iapPrice)
-                        } else {
-                            stringResource(R.string.upgrade_screen_iap_action)
-                        },
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun GraceContent(
-    grace: GraceHint,
-    restoreInProgress: Boolean,
+    onSubscription: () -> Unit,
+    onSubscriptionTrial: () -> Unit,
     onRestore: () -> Unit,
-    onContactSupport: () -> Unit,
+    onRetry: () -> Unit,
 ) {
-    StatusCard(
-        title = stringResource(R.string.upgrade_screen_grace_title),
-        body = stringResource(
-            if (grace.showDiagnostics) R.string.upgrade_screen_grace_diagnostics_body
-            else R.string.upgrade_screen_grace_body
-        ),
-    ) {
-        if (grace.showDiagnostics) {
-            Button(
-                onClick = onRestore,
-                enabled = !restoreInProgress,
-                modifier = Modifier.fillMaxWidth(),
+    val grace = state.grace
+    val inGrace = grace != null
+
+    if (grace != null) {
+        UpgradeGraceCard(
+            showDiagnostics = grace.showDiagnostics,
+            onRestore = onRestore,
+            restoreInProgress = state.restoreInProgress,
+            busy = state.anyOperationInProgress,
+        )
+    }
+
+    // Grace users never see the sales pitch (they are Pro; sales copy next to a "still active" card
+    // reads as a contradiction). The OFFERS follow the episode age: a young episode (likely a
+    // self-healing blip) shows calm status only, an aged one adds restore AND the offers so an
+    // expired subscriber can switch without waiting out the full grace window.
+    if (!inGrace) {
+        UpgradePreambleCard(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+        )
+
+        if (state.showRestoreBanner) {
+            // The targeted returning-buyer nudge: emphasized, and the ONLY restore affordance on the
+            // screen — a second one below would make the screen feel uncertain about its own advice.
+            UpgradeRestoreSection(
+                title = stringResource(R.string.upgrade_screen_restore_banner_title),
+                body = stringResource(R.string.upgrade_screen_restore_banner_body),
+                onRestore = onRestore,
+                restoreInProgress = state.restoreInProgress,
+                busy = state.anyOperationInProgress,
+                emphasized = true,
+            )
+        }
+
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_benefits_title),
+            icon = Icons.TwoTone.AutoAwesome,
+        ) {
+            UpgradeFeatureList(text = stringResource(R.string.upgrade_screen_benefits_body))
+        }
+    }
+
+    if (grace == null || grace.showDiagnostics) {
+        UpgradeOffersBox(
+            state = state,
+            onIap = onIap,
+            onSubscription = onSubscription,
+            onSubscriptionTrial = onSubscriptionTrial,
+            onRetry = onRetry,
+        )
+    }
+
+    // Restore is account reconciliation, not an offer — its own described section, after the offers.
+    // Only for plain acquisition: returning buyers get the emphasized section up top, grace users'
+    // restore is owned by the grace card's two-stage disclosure.
+    if (!inGrace && !state.showRestoreBanner) {
+        UpgradeRestoreSection(
+            title = stringResource(R.string.upgrade_screen_restore_banner_title),
+            body = stringResource(R.string.upgrade_screen_restore_body),
+            onRestore = onRestore,
+            restoreInProgress = state.restoreInProgress,
+            busy = state.anyOperationInProgress,
+        )
+    }
+}
+
+// Each offer phase brings its OWN container: the Unavailable state is a full card itself (wrapping
+// it in the action card would nest a card in a card). Animated by phase KIND only, so per-tap
+// field changes (restore/verification progress) don't cross-fade the card.
+@Composable
+private fun UpgradeOffersBox(
+    state: UpgradeUiState.Loaded,
+    onIap: () -> Unit,
+    onSubscription: () -> Unit,
+    onSubscriptionTrial: () -> Unit,
+    onRetry: () -> Unit,
+) {
+    AnimatedContent(
+        targetState = state.offers,
+        transitionSpec = { fadeIn() togetherWith fadeOut() },
+        contentKey = { it::class },
+        label = "upgrade-offers",
+    ) { offers ->
+        when (offers) {
+            OfferState.Loading -> UpgradeActionCard { UpgradeLoadingBlock() }
+            is OfferState.Unavailable -> UpgradeInlineStateCard(
+                title = stringResource(R.string.upgrades_gplay_unavailable_error_title),
+                body = stringResource(R.string.upgrades_gplay_unavailable_error_description),
+                icon = Icons.TwoTone.WarningAmber,
             ) {
-                if (restoreInProgress) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                    Spacer(modifier = Modifier.width(8.dp))
+                // Play can be slow rather than broken (cold store, first sign-in): let the user
+                // re-run the offer queries instead of leaving a dead screen.
+                OutlinedButton(onClick = onRetry, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(CommonR.string.general_refresh_action))
                 }
-                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
-            Spacer(modifier = Modifier.height(8.dp))
-            OutlinedButton(onClick = onContactSupport, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(R.string.upgrade_screen_contact_support_action))
-            }
-        } else {
-            Box(
-                modifier = Modifier.fillMaxWidth(),
-                contentAlignment = Alignment.CenterStart,
-            ) {
-                CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+
+            OfferState.Ready -> UpgradeActionCard {
+                LoadedOffers(
+                    state = state,
+                    onIap = onIap,
+                    onSubscription = onSubscription,
+                    onSubscriptionTrial = onSubscriptionTrial,
+                    onRetry = onRetry,
+                )
             }
         }
     }
@@ -404,220 +306,13 @@ private fun GraceContent(
 
 @Composable
 private fun FreeStatusContent(onSeeUpgradeOptions: () -> Unit) {
-    StatusCard(
+    UpgradeSectionCard(
         title = stringResource(R.string.upgrade_screen_free_status_title),
-        body = stringResource(R.string.upgrade_screen_free_status_body),
+        icon = Icons.TwoTone.AutoAwesome,
     ) {
+        UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_free_status_body))
         Button(onClick = onSeeUpgradeOptions, modifier = Modifier.fillMaxWidth()) {
             Text(text = stringResource(R.string.upgrade_screen_see_options_action))
-        }
-    }
-}
-
-@Composable
-private fun OffersContent(
-    state: UpgradeUiState.Loaded,
-    onIap: () -> Unit,
-    onSubscription: () -> Unit,
-    onSubscriptionTrial: () -> Unit,
-    onRestore: () -> Unit,
-) {
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        ),
-    ) {
-        Text(
-            text = stringResource(R.string.upgrade_screen_preamble),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(16.dp),
-        )
-    }
-
-    if (state.showRestoreBanner) {
-        Spacer(modifier = Modifier.height(16.dp))
-        RestoreBanner(onRestore = onRestore, restoreInProgress = state.restoreInProgress)
-    }
-
-    Spacer(modifier = Modifier.height(24.dp))
-
-    Text(
-        text = stringResource(R.string.upgrade_screen_benefits_title),
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-    Text(
-        text = stringResource(R.string.upgrade_screen_benefits_body),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-
-    Spacer(modifier = Modifier.height(24.dp))
-
-    Text(
-        text = stringResource(R.string.upgrade_screen_how_title),
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-    Text(
-        text = stringResource(R.string.upgrade_screen_how_body2),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-    if (state.subscriptionAction == SubscriptionAction.TRIAL) {
-        Text(
-            text = stringResource(R.string.upgrade_screen_how_trial_hint),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-
-    Spacer(modifier = Modifier.height(24.dp))
-
-    if (!state.subAvailable && !state.iapAvailable) {
-        PricingUnavailable()
-    } else {
-        PricingContent(
-            state = state,
-            onIap = onIap,
-            onSubscription = onSubscription,
-            onSubscriptionTrial = onSubscriptionTrial,
-        )
-    }
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    // Restore is available regardless of whether pricing could be loaded — a returning buyer with a
-    // flaky Play connection is exactly who needs it.
-    TextButton(
-        onClick = onRestore,
-        enabled = !state.restoreInProgress,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
-    }
-}
-
-@Composable
-private fun PricingContent(
-    state: UpgradeUiState.Loaded,
-    onIap: () -> Unit,
-    onSubscription: () -> Unit,
-    onSubscriptionTrial: () -> Unit,
-) {
-    if (state.subAvailable) {
-        Button(
-            onClick = if (state.subscriptionAction == SubscriptionAction.TRIAL) onSubscriptionTrial else onSubscription,
-            enabled = state.subscriptionEnabled,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(
-                text = stringResource(
-                    if (state.subscriptionAction == SubscriptionAction.TRIAL) R.string.upgrade_screen_subscription_trial_action
-                    else R.string.upgrade_screen_subscription_action
-                ),
-            )
-        }
-        state.subscriptionPrice?.let { price ->
-            Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint, price),
-                style = MaterialTheme.typography.labelSmall,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    OutlinedButton(
-        onClick = onIap,
-        enabled = state.iapEnabled && state.iapAvailable,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text(text = stringResource(R.string.upgrade_screen_iap_action))
-    }
-    state.iapPrice?.let { price ->
-        Text(
-            text = stringResource(R.string.upgrade_screen_iap_action_hint, price),
-            style = MaterialTheme.typography.labelSmall,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
-}
-
-@Composable
-private fun RestoreBanner(
-    onRestore: () -> Unit,
-    restoreInProgress: Boolean = false,
-) {
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        ),
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_restore_banner_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.upgrade_screen_restore_banner_body),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(
-                onClick = onRestore,
-                enabled = !restoreInProgress,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                if (restoreInProgress) {
-                    CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
-                    Spacer(modifier = Modifier.width(8.dp))
-                }
-                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
-            }
-        }
-    }
-}
-
-@Composable
-private fun PricingUnavailable() {
-    val context = LocalContext.current
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.upgrades_gplay_unavailable_error_title),
-            style = MaterialTheme.typography.titleMedium,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = stringResource(R.string.upgrades_gplay_unavailable_error_description),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        OutlinedButton(
-            onClick = {
-                try {
-                    val intent = Intent().apply {
-                        action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                        data = Uri.fromParts("package", "com.android.vending", null)
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    }
-                    context.startActivity(intent)
-                } catch (e: ActivityNotFoundException) {
-                    Toast.makeText(context, "Google Play is not installed", Toast.LENGTH_SHORT).show()
-                }
-            },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(text = "Google Play")
         }
     }
 }
@@ -655,21 +350,29 @@ private fun CheckFailedDialog(onDismiss: () -> Unit) {
     )
 }
 
+// Leads with the just-happened live Play check (hedged: RestoreFailed also fires on timeout, so the
+// copy never claims a successful check). This dialog is the ONLY contact-support surface —
+// escalation comes after an empty restore, never before.
 @Composable
-private fun RestoreFailedDialog(onDismiss: () -> Unit) {
+private fun RestoreFailedDialog(onContactSupport: () -> Unit, onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         text = {
             Text(
                 text = listOf(
-                    stringResource(R.string.upgrade_screen_restore_purchase_message),
-                    stringResource(R.string.upgrade_screen_restore_troubleshooting_msg),
-                    stringResource(R.string.upgrade_screen_restore_sync_patience_hint),
+                    stringResource(R.string.upgrade_screen_restore_checked_message),
                     stringResource(R.string.upgrade_screen_restore_multiaccount_hint),
+                    stringResource(R.string.upgrade_screen_restore_sync_patience_hint),
+                    stringResource(R.string.upgrade_screen_restore_contact_hint),
                 ).joinToString("\n\n"),
             )
         },
         confirmButton = {
+            TextButton(onClick = onContactSupport) {
+                Text(text = stringResource(R.string.upgrade_screen_contact_support_action))
+            }
+        },
+        dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(text = stringResource(CommonR.string.general_dismiss_action))
             }
@@ -677,97 +380,101 @@ private fun RestoreFailedDialog(onDismiss: () -> Unit) {
     )
 }
 
-@Preview2
+private fun previewLoaded(
+    subscriptionAction: SubscriptionAction = SubscriptionAction.STANDARD,
+    subscriptionPrice: String? = "€1.99",
+    iapPrice: String? = "€9.99",
+    offers: OfferState = OfferState.Ready,
+    ownership: Ownership = Ownership(),
+    grace: GraceHint? = null,
+    showRestoreBanner: Boolean = false,
+    manageMode: Boolean = false,
+    viewingOffers: Boolean = false,
+) = UpgradeUiState.Loaded(
+    subscriptionAction = subscriptionAction,
+    subscriptionEnabled = subscriptionAction != SubscriptionAction.UNAVAILABLE && ownership.subscription == null,
+    subscriptionPrice = subscriptionPrice,
+    iapEnabled = !ownership.hasIap && iapPrice != null,
+    iapPrice = iapPrice,
+    offers = offers,
+    ownership = ownership,
+    grace = grace,
+    showRestoreBanner = showRestoreBanner,
+    manageMode = manageMode,
+    viewingOffers = viewingOffers,
+)
+
 @Composable
-private fun UpgradeScreenLoadingPreview() = PreviewWrapper {
+private fun PreviewUpgradeScreen(state: UpgradeUiState?) {
     UpgradeScreen(
-        state = UpgradeUiState.Loading,
+        state = state,
         onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
+        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onRetry = {},
     )
 }
 
 @Preview2
 @Composable
+private fun UpgradeScreenLoadingPreview() = PreviewWrapper { PreviewUpgradeScreen(UpgradeUiState.Loading) }
+
+@Preview2
+@Composable
 private fun UpgradeScreenOffersPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeUiState.Loaded(
-            subscriptionAction = SubscriptionAction.STANDARD,
-            subscriptionEnabled = true,
-            subscriptionPrice = "€1.99",
-            iapEnabled = true,
-            iapPrice = "€9.99",
+    PreviewUpgradeScreen(previewLoaded(subscriptionAction = SubscriptionAction.TRIAL))
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenUnavailablePreview() = PreviewWrapper {
+    PreviewUpgradeScreen(
+        previewLoaded(
+            subscriptionAction = SubscriptionAction.UNAVAILABLE,
+            subscriptionPrice = null,
+            iapPrice = null,
+            offers = OfferState.Unavailable(RuntimeException("Play unavailable")),
         ),
-        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
 private fun UpgradeScreenOwnedSubRenewingPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeUiState.Loaded(
+    PreviewUpgradeScreen(
+        previewLoaded(
             subscriptionAction = SubscriptionAction.UNAVAILABLE,
-            subscriptionEnabled = false,
             subscriptionPrice = null,
-            iapEnabled = false,
-            iapPrice = "€9.99",
             ownership = Ownership(hasIap = false, subscription = SubscriptionOwnership(isAutoRenewing = true)),
         ),
-        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
 private fun UpgradeScreenSwitchAvailablePreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeUiState.Loaded(
+    PreviewUpgradeScreen(
+        previewLoaded(
             subscriptionAction = SubscriptionAction.UNAVAILABLE,
-            subscriptionEnabled = false,
             subscriptionPrice = null,
-            iapEnabled = true,
-            iapPrice = "€9.99",
             ownership = Ownership(hasIap = false, subscription = SubscriptionOwnership(isAutoRenewing = false)),
         ),
-        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
 private fun UpgradeScreenGraceDiagnosticsPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeUiState.Loaded(
+    PreviewUpgradeScreen(
+        previewLoaded(
             subscriptionAction = SubscriptionAction.UNAVAILABLE,
-            subscriptionEnabled = false,
             subscriptionPrice = null,
-            iapEnabled = false,
             iapPrice = null,
             grace = GraceHint(showDiagnostics = true),
         ),
-        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
     )
 }
 
 @Preview2
 @Composable
 private fun UpgradeScreenFreeStatusPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeUiState.Loaded(
-            subscriptionAction = SubscriptionAction.STANDARD,
-            subscriptionEnabled = true,
-            subscriptionPrice = "€1.99",
-            iapEnabled = true,
-            iapPrice = "€9.99",
-            manageMode = true,
-            viewingOffers = false,
-        ),
-        onNavigateUp = {}, onIap = {}, onSubscription = {}, onSubscriptionTrial = {},
-        onRestore = {}, onManageSubscription = {}, onSeeUpgradeOptions = {}, onContactSupport = {},
-    )
+    PreviewUpgradeScreen(previewLoaded(manageMode = true, viewingOffers = false))
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeUiState.kt
@@ -14,11 +14,19 @@ sealed interface UpgradeUiState {
         val subscriptionPrice: String?,
         val iapEnabled: Boolean,
         val iapPrice: String?,
+        // Offer-box phase, independent of the dashboard: an owner/grace/free user renders their own
+        // view even while (or after) the SKU queries are still loading or have failed.
+        val offers: OfferState = OfferState.Loading,
         val ownership: Ownership = Ownership(),
         val grace: GraceHint? = null,
         val showRestoreBanner: Boolean = false,
         val settled: Boolean = true,
+        // Manual restore only — drives the in-button spinner.
         val restoreInProgress: Boolean = false,
+        // Manual OR the repo's invisible already-owned auto-restore — disables restore surfaces so a
+        // manual restore can't race the automatic one (which the VM's CAS guard can't see).
+        val restoreBusy: Boolean = false,
+        // Pre-IAP verification / purchase launch OR auto-restore — disables purchase actions.
         val verificationInProgress: Boolean = false,
         // Manage route + free user: show the calm status page first, revealing the offers only when
         // the user asks. Sales route or an existing owner/grace user always sees the relevant view.
@@ -27,10 +35,21 @@ sealed interface UpgradeUiState {
     ) : UpgradeUiState {
         val subAvailable: Boolean get() = subscriptionAction != SubscriptionAction.UNAVAILABLE
         val iapAvailable: Boolean get() = iapPrice != null
+        // Any entitlement operation (manual/auto restore, purchase verify/launch) is in flight — the
+        // single-flight guard rejects a second one, so every action surface disables to match.
+        val anyOperationInProgress: Boolean get() = restoreBusy || verificationInProgress
         val isFree: Boolean get() = !ownership.ownsAnything && grace == null
         // Free user on the manage route who hasn't asked to see the offers yet.
         val showFreeStatus: Boolean get() = isFree && manageMode && !viewingOffers
     }
+}
+
+// The acquisition offers box phase. Prices/actions themselves live on Loaded (owners read the IAP
+// price for the switch offer regardless of this phase); this only gates the offers-box rendering.
+sealed interface OfferState {
+    data object Loading : OfferState
+    data class Unavailable(val error: Throwable) : OfferState
+    data object Ready : OfferState
 }
 
 // Pro but no owned purchase in the current data — the grace period is carrying the entitlement.
@@ -60,48 +79,76 @@ fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
         ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
 )
 
-// Aggregate result of the one-shot SKU detail queries. `done` distinguishes "queries still running"
-// from "queries finished but found nothing" — owners render without waiting either way.
-data class SkuQueryState(
-    val done: Boolean = false,
-    val iap: SkuDetails? = null,
-    val sub: SkuDetails? = null,
-)
+// One aggregate SKU-detail query per retry generation. `Pending` distinguishes "queries still
+// running" from a finished `Done` — a Done whose Results are both failures becomes the offers-box
+// Unavailable state, while both empty-but-successful stays Ready (a product simply has no offer).
+sealed interface SkuQueries {
+    data object Pending : SkuQueries
+    data class Done(
+        val iap: Result<List<SkuDetails>>,
+        val sub: Result<List<SkuDetails>>,
+    ) : SkuQueries
+}
 
 fun toLoadedState(
-    skus: SkuQueryState,
+    queries: SkuQueries,
     ownership: Ownership,
     grace: GraceHint?,
     showRestoreBanner: Boolean,
     settled: Boolean,
     restoreInProgress: Boolean,
+    restoreBusy: Boolean,
     verificationInProgress: Boolean,
     manageMode: Boolean,
     viewingOffers: Boolean,
 ): UpgradeUiState.Loaded {
-    val iapOffer = skus.iap?.details?.oneTimePurchaseOfferDetails
-    val subOffers = skus.sub?.details?.subscriptionOfferDetails
+    val done = queries as? SkuQueries.Done
+    val iapDetails = done?.iap?.getOrNull()?.firstOrNull()
+    val subDetails = done?.sub?.getOrNull()?.firstOrNull()
+
+    val iapOffer = iapDetails?.details?.oneTimePurchaseOfferDetails
+    val subOffers = subDetails?.details?.subscriptionOfferDetails
     val baseOffer = subOffers?.firstOrNull { OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(it) }
     val trialOffer = subOffers?.firstOrNull { OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(it) }
 
+    val subscriptionAction = when {
+        trialOffer != null -> SubscriptionAction.TRIAL
+        baseOffer != null -> SubscriptionAction.STANDARD
+        else -> SubscriptionAction.UNAVAILABLE
+    }
+    val subscriptionPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice
+    val iapPrice = iapOffer?.formattedPrice
+    val subAvailable = subscriptionAction != SubscriptionAction.UNAVAILABLE
+    val iapAvailable = iapPrice != null
+
+    val offers: OfferState = when {
+        done == null -> OfferState.Loading
+        // Only a genuine query FAILURE for BOTH products is "unavailable". Empty-but-successful
+        // stays Ready — a product just has no offer, and its button ends up disabled below.
+        done.iap.isFailure && done.sub.isFailure -> OfferState.Unavailable(
+            done.iap.exceptionOrNull() ?: done.sub.exceptionOrNull() ?: IllegalStateException("Offers unavailable"),
+        )
+
+        else -> OfferState.Ready
+    }
+
+    // `settled` gates all purchase actions until the first billing reconciliation (or its bounded
+    // fallback): an owner on a fresh install must not buy the other product before their existing
+    // purchase has been seen. `!available` keeps a product whose offer didn't load un-launchable.
+    val busy = restoreBusy || verificationInProgress
     return UpgradeUiState.Loaded(
-        subscriptionAction = when {
-            trialOffer != null -> SubscriptionAction.TRIAL
-            baseOffer != null -> SubscriptionAction.STANDARD
-            else -> SubscriptionAction.UNAVAILABLE
-        },
-        // `settled` gates all purchase actions until the first billing reconciliation (or its
-        // bounded fallback): the initially-empty purchase state must not let an owner on a fresh
-        // install buy the other product before their existing purchase has been seen.
-        subscriptionEnabled = settled && ownership.subscription == null && !restoreInProgress && !verificationInProgress,
-        subscriptionPrice = baseOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = settled && !ownership.hasIap && !restoreInProgress && !verificationInProgress,
-        iapPrice = iapOffer?.formattedPrice,
+        subscriptionAction = subscriptionAction,
+        subscriptionEnabled = settled && ownership.subscription == null && subAvailable && !busy,
+        subscriptionPrice = subscriptionPrice,
+        iapEnabled = settled && !ownership.hasIap && iapAvailable && !busy,
+        iapPrice = iapPrice,
+        offers = offers,
         ownership = ownership,
         grace = grace,
         showRestoreBanner = showRestoreBanner,
         settled = settled,
         restoreInProgress = restoreInProgress,
+        restoreBusy = restoreBusy,
         verificationInProgress = verificationInProgress,
         manageMode = manageMode,
         viewingOffers = viewingOffers,

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -32,7 +32,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
@@ -40,6 +39,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
@@ -97,28 +97,41 @@ class UpgradeViewModel @Inject constructor(
         },
     ).stateIn(vmScope, SharingStarted.Eagerly, false)
 
-    // One aggregate SKU-detail query per ViewModel lifetime, both types concurrently. Failures
-    // resolve to null details — owners/grace render price-independently, acquisition users get the
-    // fallback purchase UI.
-    private val skuQueries = flow {
-        emit(SkuQueryState())
-        val result = coroutineScope {
-            val iap = async { querySkuDetailsSafe(OurSku.Iap.PRO_UPGRADE) }
-            val sub = async { querySkuDetailsSafe(OurSku.Sub.PRO_UPGRADE) }
-            SkuQueryState(done = true, iap = iap.await(), sub = sub.await())
+    // Re-runnable via retryTrigger: after a full "Play unavailable" episode the Lazily-cached failure
+    // would otherwise brick the offers box for the whole ViewModel lifetime.
+    private val retryTrigger = MutableStateFlow(0)
+
+    // One aggregate SKU-detail query per retry generation, both types concurrently, landing in a
+    // single Done so the UI can never combine results from two different attempts. Owners/grace
+    // render price-independently; acquisition users see Loading/Unavailable/Ready derived from this.
+    private val skuQueries = retryTrigger.flatMapLatest {
+        flow {
+            emit(SkuQueries.Pending)
+            val done = coroutineScope {
+                val iap = async { querySkuDetails(OurSku.Iap.PRO_UPGRADE) }
+                val sub = async { querySkuDetails(OurSku.Sub.PRO_UPGRADE) }
+                SkuQueries.Done(iap = iap.await(), sub = sub.await())
+            }
+            emit(done)
         }
-        emit(result)
     }.shareIn(vmScope, SharingStarted.Lazily, replay = 1)
 
-    private suspend fun querySkuDetailsSafe(sku: Sku): SkuDetails? = try {
-        withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
-            upgradeRepo.querySkus(sku).firstOrNull()
-        }
+    // Empty is a failure (BillingConnection.querySkus throws on empty details) and a timeout maps to
+    // a failure Result — both let the mapper decide Unavailable vs a partially-available Ready.
+    private suspend fun querySkuDetails(sku: Sku): Result<List<SkuDetails>> = try {
+        val details = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) { upgradeRepo.querySkus(sku).toList() }
+            ?: throw IllegalStateException("SKU query timed out for ${sku.id}")
+        Result.success(details)
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
         log(TAG, WARN) { "Failed to query SKU ${sku.id}: ${e.asLog()}" }
-        null
+        Result.failure(e)
+    }
+
+    fun retrySkuQuery() {
+        log(TAG) { "retrySkuQuery()" }
+        retryTrigger.update { it + 1 }
     }
 
     // Re-evaluates the grace presentation when the open episode crosses the diagnostics threshold —
@@ -158,8 +171,9 @@ class UpgradeViewModel @Inject constructor(
 
     private data class UiInputs(
         val settled: Boolean,
-        val restoring: Boolean,
-        val busy: Boolean,
+        val restoreInProgress: Boolean,
+        val restoreBusy: Boolean,
+        val verificationInProgress: Boolean,
         val manage: Boolean,
         val viewingOffers: Boolean,
     )
@@ -171,12 +185,15 @@ class UpgradeViewModel @Inject constructor(
         manageRoute.filterNotNull(),
         viewingOffers,
     ) { isSettled, operation, autoRestoring, manage, offers ->
+        val manualRestoring = operation == Operation.RESTORE
         UiInputs(
             settled = isSettled,
-            restoring = operation == Operation.RESTORE,
-            // The invisible already-owned reconciliation runs off the VM's guard — treat it as busy
-            // so the buy buttons stay disabled while it resolves.
-            busy = operation == Operation.PURCHASE || autoRestoring,
+            // Manual restore drives the in-button spinner...
+            restoreInProgress = manualRestoring,
+            // ...while the invisible already-owned reconciliation folds into both busy signals, so
+            // neither a manual restore nor a purchase can be started while it resolves.
+            restoreBusy = manualRestoring || autoRestoring,
+            verificationInProgress = operation == Operation.PURCHASE || autoRestoring,
             manage = manage,
             viewingOffers = offers,
         )
@@ -198,21 +215,25 @@ class UpgradeViewModel @Inject constructor(
             null
         }
 
-        // Owners and grace users render price-independently: their status view must not degrade to a
-        // spinner (or an error) just because the SKU pricing queries failed or are slow.
-        val priceIndependent = ownership.ownsAnything || grace != null
-        if (!priceIndependent && !skus.done) {
+        // Hidden while a grace period or an actual purchase keeps the user Pro.
+        val showRestoreBanner = billing.wasEverPro && info?.isPro != true
+        // Anyone whose primary view doesn't need offer prices renders a Loaded dashboard immediately;
+        // the offers box carries its own Loading/Unavailable phase. That's owners and grace users,
+        // but ALSO the manage/free-status calm page and the returning-buyer restore banner — none of
+        // them should sit behind a full-screen spinner until a slow/hanging SKU query resolves.
+        val priceIndependent = ownership.ownsAnything || grace != null || inputs.manage || showRestoreBanner
+        if (!priceIndependent && skus is SkuQueries.Pending) {
             UpgradeUiState.Loading
         } else {
             toLoadedState(
-                skus = skus,
+                queries = skus,
                 ownership = ownership,
                 grace = grace,
-                // Hidden while a grace period or an actual purchase keeps the user Pro.
-                showRestoreBanner = billing.wasEverPro && info?.isPro != true,
+                showRestoreBanner = showRestoreBanner,
                 settled = inputs.settled,
-                restoreInProgress = inputs.restoring,
-                verificationInProgress = inputs.busy,
+                restoreInProgress = inputs.restoreInProgress,
+                restoreBusy = inputs.restoreBusy,
+                verificationInProgress = inputs.verificationInProgress,
                 manageMode = inputs.manage,
                 viewingOffers = inputs.viewingOffers,
             )
@@ -338,6 +359,13 @@ class UpgradeViewModel @Inject constructor(
     }
 
     fun restorePurchase() = launch {
+        // The repo's invisible already-owned auto-restore is external to the CAS guard below, so it
+        // can't be rejected by it — bail explicitly if one is running rather than stacking a second
+        // concurrent restore. The UI also disables the button via restoreBusy; this is the backstop.
+        if (upgradeRepo.autoRestoreInProgress.value) {
+            log(TAG) { "restorePurchase() ignored, an auto-restore is in flight" }
+            return@launch
+        }
         // Same authoritative guard as purchases: a single CAS from null admits at most one operation,
         // so a restore can't overlap an in-flight verification/launch and vice versa (no stacked
         // result dialogs), and repeated restore taps collapse to one.

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">Octi Pro</string>
+    <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
+    <string name="app_name_upgrade_postfix">Pro</string>
 
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
@@ -19,6 +21,8 @@
     </plurals>
 
     <string name="upgrade_screen_title">Get Octi Pro</string>
+    <string name="upgrade_screen_navigate_up">Navigate up</string>
+    <string name="upgrade_screen_progress_loading">Loading…</string>
     <string name="upgrade_screen_preamble">Octi has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_benefits_title">Benefits</string>
     <string name="upgrade_screen_benefits_body">• More than 3 devices 💯\n• Different themes 🎨\n• More options ⚙️\n• Extra sync servers🖥️️\n• Continued development ☕\n• A motivated developer 🧙</string>
@@ -34,6 +38,15 @@
     <string name="upgrade_screen_iap_action">One-time purchase</string>
     <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
+    <!-- Offers box -->
+    <string name="upgrade_screen_offers_title">Upgrade options</string>
+    <string name="upgrade_screen_offers_or">or</string>
+    <string name="upgrade_screen_offers_body">Both unlock the same features — pick whichever pricing you prefer. Cancel anytime.</string>
+    <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>
+    <string name="upgrade_screen_subscription_offer_body">Starts with a free 14-day trial, then billed once per year until cancelled.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Billed once per year until cancelled.</string>
+    <string name="upgrade_screen_iap_offer_title">One-time purchase</string>
+    <string name="upgrade_screen_iap_offer_body">Pay once, yours forever — no subscription.</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
     <string name="upgrade_screen_restore_banner_title">Already bought Pro?</string>
     <string name="upgrade_screen_restore_banner_body">It looks like you upgraded to Pro on this device before. If you still own the upgrade, restoring will unlock it again.</string>
@@ -42,6 +55,12 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
     <string name="upgrade_screen_restore_success_message">Purchase restored — thank you!</string>
+    <!-- Restore section copy (plain acquisition + ownership recheck) and failed-restore dialog -->
+    <string name="upgrade_screen_restore_body">Already bought Pro on this account? Ask Google Play to re-check this app\'s purchases.</string>
+    <string name="upgrade_screen_restore_status_title">Purchase status</string>
+    <string name="upgrade_screen_restore_status_body">Re-check your purchases with Google Play if your Pro status ever looks out of date.</string>
+    <string name="upgrade_screen_restore_checked_message">We asked Google Play to re-check this app\'s purchases but couldn\'t confirm one for the current account.</string>
+    <string name="upgrade_screen_restore_contact_hint">Still stuck? Contact support and we\'ll help sort it out.</string>
     <!-- Pro status / ownership -->
     <string name="upgrade_screen_owned_title">You are Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_body">Thanks for supporting Octi! Your Pro features are unlocked.</string>
@@ -52,6 +71,10 @@
     <string name="upgrade_screen_owned_sub_not_renewing_body">Your Pro subscription is active but set to not renew. It stays active until the end of the current period.</string>
     <string name="upgrade_screen_owned_both_title">You own both</string>
     <string name="upgrade_screen_owned_both_warning">You own both the subscription and the one-time purchase. To avoid paying twice, cancel the subscription in Google Play — you keep Pro through the lifetime purchase.</string>
+    <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <string name="upgrade_screen_owned_hero_title">You are Octi Pro 🎉</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Thanks for buying %1$s! Your Pro features are unlocked and never expire.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Thanks for subscribing to %1$s! Your Pro features are unlocked.</string>
     <string name="upgrade_screen_manage_subscription_action">Manage subscription</string>
     <!-- Switch subscription → one-time purchase -->
     <string name="upgrade_screen_switch_title">Switch to a one-time purchase</string>
@@ -65,7 +88,7 @@
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro is still active</string>
     <string name="upgrade_screen_grace_body">We\'re confirming your purchase with Google Play. Your Pro features stay unlocked in the meantime.</string>
-    <string name="upgrade_screen_grace_diagnostics_body">We still can\'t confirm your purchase with Google Play. Your Pro features remain unlocked for now. Try restoring, or contact support if this persists.</string>
+    <string name="upgrade_screen_grace_diagnostics_body">We still can\'t confirm your purchase with Google Play. Your Pro features remain unlocked for now. Try restoring to reconnect it.</string>
     <string name="upgrade_screen_contact_support_action">Contact support</string>
     <!-- Free status page (manage entry) -->
     <string name="upgrade_screen_free_status_title">You are on the free version</string>

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -3,23 +3,30 @@ package eu.darken.octi.common.upgrade.core.billing.client
 import com.android.billingclient.api.BillingClient
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetailsResponseListener
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesResult
+import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryPurchasesParams
 import com.android.billingclient.api.queryPurchasesAsync
 import eu.darken.octi.common.upgrade.core.OurSku
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -186,6 +193,36 @@ class BillingConnectionTest : BaseTest() {
             overlay.value shouldBe listOf(racing)
         } finally {
             unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySkus is cancellable when Play never invokes the product-details callback`() = runTest2 {
+        val client = mockk<BillingClient>()
+        // Play accepts the query but never calls back. With a non-cancellable suspendCoroutine a
+        // withTimeout around this could never resume — the test would hang. It must complete.
+        every { client.queryProductDetailsAsync(any<QueryProductDetailsParams>(), any()) } just Runs
+        val (connection, _) = connectionWith(client)
+
+        val result = withTimeoutOrNull(5_000) { connection.querySkus(OurSku.Iap.PRO_UPGRADE) }
+
+        result shouldBe null
+    }
+
+    @Test fun `querySkus ignores a product-details callback that arrives after cancellation`() = runTest2 {
+        val client = mockk<BillingClient>()
+        val listener = slot<ProductDetailsResponseListener>()
+        every { client.queryProductDetailsAsync(any<QueryProductDetailsParams>(), capture(listener)) } just Runs
+        val (connection, _) = connectionWith(client)
+
+        withTimeoutOrNull(5_000) { connection.querySkus(OurSku.Iap.PRO_UPGRADE) } shouldBe null
+
+        // Play finally answers after we already timed out and cancelled: resuming a dead continuation
+        // would crash. The isActive guard must drop it silently.
+        shouldNotThrowAny {
+            listener.captured.onProductDetailsResponse(
+                BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build(),
+                mockk(relaxed = true),
+            )
         }
     }
 

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModelTest.kt
@@ -9,12 +9,14 @@ import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.widget.WidgetManager
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,12 +49,13 @@ class UpgradeViewModelTest : BaseTest() {
         info: UpgradeRepoGplay.Info = UpgradeRepoGplay.Info(gracePeriod = false, billingData = null),
         wasEverPro: Boolean = false,
         settled: Boolean = true,
+        autoRestore: Boolean = false,
     ): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(info)
         every { this@apply.wasEverPro } returns MutableStateFlow(wasEverPro)
         every { proUnconfirmedSince } returns MutableStateFlow(0L)
         every { isSettled } returns MutableStateFlow(settled)
-        every { autoRestoreInProgress } returns MutableStateFlow(false)
+        every { autoRestoreInProgress } returns MutableStateFlow(autoRestore)
         coEvery { querySkus(any()) } returns emptyList()
     }
 
@@ -280,6 +283,152 @@ class UpgradeViewModelTest : BaseTest() {
 
         navs.isEmpty() shouldBe true
         job.cancel()
+    }
+
+    private fun UpgradeUiState?.asLoaded() = this as UpgradeUiState.Loaded
+
+    @Test fun `both sku queries failing shows the offers box as unavailable`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play down")
+        val vm = buildVm(repo)
+
+        val loaded = async {
+            vm.state.first { (it as? UpgradeUiState.Loaded)?.offers is OfferState.Unavailable }.asLoaded()
+        }
+        advanceUntilIdle()
+
+        loaded.await().offers.shouldBeInstanceOf<OfferState.Unavailable>()
+    }
+
+    @Test fun `retry recovers the offers box after a failure`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        var failing = true
+        coEvery { repo.querySkus(any()) } coAnswers {
+            if (failing) throw IllegalStateException("Play down") else emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val failed = async {
+            vm.state.first { (it as? UpgradeUiState.Loaded)?.offers is OfferState.Unavailable }
+        }
+        advanceUntilIdle()
+        failed.await()
+
+        failing = false
+        vm.retrySkuQuery()
+        val recovered = async {
+            vm.state.first { (it as? UpgradeUiState.Loaded)?.offers is OfferState.Ready }
+        }
+        advanceUntilIdle()
+
+        recovered.await().asLoaded().offers shouldBe OfferState.Ready
+    }
+
+    @Test fun `manage-route free user survives a sku failure and still shows the free status page`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo()
+            coEvery { repo.querySkus(any()) } throws IllegalStateException("Play down")
+            val vm = buildVm(repo, manage = true)
+
+            // The failure must NOT blank the calm free-status page into a full error screen.
+            val loaded = async { vm.state.first { it is UpgradeUiState.Loaded }.asLoaded() }
+            advanceUntilIdle()
+
+            loaded.await().showFreeStatus shouldBe true
+        }
+
+    @Test fun `returning buyer keeps the restore banner even when offers fail`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(wasEverPro = true)
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play down")
+        val vm = buildVm(repo)
+
+        val loaded = async {
+            vm.state.first { (it as? UpgradeUiState.Loaded)?.offers is OfferState.Unavailable }.asLoaded()
+        }
+        advanceUntilIdle()
+
+        loaded.await().showRestoreBanner shouldBe true
+    }
+
+    @Test fun `grace user renders loaded despite a sku failure`() = runTest2(context = testDispatcher) {
+        // gracePeriod isPro without any owned purchase: price-independent, must not become Unavailable.
+        val repo = mockRepo(info = UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play down")
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is UpgradeUiState.Loaded }.asLoaded() }
+        advanceUntilIdle()
+
+        loaded.await().grace shouldBe GraceHint(showDiagnostics = false)
+    }
+
+    @Test fun `a single failing product type is not a full unavailable`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        // SUB query fails, IAP succeeds (empty): a partial failure keeps the offers box Ready.
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws IllegalStateException("SUB down")
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } returns emptyList()
+        val vm = buildVm(repo)
+
+        val loaded = async {
+            vm.state.first { it is UpgradeUiState.Loaded && it.offers !is OfferState.Loading }.asLoaded()
+        }
+        advanceUntilIdle()
+
+        loaded.await().offers shouldBe OfferState.Ready
+    }
+
+    @Test fun `an unsettled owner keeps settled false so the switch stays gated`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(info = infoOf(purchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false)), settled = false)
+        val vm = buildVm(repo)
+
+        val loaded = async { vm.state.first { it is UpgradeUiState.Loaded }.asLoaded() }
+        runCurrent()
+
+        loaded.await().apply {
+            ownership.subscription?.isAutoRenewing shouldBe false
+            settled shouldBe false
+        }
+    }
+
+    @Test fun `manage-route free user renders loaded with loading offers while the sku query hangs`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo()
+            coEvery { repo.querySkus(any()) } coAnswers { awaitCancellation() }
+            val vm = buildVm(repo, manage = true)
+
+            // Must NOT sit behind a full-screen spinner: the calm free page needs no offer prices.
+            val loaded = async { vm.state.first { it is UpgradeUiState.Loaded }.asLoaded() }
+            runCurrent()
+
+            loaded.await().apply {
+                showFreeStatus shouldBe true
+                offers shouldBe OfferState.Loading
+            }
+        }
+
+    @Test fun `returning buyer renders loaded with loading offers while the sku query hangs`() =
+        runTest2(context = testDispatcher) {
+            val repo = mockRepo(wasEverPro = true)
+            coEvery { repo.querySkus(any()) } coAnswers { awaitCancellation() }
+            val vm = buildVm(repo)
+
+            val loaded = async { vm.state.first { it is UpgradeUiState.Loaded }.asLoaded() }
+            runCurrent()
+
+            loaded.await().apply {
+                showRestoreBanner shouldBe true
+                offers shouldBe OfferState.Loading
+            }
+        }
+
+    @Test fun `an in-flight auto-restore blocks a manual restore`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo(autoRestore = true)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.restorePurchaseNow() }
     }
 
     companion object {


### PR DESCRIPTION
Ports SD Maid SE's refined upgrade dashboard onto Octi's Google Play upgrade screen, adapted so Octi keeps its stronger safety gates. Opened as **draft** — see caveats at the bottom.

## UI
- New shared card vocabulary (`UpgradeContent.kt`): `CenterAlignedTopAppBar` with a collapsing, colored "Octi **Pro**" title (i18n-safe postfix string, no substring location), 560dp-capped centered content, icon-led `ElevatedCard`s, checkmark feature list (accepts `•`/`-`), action/error cards, back-button content description.
- Split into `UpgradeOffers` (offers card: Stars header, `title · price` rows, "or" divider, footnote, "Refresh offers" on partial failure), `UpgradeOwnership` (mascot hero + per-purchase icon cards + settled-gated switch + recheck-status restore + grace card), `UpgradeRestore` (emphasized/plain variants).
- Contact-support moved to the restore-failed dialog (removed from the grace card); dialogs use `rememberSaveable`.

## State / logic
- Offer availability is a **nested `OfferState { Loading | Unavailable(error) | Ready }`** on `Loaded`, not a top-level state — so owner, grace, free/manage page, and returning-buyer restore all render during a Play outage. `Unavailable` is driven by query **failure** only (empty is a failure at the VM boundary); sealed `SkuQueries.Done(Result, Result)`, both-fail → Unavailable, partial → Ready.
- First-class **Retry** for failed offers (`retrySkuQuery`).
- Preserved Octi-only behavior: `manage`/free-status calm page, injected Clock, `settled` fallback gate, `autoClose`. Auto-restore now also blocks manual restore.
- **`BillingConnection.querySkus`** converted to `suspendCancellableCoroutine` with an `isActive` guard, so the 15s timeout is actually bounded and Retry can't hang on a callback that never fires.

## Tests
- `BillingConnectionTest`: cancellability + late-callback-after-cancel.
- `UpgradeViewModelTest` (24): both-fail → Unavailable, retry recovery, partial failure stays Ready, manage/returning-buyer survive SKU failure (immediate `Loaded`, offers `Loading`), unsettled-owner gating, auto-restore blocks manual restore.

## Verification
- `assembleGplayDebug` ✅ · `testGplayDebugUnitTest` ✅ (179 tests, 0 failures) · Codex plan + implementation review (findings addressed) · on-device smoke on a Pixel_8 emulator ✅ (upgrade screen renders end-to-end with real prices, no crash).

## Draft caveats
- `lintGplayDebug` could not run in this environment (pre-existing, unrelated dependency-resolution failure: `androidx.test:rules:1.6.2`). No gradle/dependency files were touched.
- New base-English strings are untranslated pending Crowdin (they show in English on non-English devices until then).
- Left as intentional: the owned switch-to-IAP button is gated on `settled` but not `iapEnabled` (matches shipped SDM — billing re-queries on launch). A residual, benign auto-restore/manual-restore TOCTOU window remains (idempotent Play reads, no double-charge); fully closing it needs a cross-layer coordinator, out of scope here.