### PR TITLE
Fix background sync stopping until the app is restarted

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/http/StreamingClient.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/http/StreamingClient.kt
@@ -1,0 +1,16 @@
+package eu.darken.octi.common.http
+
+import javax.inject.Qualifier
+
+/**
+ * Marks the `OkHttpClient` dedicated to streaming transfers (blob upload/download).
+ *
+ * The default client carries a total `callTimeout`, which spans response-body consumption. Blob
+ * bodies are handed out and consumed later (decryption in the blob store), so that bound would
+ * truncate large or slow transfers. This client uses per-socket timeouts only and header-level
+ * logging so the logging interceptor can't buffer a streaming body into memory.
+ */
+@Qualifier
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+annotation class StreamingClient

--- a/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
@@ -713,6 +713,7 @@ private class PreviewConnector(
     override val completions: SharedFlow<ConnectorOperation.Terminal> = MutableSharedFlow()
 
     override fun submit(command: ConnectorCommand): OperationId = OperationId.create()
+    override fun submitExclusive(command: ConnectorCommand): OperationId = OperationId.create()
 
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = ConnectorOperation.Succeeded(
         id = id,

--- a/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
+++ b/app/src/debug/java/eu/darken/octi/screenshots/ScreenshotContent.kt
@@ -722,6 +722,7 @@ private class PreviewConnector(
         finishedAt = NOW,
     )
 
+    override fun cancel(id: OperationId): Boolean = false
     override fun dismiss(id: OperationId) = Unit
 }
 

--- a/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
@@ -46,10 +46,15 @@ class HttpModule {
         connectTimeout(TIMEOUT.toJavaDuration())
         readTimeout(TIMEOUT.toJavaDuration())
         writeTimeout(TIMEOUT.toJavaDuration())
-        // The per-socket timeouts above do NOT cover time an async call spends queued in OkHttp's
-        // Dispatcher (maxRequestsPerHost = 5, one slot permanently held by the live-mode
-        // WebSocket). Only callTimeout bounds the full call including that queue time — without it
-        // a queued request can suspend indefinitely and wedge whatever awaits it.
+        // Bounds a call end-to-end once the dispatcher starts it — redirects, retries and full body
+        // consumption — none of which the per-socket timeouts above cover on their own.
+        //
+        // What it does NOT cover, verified against OkHttp 4.9.1 in WebSocketCallTimeoutTest: time
+        // an async call spends *queued* in the Dispatcher. RealCall.enqueue() only calls
+        // callStart(); the call timeout is entered in AsyncCall.run(), i.e. when the call is
+        // actually dispatched. With maxRequestsPerHost = 5 and one slot permanently held by the
+        // live-mode WebSocket, a queued call can therefore still wait arbitrarily long. That gap is
+        // closed one level up, by the connector processor's per-command bound.
         callTimeout(CALL_TIMEOUT.toJavaDuration())
         retryOnConnectionFailure(true)
         addInterceptor(loggingInterceptor)

--- a/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/http/HttpModule.kt
@@ -14,6 +14,7 @@ import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
+import java.time.Duration
 import javax.inject.Qualifier
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
@@ -45,8 +46,41 @@ class HttpModule {
         connectTimeout(TIMEOUT.toJavaDuration())
         readTimeout(TIMEOUT.toJavaDuration())
         writeTimeout(TIMEOUT.toJavaDuration())
+        // The per-socket timeouts above do NOT cover time an async call spends queued in OkHttp's
+        // Dispatcher (maxRequestsPerHost = 5, one slot permanently held by the live-mode
+        // WebSocket). Only callTimeout bounds the full call including that queue time — without it
+        // a queued request can suspend indefinitely and wedge whatever awaits it.
+        callTimeout(CALL_TIMEOUT.toJavaDuration())
         retryOnConnectionFailure(true)
         addInterceptor(loggingInterceptor)
+        addInterceptor(userAgentInterceptor)
+    }.build()
+
+    /**
+     * Separate client for streaming transfers — see [StreamingClient] for why the total-call bound
+     * and body logging of [baseHttpClient] are unusable here.
+     */
+    @StreamingClient
+    @Singleton
+    @Provides
+    fun streamingHttpClient(
+        userAgentInterceptor: UserAgentInterceptor,
+    ): OkHttpClient = OkHttpClient().newBuilder().apply {
+        // No cache: blob bodies are large, encrypted and consumed exactly once.
+        connectTimeout(TIMEOUT.toJavaDuration())
+        readTimeout(TIMEOUT.toJavaDuration())
+        writeTimeout(TIMEOUT.toJavaDuration())
+        // Total-call bound disabled on purpose. The response body is consumed by the caller after
+        // the call returns (decryption in the blob store), so any finite value here would abort
+        // large or slow transfers mid-body. The per-socket timeouts above still guarantee progress.
+        callTimeout(Duration.ZERO)
+        retryOnConnectionFailure(true)
+        addInterceptor(
+            HttpLoggingInterceptor { log(TAG, VERBOSE) { it } }.apply {
+                // HEADERS, never BODY: the body interceptor buffers the whole streamed payload.
+                level = HttpLoggingInterceptor.Level.HEADERS
+            }
+        )
         addInterceptor(userAgentInterceptor)
     }.build()
 
@@ -66,5 +100,6 @@ class HttpModule {
     companion object {
         private val TAG = logTag("Http")
         private val TIMEOUT = 20.seconds
+        private val CALL_TIMEOUT = 60.seconds
     }
 }

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -22,10 +22,12 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -97,7 +99,22 @@ class SyncOrchestrator @Inject constructor(
             .onEach {
                 log(TAG) { "pendingSyncTrigger: syncing pending writes" }
                 try {
-                    syncManager.sync(SyncOptions(readData = false, stats = false))
+                    // This collector lives on @AppScope and is never cancelled, so parking in here
+                    // takes background sync down for the lifetime of the process. Bound it: the
+                    // request is already accumulated in the manager, so giving up on the wait only
+                    // costs us the completion signal, not the work.
+                    val completed = withTimeoutOrNull(SYNC_WATCHDOG_TIMEOUT) {
+                        syncManager.sync(SyncOptions(readData = false, stats = false))
+                        true
+                    }
+                    if (completed == null) {
+                        val stuck = syncManager.activeConnectorSyncs.value
+                        log(TAG, WARN) {
+                            "pendingSyncTrigger: sync exceeded $SYNC_WATCHDOG_TIMEOUT, " +
+                                "still in flight: ${stuck.map { it.logLabel }}, " +
+                                "last outcomes: ${syncManager.lastConnectorSyncOutcomes.value}"
+                        }
+                    }
                     consecutiveFailures = 0
                 } catch (e: CancellationException) {
                     throw e
@@ -121,6 +138,7 @@ class SyncOrchestrator @Inject constructor(
     companion object {
         private const val MAX_RETRIES = 3
         private val RETRY_BASE_DELAY = 2.seconds
+        private val SYNC_WATCHDOG_TIMEOUT = 2.minutes
         private val TAG = logTag("App", "Sync", "Orchestrator")
 
         private fun SyncWorkerControl.WorkerState.WorkerInfo.toOrchestratorInfo() = BackgroundSyncState.WorkerInfo(

--- a/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
+++ b/app/src/main/java/eu/darken/octi/sync/core/SyncOrchestrator.kt
@@ -100,9 +100,10 @@ class SyncOrchestrator @Inject constructor(
                 log(TAG) { "pendingSyncTrigger: syncing pending writes" }
                 try {
                     // This collector lives on @AppScope and is never cancelled, so parking in here
-                    // takes background sync down for the lifetime of the process. Bound it: the
-                    // request is already accumulated in the manager, so giving up on the wait only
-                    // costs us the completion signal, not the work.
+                    // takes background sync down for the lifetime of the process. Bound it. If
+                    // another caller is still waiting on the same run, the work continues without
+                    // us; if we were the last one, the manager cancels the run rather than leaving
+                    // it hitting the network for a result nobody reads.
                     val completed = withTimeoutOrNull(SYNC_WATCHDOG_TIMEOUT) {
                         syncManager.sync(SyncOptions(readData = false, stats = false))
                         true

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
@@ -564,6 +564,7 @@ private class PreviewConnector(
         finishedAt = PREVIEW_NOW,
     )
 
+    override fun cancel(id: OperationId): Boolean = false
     override fun dismiss(id: OperationId) = Unit
 }
 

--- a/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/list/SyncListScreen.kt
@@ -555,6 +555,7 @@ private class PreviewConnector(
     override val completions: SharedFlow<ConnectorOperation.Terminal> = MutableSharedFlow()
 
     override fun submit(command: ConnectorCommand): OperationId = OperationId.create()
+    override fun submitExclusive(command: ConnectorCommand): OperationId = OperationId.create()
 
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = ConnectorOperation.Succeeded(
         id = id,

--- a/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/octi/sync/core/SyncOrchestratorTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -53,6 +54,8 @@ class SyncOrchestratorTest : BaseTest() {
         every { syncManager.connectors } returns connectorsFlow
         every { syncManager.pendingSyncTrigger } returns pendingSyncTriggerFlow
         every { syncWorkerControl.workerState } returns workerStateFlow
+        every { syncManager.activeConnectorSyncs } returns MutableStateFlow(emptySet())
+        every { syncManager.lastConnectorSyncOutcomes } returns MutableStateFlow(emptyMap())
     }
 
     private fun createOrchestrator(scope: CoroutineScope) = SyncOrchestrator(
@@ -221,6 +224,31 @@ class SyncOrchestratorTest : BaseTest() {
             pendingSyncTriggerFlow.emit(Unit)
             advanceUntilIdle()
 
+            verify(exactly = 0) { syncManager.requestSync() }
+        }
+
+        @Test
+        fun `collector keeps collecting after a sync exceeds its bound`() = runTest2(autoCancel = true) {
+            // This collector runs on @AppScope and is never cancelled — a sync that never returns
+            // used to take background sync down until the process died.
+            var callCount = 0
+            coEvery { syncManager.sync(any<SyncOptions>()) } coAnswers {
+                callCount++
+                if (callCount == 1) awaitCancellation()
+            }
+
+            val orchestrator = createOrchestrator(this)
+            orchestrator.start()
+            advanceUntilIdle()
+
+            pendingSyncTriggerFlow.emit(Unit)
+            advanceUntilIdle() // runs past the watchdog bound
+
+            pendingSyncTriggerFlow.emit(Unit)
+            advanceUntilIdle()
+
+            coVerify(exactly = 2) { syncManager.sync(any<SyncOptions>()) }
+            // A timed-out wait is not a failure to retry — the request is already accumulated.
             verify(exactly = 0) { syncManager.requestSync() }
         }
 

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
@@ -6,16 +6,22 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.sync.core.errors.ConnectorCancelledException
 import eu.darken.octi.sync.core.errors.ConnectorPausedException
 import eu.darken.octi.sync.core.errors.ConnectorStoppedException
+import eu.darken.octi.sync.core.errors.ConnectorTimeoutException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -26,8 +32,13 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+import kotlin.time.TimeSource
 
 /**
  * Actor-like command processor for a [SyncConnector].
@@ -42,6 +53,10 @@ import kotlin.time.Clock
  * [CompletableDeferred]s back [await] and are independent of retention, so waiters can never be
  * starved by trimming.
  *
+ * Every command runs under a per-command bound ([timeouts]) in a child coroutine, so a wedged
+ * executor fails its own operation instead of parking the actor forever. [cancel] terminates a
+ * single operation without touching the actor.
+ *
  * Hubs own the processor lifetime: construct the connector, then call [start] with a scope tied
  * to the connector's lifetime. Cancelling that scope fails any still-pending ops so waiters don't
  * hang.
@@ -50,11 +65,35 @@ class ConnectorProcessor(
     private val connectorId: ConnectorId,
     private val syncSettings: SyncSettings,
     private val displayRetention: Int = 20,
+    private val timeouts: Timeouts = Timeouts(),
     private val executor: suspend (ConnectorCommand) -> Unit,
 ) {
 
+    /**
+     * Per-command bounds.
+     *
+     * [destructive] covers [ConnectorCommand.Reset] and [ConnectorCommand.DeleteDevice]. Those get
+     * a deliberately generous bound and are excluded from [cancel] entirely: a destructive command
+     * that is reported failed locally may already have taken effect remotely, so aborting one
+     * mid-flight trades a bounded wait for an unknown remote state. Let them finish.
+     */
+    data class Timeouts(
+        val sync: Duration = 3.minutes,
+        val destructive: Duration = 10.minutes,
+        val local: Duration = 1.minutes,
+    ) {
+        companion object {
+            /** No per-command bound. For tests that model an executor which never returns. */
+            val UNBOUNDED = Timeouts(
+                sync = Duration.INFINITE,
+                destructive = Duration.INFINITE,
+                local = Duration.INFINITE,
+            )
+        }
+    }
+
     private data class Pending(
-        val queued: ConnectorOperation.Queued,
+        var queued: ConnectorOperation.Queued,
         val result: CompletableDeferred<ConnectorOperation.Terminal>,
     )
 
@@ -63,9 +102,16 @@ class ConnectorProcessor(
 
     // Serializes the submit/shutdown ownership decision: a submit either registers in [pending] before
     // shutdown claims it, or is rejected once [stopped] is set — never both, and never onto a closed
-    // inbox with no consumer.
+    // inbox with no consumer. Also guards the coalescing slot and the cancellation bookkeeping below,
+    // all of which are read from both submit/cancel callers and the actor loop.
     private val lifecycleLock = Any()
     private var stopped = false
+
+    /** Id of the newest submitted [ConnectorCommand.Sync] that has not started processing yet. */
+    private var queuedSyncId: OperationId? = null
+    private val cancelRequests = mutableSetOf<OperationId>()
+    private val started = mutableSetOf<OperationId>()
+    private val inFlight = mutableMapOf<OperationId, Deferred<Unit>>()
 
     private val _operations = MutableStateFlow<List<ConnectorOperation>>(emptyList())
     val operations: StateFlow<List<ConnectorOperation>> = _operations.asStateFlow()
@@ -95,6 +141,7 @@ class ConnectorProcessor(
             // regardless of `operations` retention trimming. The map dies with the processor anyway.
             val snapshot = synchronized(lifecycleLock) {
                 stopped = true
+                queuedSyncId = null
                 inbox.close()
                 pending.values.toList()
             }
@@ -141,7 +188,9 @@ class ConnectorProcessor(
             if (stopped) {
                 false
             } else {
+                coalesceSyncLocked(command)?.let { return it }
                 pending[id] = entry
+                if (command is ConnectorCommand.Sync) queuedSyncId = id
                 _operations.update { (it + queued).trim() }
                 check(inbox.trySend(entry).isSuccess) { "inbox closed while not stopped" }
                 true
@@ -155,6 +204,31 @@ class ConnectorProcessor(
             failEntry(entry, ConnectorStoppedException(connectorId))
         }
         return id
+    }
+
+    /**
+     * Folds a [ConnectorCommand.Sync] into the queued-but-not-yet-started Sync, if there is one.
+     *
+     * Without this, a caller that keeps re-requesting (takeovers, retries, event bursts) grows the
+     * UNLIMITED inbox without bound behind a slow command. The merged request is a superset of
+     * both, so every caller awaiting the returned id is served in full.
+     *
+     * @return the id of the op the command was folded into, or null if it must be enqueued.
+     */
+    private fun coalesceSyncLocked(command: ConnectorCommand): OperationId? {
+        if (command !is ConnectorCommand.Sync) return null
+        val existingId = queuedSyncId ?: return null
+        val existing = pending[existingId] ?: return null
+        val existingCommand = existing.queued.command
+        if (existingCommand !is ConnectorCommand.Sync || existing.result.isCompleted) return null
+
+        val merged = existing.queued.copy(
+            command = ConnectorCommand.Sync(existingCommand.options.merge(command.options)),
+        )
+        existing.queued = merged
+        _operations.update { ops -> ops.map { if (it.id == merged.id) merged else it } }
+        log(TAG, VERBOSE) { "processor($connectorId): coalesced Sync into $existingId" }
+        return existingId
     }
 
     // Completes an unaccepted [entry] as Failed and publishes it. Only reachable from the submit-after-
@@ -183,71 +257,200 @@ class ConnectorProcessor(
         error("No operation with id=$id known to processor($connectorId)")
     }
 
+    /**
+     * Terminates the operation with [id] — running or still queued — without stopping the actor.
+     * The op reaches [ConnectorOperation.Failed] with a [ConnectorCancelledException], so waiters
+     * are released and the connector stops reporting itself busy.
+     *
+     * Destructive commands are refused: see [Timeouts].
+     *
+     * @return true if the operation was cancelled or already marked for cancellation.
+     */
+    fun cancel(id: OperationId): Boolean {
+        val entry = pending[id] ?: return false
+        if (entry.queued.command.isDestructive) {
+            log(TAG, WARN) { "processor($connectorId): refusing to cancel destructive $id" }
+            return false
+        }
+        // `started` marks the window between the actor claiming an op and the work being registered
+        // in `inFlight`. Inside it we must neither cancel a job (there is none yet) nor terminate the
+        // op ourselves (the actor is about to run it); leaving the request in `cancelRequests` is
+        // enough — runCommand re-reads it under this same lock before starting the work.
+        val work = synchronized(lifecycleLock) {
+            cancelRequests += id
+            inFlight[id] ?: if (id in started) return true else null
+        }
+        if (work != null) {
+            log(TAG) { "processor($connectorId): cancelling in-flight $id" }
+            work.cancel(CancellationException("Operation $id cancelled"))
+        } else {
+            // Not claimed by the actor yet. Terminate it here so the waiter is released immediately
+            // instead of queueing behind whatever is currently running; the actor's pre-start check
+            // reads the same `cancelRequests` under the same lock, so the executor never runs for it.
+            log(TAG) { "processor($connectorId): cancelling queued $id" }
+            val now = Clock.System.now()
+            publishTerminal(entry, cancelledTerminal(entry, now))
+        }
+        return true
+    }
+
+    private fun cancelledTerminal(entry: Pending, startedAt: Instant) = ConnectorOperation.Failed(
+        id = entry.queued.id,
+        command = entry.queued.command,
+        submittedAt = entry.queued.submittedAt,
+        startedAt = startedAt,
+        finishedAt = Clock.System.now(),
+        error = ConnectorCancelledException(connectorId),
+    )
+
     fun dismiss(id: OperationId) {
         _operations.update { ops -> ops.filterNot { it is ConnectorOperation.Terminal && it.id == id } }
     }
 
     private suspend fun processOne(entry: Pending) {
+        val id = entry.queued.id
         val startedAt = Clock.System.now()
-        val processing = ConnectorOperation.Processing(
-            id = entry.queued.id,
-            command = entry.queued.command,
-            submittedAt = entry.queued.submittedAt,
-            startedAt = startedAt,
-        )
-        _operations.update { ops -> ops.map { if (it.id == entry.queued.id) processing else it } }
 
-        val terminal: ConnectorOperation.Terminal = try {
-            guardPauseIfNeeded(entry.queued.command)
-            executor(entry.queued.command)
-            ConnectorOperation.Succeeded(
-                id = entry.queued.id,
+        val cancelledBeforeStart = synchronized(lifecycleLock) {
+            // This op is now claimed by the actor, so no later submit may fold into it.
+            if (queuedSyncId == id) queuedSyncId = null
+            if (id in cancelRequests) {
+                true
+            } else {
+                started += id
+                false
+            }
+        }
+        try {
+            // publishTerminal is a no-op if cancel() already completed this op.
+            if (cancelledBeforeStart || entry.result.isCompleted) {
+                publishTerminal(entry, cancelledTerminal(entry, startedAt))
+                return
+            }
+
+            val processing = ConnectorOperation.Processing(
+                id = id,
                 command = entry.queued.command,
                 submittedAt = entry.queued.submittedAt,
                 startedAt = startedAt,
-                finishedAt = Clock.System.now(),
             )
+            _operations.update { ops -> ops.map { if (it.id == id) processing else it } }
+
+            val terminal: ConnectorOperation.Terminal = try {
+                guardPauseIfNeeded(entry.queued.command)
+                runCommand(entry)
+                ConnectorOperation.Succeeded(
+                    id = id,
+                    command = entry.queued.command,
+                    submittedAt = entry.queued.submittedAt,
+                    startedAt = startedAt,
+                    finishedAt = Clock.System.now(),
+                )
+            } catch (e: CancellationException) {
+                val failed = ConnectorOperation.Failed(
+                    id = id,
+                    command = entry.queued.command,
+                    submittedAt = entry.queued.submittedAt,
+                    startedAt = startedAt,
+                    finishedAt = Clock.System.now(),
+                    error = e,
+                )
+                publishTerminal(entry, failed)
+                // If the processor scope itself is cancelling, rethrow so the loop exits; otherwise
+                // keep looping so a per-command timeout/cancel doesn't kill the actor.
+                currentCoroutineContext().ensureActive()
+                return
+            } catch (e: Throwable) {
+                log(TAG, ERROR) { "processor($connectorId) ${entry.queued.command}: ${e.asLog()}" }
+                ConnectorOperation.Failed(
+                    id = id,
+                    command = entry.queued.command,
+                    submittedAt = entry.queued.submittedAt,
+                    startedAt = startedAt,
+                    finishedAt = Clock.System.now(),
+                    error = e,
+                )
+            }
+
+            // After a successful Resume, enqueue a Sync on our own queue BEFORE publishing Resume's
+            // terminal. Completing the Resume deferred can wake a waiter that immediately submits
+            // (e.g. Pause) on another thread; enqueuing the Sync first guarantees it lands in the
+            // inbox ahead of that command, so the post-resume sync is ordered deterministically
+            // (Resume → Sync → …).
+            if (terminal is ConnectorOperation.Succeeded && entry.queued.command == ConnectorCommand.Resume) {
+                submit(ConnectorCommand.Sync())
+            }
+
+            publishTerminal(entry, terminal)
+        } finally {
+            synchronized(lifecycleLock) {
+                cancelRequests.remove(id)
+                started.remove(id)
+            }
+        }
+    }
+
+    /**
+     * Runs [executor] in a child coroutine under the command's bound.
+     *
+     * The child is what makes both bounding and [cancel] possible: cancelling it leaves the actor
+     * loop itself untouched. Only the timeout we installed here becomes a
+     * [ConnectorTimeoutException] — a cancellation of the processor scope stays a plain
+     * cancellation and propagates so the actor can shut down.
+     */
+    private suspend fun runCommand(entry: Pending) = coroutineScope {
+        val id = entry.queued.id
+        val command = entry.queued.command
+        val limit = command.timeout
+
+        val work = async(start = CoroutineStart.LAZY) {
+            if (!limit.isFinite()) {
+                executor(command)
+            } else {
+                val mark = TimeSource.Monotonic.markNow()
+                withTimeout(limit) { executor(command) }
+                // A body that never reaches a suspension point — blocking I/O, a busy loop — cannot
+                // be cancelled, so withTimeout returns normally however long it overran. Comparing
+                // elapsed time is what makes the bound hold for those too: an op that outlived its
+                // budget fails, it never reports success.
+                if (mark.elapsedNow() > limit) throw ConnectorTimeoutException(connectorId, command, limit)
+            }
+        }
+        val cancelBeforeStart = synchronized(lifecycleLock) {
+            if (id in cancelRequests) {
+                true
+            } else {
+                inFlight[id] = work
+                false
+            }
+        }
+        if (cancelBeforeStart) {
+            work.cancel(CancellationException("Operation $id cancelled"))
+        } else {
+            work.start()
+        }
+
+        try {
+            work.await()
+        } catch (e: TimeoutCancellationException) {
+            log(TAG, WARN) { "processor($connectorId): $command exceeded $limit" }
+            throw ConnectorTimeoutException(connectorId, command, limit)
         } catch (e: CancellationException) {
-            val failed = ConnectorOperation.Failed(
-                id = entry.queued.id,
-                command = entry.queued.command,
-                submittedAt = entry.queued.submittedAt,
-                startedAt = startedAt,
-                finishedAt = Clock.System.now(),
-                error = e,
-            )
-            publishTerminal(entry, failed)
-            // If the processor scope itself is cancelling, rethrow so the loop exits; otherwise
-            // keep looping so a per-command timeout/cancel doesn't kill the actor.
-            currentCoroutineContext().ensureActive()
-            return
-        } catch (e: Throwable) {
-            log(TAG, ERROR) { "processor($connectorId) ${entry.queued.command}: ${e.asLog()}" }
-            ConnectorOperation.Failed(
-                id = entry.queued.id,
-                command = entry.queued.command,
-                submittedAt = entry.queued.submittedAt,
-                startedAt = startedAt,
-                finishedAt = Clock.System.now(),
-                error = e,
-            )
+            val wasCancelled = synchronized(lifecycleLock) { id in cancelRequests }
+            if (wasCancelled) throw ConnectorCancelledException(connectorId)
+            throw e
+        } finally {
+            synchronized(lifecycleLock) { inFlight.remove(id) }
         }
-
-        // After a successful Resume, enqueue a Sync on our own queue BEFORE publishing Resume's terminal.
-        // Completing the Resume deferred can wake a waiter that immediately submits (e.g. Pause) on
-        // another thread; enqueuing the Sync first guarantees it lands in the inbox ahead of that
-        // command, so the post-resume sync is ordered deterministically (Resume → Sync → …).
-        if (terminal is ConnectorOperation.Succeeded && entry.queued.command == ConnectorCommand.Resume) {
-            submit(ConnectorCommand.Sync())
-        }
-
-        publishTerminal(entry, terminal)
     }
 
     private fun publishTerminal(entry: Pending, terminal: ConnectorOperation.Terminal) {
+        // complete() returns false if this op already reached terminal (e.g. cancel() raced the
+        // actor). Publishing twice would emit a duplicate completion and overwrite the first
+        // terminal in `operations`.
+        if (!entry.result.complete(terminal)) return
         _operations.update { ops -> ops.map { if (it.id == entry.queued.id) terminal else it }.trim() }
         pending.remove(entry.queued.id)
-        entry.result.complete(terminal)
         _completions.tryEmit(terminal)
     }
 
@@ -266,7 +469,18 @@ class ConnectorProcessor(
         return this.filter { it !is ConnectorOperation.Terminal || it in kept }
     }
 
+    private val ConnectorCommand.timeout: Duration
+        get() = when (this) {
+            is ConnectorCommand.Sync -> timeouts.sync
+            is ConnectorCommand.DeleteDevice, is ConnectorCommand.Reset -> timeouts.destructive
+            is ConnectorCommand.Pause, is ConnectorCommand.Resume -> timeouts.local
+        }
+
     companion object {
         private val TAG = logTag("Sync", "Connector", "Processor")
+
+        /** See [Timeouts] — these must never be aborted on a whim. */
+        internal val ConnectorCommand.isDestructive: Boolean
+            get() = this is ConnectorCommand.Reset || this is ConnectorCommand.DeleteDevice
     }
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorProcessor.kt
@@ -72,14 +72,23 @@ class ConnectorProcessor(
     /**
      * Per-command bounds.
      *
-     * [destructive] covers [ConnectorCommand.Reset] and [ConnectorCommand.DeleteDevice]. Those get
-     * a deliberately generous bound and are excluded from [cancel] entirely: a destructive command
-     * that is reported failed locally may already have taken effect remotely, so aborting one
-     * mid-flight trades a bounded wait for an unknown remote state. Let them finish.
+     * What a bound does and does not guarantee: it bounds the *reported outcome*, not the time the
+     * actor is occupied. A command body that never reaches a suspension point — blocking I/O, a
+     * busy loop — cannot be cancelled, so it keeps the actor loop for its full natural duration and
+     * only afterwards has its outcome converted to a [ConnectorTimeoutException] (see [runCommand]).
+     * What actually caps that duration is the transport: the HTTP client's `callTimeout` and the
+     * GDrive request initializer's connect/read timeouts. Treat these values as "when do we stop
+     * believing the command", not "when does the connector become free again".
+     *
+     * [destructive] covers [ConnectorCommand.Reset] and [ConnectorCommand.DeleteDevice]. It is
+     * [Duration.INFINITE] by default, and those commands are excluded from [cancel] entirely: a
+     * destructive command that is reported failed locally may already have taken effect remotely,
+     * so aborting one mid-flight trades a bounded wait for an unknown remote state. Let them
+     * finish — their transport bounds are what terminates them.
      */
     data class Timeouts(
         val sync: Duration = 3.minutes,
-        val destructive: Duration = 10.minutes,
+        val destructive: Duration = Duration.INFINITE,
         val local: Duration = 1.minutes,
     ) {
         companion object {
@@ -95,6 +104,8 @@ class ConnectorProcessor(
     private data class Pending(
         var queued: ConnectorOperation.Queued,
         val result: CompletableDeferred<ConnectorOperation.Terminal>,
+        /** Whether later Syncs may be folded into this entry — see [submit] vs [submitExclusive]. */
+        val coalescible: Boolean,
     )
 
     private val inbox = Channel<Pending>(capacity = Channel.UNLIMITED)
@@ -107,7 +118,12 @@ class ConnectorProcessor(
     private val lifecycleLock = Any()
     private var stopped = false
 
-    /** Id of the newest submitted [ConnectorCommand.Sync] that has not started processing yet. */
+    /**
+     * Id of the newest coalescible [ConnectorCommand.Sync] that is still the last queued command.
+     * Cleared as soon as anything else is enqueued, so folding can never reorder a Sync across a
+     * command that is an ordering barrier (Pause/Resume/Reset/DeleteDevice), and never hands an
+     * exclusive submitter's id to somebody else.
+     */
     private var queuedSyncId: OperationId? = null
     private val cancelRequests = mutableSetOf<OperationId>()
     private val started = mutableSetOf<OperationId>()
@@ -172,11 +188,27 @@ class ConnectorProcessor(
         }
     }
 
-    fun submit(command: ConnectorCommand): OperationId {
+    /**
+     * Enqueues [command]. A [ConnectorCommand.Sync] may be folded into an equivalent queued Sync,
+     * in which case the returned id is shared with those callers.
+     */
+    fun submit(command: ConnectorCommand): OperationId = submit(command, coalescible = true)
+
+    /**
+     * Like [submit], but the returned [OperationId] belongs to this caller alone: the op is never
+     * folded into another, and no later Sync is ever folded into it.
+     *
+     * Required by anybody who may [cancel] the returned id. A shared id cancelled on one caller's
+     * behalf would fail every other caller that folded into it — including one whose narrower
+     * filters would silently be dropped along the way.
+     */
+    fun submitExclusive(command: ConnectorCommand): OperationId = submit(command, coalescible = false)
+
+    private fun submit(command: ConnectorCommand, coalescible: Boolean): OperationId {
         val id = OperationId.create()
         val queued = ConnectorOperation.Queued(id, command, Clock.System.now())
         val deferred = CompletableDeferred<ConnectorOperation.Terminal>()
-        val entry = Pending(queued, deferred)
+        val entry = Pending(queued, deferred, coalescible)
 
         // Register the pending entry, publish the Queued op, and enqueue — all under the lock. The
         // shutdown path runs under the same lock, so it sees an all-or-nothing submit: either the op is
@@ -188,9 +220,12 @@ class ConnectorProcessor(
             if (stopped) {
                 false
             } else {
-                coalesceSyncLocked(command)?.let { return it }
+                if (coalescible) coalesceSyncLocked(command)?.let { return it }
                 pending[id] = entry
-                if (command is ConnectorCommand.Sync) queuedSyncId = id
+                // Anything that is not a foldable Sync ends the coalescing window: the tracked Sync
+                // is no longer the last queued command, so folding into it would run it ahead of
+                // what we are enqueueing here.
+                queuedSyncId = if (coalescible && command is ConnectorCommand.Sync) id else null
                 _operations.update { (it + queued).trim() }
                 check(inbox.trySend(entry).isSuccess) { "inbox closed while not stopped" }
                 true
@@ -207,7 +242,8 @@ class ConnectorProcessor(
     }
 
     /**
-     * Folds a [ConnectorCommand.Sync] into the queued-but-not-yet-started Sync, if there is one.
+     * Folds a [ConnectorCommand.Sync] into the queued-but-not-yet-started coalescible Sync, if
+     * there is one — and only while that Sync is still the last queued command.
      *
      * Without this, a caller that keeps re-requesting (takeovers, retries, event bursts) grows the
      * UNLIMITED inbox without bound behind a slow command. The merged request is a superset of
@@ -220,6 +256,7 @@ class ConnectorProcessor(
         val existingId = queuedSyncId ?: return null
         val existing = pending[existingId] ?: return null
         val existingCommand = existing.queued.command
+        if (!existing.coalescible) return null
         if (existingCommand !is ConnectorCommand.Sync || existing.result.isCompleted) return null
 
         val merged = existing.queued.copy(

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
@@ -27,8 +27,20 @@ interface SyncConnector {
     val syncEvents: Flow<SyncEvent> get() = emptyFlow()
     val syncEventMode: StateFlow<EventMode> get() = MutableStateFlow(EventMode.NONE)
 
-    /** Non-suspending. Enqueues [command]; observe [operations] / [completions] for lifecycle. */
+    /**
+     * Non-suspending. Enqueues [command]; observe [operations] / [completions] for lifecycle.
+     *
+     * A [ConnectorCommand.Sync] may be folded into an equivalent queued Sync, so the returned id
+     * can be shared with other callers. Use [submitExclusive] if you may [cancel] it.
+     */
     fun submit(command: ConnectorCommand): OperationId
+
+    /**
+     * Like [submit], but the returned [OperationId] is never shared: the op is not folded into
+     * another and nothing is folded into it. Required for any op the caller may [cancel] —
+     * cancelling a shared id would fail unrelated callers and drop their narrower filters.
+     */
+    fun submitExclusive(command: ConnectorCommand): OperationId
 
     /** Suspends until the op with [id] reaches terminal state. */
     suspend fun await(id: OperationId): ConnectorOperation.Terminal

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncConnector.kt
@@ -33,6 +33,14 @@ interface SyncConnector {
     /** Suspends until the op with [id] reaches terminal state. */
     suspend fun await(id: OperationId): ConnectorOperation.Terminal
 
+    /**
+     * Terminates the op with [id] if it is still queued or running. Destructive commands are
+     * refused — see `ConnectorProcessor.Timeouts`.
+     *
+     * @return true if the op was cancelled.
+     */
+    fun cancel(id: OperationId): Boolean
+
     /** Remove a terminal entry from [operations]. No effect on pending ops. */
     fun dismiss(id: OperationId)
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -17,11 +17,16 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.shareIn
 import eu.darken.octi.sync.core.cache.SyncCache
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -30,16 +35,22 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 @Singleton
 class SyncManager @Inject constructor(
@@ -51,9 +62,66 @@ class SyncManager @Inject constructor(
     private val connectorSyncState: ConnectorSyncState,
 ) {
 
-    private val syncLock = Mutex()
-    private val pendingSync = AtomicBoolean(false)
+    /**
+     * Guards the whole single-flight transition — {active run, its start mark, the pending request,
+     * the generation token} move together or not at all. Held only for those decisions, never
+     * across connector work.
+     */
+    private val stateLock = Mutex()
+    private var activeRun: ActiveRun? = null
+    private var pendingRequest: PendingRequest? = null
+    private var generationCounter = 0L
+
+    /**
+     * Monotonic on purpose: a wall-clock jump must not make a run look stale (superseding healthy
+     * work) or eternally fresh (never superseding wedged work). Overridable for tests only.
+     */
+    internal var timeSource: TimeSource = TimeSource.Monotonic
+
     private val modulePayloads = ConcurrentHashMap<ModuleId, SyncWrite.Device.Module>()
+
+    private val _activeConnectorSyncs = MutableStateFlow(emptySet<ConnectorId>())
+
+    /** Connectors with a sync submitted by this manager that has not reached a terminal state. */
+    val activeConnectorSyncs: StateFlow<Set<ConnectorId>> = _activeConnectorSyncs.asStateFlow()
+
+    sealed interface ConnectorSyncOutcome {
+        data object Success : ConnectorSyncOutcome
+        data class Failure(val error: Throwable) : ConnectorSyncOutcome
+    }
+
+    private val _lastConnectorSyncOutcomes = MutableStateFlow(emptyMap<ConnectorId, ConnectorSyncOutcome>())
+
+    /** Result of the most recent sync this manager ran per connector. */
+    val lastConnectorSyncOutcomes: StateFlow<Map<ConnectorId, ConnectorSyncOutcome>> =
+        _lastConnectorSyncOutcomes.asStateFlow()
+
+    /**
+     * One iteration's worth of work: the union of every request folded into it, plus the callers
+     * waiting for that work to finish.
+     */
+    private class PendingRequest(
+        var options: SyncOptions,
+        val waiters: MutableList<CompletableDeferred<Unit>> = mutableListOf(),
+    ) {
+        fun absorb(other: PendingRequest) {
+            options = options.merge(other.options)
+            waiters += other.waiters
+        }
+    }
+
+    private class ActiveRun(val generation: Long) {
+        lateinit var job: Job
+
+        /** Reset per iteration, so a run that keeps doing real work never ages into staleness. */
+        var startedAt: TimeMark? = null
+
+        /** Non-null while a batch is executing — folded back into pending if the run is cancelled. */
+        var currentBatch: PendingRequest? = null
+
+        /** What to cancel when this run is superseded: the actual connector operations. */
+        val inFlightOps = ConcurrentHashMap<ConnectorId, Pair<SyncConnector, OperationId>>()
+    }
 
     private val syncRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
@@ -162,35 +230,137 @@ class SyncManager @Inject constructor(
         .setupCommonEventHandlers(TAG) { "syncData" }
         .shareLatest(scope + dispatcherProvider.Default)
 
+    /**
+     * Runs [options] against every active connector, and does not return until that work is done.
+     *
+     * Single-flight with accumulation: a request arriving while a run is in progress is merged into
+     * the run's next iteration instead of being dropped, so no caller's scope is silently absorbed
+     * by whichever request happened to hold the lock. If the current run has been working on the
+     * same iteration for longer than [SYNC_STALE_AFTER] it is superseded — its connector
+     * operations are cancelled and a fresh run takes over carrying every outstanding request.
+     */
     suspend fun sync(options: SyncOptions = SyncOptions()) {
         log(TAG) { "sync(${options.logLabel})" }
-        if (!syncLock.tryLock()) {
-            pendingSync.set(true)
-            log(TAG) { "Sync already in progress, flagged for re-run" }
-            return
-        }
-        try {
-            do {
-                pendingSync.set(false)
-                val syncJobs = connectors.first().map {
-                    scope.launch {
-                        try {
-                            sync(it.identifier, options = options)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "sync(): ${it.identifier} failed: ${e.asLog()}" }
-                        }
-                    }
+        val waiter = CompletableDeferred<Unit>()
+        stateLock.withLock {
+            enqueueLocked(PendingRequest(options, mutableListOf(waiter)))
+            val current = activeRun
+            val age = current?.startedAt?.elapsedNow()
+            when {
+                current == null -> startRunLocked()
+                age != null && age >= SYNC_STALE_AFTER -> {
+                    log(TAG, WARN) { "sync(): run ${current.generation} stuck for $age, superseding" }
+                    supersedeLocked(current)
+                    startRunLocked()
                 }
-                syncJobs.joinAll()
-            } while (pendingSync.getAndSet(false))
+                else -> log(TAG) { "sync(): folded into run ${current.generation}" }
+            }
+        }
+        waiter.await()
+    }
+
+    /** Callers must hold [stateLock]. */
+    private fun enqueueLocked(request: PendingRequest) {
+        pendingRequest = pendingRequest?.also { it.absorb(request) } ?: request
+    }
+
+    /** Callers must hold [stateLock]. */
+    private fun startRunLocked() {
+        val run = ActiveRun(++generationCounter)
+        // LAZY so the run object is fully wired (and published as `activeRun`) before its body can
+        // observe it — the body's first act is to take this very lock.
+        val job = scope.launch(start = CoroutineStart.LAZY) { runLoop(run) }
+        run.job = job
+        activeRun = run
+        log(TAG) { "startRun(${run.generation})" }
+        job.start()
+    }
+
+    /**
+     * Callers must hold [stateLock]. Cancels the connector operations first: cancelling only our
+     * own waiter would leave the command running inside the connector's actor, and the replacement
+     * would simply queue behind it.
+     */
+    private fun supersedeLocked(run: ActiveRun) {
+        run.inFlightOps.forEach { (connectorId, entry) ->
+            val (connector, opId) = entry
+            val cancelled = connector.cancel(opId)
+            log(TAG, WARN) { "supersede(${run.generation}): cancel ${connectorId.logLabel} -> $cancelled" }
+        }
+        run.job.cancel(CancellationException("Sync run ${run.generation} superseded"))
+    }
+
+    private suspend fun runLoop(run: ActiveRun) {
+        try {
+            while (true) {
+                val batch = stateLock.withLock {
+                    val next = pendingRequest ?: return@withLock null
+                    pendingRequest = null
+                    run.startedAt = timeSource.markNow()
+                    run.currentBatch = next
+                    next
+                } ?: break
+
+                try {
+                    executeBatch(run, batch.options)
+                    stateLock.withLock { run.currentBatch = null }
+                    batch.waiters.forEach { it.complete(Unit) }
+                } catch (e: CancellationException) {
+                    // Leave currentBatch set — the finally folds it back into pending so a
+                    // superseded batch's requests and waiters are carried by the next run.
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "runLoop(${run.generation}) failed: ${e.asLog()}" }
+                    stateLock.withLock { run.currentBatch = null }
+                    batch.waiters.forEach { it.completeExceptionally(e) }
+                }
+            }
         } finally {
-            syncLock.unlock()
+            // The whole exit decision happens under one lock hold, so there is no window between
+            // "nothing pending" and "no longer the active run" for a request to fall into.
+            withContext(NonCancellable) {
+                stateLock.withLock {
+                    // Compare before clearing: a superseded run must not clear its replacement.
+                    if (activeRun?.generation == run.generation) activeRun = null
+                    run.currentBatch?.let { leftover ->
+                        run.currentBatch = null
+                        log(TAG, WARN) { "runLoop(${run.generation}): folding cancelled batch back in" }
+                        enqueueLocked(leftover)
+                    }
+                    if (pendingRequest != null && activeRun == null) startRunLocked()
+                }
+            }
         }
     }
 
-    suspend fun sync(connectorId: ConnectorId, options: SyncOptions = SyncOptions()) {
+    private suspend fun executeBatch(run: ActiveRun, options: SyncOptions) {
+        // Bounded: an unresolved connector list must not wedge the run (and with it every waiter).
+        val targets = withTimeoutOrNull(CONNECTOR_RESOLVE_TIMEOUT) { connectors.first() }
+        if (targets == null) {
+            log(TAG, WARN) { "executeBatch(): connectors unresolved after $CONNECTOR_RESOLVE_TIMEOUT" }
+            return
+        }
+        // Structured children of the run: cancelling the run actually stops them, which detached
+        // scope.launch calls would not.
+        supervisorScope {
+            targets.map { connector ->
+                launch {
+                    try {
+                        sync(connector.identifier, options, run)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "sync(): ${connector.identifier} failed: ${e.asLog()}" }
+                    }
+                }
+            }.joinAll()
+        }
+    }
+
+    suspend fun sync(connectorId: ConnectorId, options: SyncOptions = SyncOptions()) =
+        sync(connectorId, options, run = null)
+
+    private suspend fun sync(connectorId: ConnectorId, options: SyncOptions, run: ActiveRun?) {
         log(TAG) { "sync(${connectorId.logLabel}, ${options.logLabel})" }
         // Fast-path defense: avoid submitting work we already know the processor will reject.
         // The processor also enforces the pause guard authoritatively.
@@ -226,7 +396,27 @@ class SyncManager @Inject constructor(
         }
 
         // Connector sets hashes inline for each successfully-written module — no post-call update here.
-        connector.execute(ConnectorCommand.Sync(effectiveOptions))
+        // Submit and await separately (rather than execute()) so a supersede has the operation id to
+        // cancel; cancelling only the waiter would leave the command running.
+        val opId = connector.submit(ConnectorCommand.Sync(effectiveOptions))
+        run?.inFlightOps?.put(connectorId, connector to opId)
+        _activeConnectorSyncs.update { it + connectorId }
+        try {
+            when (val terminal = connector.await(opId)) {
+                is ConnectorOperation.Succeeded -> {
+                    _lastConnectorSyncOutcomes.update { it + (connectorId to ConnectorSyncOutcome.Success) }
+                }
+                is ConnectorOperation.Failed -> {
+                    _lastConnectorSyncOutcomes.update {
+                        it + (connectorId to ConnectorSyncOutcome.Failure(terminal.error))
+                    }
+                    throw terminal.error
+                }
+            }
+        } finally {
+            run?.inFlightOps?.remove(connectorId)
+            _activeConnectorSyncs.update { it - connectorId }
+        }
     }
 
     fun updatePayload(payload: SyncWrite.Device.Module) {
@@ -298,5 +488,13 @@ class SyncManager @Inject constructor(
 
     companion object {
         private val TAG = logTag("Sync", "Manager")
+
+        /**
+         * How long one run iteration may work before a newly arriving request takes over. Above the
+         * connector processor's per-command bound on purpose: in practice a wedged command fails
+         * itself first, and this is the backstop for anything the processor cannot bound.
+         */
+        internal val SYNC_STALE_AFTER = 5.minutes
+        private val CONNECTOR_RESOLVE_TIMEOUT = 10.seconds
     }
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -69,7 +69,7 @@ class SyncManager @Inject constructor(
      */
     private val stateLock = Mutex()
     private var activeRun: ActiveRun? = null
-    private var pendingRequest: PendingRequest? = null
+    private val pendingRequests = mutableListOf<RequestRecord>()
     private var generationCounter = 0L
 
     /**
@@ -97,17 +97,12 @@ class SyncManager @Inject constructor(
         _lastConnectorSyncOutcomes.asStateFlow()
 
     /**
-     * One iteration's worth of work: the union of every request folded into it, plus the callers
-     * waiting for that work to finish.
+     * A single caller's request. Requests stay separate until a batch actually executes: merging
+     * them up front would make one caller's scope indistinguishable from another's, and a caller
+     * that gives up could then no longer withdraw exactly what it asked for.
      */
-    private class PendingRequest(
-        var options: SyncOptions,
-        val waiters: MutableList<CompletableDeferred<Unit>> = mutableListOf(),
-    ) {
-        fun absorb(other: PendingRequest) {
-            options = options.merge(other.options)
-            waiters += other.waiters
-        }
+    private class RequestRecord(val options: SyncOptions) {
+        val waiter = CompletableDeferred<Unit>()
     }
 
     private class ActiveRun(val generation: Long) {
@@ -116,8 +111,11 @@ class SyncManager @Inject constructor(
         /** Reset per iteration, so a run that keeps doing real work never ages into staleness. */
         var startedAt: TimeMark? = null
 
-        /** Non-null while a batch is executing — folded back into pending if the run is cancelled. */
-        var currentBatch: PendingRequest? = null
+        /**
+         * The requests this iteration is working for. Non-null while a batch is executing — folded
+         * back into pending if the run is cancelled, and emptied when its last owner walks away.
+         */
+        var currentBatch: MutableList<RequestRecord>? = null
 
         /** What to cancel when this run is superseded: the actual connector operations. */
         val inFlightOps = ConcurrentHashMap<ConnectorId, Pair<SyncConnector, OperationId>>()
@@ -238,12 +236,16 @@ class SyncManager @Inject constructor(
      * by whichever request happened to hold the lock. If the current run has been working on the
      * same iteration for longer than [SYNC_STALE_AFTER] it is superseded — its connector
      * operations are cancelled and a fresh run takes over carrying every outstanding request.
+     *
+     * Cancelling the caller withdraws that caller's request. If it was the last one the current
+     * iteration was working for, the iteration itself is cancelled — connector operations included.
+     * As long as another caller still wants it, the work continues untouched.
      */
     suspend fun sync(options: SyncOptions = SyncOptions()) {
         log(TAG) { "sync(${options.logLabel})" }
-        val waiter = CompletableDeferred<Unit>()
+        val record = RequestRecord(options)
         stateLock.withLock {
-            enqueueLocked(PendingRequest(options, mutableListOf(waiter)))
+            pendingRequests += record
             val current = activeRun
             val age = current?.startedAt?.elapsedNow()
             when {
@@ -256,12 +258,37 @@ class SyncManager @Inject constructor(
                 else -> log(TAG) { "sync(): folded into run ${current.generation}" }
             }
         }
-        waiter.await()
+        try {
+            record.waiter.await()
+        } catch (e: CancellationException) {
+            // Our caller is gone: the worker was stopped, a watchdog timed out, a UI scope died.
+            // The run lives on @AppScope, so without this it would keep doing network work for a
+            // result nobody reads. NonCancellable because we are already being cancelled.
+            withContext(NonCancellable) { abandon(record) }
+            throw e
+        }
     }
 
-    /** Callers must hold [stateLock]. */
-    private fun enqueueLocked(request: PendingRequest) {
-        pendingRequest = pendingRequest?.also { it.absorb(request) } ?: request
+    /**
+     * Withdraws [record] on behalf of a cancelled caller, and cancels the run if that leaves the
+     * executing iteration with no owner at all.
+     */
+    private suspend fun abandon(record: RequestRecord) = stateLock.withLock {
+        pendingRequests.remove(record)
+        val run = activeRun ?: return@withLock
+        val batch = run.currentBatch ?: return@withLock
+        if (!batch.remove(record)) return@withLock
+        if (batch.isNotEmpty()) {
+            // Another caller still wants this work. Options already merged into the executing
+            // command cannot be subtracted anyway — leave it running.
+            log(TAG) { "abandon(): run ${run.generation} still has ${batch.size} owner(s)" }
+            return@withLock
+        }
+        log(TAG, WARN) { "abandon(): last caller of run ${run.generation} left, cancelling its work" }
+        // Detach the batch BEFORE cancelling: the run's finally folds a still-attached batch back
+        // into pending, which would restart the very work we are abandoning.
+        run.currentBatch = null
+        supersedeLocked(run)
     }
 
     /** Callers must hold [stateLock]. */
@@ -293,26 +320,29 @@ class SyncManager @Inject constructor(
     private suspend fun runLoop(run: ActiveRun) {
         try {
             while (true) {
-                val batch = stateLock.withLock {
-                    val next = pendingRequest ?: return@withLock null
-                    pendingRequest = null
+                // Merging happens here and nowhere earlier: one option set per executing batch,
+                // computed under the same lock hold that claims the records.
+                val options = stateLock.withLock {
+                    if (pendingRequests.isEmpty()) return@withLock null
+                    val next = pendingRequests.toMutableList()
+                    pendingRequests.clear()
                     run.startedAt = timeSource.markNow()
                     run.currentBatch = next
-                    next
+                    next.map { it.options }.reduce { acc, o -> acc.merge(o) }
                 } ?: break
 
                 try {
-                    executeBatch(run, batch.options)
-                    stateLock.withLock { run.currentBatch = null }
-                    batch.waiters.forEach { it.complete(Unit) }
+                    executeBatch(run, options)
+                    // Detach and release atomically: a caller that abandoned while this batch ran
+                    // is no longer in the list, so it is not "completed" behind its own back.
+                    detachOwners(run).forEach { it.waiter.complete(Unit) }
                 } catch (e: CancellationException) {
                     // Leave currentBatch set — the finally folds it back into pending so a
                     // superseded batch's requests and waiters are carried by the next run.
                     throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "runLoop(${run.generation}) failed: ${e.asLog()}" }
-                    stateLock.withLock { run.currentBatch = null }
-                    batch.waiters.forEach { it.completeExceptionally(e) }
+                    detachOwners(run).forEach { it.waiter.completeExceptionally(e) }
                 }
             }
         } finally {
@@ -325,12 +355,18 @@ class SyncManager @Inject constructor(
                     run.currentBatch?.let { leftover ->
                         run.currentBatch = null
                         log(TAG, WARN) { "runLoop(${run.generation}): folding cancelled batch back in" }
-                        enqueueLocked(leftover)
+                        pendingRequests.addAll(0, leftover)
                     }
-                    if (pendingRequest != null && activeRun == null) startRunLocked()
+                    if (pendingRequests.isNotEmpty() && activeRun == null) startRunLocked()
                 }
             }
         }
+    }
+
+    private suspend fun detachOwners(run: ActiveRun): List<RequestRecord> = stateLock.withLock {
+        val owners = run.currentBatch.orEmpty().toList()
+        run.currentBatch = null
+        owners
     }
 
     private suspend fun executeBatch(run: ActiveRun, options: SyncOptions) {
@@ -397,8 +433,10 @@ class SyncManager @Inject constructor(
 
         // Connector sets hashes inline for each successfully-written module — no post-call update here.
         // Submit and await separately (rather than execute()) so a supersede has the operation id to
-        // cancel; cancelling only the waiter would leave the command running.
-        val opId = connector.submit(ConnectorCommand.Sync(effectiveOptions))
+        // cancel; cancelling only the waiter would leave the command running. Exclusive because we
+        // may cancel this id: a coalesced one is shared, and cancelling it would fail unrelated
+        // callers — including a targeted foreground sync whose filters would be dropped with it.
+        val opId = connector.submitExclusive(ConnectorCommand.Sync(effectiveOptions))
         run?.inFlightOps?.put(connectorId, connector to opId)
         _activeConnectorSyncs.update { it + connectorId }
         try {

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -103,6 +103,16 @@ class SyncManager @Inject constructor(
      */
     private class RequestRecord(val options: SyncOptions) {
         val waiter = CompletableDeferred<Unit>()
+
+        /**
+         * The run that claimed this record into its batch, or null while it is still pending.
+         * Guarded by [stateLock].
+         *
+         * Ownership has to be read off the record rather than inferred from [activeRun]: a run that
+         * was superseded but whose cancellation has not landed yet still holds its batch, while
+         * [activeRun] is already its replacement.
+         */
+        var ownerRun: ActiveRun? = null
     }
 
     private class ActiveRun(val generation: Long) {
@@ -275,9 +285,13 @@ class SyncManager @Inject constructor(
      */
     private suspend fun abandon(record: RequestRecord) = stateLock.withLock {
         pendingRequests.remove(record)
-        val run = activeRun ?: return@withLock
+        // The owner comes from the record, not from activeRun: a superseded run whose cancellation
+        // is still in flight keeps its batch, and activeRun already points at the replacement. Going
+        // through activeRun would silently fail to find the record and leave it to be folded back in.
+        val run = record.ownerRun ?: return@withLock
         val batch = run.currentBatch ?: return@withLock
         if (!batch.remove(record)) return@withLock
+        record.ownerRun = null
         if (batch.isNotEmpty()) {
             // Another caller still wants this work. Options already merged into the executing
             // command cannot be subtracted anyway — leave it running.
@@ -286,7 +300,8 @@ class SyncManager @Inject constructor(
         }
         log(TAG, WARN) { "abandon(): last caller of run ${run.generation} left, cancelling its work" }
         // Detach the batch BEFORE cancelling: the run's finally folds a still-attached batch back
-        // into pending, which would restart the very work we are abandoning.
+        // into pending, which would restart the very work we are abandoning. Applies whether or not
+        // this run is still activeRun — a superseded run folds its leftovers back just the same.
         run.currentBatch = null
         supersedeLocked(run)
     }
@@ -307,6 +322,10 @@ class SyncManager @Inject constructor(
      * Callers must hold [stateLock]. Cancels the connector operations first: cancelling only our
      * own waiter would leave the command running inside the connector's actor, and the replacement
      * would simply queue behind it.
+     *
+     * [run] need not be [activeRun]: a run that was already superseded can still be holding a batch
+     * and in-flight operations, and both have to go when its last owner walks away. Only this run's
+     * own operation ids are cancelled, so a replacement run's work is never touched.
      */
     private fun supersedeLocked(run: ActiveRun) {
         run.inFlightOps.forEach { (connectorId, entry) ->
@@ -326,6 +345,9 @@ class SyncManager @Inject constructor(
                     if (pendingRequests.isEmpty()) return@withLock null
                     val next = pendingRequests.toMutableList()
                     pendingRequests.clear()
+                    // Stamp ownership while claiming, so a caller that gives up later can find the
+                    // batch holding its record without having to guess which run that is.
+                    next.forEach { it.ownerRun = run }
                     run.startedAt = timeSource.markNow()
                     run.currentBatch = next
                     next.map { it.options }.reduce { acc, o -> acc.merge(o) }
@@ -355,6 +377,9 @@ class SyncManager @Inject constructor(
                     run.currentBatch?.let { leftover ->
                         run.currentBatch = null
                         log(TAG, WARN) { "runLoop(${run.generation}): folding cancelled batch back in" }
+                        // Back to unowned: whichever run claims them next stamps itself, and until
+                        // then an abandoning caller must find them in pendingRequests, not here.
+                        leftover.forEach { it.ownerRun = null }
                         pendingRequests.addAll(0, leftover)
                     }
                     if (pendingRequests.isNotEmpty() && activeRun == null) startRunLocked()
@@ -365,6 +390,7 @@ class SyncManager @Inject constructor(
 
     private suspend fun detachOwners(run: ActiveRun): List<RequestRecord> = stateLock.withLock {
         val owners = run.currentBatch.orEmpty().toList()
+        owners.forEach { it.ownerRun = null }
         run.currentBatch = null
         owners
     }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncOptions.kt
@@ -16,6 +16,22 @@ data class SyncOptions(
         val expectedHash: String,
     )
 
+    /**
+     * Union of two requests — the result satisfies both.
+     *
+     * Booleans OR, filters union, and a `null` filter (meaning "everything") absorbs a narrower
+     * one. Never intersect: a request that is coalesced into another must not lose scope, e.g. a
+     * write-only request must not swallow a caller's full read.
+     */
+    fun merge(other: SyncOptions): SyncOptions = SyncOptions(
+        stats = stats || other.stats,
+        readData = readData || other.readData,
+        writeData = writeData || other.writeData,
+        writePayload = mergePayloads(writePayload, other.writePayload),
+        moduleFilter = unionOrAll(moduleFilter, other.moduleFilter),
+        deviceFilter = unionOrAll(deviceFilter, other.deviceFilter),
+    )
+
     val logLabel: String
         get() = buildString {
             append("SyncOptions(")
@@ -25,4 +41,21 @@ data class SyncOptions(
             deviceFilter?.let { append(", devices=${it.size}") }
             append(")")
         }
+
+    companion object {
+        private fun <T> unionOrAll(a: Set<T>?, b: Set<T>?): Set<T>? = when {
+            a == null || b == null -> null
+            else -> a + b
+        }
+
+        /** Latest payload per module wins — [b] is the newer request. */
+        private fun mergePayloads(a: List<ModuleWrite>, b: List<ModuleWrite>): List<ModuleWrite> {
+            if (b.isEmpty()) return a
+            if (a.isEmpty()) return b
+            val byModule = LinkedHashMap<ModuleId, ModuleWrite>()
+            a.forEach { byModule[it.module.moduleId] = it }
+            b.forEach { byModule[it.module.moduleId] = it }
+            return byModule.values.toList()
+        }
+    }
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorCancelledException.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorCancelledException.kt
@@ -1,0 +1,15 @@
+package eu.darken.octi.sync.core.errors
+
+import eu.darken.octi.sync.core.ConnectorId
+
+/**
+ * Terminal error for an operation that was explicitly cancelled via `ConnectorProcessor.cancel`,
+ * i.e. superseded by a newer request rather than failing on its own.
+ *
+ * Deliberately NOT a [kotlinx.coroutines.CancellationException] — same rationale as
+ * [ConnectorStoppedException]: the operation's waiter must see an ordinary connector failure, not
+ * its own coroutine being cancelled.
+ */
+class ConnectorCancelledException(
+    val connectorId: ConnectorId,
+) : IllegalStateException("Operation on ${connectorId.logLabel} was cancelled")

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorTimeoutException.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/errors/ConnectorTimeoutException.kt
@@ -1,0 +1,19 @@
+package eu.darken.octi.sync.core.errors
+
+import eu.darken.octi.sync.core.ConnectorCommand
+import eu.darken.octi.sync.core.ConnectorId
+import kotlin.time.Duration
+
+/**
+ * Terminal error for a command whose executor exceeded the processor's per-command bound.
+ *
+ * Deliberately NOT a [kotlinx.coroutines.CancellationException] — same rationale as
+ * [ConnectorStoppedException]. The processor's own cancellation branch would otherwise record an
+ * expired command as a plain cancellation, and callers that catch cancellation to honor structured
+ * concurrency must treat this as an ordinary connector failure and carry on.
+ */
+class ConnectorTimeoutException(
+    val connectorId: ConnectorId,
+    val command: ConnectorCommand,
+    val timeout: Duration,
+) : IllegalStateException("Connector ${connectorId.logLabel} timed out after $timeout on $command")

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class ConnectorProcessorTest : BaseTest() {
@@ -504,6 +505,28 @@ class ConnectorProcessorTest : BaseTest() {
         }
 
         @Test
+        fun `destructive commands are unbounded by default`() = runTest2 {
+            // A Reset/DeleteDevice reported failed locally may already have taken effect remotely,
+            // so no bound may cancel one mid-flight. The transport timeouts terminate it instead.
+            val (proc, job) = buildProcessor(
+                timeouts = ConnectorProcessor.Timeouts(),
+                executor = { cmd ->
+                    if (cmd is ConnectorCommand.Reset || cmd is ConnectorCommand.DeleteDevice) delay(60.minutes)
+                },
+            )
+
+            val resetId = proc.submit(ConnectorCommand.Reset)
+            val deleteId = proc.submit(ConnectorCommand.DeleteDevice(DeviceId("a")))
+            advanceUntilIdle()
+
+            proc.await(resetId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            proc.await(deleteId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
         fun `destructive commands get the destructive bound`() = runTest2 {
             val (proc, job) = buildProcessor(
                 timeouts = shortTimeouts,
@@ -690,6 +713,76 @@ class ConnectorProcessorTest : BaseTest() {
             val merged = (executed.last() as ConnectorCommand.Sync).options
             merged.readData shouldBe true
             merged.writeData shouldBe true
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `coalescing never crosses a non-Sync command`() = runTest2 {
+            // running command -> Sync A -> Pause -> Sync B. Folding B into A would run a sync that
+            // was requested AFTER the pause BEFORE it, escaping the pause guard entirely.
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+                if (cmd is ConnectorCommand.Pause) {
+                    pauseStatesValue.value = setOf(ConnectorPauseState(connectorId, cmd.reason))
+                }
+            })
+
+            proc.submit(ConnectorCommand.Reset) // occupies the actor on the gate
+            advanceUntilIdle()
+
+            val syncA = proc.submit(ConnectorCommand.Sync())
+            val pauseId = proc.submit(ConnectorCommand.Pause())
+            val syncB = proc.submit(ConnectorCommand.Sync())
+            (syncB == syncA) shouldBe false
+            (pauseId == syncA) shouldBe false
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            // Four ops processed in submission order; Sync B is reached after Pause, where the
+            // guard rejects it before the executor — so it never lands in `executed`.
+            executed.map { it::class.simpleName } shouldBe listOf("Reset", "Sync", "Pause")
+            proc.await(syncA).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            proc.await(pauseId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            val terminalB = proc.await(syncB)
+            terminalB.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            terminalB.error.shouldBeInstanceOf<ConnectorPausedException>()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `exclusive submissions are neither folded into nor folded from`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+            })
+
+            proc.submit(ConnectorCommand.Sync()) // occupies the actor on the gate
+            advanceUntilIdle()
+
+            val exclusive = proc.submitExclusive(ConnectorCommand.Sync())
+            val coalescible = proc.submit(ConnectorCommand.Sync())
+            val second = proc.submit(ConnectorCommand.Sync())
+
+            (coalescible == exclusive) shouldBe false
+            // Ordinary submits still fold into each other.
+            second shouldBe coalescible
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            executed.shouldHaveSize(3)
+            proc.await(exclusive).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            proc.await(coalescible).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
 
             job.cancel()
             advanceUntilIdle()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorProcessorTest.kt
@@ -1,10 +1,13 @@
 package eu.darken.octi.sync.core
 
 import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.sync.core.errors.ConnectorCancelledException
 import eu.darken.octi.sync.core.errors.ConnectorPausedException
 import eu.darken.octi.sync.core.errors.ConnectorStoppedException
+import eu.darken.octi.sync.core.errors.ConnectorTimeoutException
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
@@ -12,19 +15,31 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class ConnectorProcessorTest : BaseTest() {
 
@@ -43,8 +58,15 @@ class ConnectorProcessorTest : BaseTest() {
         }
     }
 
+    /**
+     * Defaults to [ConnectorProcessor.Timeouts.UNBOUNDED]: most tests here gate an executor on a
+     * deferred and then call [advanceUntilIdle], which would otherwise run the virtual clock into
+     * the production per-command bound and turn every gated op into a timeout. The bounds
+     * themselves are covered by the dedicated tests below, which pass explicit short values.
+     */
     private fun TestScope.buildProcessor(
         retention: Int = 20,
+        timeouts: ConnectorProcessor.Timeouts = ConnectorProcessor.Timeouts.UNBOUNDED,
         executor: suspend (ConnectorCommand) -> Unit = { },
     ): Pair<ConnectorProcessor, Job> {
         val job = SupervisorJob()
@@ -52,6 +74,7 @@ class ConnectorProcessorTest : BaseTest() {
             connectorId = connectorId,
             syncSettings = syncSettings,
             displayRetention = retention,
+            timeouts = timeouts,
             executor = executor,
         )
         processor.start(this + job)
@@ -196,7 +219,8 @@ class ConnectorProcessorTest : BaseTest() {
     @Test
     fun `retention trims completed ops beyond limit`() = runTest2 {
         val (proc, job) = buildProcessor(retention = 3, executor = { })
-        repeat(5) { proc.submit(ConnectorCommand.Sync()) }
+        // Distinct commands: queued Syncs coalesce into one op, which would defeat the point here.
+        repeat(5) { proc.submit(ConnectorCommand.DeleteDevice(DeviceId("device-$it"))) }
         advanceUntilIdle()
 
         val ops = proc.operations.first()
@@ -283,7 +307,7 @@ class ConnectorProcessorTest : BaseTest() {
         val (proc, job) = buildProcessor(executor = { gate.await() })
 
         proc.submit(ConnectorCommand.Sync()) // becomes Processing (awaits gate)
-        proc.submit(ConnectorCommand.Sync()) // stays Queued behind it
+        proc.submit(ConnectorCommand.DeleteDevice(DeviceId("a"))) // stays Queued behind it
         advanceUntilIdle()
 
         // Busy: at least one Queued/Processing entry.
@@ -334,7 +358,8 @@ class ConnectorProcessorTest : BaseTest() {
         // they resolve from their deferred and must never hang, independent of retention trimming.
         val (proc, job) = buildProcessor(retention = 2, executor = { gate.await() })
 
-        val ids = (1..5).map { proc.submit(ConnectorCommand.Sync()) }
+        // Distinct commands: queued Syncs would coalesce into a single op.
+        val ids = (1..5).map { proc.submit(ConnectorCommand.DeleteDevice(DeviceId("device-$it"))) }
         val waiters = ids.map { id -> async { proc.await(id) } }
         advanceUntilIdle() // first becomes Processing on the gate, rest stay Queued; all waiters suspend
 
@@ -351,7 +376,8 @@ class ConnectorProcessorTest : BaseTest() {
         val (proc, job) = buildProcessor(executor = { gate.await() })
 
         proc.submit(ConnectorCommand.Sync()) // becomes Processing, blocks on the gate
-        val queuedId = proc.submit(ConnectorCommand.Sync()) // never pulled — stays Queued behind it
+        // Not a Sync: a queued Sync would coalesce into the one already in flight.
+        val queuedId = proc.submit(ConnectorCommand.DeleteDevice(DeviceId("a"))) // stays Queued behind it
         advanceUntilIdle()
 
         job.cancel()
@@ -364,5 +390,332 @@ class ConnectorProcessorTest : BaseTest() {
         terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
         // ConnectorStoppedException is an IllegalStateException, not a CancellationException.
         terminal.error.shouldBeInstanceOf<ConnectorStoppedException>()
+    }
+
+    @Nested
+    inner class `per-command timeouts` {
+
+        private val shortTimeouts = ConnectorProcessor.Timeouts(
+            sync = 10.seconds,
+            destructive = 60.seconds,
+            local = 10.seconds,
+        )
+
+        @Test
+        fun `executor that never returns fails with ConnectorTimeoutException`() = runTest2 {
+            val (proc, job) = buildProcessor(
+                timeouts = shortTimeouts,
+                executor = { awaitCancellation() },
+            )
+
+            val id = proc.submit(ConnectorCommand.Sync())
+            advanceUntilIdle()
+
+            val terminal = proc.await(id)
+            terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            terminal.error.shouldBeInstanceOf<ConnectorTimeoutException>()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `timed out op clears busy state and the actor keeps processing`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val (proc, job) = buildProcessor(
+                timeouts = shortTimeouts,
+                executor = { cmd ->
+                    if (cmd is ConnectorCommand.Sync) awaitCancellation() else executed += cmd
+                },
+            )
+
+            proc.submit(ConnectorCommand.Sync())
+            val nextId = proc.submit(ConnectorCommand.Reset)
+            advanceUntilIdle()
+
+            // isBusy is derived from Queued/Processing entries — a wedged op must not keep it true.
+            proc.operations.first()
+                .none { it is ConnectorOperation.Queued || it is ConnectorOperation.Processing } shouldBe true
+            proc.await(nextId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            executed.shouldHaveSize(1)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `NonCancellable executor still reaches a terminal state`() = runTest2 {
+            // A plain cancellable fake would pass even if the bound were inert. This one models the
+            // real hazard: work that ignores cancellation entirely.
+            val released = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(
+                timeouts = shortTimeouts,
+                executor = {
+                    withContext(NonCancellable) {
+                        withTimeoutOrNull(30.seconds) { awaitCancellation() }
+                        released.complete(Unit)
+                    }
+                },
+            )
+
+            val id = proc.submit(ConnectorCommand.Sync())
+            advanceUntilIdle()
+
+            released.isCompleted shouldBe true
+            val terminal = proc.await(id)
+            terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            terminal.error.shouldBeInstanceOf<ConnectorTimeoutException>()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `thread-blocking executor is bounded once it returns`() = runTest2 {
+            // Real dispatchers on purpose: the hazard here is a body that blocks a thread and so
+            // cannot be interrupted by cancellation at all. Virtual time cannot model that, and a
+            // fake that merely suspends would pass even if the bound were inert.
+            withContext(Dispatchers.Default) {
+                val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+                val processor = ConnectorProcessor(
+                    connectorId = connectorId,
+                    syncSettings = syncSettings,
+                    timeouts = ConnectorProcessor.Timeouts(
+                        sync = 200.milliseconds,
+                        destructive = 10.seconds,
+                        local = 10.seconds,
+                    ),
+                    executor = { cmd -> if (cmd is ConnectorCommand.Sync) Thread.sleep(1000) },
+                )
+                processor.start(scope)
+
+                // The blocking call outlives its bound by far, yet the op still resolves — and as
+                // Failed, never Succeeded.
+                val terminal = processor.await(processor.submit(ConnectorCommand.Sync()))
+                terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+                terminal.error.shouldBeInstanceOf<ConnectorTimeoutException>()
+
+                // ...and the actor survived it.
+                processor.await(processor.submit(ConnectorCommand.Reset))
+                    .shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+
+                scope.cancel()
+            }
+        }
+
+        @Test
+        fun `destructive commands get the destructive bound`() = runTest2 {
+            val (proc, job) = buildProcessor(
+                timeouts = shortTimeouts,
+                executor = { awaitCancellation() },
+            )
+
+            val syncId = proc.submit(ConnectorCommand.Sync())
+            val resetId = proc.submit(ConnectorCommand.Reset)
+            advanceUntilIdle()
+
+            val syncTerminal = proc.await(syncId)
+            val resetTerminal = proc.await(resetId)
+            syncTerminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            resetTerminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            (syncTerminal.error as ConnectorTimeoutException).timeout shouldBe shortTimeouts.sync
+            (resetTerminal.error as ConnectorTimeoutException).timeout shouldBe shortTimeouts.destructive
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `cancellation` {
+
+        @Test
+        fun `cancel terminates an in-flight op without stopping the actor`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                if (cmd is ConnectorCommand.Sync) awaitCancellation() else executed += cmd
+            })
+
+            val syncId = proc.submit(ConnectorCommand.Sync())
+            advanceUntilIdle()
+
+            proc.cancel(syncId) shouldBe true
+            advanceUntilIdle()
+
+            val terminal = proc.await(syncId)
+            terminal.shouldBeInstanceOf<ConnectorOperation.Failed>()
+            // Not a CancellationException: the waiter must see a connector failure, not its own
+            // coroutine being cancelled.
+            terminal.error.shouldBeInstanceOf<ConnectorCancelledException>()
+
+            val nextId = proc.submit(ConnectorCommand.Reset)
+            advanceUntilIdle()
+            proc.await(nextId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            executed.shouldHaveSize(1)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `cancelling a queued op releases its waiter immediately and never runs it`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+            })
+
+            proc.submit(ConnectorCommand.Sync()) // becomes Processing on the gate
+            advanceUntilIdle()
+            val queuedId = proc.submit(ConnectorCommand.Sync()) // queued behind it
+
+            proc.cancel(queuedId) shouldBe true
+            // No advance: the waiter resolves without the actor ever reaching the op.
+            proc.await(queuedId).shouldBeInstanceOf<ConnectorOperation.Failed>()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            executed.shouldHaveSize(1)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `destructive commands are not cancelled mid-flight`() = runTest2 {
+            // A destructive command reported failed locally may already have taken effect remotely,
+            // so it is never aborted on request — it runs to completion.
+            val gate = CompletableDeferred<Unit>()
+            val completed = mutableListOf<ConnectorCommand>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                gate.await()
+                completed += cmd
+            })
+
+            val resetId = proc.submit(ConnectorCommand.Reset)
+            advanceUntilIdle()
+
+            proc.cancel(resetId) shouldBe false
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            proc.await(resetId).shouldBeInstanceOf<ConnectorOperation.Succeeded>()
+            completed.shouldHaveSize(1)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `coalescing` {
+
+        @Test
+        fun `queued syncs fold into one op instead of growing the inbox`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+            })
+
+            proc.submit(ConnectorCommand.Sync()) // becomes Processing on the gate
+            advanceUntilIdle()
+
+            val ids = (1..50).map { proc.submit(ConnectorCommand.Sync()) }
+            ids.toSet().shouldHaveSize(1)
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            // The 50 requests were served by a single additional execution.
+            executed.shouldHaveSize(2)
+            ids.forEach { proc.await(it).shouldBeInstanceOf<ConnectorOperation.Succeeded>() }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `flood at a cadence shorter than the command timeout does not grow the inbox`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val (proc, job) = buildProcessor(
+                timeouts = ConnectorProcessor.Timeouts(
+                    sync = 60.seconds,
+                    destructive = 60.seconds,
+                    local = 60.seconds,
+                ),
+                executor = { cmd ->
+                    executed += cmd
+                    delay(50.seconds) // slower than the request cadence, faster than the bound
+                },
+            )
+
+            repeat(100) {
+                proc.submit(ConnectorCommand.Sync())
+                advanceTimeBy(1.seconds)
+            }
+            advanceUntilIdle()
+
+            // Requests arriving while one command runs collapse into a single queued follow-up, so
+            // the queue can never outgrow "one running + one queued".
+            proc.operations.first().count { it is ConnectorOperation.Queued } shouldBe 0
+            executed.size shouldBeLessThan 10
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `coalesced options are the union of every folded request`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+            })
+
+            proc.submit(ConnectorCommand.Sync())
+            advanceUntilIdle()
+
+            proc.submit(ConnectorCommand.Sync(SyncOptions(stats = false, readData = false, writeData = true)))
+            proc.submit(ConnectorCommand.Sync(SyncOptions(stats = false, readData = true, writeData = false)))
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            val merged = (executed.last() as ConnectorCommand.Sync).options
+            merged.readData shouldBe true
+            merged.writeData shouldBe true
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a running sync is never folded into`() = runTest2 {
+            val executed = mutableListOf<ConnectorCommand>()
+            val gate = CompletableDeferred<Unit>()
+            val (proc, job) = buildProcessor(executor = { cmd ->
+                executed += cmd
+                if (executed.size == 1) gate.await()
+            })
+
+            val runningId = proc.submit(ConnectorCommand.Sync())
+            advanceUntilIdle()
+
+            val laterId = proc.submit(ConnectorCommand.Sync())
+            (laterId == runningId) shouldBe false
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            executed.shouldHaveSize(2)
+
+            job.cancel()
+            advanceUntilIdle()
+        }
     }
 }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
@@ -80,6 +80,7 @@ class SyncManagerSingleFlightTest : BaseTest() {
     private inner class FakeConnector(
         override val identifier: ConnectorId,
         processorScope: CoroutineScope,
+        onOther: suspend (ConnectorCommand) -> Unit = { },
         executor: suspend (SyncOptions) -> Unit,
     ) : SyncConnector {
         private val processor = ConnectorProcessor(
@@ -90,6 +91,8 @@ class SyncManagerSingleFlightTest : BaseTest() {
                 if (command is ConnectorCommand.Sync) {
                     executions += command.options
                     executor(command.options)
+                } else {
+                    onOther(command)
                 }
             },
         )
@@ -464,36 +467,59 @@ class SyncManagerSingleFlightTest : BaseTest() {
 
         @Test
         fun `a direct per-connector sync survives the manager superseding its own run`() = runTest2 {
-            // Both would share one coalesced op if the manager's submissions were coalescible;
-            // supersede would then cancel the direct caller's op too.
+            // Both syncs queue behind a destructive command, so the manager's Sync used to fold
+            // into the direct caller's queued op and receive that shared id. Superseding then
+            // cancelled the direct caller along with it, dropping its module filter.
             val timeSource = TestTimeSource()
             val processorJob = SupervisorJob()
-            val hang = CompletableDeferred<Unit>()
-            connectorsFlow.value = listOf(
-                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) hang.await() },
+            val blocker = CompletableDeferred<Unit>()
+            val connector = FakeConnector(
+                connectorId1,
+                this + processorJob,
+                onOther = { blocker.await() },
+                executor = { },
             )
+            connectorsFlow.value = listOf(connector)
             val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            // Occupies the actor: Reset is destructive, so supersede cannot cancel it either.
+            connector.submit(ConnectorCommand.Reset)
+            advanceUntilIdle()
+
+            var directOutcome: Result<Unit>? = null
+            val direct = launch {
+                directOutcome = runCatching {
+                    sm.sync(
+                        connectorId1,
+                        SyncOptions(
+                            stats = false,
+                            readData = true,
+                            writeData = false,
+                            moduleFilter = setOf(powerModuleId),
+                        ),
+                    )
+                }
+            }
             advanceUntilIdle()
 
             val stuck = launch { sm.sync() }
             advanceUntilIdle()
 
-            var directCompleted = false
-            val direct = launch {
-                sm.sync(connectorId1, SyncOptions(stats = false, readData = true, writeData = false))
-                directCompleted = true
-            }
-            advanceUntilIdle()
-
             timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
             val replacement = launch { sm.sync() }
             advanceUntilIdle()
-            replacement.join()
 
+            blocker.complete(Unit)
+            advanceUntilIdle()
             direct.join()
-            directCompleted shouldBe true
+
+            // The direct caller's own op ran, with its filter intact.
+            directOutcome!!.isSuccess shouldBe true
+            executions.count { it.moduleFilter == setOf(powerModuleId) } shouldBe 1
 
             stuck.cancel()
+            replacement.cancel()
             processorJob.cancel()
             job.cancel()
             advanceUntilIdle()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
@@ -103,6 +103,7 @@ class SyncManagerSingleFlightTest : BaseTest() {
         override val operations = processor.operations
         override val completions = processor.completions
         override fun submit(command: ConnectorCommand) = processor.submit(command)
+        override fun submitExclusive(command: ConnectorCommand) = processor.submitExclusive(command)
         override suspend fun await(id: OperationId) = processor.await(id)
         override fun cancel(id: OperationId) = processor.cancel(id)
         override fun dismiss(id: OperationId) = processor.dismiss(id)
@@ -345,6 +346,154 @@ class SyncManagerSingleFlightTest : BaseTest() {
             executions.last().readData shouldBe true
             executions.last().writeData shouldBe true
 
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `caller cancellation` {
+
+        @Test
+        fun `cancelling the last caller cancels the connector operation`() = runTest2 {
+            val processorJob = SupervisorJob()
+            val events = mutableListOf<String>()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) {
+                    events += "start"
+                    try {
+                        hang.await()
+                    } finally {
+                        events += "end"
+                    }
+                },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val caller = launch { sm.sync() }
+            advanceUntilIdle()
+            events shouldBe listOf("start")
+
+            // The run lives on @AppScope: without withdrawing the request, cancelling the caller
+            // would leave the connector command hitting the network for nobody.
+            caller.cancel()
+            advanceUntilIdle()
+
+            events shouldBe listOf("start", "end")
+            executions shouldHaveSize 1
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `cancelling one of two coalesced callers leaves the work running`() = runTest2 {
+            val processorJob = SupervisorJob()
+            val events = mutableListOf<String>()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) {
+                    events += "start"
+                    try {
+                        hang.await()
+                    } finally {
+                        events += "end"
+                    }
+                },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            // Both records land before the run claims a batch, so they own the same iteration.
+            val first = launch { sm.sync(SyncOptions(stats = false, readData = true, writeData = false)) }
+            val second = launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            advanceUntilIdle()
+            events shouldBe listOf("start")
+
+            first.cancel()
+            advanceUntilIdle()
+
+            // Still running for the remaining owner — options already merged into the executing
+            // command cannot be subtracted mid-flight.
+            events shouldBe listOf("start")
+
+            hang.complete(Unit)
+            advanceUntilIdle()
+            second.join()
+            events shouldBe listOf("start", "end")
+            executions shouldHaveSize 1
+            executions.single().readData shouldBe true
+            executions.single().writeData shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a cancelled caller does not take another caller's queued request with it`() = runTest2 {
+            val processorJob = SupervisorJob()
+            val gate = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val stuck = launch { sm.sync() }
+            advanceUntilIdle()
+
+            // Arrives after the batch was claimed, so it waits for the next iteration.
+            val later = launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            advanceUntilIdle()
+
+            stuck.cancel()
+            advanceUntilIdle()
+            later.join()
+
+            executions.last().writeData shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a direct per-connector sync survives the manager superseding its own run`() = runTest2 {
+            // Both would share one coalesced op if the manager's submissions were coalescible;
+            // supersede would then cancel the direct caller's op too.
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) hang.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val stuck = launch { sm.sync() }
+            advanceUntilIdle()
+
+            var directCompleted = false
+            val direct = launch {
+                sm.sync(connectorId1, SyncOptions(stats = false, readData = true, writeData = false))
+                directCompleted = true
+            }
+            advanceUntilIdle()
+
+            timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
+            val replacement = launch { sm.sync() }
+            advanceUntilIdle()
+            replacement.join()
+
+            direct.join()
+            directCompleted shouldBe true
+
+            stuck.cancel()
             processorJob.cancel()
             job.cancel()
             advanceUntilIdle()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
@@ -1,0 +1,476 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.sync.core.cache.SyncCache
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TestTimeSource
+
+/**
+ * Single-flight behaviour of [SyncManager.sync].
+ *
+ * The connectors here are backed by a real [ConnectorProcessor] rather than a mock: a fake that
+ * simply returns would pass even if supersession never reached the connector, and the ordering
+ * guarantee ("the superseded command is terminal before its replacement starts") only exists
+ * because the processor is a serial actor.
+ */
+class SyncManagerSingleFlightTest : BaseTest() {
+
+    private val connectorId1 = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "test", account = "acc1")
+    private val connectorId2 = ConnectorId(type = ConnectorType.GDRIVE, subtype = "test", account = "acc2")
+    private val deviceId = DeviceId("device-1")
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+
+    private lateinit var syncSettings: SyncSettings
+    private lateinit var pauseStatesValue: MutableStateFlow<Set<ConnectorPauseState>>
+    private lateinit var syncCache: SyncCache
+    private lateinit var connectorHub: ConnectorHub
+    private lateinit var connectorsFlow: MutableStateFlow<List<SyncConnector>>
+    private lateinit var connectorSyncState: ConnectorSyncState
+
+    /** Records what the executor saw, so tests can assert on accumulated options. */
+    private val executions = mutableListOf<SyncOptions>()
+
+    @BeforeEach
+    fun setup() {
+        executions.clear()
+        pauseStatesValue = MutableStateFlow(emptySet())
+        syncSettings = mockk(relaxed = true) {
+            every { connectorPauseStates } returns pauseStatesValue
+            every { pausedConnectorIds } returns pauseStatesValue.map { it.connectorIds }
+            coEvery { isPaused(any()) } coAnswers {
+                pauseStatesValue.value.reasonFor(firstArg<ConnectorId>()) != null
+            }
+            coEvery { migrateLegacyPauseStates() } coAnswers { }
+        }
+        every { syncSettings.deviceId } returns deviceId
+        syncCache = mockk(relaxed = true)
+        connectorSyncState = ConnectorSyncState()
+        connectorsFlow = MutableStateFlow(emptyList())
+        connectorHub = mockk(relaxed = true) {
+            every { connectors } returns connectorsFlow
+        }
+    }
+
+    /** A connector driven by a real [ConnectorProcessor], so cancel()/coalescing are the real thing. */
+    private inner class FakeConnector(
+        override val identifier: ConnectorId,
+        processorScope: CoroutineScope,
+        executor: suspend (SyncOptions) -> Unit,
+    ) : SyncConnector {
+        private val processor = ConnectorProcessor(
+            connectorId = identifier,
+            syncSettings = syncSettings,
+            timeouts = ConnectorProcessor.Timeouts.UNBOUNDED,
+            executor = { command ->
+                if (command is ConnectorCommand.Sync) {
+                    executions += command.options
+                    executor(command.options)
+                }
+            },
+        )
+
+        val job: Job = processor.start(processorScope)
+
+        override val accountLabel: String = "fake"
+        override val capabilities = ConnectorCapabilities(deviceRemovalPolicy = DeviceRemovalPolicy.REMOVE_LOCAL_ONLY)
+        override val state = flowOf<SyncConnectorState>()
+        override val data = flowOf<SyncRead?>(null)
+        override val operations = processor.operations
+        override val completions = processor.completions
+        override fun submit(command: ConnectorCommand) = processor.submit(command)
+        override suspend fun await(id: OperationId) = processor.await(id)
+        override fun cancel(id: OperationId) = processor.cancel(id)
+        override fun dismiss(id: OperationId) = processor.dismiss(id)
+    }
+
+    private fun TestScope.createSyncManager(timeSource: TestTimeSource? = null): Pair<SyncManager, Job> {
+        val job = Job()
+        val sm = SyncManager(
+            scope = this + job,
+            dispatcherProvider = mockk(relaxed = true) {
+                every { Default } returns coroutineContext[kotlinx.coroutines.CoroutineDispatcher.Key]!!
+            },
+            syncSettings = syncSettings,
+            syncCache = syncCache,
+            connectorHubs = setOf(connectorHub),
+            connectorSyncState = connectorSyncState,
+        )
+        if (timeSource != null) sm.timeSource = timeSource
+        return sm to job
+    }
+
+    @Nested
+    inner class `coalescing` {
+
+        @Test
+        fun `a request arriving mid-run is accumulated, not lost`() = runTest2 {
+            val gate = CompletableDeferred<Unit>()
+            val processorJob = SupervisorJob()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val first = launch { sm.sync(SyncOptions(stats = false, readData = true, writeData = false)) }
+            advanceUntilIdle()
+
+            // Arrives while the first batch is in flight. Its scope must survive into the re-run —
+            // a write request absorbed by a read-only one would silently drop the write.
+            val second = launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            first.join()
+            second.join()
+
+            executions shouldHaveSize 2
+            executions[0].readData shouldBe true
+            executions[0].writeData shouldBe false
+            executions[1].writeData shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `requests arriving in the final-check window are accumulated, not lost`() = runTest2 {
+            // The run decides "nothing pending, I'm done" and clears itself under the same lock a
+            // new request takes, so a request can never fall between the two.
+            val processorJob = SupervisorJob()
+            connectorsFlow.value = listOf(FakeConnector(connectorId1, this + processorJob) { })
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val waiters = (1..20).map {
+                launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            }
+            advanceUntilIdle()
+            waiters.forEach { it.join() }
+
+            // Every caller's request ran (each returned), while the runs stayed coalesced.
+            executions.size shouldBeLessThan 20
+            executions.forEach { it.writeData shouldBe true }
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a folded request still waits for its own work to run`() = runTest2 {
+            val gate = CompletableDeferred<Unit>()
+            val processorJob = SupervisorJob()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            launch { sm.sync() }
+            advanceUntilIdle()
+
+            var secondReturned = false
+            val second = launch {
+                sm.sync(SyncOptions(stats = false, readData = false, writeData = true))
+                secondReturned = true
+            }
+            advanceUntilIdle()
+            secondReturned shouldBe false
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            second.join()
+            secondReturned shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `supersession` {
+
+        @Test
+        fun `a hanging connector does not block later syncs forever`() = runTest2 {
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) hang.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val stuck = launch { sm.sync() }
+            advanceUntilIdle()
+            executions shouldHaveSize 1
+
+            // Past the staleness threshold the wedged run is taken over instead of the new request
+            // being dropped on the floor.
+            timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
+            val later = launch { sm.sync() }
+            advanceUntilIdle()
+            later.join()
+
+            executions shouldHaveSize 2
+            stuck.cancel()
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a request within the staleness window coalesces instead of superseding`() = runTest2 {
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val gate = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val first = launch { sm.sync() }
+            advanceUntilIdle()
+
+            timeSource += SyncManager.SYNC_STALE_AFTER - 1.minutes
+            val second = launch { sm.sync() }
+            advanceUntilIdle()
+
+            // Still only the original execution — the second request waits for the run instead of
+            // tearing it down.
+            executions shouldHaveSize 1
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            first.join()
+            second.join()
+            executions shouldHaveSize 2
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `the superseded command is terminal before its replacement starts`() = runTest2 {
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val events = mutableListOf<String>()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) {
+                    val index = executions.size
+                    events += "start-$index"
+                    try {
+                        if (index == 1) hang.await()
+                    } finally {
+                        events += "end-$index"
+                    }
+                },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val stuck = launch { sm.sync() }
+            advanceUntilIdle()
+
+            timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
+            val replacement = launch { sm.sync() }
+            advanceUntilIdle()
+            replacement.join()
+
+            // Not merely "the manager's waiter was cancelled": the connector's own command reached
+            // terminal state first, and only then did the replacement begin.
+            events shouldBe listOf("start-1", "end-1", "start-2", "end-2")
+            stuck.cancel()
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a superseded batch's request is carried into the replacement run`() = runTest2 {
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val hang = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) hang.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            // A write-only request gets stuck...
+            val stuck = launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            advanceUntilIdle()
+
+            // ...and a read-only one supersedes it. The write must not be dropped.
+            timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
+            val later = launch { sm.sync(SyncOptions(stats = false, readData = true, writeData = false)) }
+            advanceUntilIdle()
+            later.join()
+            stuck.join()
+
+            executions.last().readData shouldBe true
+            executions.last().writeData shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `connector resolution` {
+
+        @Test
+        fun `connectors that never emit do not wedge the run`() = runTest2 {
+            // A hub whose connector flow never emits used to leave the critical section held for
+            // the process lifetime.
+            val neverEmits = mockk<ConnectorHub>(relaxed = true) {
+                every { connectors } returns MutableSharedFlow()
+            }
+            connectorHub = neverEmits
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val first = launch { sm.sync() }
+            advanceUntilIdle()
+            first.join()
+
+            // And the manager still accepts work afterwards.
+            val second = launch { sm.sync() }
+            advanceUntilIdle()
+            second.join()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `progress` {
+
+        @Test
+        fun `in-flight connectors are exposed while a sync runs`() = runTest2 {
+            val processorJob = SupervisorJob()
+            val gate = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+                FakeConnector(connectorId2, this + processorJob) { },
+            )
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val running = launch { sm.sync() }
+            advanceUntilIdle()
+
+            sm.activeConnectorSyncs.value shouldBe setOf(connectorId1)
+            sm.lastConnectorSyncOutcomes.value[connectorId2] shouldBe SyncManager.ConnectorSyncOutcome.Success
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            running.join()
+            sm.activeConnectorSyncs.value shouldBe emptySet()
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `payloads` {
+
+        @Test
+        fun `accumulated writes still carry the changed module payload`() = runTest2 {
+            val processorJob = SupervisorJob()
+            connectorsFlow.value = listOf(FakeConnector(connectorId1, this + processorJob) { })
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.updatePayload(
+                mockk<SyncWrite.Device.Module> {
+                    every { moduleId } returns powerModuleId
+                    every { payload } returns okio.ByteString.of(1, 2, 3)
+                }
+            )
+
+            launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }.join()
+            advanceUntilIdle()
+
+            executions.first().writePayload.single().module.moduleId shouldBe powerModuleId
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
+    inner class `timing` {
+
+        @Test
+        fun `staleness uses a monotonic source, unaffected by wall-clock jumps`() = runTest2 {
+            // Virtual time advancing (which a wall-clock-based check would follow) must not make a
+            // healthy run look stale — only the injected monotonic source decides.
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val gate = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(connectorId1, this + processorJob) { if (executions.size == 1) gate.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val first = launch { sm.sync() }
+            advanceUntilIdle()
+
+            advanceTimeBy(60.minutes)
+            val second = launch { sm.sync() }
+            advanceUntilIdle()
+
+            executions shouldHaveSize 1
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            first.join()
+            second.join()
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSingleFlightTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +23,7 @@ import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -81,6 +83,12 @@ class SyncManagerSingleFlightTest : BaseTest() {
         override val identifier: ConnectorId,
         processorScope: CoroutineScope,
         onOther: suspend (ConnectorCommand) -> Unit = { },
+        /**
+         * When set, the FIRST [await] parks non-cancellably until it completes — modelling a
+         * manager-side wait that does not unwind the moment its run is superseded, which is what
+         * blocking connector work (GDrive's `.execute()`) produces in practice.
+         */
+        private val awaitHold: CompletableDeferred<Unit>? = null,
         executor: suspend (SyncOptions) -> Unit,
     ) : SyncConnector {
         private val processor = ConnectorProcessor(
@@ -107,7 +115,17 @@ class SyncManagerSingleFlightTest : BaseTest() {
         override val completions = processor.completions
         override fun submit(command: ConnectorCommand) = processor.submit(command)
         override fun submitExclusive(command: ConnectorCommand) = processor.submitExclusive(command)
-        override suspend fun await(id: OperationId) = processor.await(id)
+        private var awaitHoldUsed = false
+
+        override suspend fun await(id: OperationId): ConnectorOperation.Terminal {
+            val hold = awaitHold
+            if (hold == null || awaitHoldUsed) return processor.await(id)
+            awaitHoldUsed = true
+            val terminal = processor.await(id)
+            withContext(NonCancellable) { hold.await() }
+            return terminal
+        }
+
         override fun cancel(id: OperationId) = processor.cancel(id)
         override fun dismiss(id: OperationId) = processor.dismiss(id)
     }
@@ -459,6 +477,60 @@ class SyncManagerSingleFlightTest : BaseTest() {
             later.join()
 
             executions.last().writeData shouldBe true
+
+            processorJob.cancel()
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `a caller cancelled after its run was superseded leaves nothing behind`() = runTest2 {
+            // Run A is superseded, so activeRun is already B, but A's cancellation has not landed:
+            // it still owns the batch holding the stuck caller's record. Resolving the owning batch
+            // through activeRun misses that record entirely, and A's finally then folds it back into
+            // pending — so the withdrawn options run again for a caller that is long gone.
+            val timeSource = TestTimeSource()
+            val processorJob = SupervisorJob()
+            val releaseA = CompletableDeferred<Unit>()
+            val gateB = CompletableDeferred<Unit>()
+            connectorsFlow.value = listOf(
+                FakeConnector(
+                    connectorId1,
+                    this + processorJob,
+                    awaitHold = releaseA,
+                ) { if (executions.size == 2) gateB.await() },
+            )
+            val (sm, job) = createSyncManager(timeSource)
+            advanceUntilIdle()
+
+            val optionsA = SyncOptions(
+                stats = false,
+                readData = true,
+                writeData = false,
+                moduleFilter = setOf(powerModuleId),
+            )
+            val stuck = launch { sm.sync(optionsA) }
+            advanceUntilIdle()
+            executions shouldHaveSize 1
+
+            // Past the staleness threshold: B takes over while A is still parked in its wait.
+            timeSource += SyncManager.SYNC_STALE_AFTER + 1.minutes
+            val replacement = launch { sm.sync(SyncOptions(stats = false, readData = false, writeData = true)) }
+            advanceUntilIdle()
+            executions shouldHaveSize 2
+
+            // The only owner of A's batch walks away inside that window.
+            stuck.cancel()
+            advanceUntilIdle()
+
+            releaseA.complete(Unit)
+            gateB.complete(Unit)
+            advanceUntilIdle()
+            replacement.join()
+
+            // A's options were withdrawn: never requeued, never executed a second time.
+            executions shouldHaveSize 2
+            executions.count { it.moduleFilter == setOf(powerModuleId) } shouldBe 1
 
             processorJob.cancel()
             job.cancel()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
@@ -673,7 +673,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
     @Nested
     inner class `sync lock contention` {
         @Test
-        fun `pending flag triggers re-run after current sync completes`() = runTest2 {
+        fun `request arriving mid-sync triggers a re-run after the current one completes`() = runTest2 {
             val (sm, job) = createSyncManager()
             advanceUntilIdle()
 
@@ -694,18 +694,19 @@ class SyncManagerSyncWriteTest : BaseTest() {
                 )
             }
 
-            // First sync acquires lock and blocks inside connector.await()
+            // First sync starts a run and blocks inside connector.await()
             val firstSync = launch { sm.sync(SyncOptions(writeData = true, readData = false, stats = false)) }
             advanceUntilIdle()
 
-            // Second sync hits tryLock failure and sets pending flag
-            sm.sync(SyncOptions(writeData = true, readData = false, stats = false))
+            // Second sync folds into the run's next iteration — and waits for it, hence the launch.
+            val secondSync = launch { sm.sync(SyncOptions(writeData = true, readData = false, stats = false)) }
             advanceUntilIdle()
 
-            // Release the gate — first sync completes, then re-runs due to pending flag
+            // Release the gate — the first batch completes, then the folded one runs
             gate.complete(Unit)
             advanceUntilIdle()
             firstSync.join()
+            secondSync.join()
 
             // connector.submit should have been called twice: original + pending re-run
             coVerify(exactly = 2) { connector1.submit(match { it is ConnectorCommand.Sync }) }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
@@ -59,14 +59,17 @@ class SyncManagerSyncWriteTest : BaseTest() {
 
     /**
      * Set up a mocked connector that behaves like a real one for SyncManager's purposes:
-     * submit() returns a fresh OperationId and, for Pause/Resume commands, side-effects the
-     * paused-connectors setting (matching what the real processor would do). await() returns a
-     * Succeeded terminal so execute() returns cleanly.
+     * submit()/submitExclusive() return a fresh OperationId and, for Pause/Resume commands,
+     * side-effect the paused-connectors setting (matching what the real processor would do).
+     * await() returns a Succeeded terminal so execute() returns cleanly.
+     *
+     * SyncManager submits Syncs through submitExclusive() (it may cancel those ids), while
+     * Pause/Resume/Reset go through execute() → submit(); the verifications below follow that
+     * split.
      */
     private fun SyncConnector.wireProcessorSideEffects() {
         val cid = this.identifier
-        every { submit(any()) } answers {
-            val cmd = firstArg<ConnectorCommand>()
+        val onSubmit: (ConnectorCommand) -> OperationId = { cmd ->
             when (cmd) {
                 is ConnectorCommand.Pause -> pauseStatesValue.value = pauseStatesValue.value
                     .filterNot { it.connectorId == cid }
@@ -78,6 +81,8 @@ class SyncManagerSyncWriteTest : BaseTest() {
             }
             OperationId.create()
         }
+        every { submit(any()) } answers { onSubmit(firstArg()) }
+        every { submitExclusive(any()) } answers { onSubmit(firstArg()) }
         // await() takes a @JvmInline value class (OperationId). MockK unwraps value classes
         // so firstArg<OperationId>() would cast a String → use a fresh id in the response.
         coEvery { await(any()) } answers {
@@ -198,7 +203,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val cmdSlot = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmdSlot)) }
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
             cmdSlot.syncOptions().writePayload.single().module.moduleId shouldBe powerModuleId
 
             job.cancel()
@@ -216,7 +221,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val cmdSlot = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmdSlot)) }
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
             cmdSlot.syncOptions().writePayload.map { it.module.moduleId } shouldContainExactlyInAnyOrder
                 listOf(powerModuleId, wifiModuleId)
 
@@ -235,7 +240,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val cmdSlot = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmdSlot)) }
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
             cmdSlot.syncOptions().writePayload.size shouldBe 1
             cmdSlot.syncOptions().writePayload.single().module.payload shouldBe "new-data".encodeUtf8()
 
@@ -253,7 +258,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = false, readData = false, stats = false))
 
             val cmdSlot = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmdSlot)) }
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
             cmdSlot.syncOptions().writePayload shouldBe emptyList()
 
             job.cancel()
@@ -268,7 +273,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val cmdSlot = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmdSlot)) }
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
             cmdSlot.syncOptions().writePayload shouldBe emptyList()
 
             job.cancel()
@@ -291,7 +296,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             // First sync — hash mismatch, module included
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
             val firstCmds = mutableListOf<ConnectorCommand>()
-            coVerify { connector1.submit(capture(firstCmds)) }
+            coVerify { connector1.submitExclusive(capture(firstCmds)) }
             (firstCmds.first() as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             // Simulate connector setting the hash after successful write
@@ -301,7 +306,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             // Second sync — hash matches, module skipped
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
             val allCmds = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector1.submit(capture(allCmds)) }
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(allCmds)) }
             (allCmds.last() as ConnectorCommand.Sync).options.writePayload shouldBe emptyList()
 
             job.cancel()
@@ -325,7 +330,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val allCmds = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector1.submit(capture(allCmds)) }
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(allCmds)) }
             val lastOptions = (allCmds.last() as ConnectorCommand.Sync).options
             lastOptions.writePayload.size shouldBe 1
             lastOptions.writePayload.single().module.payload shouldBe "new-data".encodeUtf8()
@@ -351,7 +356,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId2, SyncOptions(writeData = true, readData = false, stats = false))
 
             val cmd2 = slot<ConnectorCommand>()
-            coVerify { connector2.submit(capture(cmd2)) }
+            coVerify { connector2.submitExclusive(capture(cmd2)) }
             (cmd2.captured as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             job.cancel()
@@ -376,11 +381,11 @@ class SyncManagerSyncWriteTest : BaseTest() {
 
             // Both should have received the module on first sync
             val cmd1 = slot<ConnectorCommand>()
-            coVerify { connector1.submit(capture(cmd1)) }
+            coVerify { connector1.submitExclusive(capture(cmd1)) }
             (cmd1.captured as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             val cmd2 = slot<ConnectorCommand>()
-            coVerify { connector2.submit(capture(cmd2)) }
+            coVerify { connector2.submitExclusive(capture(cmd2)) }
             (cmd2.captured as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             // Second sync for both — hashes match, both empty
@@ -388,11 +393,11 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId2, SyncOptions(writeData = true, readData = false, stats = false))
 
             val all1 = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector1.submit(capture(all1)) }
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(all1)) }
             (all1.last() as ConnectorCommand.Sync).options.writePayload shouldBe emptyList()
 
             val all2 = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector2.submit(capture(all2)) }
+            coVerify(exactly = 2) { connector2.submitExclusive(capture(all2)) }
             (all2.last() as ConnectorCommand.Sync).options.writePayload shouldBe emptyList()
 
             job.cancel()
@@ -418,7 +423,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val all = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector1.submit(capture(all)) }
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(all)) }
             (all.last() as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             job.cancel()
@@ -436,7 +441,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             val unknownId = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "unknown", account = "unknown")
             sm.sync(unknownId, SyncOptions(writeData = true, readData = false, stats = false))
 
-            coVerify(exactly = 0) { connector1.submit(any()) }
+            coVerify(exactly = 0) { connector1.submitExclusive(any()) }
 
             job.cancel()
             advanceUntilIdle()
@@ -455,7 +460,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
 
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
-            coVerify(exactly = 0) { connector1.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 0) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             job.cancel()
             advanceUntilIdle()
@@ -488,8 +493,8 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(SyncOptions(writeData = true, readData = false, stats = false))
             advanceUntilIdle()
 
-            coVerify(exactly = 0) { connector1.submit(match { it is ConnectorCommand.Sync }) }
-            coVerify(exactly = 1) { connector2.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 0) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 1) { connector2.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             job.cancel()
             advanceUntilIdle()
@@ -504,12 +509,12 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.updatePayload(createModule(powerModuleId, "data"))
 
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
-            coVerify(exactly = 0) { connector1.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 0) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             pauseStatesValue.value = emptySet()
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
-            coVerify(exactly = 1) { connector1.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 1) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             job.cancel()
             advanceUntilIdle()
@@ -635,7 +640,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
 
             val all = mutableListOf<ConnectorCommand>()
-            coVerify(exactly = 2) { connector1.submit(capture(all)) }
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(all)) }
             (all[0] as ConnectorCommand.Sync).options.writePayload.single().module.payload shouldBe "v1".encodeUtf8()
             (all[1] as ConnectorCommand.Sync).options.writePayload.single().module.payload shouldBe "v2".encodeUtf8()
 
@@ -662,7 +667,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
 
             // connector2 should have been called despite connector1 failure
             val cmd2 = slot<ConnectorCommand>()
-            coVerify { connector2.submit(capture(cmd2)) }
+            coVerify { connector2.submitExclusive(capture(cmd2)) }
             (cmd2.captured as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
 
             job.cancel()
@@ -709,7 +714,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             secondSync.join()
 
             // connector.submit should have been called twice: original + pending re-run
-            coVerify(exactly = 2) { connector1.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 2) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             job.cancel()
             advanceUntilIdle()
@@ -725,7 +730,7 @@ class SyncManagerSyncWriteTest : BaseTest() {
             sm.sync(SyncOptions(writeData = true, readData = false, stats = false))
             advanceUntilIdle()
 
-            coVerify(exactly = 1) { connector1.submit(match { it is ConnectorCommand.Sync }) }
+            coVerify(exactly = 1) { connector1.submitExclusive(match { it is ConnectorCommand.Sync }) }
 
             job.cancel()
             advanceUntilIdle()

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncOptionsMergeTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncOptionsMergeTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.module.core.ModuleId
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SyncOptionsMergeTest : BaseTest() {
+
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+    private val wifiModuleId = ModuleId("eu.darken.octi.module.core.wifi")
+
+    private fun moduleWrite(moduleId: ModuleId, payload: String) = SyncOptions.ModuleWrite(
+        module = mockk<SyncWrite.Device.Module> {
+            every { this@mockk.moduleId } returns moduleId
+            every { this@mockk.payload } returns payload.encodeUtf8()
+        },
+        expectedHash = payload,
+    )
+
+    @Test
+    fun `booleans are ORed, never intersected`() {
+        val writeOnly = SyncOptions(stats = false, readData = false, writeData = true)
+        val readOnly = SyncOptions(stats = false, readData = true, writeData = false)
+
+        val merged = writeOnly.merge(readOnly)
+
+        merged.readData shouldBe true
+        merged.writeData shouldBe true
+        merged.stats shouldBe false
+    }
+
+    @Test
+    fun `a null filter means everything and absorbs a narrower one`() {
+        val filtered = SyncOptions(moduleFilter = setOf(powerModuleId), deviceFilter = setOf(DeviceId("a")))
+        val unfiltered = SyncOptions()
+
+        filtered.merge(unfiltered).moduleFilter shouldBe null
+        filtered.merge(unfiltered).deviceFilter shouldBe null
+        unfiltered.merge(filtered).moduleFilter shouldBe null
+    }
+
+    @Test
+    fun `filters union`() {
+        val a = SyncOptions(moduleFilter = setOf(powerModuleId), deviceFilter = setOf(DeviceId("a")))
+        val b = SyncOptions(moduleFilter = setOf(wifiModuleId), deviceFilter = setOf(DeviceId("b")))
+
+        val merged = a.merge(b)
+
+        merged.moduleFilter shouldBe setOf(powerModuleId, wifiModuleId)
+        merged.deviceFilter shouldBe setOf(DeviceId("a"), DeviceId("b"))
+    }
+
+    @Test
+    fun `payloads keep one entry per module with the newer one winning`() {
+        val a = SyncOptions(writePayload = listOf(moduleWrite(powerModuleId, "v1")))
+        val b = SyncOptions(
+            writePayload = listOf(moduleWrite(powerModuleId, "v2"), moduleWrite(wifiModuleId, "wifi")),
+        )
+
+        val merged = a.merge(b)
+
+        merged.writePayload.size shouldBe 2
+        merged.writePayload.single { it.module.moduleId == powerModuleId }.expectedHash shouldBe "v2"
+    }
+}

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -144,6 +144,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     override val completions: SharedFlow<ConnectorOperation.Terminal> get() = processor.completions
     override fun submit(command: ConnectorCommand): OperationId = processor.submit(command)
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = processor.await(id)
+    override fun cancel(id: OperationId): Boolean = processor.cancel(id)
     override fun dismiss(id: OperationId) = processor.dismiss(id)
 
     /** Start the processor loop. Called by the hub after construction with a connector-lifetime scope. */

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -602,35 +602,38 @@ class GDriveAppDataConnector @AssistedInject constructor(
         log(TAG, DEBUG) { "readDriveByFileIds(): Fetching ${cachedIds.size} files directly by ID" }
         val start = TimeSource.Monotonic.markNow()
 
-        val fetchJobs = cachedIds.map { (key, fileId) ->
-            val (deviceId, moduleId) = key
-            scope.async(dispatcherProvider.IO) {
-                val file = getFileMetadata(fileId)
+        // Structured: the per-file fetches are children of this call, so cancelling the command
+        // that triggered the read actually stops them. On the connector's own scope they would
+        // outlive their waiter and keep hitting Drive after the command was abandoned.
+        val modules = coroutineScope {
+            cachedIds.map { (key, fileId) ->
+                val (deviceId, moduleId) = key
+                async(dispatcherProvider.IO) {
+                    val file = getFileMetadata(fileId)
 
-                if (file.name != moduleId.id) {
-                    log(TAG, WARN) { "readDriveByFileIds(): Name mismatch for $fileId: expected=${moduleId.id}, got=${file.name}" }
-                    fileIdCache.remove(key)
-                    fileIdReverseCache.remove(fileId)
-                    return@async null
+                    if (file.name != moduleId.id) {
+                        log(TAG, WARN) { "readDriveByFileIds(): Name mismatch for $fileId: expected=${moduleId.id}, got=${file.name}" }
+                        fileIdCache.remove(key)
+                        fileIdReverseCache.remove(fileId)
+                        return@async null
+                    }
+
+                    val payload = file.readData()
+                    if (payload == null) {
+                        log(TAG, WARN) { "readDriveByFileIds(): Empty payload for $fileId" }
+                        return@async null
+                    }
+
+                    GDriveModuleData(
+                        connectorId = identifier,
+                        deviceId = deviceId,
+                        moduleId = moduleId,
+                        modifiedAt = Instant.fromEpochMilliseconds(file.modifiedTime.value),
+                        payload = payload,
+                    )
                 }
-
-                val payload = file.readData()
-                if (payload == null) {
-                    log(TAG, WARN) { "readDriveByFileIds(): Empty payload for $fileId" }
-                    return@async null
-                }
-
-                GDriveModuleData(
-                    connectorId = identifier,
-                    deviceId = deviceId,
-                    moduleId = moduleId,
-                    modifiedAt = Instant.fromEpochMilliseconds(file.modifiedTime.value),
-                    payload = payload,
-                )
-            }
-        }
-
-        val modules = fetchJobs.awaitAll().filterNotNull()
+            }.awaitAll()
+        }.filterNotNull()
         log(TAG) { "readDriveByFileIds() took ${start.elapsedNow().inWholeMilliseconds}ms" }
 
         val deviceGroups = modules.groupBy { it.deviceId }
@@ -927,13 +930,19 @@ class GDriveAppDataConnector @AssistedInject constructor(
         }
     }
 
-    private suspend fun GDriveEnvironment.writeDrive(data: SyncWrite) = withContext(NonCancellable) {
+    /**
+     * The Drive uploads are deliberately cancellable. They used to run inside
+     * `withContext(NonCancellable)`, which makes any bound placed around the command inert: a
+     * `withTimeout` around a non-cancellable body does not return until that body completes. Only
+     * the state commit below stays non-cancellable, mirroring `OctiServerConnector.runServerAction`.
+     */
+    private suspend fun GDriveEnvironment.writeDrive(data: SyncWrite) {
         log(TAG, DEBUG) { "writeDrive(): $data" }
 
         // TODO cache write data for when we are online again?
         if (!isInternetAvailable()) {
             log(TAG, WARN) { "writeDrive(): Skipping, we are offline." }
-            return@withContext
+            return
         }
 
         val userDir = rootChildCache[DEVICE_DATA_DIR_NAME]?.let { cachedDriveFolder(it, DEVICE_DATA_DIR_NAME) }
@@ -1027,7 +1036,9 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 if (!infoWritten) {
                     infoFile.writeData(infoPayload)
                 }
-                lastWrittenDeviceInfo = deviceInfo
+                // State commit: the file is published, so record what it holds even if we are
+                // being cancelled right now — otherwise the next sync rewrites it needlessly.
+                withContext(NonCancellable) { lastWrittenDeviceInfo = deviceInfo }
             } else {
                 log(TAG, VERBOSE) { "writeDrive(): Device info unchanged, skipping" }
             }

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -143,6 +143,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
     override val operations: StateFlow<List<ConnectorOperation>> get() = processor.operations
     override val completions: SharedFlow<ConnectorOperation.Terminal> get() = processor.completions
     override fun submit(command: ConnectorCommand): OperationId = processor.submit(command)
+    override fun submitExclusive(command: ConnectorCommand): OperationId = processor.submitExclusive(command)
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = processor.await(id)
     override fun cancel(id: OperationId): Boolean = processor.cancel(id)
     override fun dismiss(id: OperationId) = processor.dismiss(id)

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveBaseConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveBaseConnector.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.syncs.gdrive.core
 import android.accounts.Account
 import android.content.Context
 import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential
+import com.google.api.client.http.HttpRequestInitializer
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.services.drive.Drive
@@ -10,6 +11,7 @@ import com.google.api.services.drive.DriveScopes
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.debug.logging.logTag
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.seconds
 
 abstract class GDriveBaseConnector(
     private val dispatcherProvider: DispatcherProvider,
@@ -22,7 +24,15 @@ abstract class GDriveBaseConnector(
         val credential = GoogleAccountCredential.usingOAuth2(context, scopes).apply {
             selectedAccount = Account(account.email, "com.google")
         }
-        Drive.Builder(NetHttpTransport(), GsonFactory(), credential).apply {
+        // The Google API client's execute() is a blocking call on NetHttpTransport and is not
+        // interruptible by coroutine cancellation — a stalled request would ignore any timeout we
+        // wrap it in. Bounding it at the transport level is the only way to make it self-terminate.
+        val initializer = HttpRequestInitializer { request ->
+            credential.initialize(request)
+            request.connectTimeout = CONNECT_TIMEOUT.inWholeMilliseconds.toInt()
+            request.readTimeout = READ_TIMEOUT.inWholeMilliseconds.toInt()
+        }
+        Drive.Builder(NetHttpTransport(), GsonFactory(), initializer).apply {
             applicationName = context.getString(eu.darken.octi.common.R.string.app_name)
         }.build()
     }
@@ -37,5 +47,7 @@ abstract class GDriveBaseConnector(
 
     companion object {
         internal val TAG = logTag("Sync", "GDrive", "Connector", "Base")
+        private val CONNECT_TIMEOUT = 20.seconds
+        private val READ_TIMEOUT = 60.seconds
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -530,30 +531,37 @@ class OctiServerConnector @AssistedInject constructor(
         val targetModuleIds = moduleFilter ?: supportedModuleIds
         val isTargeted = moduleFilter != null
 
-        val devices = deviceIds.map { deviceId ->
-            scope.async moduleFetch@{
-                val moduleFetchJobs = targetModuleIds.mapIndexed { index, moduleId ->
-                    val fetchResult = try {
-                        fetchModule(deviceId, moduleId)
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "Failed to fetch: $deviceId:$moduleId:\n${e.asLog()}" }
-                        null
+        // Structured: the per-device fetches are children of this call, so cancelling the command
+        // that triggered the read actually stops the fetches. Launched on @AppScope they would
+        // outlive their waiter and keep hitting the server after a timeout.
+        val devices = coroutineScope {
+            deviceIds.map { deviceId ->
+                async moduleFetch@{
+                    val moduleFetchJobs = targetModuleIds.mapIndexed { index, moduleId ->
+                        val fetchResult = try {
+                            fetchModule(deviceId, moduleId)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "Failed to fetch: $deviceId:$moduleId:\n${e.asLog()}" }
+                            null
+                        }
+                        log(TAG, VERBOSE) { "Module fetched: $fetchResult" }
+                        // Throttle between requests only — a trailing delay is pure dead time before
+                        // the caller can publish the snapshot.
+                        if (!isTargeted && index < targetModuleIds.size - 1) delay(1.seconds)
+                        fetchResult
                     }
-                    log(TAG, VERBOSE) { "Module fetched: $fetchResult" }
-                    // Throttle between requests only — a trailing delay is pure dead time before
-                    // the caller can publish the snapshot.
-                    if (!isTargeted && index < targetModuleIds.size - 1) delay(1.seconds)
-                    fetchResult
+
+                    val modules = moduleFetchJobs.filterNotNull()
+
+                    OctiServerDeviceData(
+                        deviceId = deviceId,
+                        modules = modules,
+                    )
                 }
-
-                val modules = moduleFetchJobs.filterNotNull()
-
-                OctiServerDeviceData(
-                    deviceId = deviceId,
-                    modules = modules,
-                )
-            }
-        }.awaitAll()
+            }.awaitAll()
+        }
 
         val result = OctiServerData(
             connectorId = identifier,
@@ -694,6 +702,13 @@ class OctiServerConnector @AssistedInject constructor(
         return true
     }
 
+    /**
+     * The server call itself is deliberately cancellable. It used to run inside
+     * `withContext(NonCancellable)`, which made any bound placed around a command inert: a
+     * `withTimeout` around a non-cancellable body does not return until that body completes. Only
+     * the state commits below stay non-cancellable — they are bookkeeping that must not be lost
+     * once the call has already had its effect.
+     */
     private suspend fun <R> runServerAction(
         tag: String,
         block: suspend () -> R,
@@ -704,12 +719,11 @@ class OctiServerConnector @AssistedInject constructor(
         return try {
             serverLock.withLock {
                 try {
-                    withContext(NonCancellable) { block() }
+                    block()
                 } catch (e: OctiServerHttpException) {
                     // Per-account rate limit: hold the lock across the Retry-After delay so
                     // the next queued caller for this connector waits, not just the current
-                    // one. delay() is outside NonCancellable so a connector pause/cancel
-                    // terminates the wait promptly.
+                    // one.
                     if (e.httpCode == 429) {
                         e.retryAfterSeconds?.let { secs ->
                             log(TAG, WARN) { "runServerAction($tag): 429 rate-limited, holding lock for ${secs}s" }
@@ -719,18 +733,22 @@ class OctiServerConnector @AssistedInject constructor(
                     throw e
                 }
             }.also {
-                _state.updateBlocking {
-                    copy(
-                        lastError = null,
-                        lastActionAt = Clock.System.now(),
-                    )
+                withContext(NonCancellable) {
+                    _state.updateBlocking {
+                        copy(
+                            lastError = null,
+                            lastActionAt = Clock.System.now(),
+                        )
+                    }
                 }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             log(TAG, ERROR) { "runServerAction($tag) failed: ${e.asLog()}" }
-            _state.updateBlocking { copy(lastError = e) }
+            withContext(NonCancellable) {
+                _state.updateBlocking { copy(lastError = e) }
+            }
             throw e
         } finally {
             log(TAG, VERBOSE) { "runServerAction($tag) finished after ${start.elapsedNow().inWholeMilliseconds}ms" }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -161,6 +161,7 @@ class OctiServerConnector @AssistedInject constructor(
     override val operations: StateFlow<List<ConnectorOperation>> get() = processor.operations
     override val completions: SharedFlow<ConnectorOperation.Terminal> get() = processor.completions
     override fun submit(command: ConnectorCommand): OperationId = processor.submit(command)
+    override fun submitExclusive(command: ConnectorCommand): OperationId = processor.submitExclusive(command)
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = processor.await(id)
     override fun cancel(id: OperationId): Boolean = processor.cancel(id)
     override fun dismiss(id: OperationId) = processor.dismiss(id)

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerConnector.kt
@@ -162,6 +162,7 @@ class OctiServerConnector @AssistedInject constructor(
     override val completions: SharedFlow<ConnectorOperation.Terminal> get() = processor.completions
     override fun submit(command: ConnectorCommand): OperationId = processor.submit(command)
     override suspend fun await(id: OperationId): ConnectorOperation.Terminal = processor.await(id)
+    override fun cancel(id: OperationId): Boolean = processor.cancel(id)
     override fun dismiss(id: OperationId) = processor.dismiss(id)
 
     /** Start the processor loop. Called by the hub after construction with a connector-lifetime scope. */

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpoint.kt
@@ -11,6 +11,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.http.StreamingClient
 import eu.darken.octi.common.serialization.RetrofitJson
 import eu.darken.octi.module.core.ModuleId
 import eu.darken.octi.sync.core.CapabilitiesCodec
@@ -36,6 +37,7 @@ class OctiServerEndpoint @AssistedInject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val syncSettings: SyncSettings,
     private val baseHttpClient: OkHttpClient,
+    @StreamingClient private val streamingHttpClient: OkHttpClient,
     @RetrofitJson private val retrofitJson: Json,
     private val basicAuthInterceptor: BasicAuthInterceptor,
     private val deviceHeaderInterceptor: DeviceHeaderInterceptor,
@@ -50,13 +52,27 @@ class OctiServerEndpoint @AssistedInject constructor(
         }.build()
     }
 
-    private val api: OctiServerApi by lazy {
-        Retrofit.Builder().apply {
-            baseUrl("${serverAdress.address}/v1/")
-            client(httpClient)
-            addConverterFactory(retrofitJson.asConverterFactory("application/json".toMediaType()))
-        }.build().create(OctiServerApi::class.java)
+    private val streamingClient by lazy {
+        streamingHttpClient.newBuilder().apply {
+            addInterceptor(basicAuthInterceptor)
+            addInterceptor(deviceHeaderInterceptor)
+        }.build()
     }
+
+    private fun buildApi(client: OkHttpClient): OctiServerApi = Retrofit.Builder().apply {
+        baseUrl("${serverAdress.address}/v1/")
+        client(client)
+        addConverterFactory(retrofitJson.asConverterFactory("application/json".toMediaType()))
+    }.build().create(OctiServerApi::class.java)
+
+    private val api: OctiServerApi by lazy { buildApi(httpClient) }
+
+    /**
+     * Blob transfer routes only. These move bodies that the caller consumes after the call returns
+     * (download) or feeds in chunk by chunk (upload), neither of which fits the metadata client's
+     * total-call bound. See [StreamingClient].
+     */
+    private val streamingApi: OctiServerApi by lazy { buildApi(streamingClient) }
 
     private val ourDeviceIdString: String
         get() = syncSettings.deviceId.id
@@ -288,7 +304,7 @@ class OctiServerEndpoint @AssistedInject constructor(
     ): Long = withContext(dispatcherProvider.IO) {
         log(TAG, VERBOSE) { "appendBlobSession(session=$sessionId, offset=$offset)" }
         val response = try {
-            api.appendBlobSession(
+            streamingApi.appendBlobSession(
                 moduleId = moduleId.id,
                 sessionId = sessionId,
                 callerDeviceId = ourDeviceIdString,
@@ -354,7 +370,7 @@ class OctiServerEndpoint @AssistedInject constructor(
     ): okhttp3.ResponseBody? = withContext(dispatcherProvider.IO) {
         log(TAG, VERBOSE) { "getBlob(blobId=$serverBlobId, device=${deviceId.logLabel}, module=${moduleId.logLabel})" }
         try {
-            val response = api.getBlob(
+            val response = streamingApi.getBlob(
                 moduleId = moduleId.id,
                 blobId = serverBlobId,
                 callerDeviceId = ourDeviceIdString,

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -64,7 +65,13 @@ class OctiServerWebSocket(
      * unbounded. Both halves are pinned by `WebSocketCallTimeoutTest`.
      */
     fun connect(): Flow<SyncEvent> = callbackFlow {
+        // Own Dispatcher, not the inherited one: newBuilder() shares the base client's Dispatcher,
+        // and an established LIVE-mode socket permanently occupies one of its
+        // maxRequestsPerHost = 5 slots for this host. Saturating those slots starves ordinary API
+        // calls, which then sit queued — time no HTTP timeout covers. Isolating the sockets keeps
+        // them from competing with the calls they exist to announce.
         val wsClient = baseHttpClient.newBuilder()
+            .dispatcher(Dispatcher())
             .pingInterval(30, TimeUnit.SECONDS)
             .build()
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
@@ -59,10 +59,9 @@ class OctiServerWebSocket(
 
     /**
      * The [baseHttpClient]'s `callTimeout` is deliberately inherited. OkHttp calls
-     * `timeoutEarlyExit()` once the upgrade succeeds, so the bound covers only the handshake and
-     * the time the call spends queued in the dispatcher — it never terminates an established
-     * socket. Clearing it would leave a queued reconnect handshake unbounded, which is exactly the
-     * failure mode this connector must not have.
+     * `timeoutEarlyExit()` once the upgrade succeeds, so the bound covers the handshake only and
+     * never terminates an established socket — clearing it would just leave the handshake
+     * unbounded. Both halves are pinned by `WebSocketCallTimeoutTest`.
      */
     fun connect(): Flow<SyncEvent> = callbackFlow {
         val wsClient = baseHttpClient.newBuilder()

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocket.kt
@@ -12,11 +12,11 @@ import eu.darken.octi.sync.core.ConnectorId
 import eu.darken.octi.sync.core.DeviceId
 import eu.darken.octi.sync.core.SyncEvent
 import eu.darken.octi.sync.core.SyncSettings
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -29,6 +29,7 @@ import okhttp3.WebSocketListener
 import java.util.Base64
 import java.util.concurrent.TimeUnit
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -56,25 +57,33 @@ class OctiServerWebSocket(
         )
     }
 
+    /**
+     * The [baseHttpClient]'s `callTimeout` is deliberately inherited. OkHttp calls
+     * `timeoutEarlyExit()` once the upgrade succeeds, so the bound covers only the handshake and
+     * the time the call spends queued in the dispatcher — it never terminates an established
+     * socket. Clearing it would leave a queued reconnect handshake unbounded, which is exactly the
+     * failure mode this connector must not have.
+     */
     fun connect(): Flow<SyncEvent> = callbackFlow {
         val wsClient = baseHttpClient.newBuilder()
             .pingInterval(30, TimeUnit.SECONDS)
             .build()
 
-        var backoff = INITIAL_BACKOFF
-        var activeSocket: WebSocket? = null
+        val supervisor = SocketSupervisor()
+        var reconnectJob: Job? = null
 
         lateinit var doConnect: () -> Unit
 
-        val scheduleReconnect: () -> Unit = {
-            launch {
-                log(TAG) { "Reconnecting in $backoff" }
-                delay(backoff)
-                backoff = minOf(backoff * 2, MAX_BACKOFF)
-
-                if (!isActive) return@launch
-
-                doConnect()
+        val scheduleReconnect: (Int) -> Unit = { callbackGeneration ->
+            val backoff = supervisor.requestReconnect(callbackGeneration)
+            if (backoff == null) {
+                log(TAG, VERBOSE) { "Reconnect from generation $callbackGeneration ignored" }
+            } else {
+                reconnectJob = launch {
+                    log(TAG) { "Reconnecting in $backoff" }
+                    delay(backoff)
+                    doConnect()
+                }
             }
         }
 
@@ -91,50 +100,131 @@ class OctiServerWebSocket(
                 .header("Authorization", "Basic $authBase64")
                 .build()
 
-            log(TAG, INFO) { "Connecting to $url" }
-
-            activeSocket = wsClient.newWebSocket(request, object : WebSocketListener() {
-                override fun onOpen(webSocket: WebSocket, response: Response) {
-                    log(TAG, INFO) { "Connected" }
-                    backoff = INITIAL_BACKOFF
-                    onConnectionChanged(true)
-                }
-
-                override fun onMessage(webSocket: WebSocket, text: String) {
-                    log(TAG, VERBOSE) { "Received: $text" }
-                    try {
-                        val payload = json.decodeFromString<EventPayload>(text)
-                        payload.events.forEach { event ->
-                            val syncEvent = event.toSyncEvent() ?: return@forEach
-                            trySend(syncEvent)
-                        }
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Failed to parse message: ${e.message}" }
+            val myGeneration = supervisor.beginConnect()
+            if (myGeneration == null) {
+                log(TAG, VERBOSE) { "Not connecting, supervisor is shut down" }
+            } else {
+                log(TAG, INFO) { "Connecting to $url" }
+                val socket = wsClient.newWebSocket(request, object : WebSocketListener() {
+                    override fun onOpen(webSocket: WebSocket, response: Response) {
+                        if (!supervisor.onOpened(myGeneration)) return
+                        log(TAG, INFO) { "Connected" }
+                        onConnectionChanged(true)
                     }
-                }
 
-                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
-                    log(TAG, WARN) { "Connection failed: ${t.message}" }
-                    onConnectionChanged(false)
-                    scheduleReconnect()
-                }
+                    override fun onMessage(webSocket: WebSocket, text: String) {
+                        if (!supervisor.isCurrent(myGeneration)) return
+                        log(TAG, VERBOSE) { "Received: $text" }
+                        try {
+                            val payload = json.decodeFromString<EventPayload>(text)
+                            payload.events.forEach { event ->
+                                val syncEvent = event.toSyncEvent() ?: return@forEach
+                                trySend(syncEvent)
+                            }
+                        } catch (e: Exception) {
+                            log(TAG, WARN) { "Failed to parse message: ${e.message}" }
+                        }
+                    }
 
-                override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
-                    log(TAG, INFO) { "Connection closing: $code $reason" }
-                    onConnectionChanged(false)
-                    webSocket.close(1000, null)
-                    scheduleReconnect()
-                }
-            })
+                    override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                        if (!supervisor.isCurrent(myGeneration)) return
+                        log(TAG, WARN) { "Connection failed: ${t.message}" }
+                        onConnectionChanged(false)
+                        scheduleReconnect(myGeneration)
+                    }
+
+                    override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                        if (!supervisor.isCurrent(myGeneration)) return
+                        log(TAG, INFO) { "Connection closing: $code $reason" }
+                        onConnectionChanged(false)
+                        webSocket.close(1000, null)
+                        scheduleReconnect(myGeneration)
+                    }
+                })
+                supervisor.attach(myGeneration, socket)
+            }
         }
 
         doConnect()
 
         awaitClose {
             log(TAG, INFO) { "Closing WebSocket" }
+            // shutdown() bumps the generation before cancelling, so the onFailure that cancelling
+            // fires can no longer schedule a reconnect after the flow was torn down.
+            supervisor.shutdown()
+            reconnectJob?.cancel()
             onConnectionChanged(false)
-            activeSocket?.close(1000, "Client closing")
         }
+    }
+
+    /**
+     * Thread-safe bookkeeping for the socket lifecycle. `onFailure` and `onClosing` both want to
+     * reconnect, and cancelling a socket fires `onFailure` itself, so without generation tagging a
+     * single drop fans out into several live sockets. Every socket carries the generation it was
+     * opened with; callbacks from any other generation are dropped, at most one socket is active,
+     * and at most one reconnect is in flight.
+     *
+     * Callbacks arrive on OkHttp's reader threads while [beginConnect]/[shutdown] run on the flow's
+     * coroutine, hence the lock rather than plain fields.
+     */
+    internal class SocketSupervisor {
+
+        private val lock = Any()
+        private var generation = 0
+        private var socket: WebSocket? = null
+        private var backoff = INITIAL_BACKOFF
+        private var reconnectPending = false
+        private var closed = false
+
+        /** Retires the current socket and reserves the next generation, or null once shut down. */
+        fun beginConnect(): Int? = synchronized(lock) {
+            if (closed) return null
+            reconnectPending = false
+            // cancel(), not close(): the dispatcher slot must be released immediately instead of
+            // after a graceful close handshake.
+            socket?.cancel()
+            socket = null
+            ++generation
+        }
+
+        fun attach(generation: Int, socket: WebSocket) = synchronized(lock) {
+            if (closed || generation != this.generation) {
+                socket.cancel()
+            } else {
+                this.socket = socket
+            }
+        }
+
+        fun isCurrent(generation: Int): Boolean = synchronized(lock) {
+            !closed && generation == this.generation
+        }
+
+        /** @return false if the callback is stale and must be ignored. */
+        fun onOpened(generation: Int): Boolean = synchronized(lock) {
+            if (closed || generation != this.generation) return false
+            backoff = INITIAL_BACKOFF
+            true
+        }
+
+        /** @return how long to wait before reconnecting, or null if this request must be ignored. */
+        fun requestReconnect(generation: Int): Duration? = synchronized(lock) {
+            if (closed || generation != this.generation || reconnectPending) return null
+            reconnectPending = true
+            val current = backoff
+            backoff = minOf(backoff * 2, MAX_BACKOFF)
+            current
+        }
+
+        fun shutdown() = synchronized(lock) {
+            closed = true
+            generation++
+            socket?.cancel()
+            socket = null
+        }
+
+        /** Testing seam — the socket currently owned by the supervisor, if any. */
+        internal val activeSocket: WebSocket?
+            get() = synchronized(lock) { socket }
     }
 
     private fun EventPayload.Event.toSyncEvent(): SyncEvent? = when (type) {

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointCreateAccountTest.kt
@@ -67,6 +67,7 @@ class OctiServerEndpointCreateAccountTest : BaseTest() {
             dispatcherProvider = TestDispatcherProvider(),
             syncSettings = syncSettings,
             baseHttpClient = OkHttpClient(),
+            streamingHttpClient = OkHttpClient(),
             retrofitJson = retrofitJson,
             basicAuthInterceptor = basicAuthInterceptor,
             deviceHeaderInterceptor = deviceHeaderInterceptor,

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointWriteModuleTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerEndpointWriteModuleTest.kt
@@ -72,6 +72,7 @@ class OctiServerEndpointWriteModuleTest : BaseTest() {
             dispatcherProvider = TestDispatcherProvider(),
             syncSettings = syncSettings,
             baseHttpClient = OkHttpClient(),
+            streamingHttpClient = OkHttpClient(),
             retrofitJson = retrofitJson,
             basicAuthInterceptor = basicAuthInterceptor,
             deviceHeaderInterceptor = deviceHeaderInterceptor,

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocketSupervisorTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/OctiServerWebSocketSupervisorTest.kt
@@ -1,0 +1,116 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.WebSocket
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Reconnect hygiene of [OctiServerWebSocket.SocketSupervisor].
+ *
+ * `onFailure` and `onClosing` both want to reconnect and cancelling a socket fires `onFailure`
+ * itself, so a single drop could otherwise fan out into several live sockets — each holding one of
+ * OkHttp's five per-host dispatcher slots.
+ */
+class OctiServerWebSocketSupervisorTest : BaseTest() {
+
+    private fun supervisor() = OctiServerWebSocket.SocketSupervisor()
+
+    @Nested
+    inner class `one socket at a time` {
+
+        @Test
+        fun `opening a new socket retires the previous one`() {
+            val supervisor = supervisor()
+            val first = mockk<WebSocket>(relaxed = true)
+            val second = mockk<WebSocket>(relaxed = true)
+
+            val gen1 = supervisor.beginConnect()!!
+            supervisor.attach(gen1, first)
+            val gen2 = supervisor.beginConnect()!!
+            supervisor.attach(gen2, second)
+
+            // cancel(), not close(): the dispatcher slot has to come back immediately.
+            verify { first.cancel() }
+            supervisor.activeSocket shouldBe second
+        }
+
+        @Test
+        fun `a socket that arrives for a retired generation is cancelled, not adopted`() {
+            val supervisor = supervisor()
+            val late = mockk<WebSocket>(relaxed = true)
+
+            val gen1 = supervisor.beginConnect()!!
+            supervisor.beginConnect()
+            supervisor.attach(gen1, late)
+
+            verify { late.cancel() }
+            supervisor.activeSocket shouldBe null
+        }
+
+        @Test
+        fun `callbacks from a retired generation are ignored`() {
+            val supervisor = supervisor()
+            val gen1 = supervisor.beginConnect()!!
+            val gen2 = supervisor.beginConnect()!!
+
+            supervisor.isCurrent(gen1) shouldBe false
+            supervisor.isCurrent(gen2) shouldBe true
+            supervisor.onOpened(gen1) shouldBe false
+            supervisor.onOpened(gen2) shouldBe true
+            supervisor.requestReconnect(gen1) shouldBe null
+        }
+    }
+
+    @Nested
+    inner class `reconnects` {
+
+        @Test
+        fun `simultaneous failure and closing callbacks schedule exactly one reconnect`() {
+            val supervisor = supervisor()
+            val gen = supervisor.beginConnect()!!
+
+            supervisor.requestReconnect(gen) shouldBe 1.seconds
+            // The second callback (onClosing right after onFailure) must not stack another one.
+            supervisor.requestReconnect(gen) shouldBe null
+        }
+
+        @Test
+        fun `backoff grows per attempt and resets once connected`() {
+            val supervisor = supervisor()
+
+            val gen1 = supervisor.beginConnect()!!
+            supervisor.requestReconnect(gen1) shouldBe 1.seconds
+            val gen2 = supervisor.beginConnect()!!
+            supervisor.requestReconnect(gen2) shouldBe 2.seconds
+            val gen3 = supervisor.beginConnect()!!
+            supervisor.requestReconnect(gen3) shouldBe 4.seconds
+
+            val gen4 = supervisor.beginConnect()!!
+            supervisor.onOpened(gen4) shouldBe true
+            supervisor.requestReconnect(gen4) shouldBe 1.seconds
+        }
+
+        @Test
+        fun `nothing reconnects after the flow was torn down`() {
+            val supervisor = supervisor()
+            val socket = mockk<WebSocket>(relaxed = true)
+            val gen = supervisor.beginConnect()!!
+            supervisor.attach(gen, socket)
+
+            supervisor.shutdown()
+
+            // shutdown() bumps the generation before cancelling, so the onFailure that cancelling
+            // fires cannot schedule a reconnect.
+            verify { socket.cancel() }
+            supervisor.requestReconnect(gen) shouldBe null
+            supervisor.isCurrent(gen) shouldBe false
+            supervisor.beginConnect() shouldBe null
+            supervisor.activeSocket shouldBe null
+        }
+    }
+}

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/WebSocketCallTimeoutTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/WebSocketCallTimeoutTest.kt
@@ -1,0 +1,127 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import io.kotest.matchers.shouldBe
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Pins the two OkHttp behaviours the transport bounds are reasoned about:
+ *
+ * 1. `callTimeout` does not terminate an established WebSocket — OkHttp exits the call timeout
+ *    after a successful upgrade — so keeping the inherited timeout is safe, and clearing it (the
+ *    obvious-looking "fix") would only leave the handshake unbounded.
+ * 2. `callTimeout` does **not** cover the time a call spends queued in the Dispatcher.
+ *    `RealCall.enqueue` only calls `callStart()`; `timeout.enter()` happens in `AsyncCall.run()`,
+ *    i.e. once the call is actually dispatched. A saturated dispatcher can therefore park a call
+ *    indefinitely regardless of any HTTP timeout — which is why the bound that actually guarantees
+ *    progress lives in `ConnectorProcessor`, not here.
+ */
+class WebSocketCallTimeoutTest : BaseTest() {
+
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setup() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @AfterEach
+    fun teardown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `an established socket outlives the callTimeout that bounded its handshake`() {
+        val serverSideOpen = CountDownLatch(1)
+        server.enqueue(
+            MockResponse().withWebSocketUpgrade(object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    serverSideOpen.countDown()
+                    // Well past the client's call timeout.
+                    Thread.sleep(1500)
+                    webSocket.send("late-message")
+                }
+            })
+        )
+
+        val client = OkHttpClient.Builder()
+            .callTimeout(500, TimeUnit.MILLISECONDS)
+            .build()
+
+        val message = CountDownLatch(1)
+        val failure = CountDownLatch(1)
+        client.newWebSocket(
+            Request.Builder().url(server.url("/v1/ws")).build(),
+            object : WebSocketListener() {
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    if (text == "late-message") message.countDown()
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    failure.countDown()
+                }
+            },
+        )
+
+        serverSideOpen.await(5, TimeUnit.SECONDS) shouldBe true
+        message.await(5, TimeUnit.SECONDS) shouldBe true
+        failure.count shouldBe 1L
+    }
+
+    @Test
+    fun `a handshake stuck behind a saturated dispatcher is NOT bounded by the callTimeout`() {
+        // One in-flight call occupies the only slot; the WebSocket handshake sits in the dispatcher
+        // queue. The 500ms callTimeout does not fire while it waits there — the handshake only
+        // proceeds once the blocker frees the slot, seconds later. Documenting the gap, because the
+        // natural assumption ("callTimeout is the total call bound, queueing included") is wrong
+        // and would leave this class of wedge unfixed.
+        server.enqueue(MockResponse().setBody("blocker").setHeadersDelay(5, TimeUnit.SECONDS))
+        server.enqueue(MockResponse().withWebSocketUpgrade(object : WebSocketListener() {}))
+
+        // Shared dispatcher, separate timeouts: the blocker must not be the thing that times out.
+        val dispatcher = Dispatcher().apply { maxRequests = 1; maxRequestsPerHost = 1 }
+        val blockerClient = OkHttpClient.Builder().dispatcher(dispatcher).build()
+        val client = OkHttpClient.Builder()
+            .callTimeout(500, TimeUnit.MILLISECONDS)
+            .dispatcher(dispatcher)
+            .build()
+
+        blockerClient.newCall(Request.Builder().url(server.url("/blocker")).build())
+            .enqueue(object : okhttp3.Callback {
+                override fun onFailure(call: okhttp3.Call, e: java.io.IOException) = Unit
+                override fun onResponse(call: okhttp3.Call, response: Response) = response.close()
+            })
+
+        val queuedWhileBlocked = CountDownLatch(1)
+        val settled = CountDownLatch(1)
+        client.newWebSocket(
+            Request.Builder().url(server.url("/v1/ws")).build(),
+            object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) = settled.countDown()
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) = settled.countDown()
+            },
+        )
+
+        // The handshake is queued, not running...
+        Thread.sleep(300)
+        if (dispatcher.queuedCallsCount() == 1) queuedWhileBlocked.countDown()
+        queuedWhileBlocked.count shouldBe 0L
+
+        // ...and it is still queued well after its own call timeout would have expired.
+        Thread.sleep(1000)
+        settled.count shouldBe 1L
+    }
+}

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/regression/CrossVersionLegacyServerTest.kt
@@ -95,6 +95,9 @@ class CrossVersionLegacyServerTest : BaseTest() {
             baseHttpClient = OkHttpClient.Builder()
                 .callTimeout(30, TimeUnit.SECONDS)
                 .build(),
+            streamingHttpClient = OkHttpClient.Builder()
+                .callTimeout(30, TimeUnit.SECONDS)
+                .build(),
             // Reuse the production retrofit Json so wire-format drift in SerializationModule
             // is caught. SerializationModule is a regular `class` with @Provides — directly
             // instantiable without Hilt.


### PR DESCRIPTION
Background sync could stop entirely and stay stopped until the app process was restarted. On affected devices the dashboard showed a last-update time many hours old (14h and 19h observed) while the sync spinner kept turning.

## Root cause

`SyncManager.sync()` held a process-lifetime mutex across an unbounded wait. The lock holder is the `pendingSyncTrigger` collector in `SyncOrchestrator`, which runs on `@AppScope` and is never cancelled — so once a sync wedged, the lock was held for the lifetime of the process and every later sync short-circuited to a no-op.

The scheduler itself was healthy the whole time: the periodic worker kept firing hourly and completing quickly, which is exactly why the failure was invisible from WorkManager's side.

The wedge itself was a request that never left OkHttp's dispatcher queue. `connectTimeout`/`readTimeout`/`writeTimeout` do not cover queue time, and `callTimeout` was not set. A long-lived LIVE-mode WebSocket permanently occupies one of the five per-host dispatcher slots, so saturating them starves ordinary API calls.

The spinner never stopped because `isBusy` is derived from operations in `Queued`/`Processing`, and a wedged operation never reaches a terminal state.

## Changes

- **HTTP** — add a total `callTimeout` to the shared client, and give streaming blob transfers a separate client (no total-call bound, `HEADERS`-level logging) so large downloads aren't truncated mid-body. Add transport-level timeouts to the Google Drive client, whose blocking `execute()` ignores coroutine cancellation.
- **WebSocket** — give the event socket its own `Dispatcher` so long-lived sockets can't starve API calls, and track connections by generation so stale callbacks can't cause reconnect storms or leak dispatcher slots.
- **Connectors** — narrow `withContext(NonCancellable)` to state commits only and replace detached `scope.async` with structured concurrency, in both the Octi Server and Google Drive connectors. Without this, any timeout placed around connector work is inert: `withTimeout` around a non-cancellable body does not return until that body completes.
- **Connector processor** — per-command timeouts, operation cancellation, and coalescing of queued `Sync` commands so the unbounded inbox can't grow behind a slow command. Destructive commands (`Reset`, `DeleteDevice`) are deliberately left unbounded and uncancellable, since they may already have taken effect remotely.
- **SyncManager** — replace try-lock-and-skip with a generation-tracked single-flight that accumulates requests instead of dropping them, supersedes a stalled run (cancelling its connector operations, not merely its own waiter), and tracks per-caller ownership so a cancelled caller withdraws only its own request.

## Notes

- Requests are now accumulated rather than absorbed by whichever caller happened to hold the lock. Previously a write-only request could swallow a concurrent full read, which matters for the file-share commit path that assumes its write persisted before returning.
- A per-command timeout bounds the *outcome*, not the actor's occupancy: a body that never reaches a suspension point still holds the loop for its full duration and is only failed afterwards. Transport-level bounds are what actually cap that duration, which is why the Google Drive client needed its own.
- Tests use deliberately hostile fakes — non-cancellable and thread-blocking executors — because a plain cancellable fake passes while the real defect survives.
