### PR TITLE
Upgrade androidx.test runner/rules from 1.6.2 to 1.7.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -180,8 +180,8 @@ fun DependencyHandlerScope.addTesting() {
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
 
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test:rules:1.6.2")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test:rules:1.7.0")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.6.1")
     androidTestImplementation("androidx.test.espresso:espresso-intents:3.6.1")


### PR DESCRIPTION
`androidx.test:rules:1.6.2` was **never published** to Google Maven (returns HTTP 404). The `rules` artifact went `1.6.1 → 1.7.0`; only `runner` shipped a `1.6.2` patch. The bad pin in `buildSrc/.../Dependencies.kt` broke androidTest dependency resolution for the **Debug** variant (default `testBuildType`):

```
Could not find androidx.test:rules:1.6.2
  Required by: project ':app' > androidx.test.espresso:espresso-intents:3.6.1
```

This surfaced as `:app:generateGplayDebugAndroidTestLintModel FAILED`, breaking local `./gradlew lintGplayDebug` and any instrumented-test run. CI stayed green because its "Lint vitals" checks run the **Beta/Release** variants, which don't build the Debug androidTest lint model, so they never resolved `rules:1.6.2`.

Fix: bump both `androidx.test:runner` and `androidx.test:rules` to `1.7.0` (latest; both published, resolution verified). `lintGplayDebug` now gets past resolution.

Note: with resolution restored, `lintGplayDebug` surfaces pre-existing Debug-lint findings that were previously never runnable locally (mostly `MissingTranslation` from Crowdin translation lag, plus a few pre-existing `NewApi`/`LocalContextGetResourceValueCall` in the recorder/dashboard screens). Those are out of scope for this dependency bump.