### PR TITLE
Fix "Device no longer linked" warning doing nothing when tapped

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -15,6 +15,7 @@ import eu.darken.octi.common.flow.SingleEventFlow
 import eu.darken.octi.common.flow.combine
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.PermissionState
@@ -469,13 +470,17 @@ class DashboardVM @Inject constructor(
     }
 
     fun goToConnectorDevices(connectorId: ConnectorId) = launch {
-        log(TAG) { "goToConnectorDevices($connectorId)" }
-        navTo(Nav.Sync.Devices(connectorId = connectorId.idString))
+        navigateToConnector(connectorId, null)
     }
 
     fun goToDeviceDetails(connectorId: ConnectorId, deviceId: DeviceId) = launch {
-        log(TAG) { "goToDeviceDetails($connectorId, $deviceId)" }
-        navTo(Nav.Sync.Devices(connectorId = connectorId.idString, deviceId = deviceId.id))
+        navigateToConnector(connectorId, deviceId)
+    }
+
+    private suspend fun navigateToConnector(connectorId: ConnectorId, deviceId: DeviceId?) {
+        val isPaused = syncSettings.isPaused(connectorId)
+        log(TAG) { "navigateToConnector($connectorId, $deviceId): isPaused=$isPaused" }
+        navTo(connectorNavTarget(connectorId, deviceId, isPaused))
     }
 
     fun goToUpgrade() {
@@ -790,6 +795,21 @@ class DashboardVM @Inject constructor(
     }
 
     companion object {
+        /**
+         * A paused connector's devices screen pops itself the moment it composes (SyncDevicesScreen's
+         * isPaused guard), so routing there is a dead end that reads as a flash. Send the user to the
+         * sync list instead: that connector's card shows the issue and opens an actions sheet with the
+         * resume/repair affordance.
+         */
+        internal fun connectorNavTarget(
+            connectorId: ConnectorId,
+            deviceId: DeviceId?,
+            isPaused: Boolean,
+        ): NavigationDestination = when {
+            isPaused -> Nav.Sync.List
+            else -> Nav.Sync.Devices(connectorId = connectorId.idString, deviceId = deviceId?.id)
+        }
+
         /**
          * Sync is configured and healthy, but this device has no peers — the user set up a
          * backend but never reached the actual goal (a second device).

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/ConnectorNavTargetTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/ConnectorNavTargetTest.kt
@@ -1,0 +1,58 @@
+package eu.darken.octi.main.ui.dashboard
+
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.ConnectorId
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ConnectorNavTargetTest : BaseTest() {
+
+    private val octiserver = ConnectorId(ConnectorType.OCTISERVER, "default", "alice")
+    private val deviceA = DeviceId("device-a")
+
+    private fun call(
+        connectorId: ConnectorId = octiserver,
+        deviceId: DeviceId? = null,
+        isPaused: Boolean = false,
+    ) = DashboardVM.connectorNavTarget(
+        connectorId = connectorId,
+        deviceId = deviceId,
+        isPaused = isPaused,
+    )
+
+    @Nested
+    inner class `paused connector` {
+        @Test
+        fun `with device id routes to the sync list`() {
+            call(deviceId = deviceA, isPaused = true) shouldBe Nav.Sync.List
+        }
+
+        @Test
+        fun `without device id routes to the sync list`() {
+            call(deviceId = null, isPaused = true) shouldBe Nav.Sync.List
+        }
+    }
+
+    @Nested
+    inner class `active connector` {
+        @Test
+        fun `with device id routes to that device`() {
+            call(deviceId = deviceA, isPaused = false) shouldBe Nav.Sync.Devices(
+                connectorId = octiserver.idString,
+                deviceId = deviceA.id,
+            )
+        }
+
+        @Test
+        fun `without device id routes to the connector devices`() {
+            call(deviceId = null, isPaused = false) shouldBe Nav.Sync.Devices(
+                connectorId = octiserver.idString,
+                deviceId = null,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When an Octi Server account is deleted server-side, the dashboard shows a "Device no longer linked" error row on the device card. Tapping it flashed something on screen and then nothing happened, leaving the user on the dashboard with no way to act on the warning.

## Cause

That error row is only ever visible *while its connector is paused* — `projectDashboardIssues` deliberately exempts `CurrentDeviceNotRegistered` from the "drop issues of paused connectors" filter so it survives to drive recovery.

But tapping it routed to `Nav.Sync.Devices`, and that screen pops itself the moment it composes if the connector is paused:

```kotlin
// SyncDevicesScreen.kt
LaunchedEffect(state.isPaused, state.deletingDeviceIds) {
    if (state.isPaused && state.deletingDeviceIds.isEmpty()) onNavigateUp()
}
```

Push → compose → pop, which reads as a flash. Reproduced on a device in this state:

```
🐙:Navigation:Controller: goTo(Devices(connectorId=…, deviceId=…), popUpTo=null, inclusive=false)
🐙:Navigation:Controller: up() to Dashboard (removed Devices(…))
```

The pop guard and the clickable dashboard row were introduced by separate commits; neither is wrong on its own.

## Fix

Dashboard → connector navigation is now pause-aware:

- paused connector → `Nav.Sync.List`
- otherwise → `Nav.Sync.Devices(…)`, unchanged

Keyed on pause state rather than issue type, because that is the property the destination screen actually guards on.

No UI work was needed — the sync list is already a complete destination for this case. `ConnectorCard` already renders the connector's issues in the error colour (the data reaches it unfiltered, via `allConnectors` + `allStates`), and tapping the card opens an actions sheet with the resume/repair action, which non-Pro users are permitted to use when the pause reason is `AuthIssue`.

The routing decision sits in a pure `connectorNavTarget(...)` helper in the companion object so it is unit-testable directly, matching the other helpers there.

### Considered and rejected

- **Auto-opening the actions sheet** via a singleton focus request: the request leaks if the user backs out before the list loads and does not survive process death, and the sheet's state is a plain `remember`, so it cannot reopen after rotation. Not worth one saved tap.
- **Putting the focus on the nav key** (`Nav.Sync.List(focus)`): `NavigationController.popTo`/`goTo` match by `==`, so the four `popTo(Nav.Sync.List)` callers would stop matching and strand the user on the link screen. Fixing that means changing shared navigation semantics for every destination.

## Testing

- New `ConnectorNavTargetTest`: four cases (paused/active × device id present/absent).
- Full unit suite passes (1063 tests).
- Verified on a tablet that was genuinely in this state (Octi Server account deleted server-side):
  - **before** — tap → `goTo(Devices)` immediately followed by `up()`, back on the dashboard
  - **after** — tap → `goTo(List)` with no `up()`; lands on Sync Services, connector card shows the error, resume action reachable
  - the active Google Drive connector still navigates to Synced Devices and stays there
  - no crashes across the session, including a rotation cycle
