### PR TITLE
Fix device cards showing hours-old timestamps despite active sync

### DIFF
--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1715,9 +1715,12 @@ private fun DashboardDeviceCard(
                                 )
                                 Spacer(modifier = Modifier.width(4.dp))
                             }
+                            // Two separate signals: this timestamp is "device last seen / data last
+                            // written, whichever is newer", while the staleness warning badge next
+                            // to it stays driven purely by the age of the module data.
                             Text(
                                 text = DateUtils.getRelativeTimeSpanString(
-                                    device.meta.modifiedAt.clampToNow().toEpochMilliseconds()
+                                    device.lastActivityAt.clampToNow().toEpochMilliseconds()
                                 ).toString(),
                                 style = MaterialTheme.typography.labelSmall,
                                 color = badgeColor ?: Color.Unspecified,
@@ -2217,6 +2220,8 @@ private fun DashboardScreenPreview() = PreviewWrapper {
                     isCollapsed = false,
                     isLimited = false,
                     isCurrentDevice = false,
+                    // Seen more recently than its data changed — the card shows this.
+                    lastSeen = now - 30.seconds,
                 ),
             ),
             deviceCount = 1,
@@ -2277,6 +2282,7 @@ private fun DashboardScreenMultiDevicePreview() = PreviewWrapper {
         type: MetaInfo.DeviceType,
         batteryLevel: Int,
         isCollapsed: Boolean,
+        lastSeen: Instant?,
     ) = DashboardVM.DeviceItem(
         now = now,
         deviceId = deviceId,
@@ -2317,13 +2323,15 @@ private fun DashboardScreenMultiDevicePreview() = PreviewWrapper {
         isCollapsed = isCollapsed,
         isLimited = false,
         isCurrentDevice = false,
+        lastSeen = lastSeen,
     )
 
     DashboardScreen(
         state = DashboardVM.State(
             devices = listOf(
-                previewDevice(deviceId1, "Pixel 8", MetaInfo.DeviceType.PHONE, 75, false),
-                previewDevice(deviceId2, "Galaxy Tab S9", MetaInfo.DeviceType.TABLET, 42, true),
+                // Distinct sightings: one seen just now, one not seen since before its last write.
+                previewDevice(deviceId1, "Pixel 8", MetaInfo.DeviceType.PHONE, 75, false, now - 45.seconds),
+                previewDevice(deviceId2, "Galaxy Tab S9", MetaInfo.DeviceType.TABLET, 42, true, now - 7200.seconds),
             ),
             deviceCount = 2,
             syncStatus = DashboardVM.SyncStatus.Idle(

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -210,12 +210,25 @@ class DashboardVM @Inject constructor(
         val infos: List<ConnectorIssue> = emptyList(),
         val placeholder: PlaceholderData? = null,
         val removalTargets: List<DeviceRemovalTarget> = emptyList(),
+        /**
+         * Newest `DeviceMetadata.lastSeen` any active connector reports for this device — when the
+         * device was last observed at all, independent of whether its module payloads changed.
+         */
+        val lastSeen: Instant? = null,
         val displayLabel: String = meta?.data?.labelOrFallback
             ?: placeholder?.metadata?.label
             ?: deviceId.shortLabel,
     ) {
         val baseLabel: String
             get() = meta?.data?.labelOrFallback ?: placeholder?.metadata?.label ?: deviceId.shortLabel
+
+        /**
+         * What the card's timestamp shows: device last seen or data last written, whichever is
+         * newer. The write time is a lower bound on purpose — stale cached metadata arriving after
+         * a cache-only render must never move the card backwards in time.
+         */
+        val lastActivityAt: Instant
+            get() = maxOf(lastSeen ?: Instant.DISTANT_PAST, meta?.modifiedAt ?: Instant.DISTANT_PAST)
 
         val isPlaceholder: Boolean get() = placeholder != null
         val isDegraded: Boolean get() = placeholder?.kind == PlaceholderData.Kind.DEGRADED
@@ -673,6 +686,7 @@ class DashboardVM @Inject constructor(
     ) { now, byDevice, missingPermissions, activeConnectors, activeStates, busyIds, alerts, _, fileShare, pausedIds ->
         val statesList = activeStates.toList()
         val statesMap = activeConnectors.zip(statesList).associate { (c, s) -> c.identifier to s }
+        val lastSeenById = lastSeenByDevice(statesList)
         val fileDeleteRequests = byDevice.devices.values
             .flatMap { moduleDatas ->
                 moduleDatas.mapNotNull { it.data as? FileShareInfo }
@@ -754,6 +768,7 @@ class DashboardVM @Inject constructor(
                     isCollapsed = false, // Will be updated when applying preferences
                     isLimited = false, // Will be updated when applying preferences based on position
                     isCurrentDevice = metaModule.deviceId == syncSettings.deviceId,
+                    lastSeen = lastSeenById[deviceId],
                 )
             }
 
@@ -933,6 +948,20 @@ class DashboardVM @Inject constructor(
             .filter { (id, _) -> id in blobCapableConnectorIds }
             .flatMap { (_, state) -> state.deviceMetadata.asSequence().map { it.deviceId } }
             .toSet()
+
+        /**
+         * Newest sighting per device across every active connector's state.
+         *
+         * Flattened rather than joined per connector: a device can be reported by more than one
+         * connector, and the freshest sighting wins no matter which one saw it.
+         */
+        internal fun lastSeenByDevice(
+            states: Collection<SyncConnectorState>,
+        ): Map<DeviceId, Instant> = states
+            .flatMap { it.deviceMetadata }
+            .mapNotNull { metadata -> metadata.lastSeen?.let { metadata.deviceId to it } }
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, sightings) -> sightings.max() }
 
         /** Most-optimistic-first: a holder that may still deliver data outranks a settled one. */
         private val placeholderKindOptimism = listOf(

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceLastSeenTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceLastSeenTest.kt
@@ -1,0 +1,144 @@
+package eu.darken.octi.main.ui.dashboard
+
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.DeviceMetadata
+import eu.darken.octi.sync.core.SyncConnectorState
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Instant
+
+class DeviceLastSeenTest : BaseTest() {
+
+    private val now = Instant.parse("2026-05-05T12:00:00Z")
+    private val deviceA = DeviceId("device-a")
+    private val deviceB = DeviceId("device-b")
+
+    private fun metadata(deviceId: DeviceId, lastSeen: Instant?) = DeviceMetadata(
+        deviceId = deviceId,
+        version = "1.0.0",
+        platform = "android",
+        label = "Phone",
+        lastSeen = lastSeen,
+        addedAt = now - 1.hours,
+    )
+
+    private fun state(vararg metadata: DeviceMetadata): SyncConnectorState = object : SyncConnectorState {
+        override val lastActionAt: Instant? = now
+        override val lastError: Exception? = null
+        override val deviceMetadata: List<DeviceMetadata> = metadata.toList()
+        override val isAvailable: Boolean = true
+    }
+
+    private fun metaModule(modifiedAt: Instant) = ModuleData(
+        modifiedAt = modifiedAt,
+        deviceId = deviceA,
+        moduleId = ModuleId("meta"),
+        data = MetaInfo(
+            deviceLabel = "Phone",
+            deviceId = deviceA,
+            octiVersionName = "1.0.0",
+            octiGitSha = "abc1234",
+            deviceManufacturer = "Google",
+            deviceName = "Phone",
+            deviceType = MetaInfo.DeviceType.PHONE,
+        ),
+    )
+
+    private fun deviceItem(
+        lastSeen: Instant?,
+        metaModifiedAt: Instant?,
+    ) = DashboardVM.DeviceItem(
+        now = now,
+        deviceId = deviceA,
+        meta = metaModifiedAt?.let { metaModule(it) },
+        moduleItems = emptyList(),
+        isCollapsed = false,
+        isLimited = false,
+        isCurrentDevice = false,
+        lastSeen = lastSeen,
+    )
+
+    @Nested
+    inner class `lastSeen aggregation` {
+        @Test
+        fun `no states yields no sightings`() {
+            DashboardVM.lastSeenByDevice(emptyList()).shouldBeEmpty()
+        }
+
+        @Test
+        fun `the newest sighting across connectors wins`() {
+            val states = listOf(
+                state(metadata(deviceA, now - 30.minutes)),
+                state(metadata(deviceA, now - 2.minutes)),
+                state(metadata(deviceA, now - 10.minutes)),
+            )
+
+            DashboardVM.lastSeenByDevice(states) shouldBe mapOf(deviceA to now - 2.minutes)
+        }
+
+        @Test
+        fun `devices are tracked independently`() {
+            val states = listOf(
+                state(metadata(deviceA, now - 30.minutes), metadata(deviceB, now - 5.minutes)),
+                state(metadata(deviceA, now - 1.minutes)),
+            )
+
+            DashboardVM.lastSeenByDevice(states) shouldBe mapOf(
+                deviceA to now - 1.minutes,
+                deviceB to now - 5.minutes,
+            )
+        }
+
+        @Test
+        fun `a device without a sighting is absent`() {
+            val states = listOf(state(metadata(deviceA, null), metadata(deviceB, now - 5.minutes)))
+
+            DashboardVM.lastSeenByDevice(states) shouldBe mapOf(deviceB to now - 5.minutes)
+        }
+    }
+
+    @Nested
+    inner class `card timestamp` {
+        @Test
+        fun `a fresher sighting than the last write wins`() {
+            // Self-device on a write-only run: the module data is old, the sighting is not.
+            deviceItem(
+                lastSeen = now - 1.minutes,
+                metaModifiedAt = now - 3.hours,
+            ).lastActivityAt shouldBe now - 1.minutes
+        }
+
+        @Test
+        fun `a sighting older than the last write does not move the card backwards`() {
+            deviceItem(
+                lastSeen = now - 3.hours,
+                metaModifiedAt = now - 1.minutes,
+            ).lastActivityAt shouldBe now - 1.minutes
+        }
+
+        @Test
+        fun `no sighting falls back to the last write`() {
+            deviceItem(
+                lastSeen = null,
+                metaModifiedAt = now - 20.minutes,
+            ).lastActivityAt shouldBe now - 20.minutes
+        }
+
+        @Test
+        fun `no metadata at all leaves the item without a sighting`() {
+            val item = deviceItem(lastSeen = null, metaModifiedAt = null)
+
+            item.lastSeen.shouldBeNull()
+            item.lastActivityAt shouldBe Instant.DISTANT_PAST
+        }
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorSyncState.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/ConnectorSyncState.kt
@@ -4,25 +4,43 @@ import eu.darken.octi.module.core.ModuleId
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /**
- * Tracks the last-sent payload hash per (connectorId, moduleId) pair.
- * In-memory only — hashes repopulate naturally on restart because writeFLow
- * fires, payloads get cached, and first sync sends everything (no hashes = all mismatches).
+ * Tracks the last-sent payload hash and its age per (connectorId, moduleId) pair.
+ * In-memory only — records repopulate naturally on restart because writeFLow
+ * fires, payloads get cached, and first sync sends everything (no records = all mismatches).
  */
 @Singleton
 class ConnectorSyncState @Inject constructor() {
 
-    private val hashes = ConcurrentHashMap<Pair<ConnectorId, ModuleId>, String>()
+    private data class Record(val hash: String, val sentAt: TimeMark)
 
-    fun getHash(connectorId: ConnectorId, moduleId: ModuleId): String? =
-        hashes[connectorId to moduleId]
+    private val records = ConcurrentHashMap<Pair<ConnectorId, ModuleId>, Record>()
+
+    /**
+     * Monotonic on purpose: a wall-clock jump must not make a record look eternally fresh (never
+     * refreshing a static payload) or instantly expired. Overridable for tests only.
+     */
+    internal var timeSource: TimeSource = TimeSource.Monotonic
+
+    /** Hash and age of the last successful write, captured together. */
+    data class SentRecord(val hash: String, val age: Duration)
+
+    /**
+     * One atomic snapshot: hash and age come from the same record version. Reading them through
+     * separate calls could observe two different writes and mix a stale hash with a fresh age.
+     */
+    fun getRecord(connectorId: ConnectorId, moduleId: ModuleId): SentRecord? =
+        records[connectorId to moduleId]?.let { SentRecord(hash = it.hash, age = it.sentAt.elapsedNow()) }
 
     fun setHash(connectorId: ConnectorId, moduleId: ModuleId, hash: String) {
-        hashes[connectorId to moduleId] = hash
+        records[connectorId to moduleId] = Record(hash = hash, sentAt = timeSource.markNow())
     }
 
     fun clearConnector(connectorId: ConnectorId) {
-        hashes.keys.removeAll { it.first == connectorId }
+        records.keys.removeAll { it.first == connectorId }
     }
 }

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/SyncManager.kt
@@ -47,6 +47,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
@@ -439,8 +440,8 @@ class SyncManager @Inject constructor(
         val changedModules = if (options.writeData) {
             modulePayloads.values.mapNotNull { module ->
                 val currentHash = module.payload.sha256().hex()
-                val lastSent = connectorSyncState.getHash(connectorId, module.moduleId)
-                if (currentHash != lastSent) {
+                val record = connectorSyncState.getRecord(connectorId, module.moduleId)
+                if (record == null || record.hash != currentHash || record.age >= MODULE_REWRITE_HORIZON) {
                     SyncOptions.ModuleWrite(module = module, expectedHash = currentHash)
                 } else {
                     null
@@ -560,5 +561,14 @@ class SyncManager @Inject constructor(
          */
         internal val SYNC_STALE_AFTER = 5.minutes
         private val CONNECTOR_RESOLVE_TIMEOUT = 10.seconds
+
+        /**
+         * How long an unchanged module payload may go unwritten before it is sent again anyway.
+         * Static-payload modules (meta: labels, versions, bootedAt) never change their hash between
+         * reboots, so pure hash dedup writes them exactly once per process lifetime and every peer's
+         * view of "last written" ages into process uptime. Rewriting at roughly background-sync
+         * cadence restores the pre-dedup hourly freshness without giving up per-minute dedup.
+         */
+        internal val MODULE_REWRITE_HORIZON = 1.hours
     }
 }

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorSyncStateTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/ConnectorSyncStateTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.octi.sync.core
+
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.module.core.ModuleId
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TestTimeSource
+
+class ConnectorSyncStateTest : BaseTest() {
+
+    private val connectorId1 = ConnectorId(type = ConnectorType.OCTISERVER, subtype = "test", account = "acc1")
+    private val connectorId2 = ConnectorId(type = ConnectorType.GDRIVE, subtype = "test", account = "acc2")
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private fun create(timeSource: TestTimeSource): ConnectorSyncState = ConnectorSyncState().apply {
+        this.timeSource = timeSource
+    }
+
+    @Test
+    fun `unknown pair has no record`() {
+        val state = create(TestTimeSource())
+
+        state.getRecord(connectorId1, powerModuleId).shouldBeNull()
+    }
+
+    @Test
+    fun `record roundtrips hash and starts at zero age`() {
+        val state = create(TestTimeSource())
+
+        state.setHash(connectorId1, powerModuleId, "hash-1")
+
+        state.getRecord(connectorId1, powerModuleId) shouldBe ConnectorSyncState.SentRecord("hash-1", ZERO)
+    }
+
+    @Test
+    fun `age advances with the time source`() {
+        val timeSource = TestTimeSource()
+        val state = create(timeSource)
+
+        state.setHash(connectorId1, powerModuleId, "hash-1")
+        timeSource += 90.minutes
+
+        state.getRecord(connectorId1, powerModuleId) shouldBe ConnectorSyncState.SentRecord("hash-1", 90.minutes)
+    }
+
+    @Test
+    fun `setHash resets the age`() {
+        val timeSource = TestTimeSource()
+        val state = create(timeSource)
+
+        state.setHash(connectorId1, powerModuleId, "hash-1")
+        timeSource += 2.hours
+        state.setHash(connectorId1, powerModuleId, "hash-2")
+
+        state.getRecord(connectorId1, powerModuleId) shouldBe ConnectorSyncState.SentRecord("hash-2", ZERO)
+    }
+
+    @Test
+    fun `getRecord returns one consistent snapshot`() {
+        val timeSource = TestTimeSource()
+        val state = create(timeSource)
+
+        state.setHash(connectorId1, powerModuleId, "hash-1")
+        timeSource += 3.hours
+        val stale = state.getRecord(connectorId1, powerModuleId)!!
+
+        state.setHash(connectorId1, powerModuleId, "hash-2")
+
+        // The earlier snapshot is not mutated by the later write — hash and age moved together.
+        stale.hash shouldBe "hash-1"
+        stale.age shouldBe 3.hours
+        state.getRecord(connectorId1, powerModuleId) shouldBe ConnectorSyncState.SentRecord("hash-2", ZERO)
+    }
+
+    @Test
+    fun `records are tracked per connector and module`() {
+        val timeSource = TestTimeSource()
+        val state = create(timeSource)
+
+        state.setHash(connectorId1, powerModuleId, "power-1")
+        state.setHash(connectorId1, metaModuleId, "meta-1")
+        state.setHash(connectorId2, powerModuleId, "power-2")
+
+        state.getRecord(connectorId1, powerModuleId)!!.hash shouldBe "power-1"
+        state.getRecord(connectorId1, metaModuleId)!!.hash shouldBe "meta-1"
+        state.getRecord(connectorId2, powerModuleId)!!.hash shouldBe "power-2"
+    }
+
+    @Test
+    fun `clearConnector drops only that connector's records`() {
+        val timeSource = TestTimeSource()
+        val state = create(timeSource)
+
+        state.setHash(connectorId1, powerModuleId, "power-1")
+        state.setHash(connectorId1, metaModuleId, "meta-1")
+        state.setHash(connectorId2, powerModuleId, "power-2")
+
+        state.clearConnector(connectorId1)
+
+        state.getRecord(connectorId1, powerModuleId).shouldBeNull()
+        state.getRecord(connectorId1, metaModuleId).shouldBeNull()
+        state.getRecord(connectorId2, powerModuleId)!!.hash shouldBe "power-2"
+    }
+}

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/SyncManagerSyncWriteTest.kt
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TestTimeSource
 
 class SyncManagerSyncWriteTest : BaseTest() {
 
@@ -406,7 +408,218 @@ class SyncManagerSyncWriteTest : BaseTest() {
     }
 
     @Nested
+    inner class `rewrite horizon` {
+        // Static payloads (meta) never change their hash, so pure dedup would write them once per
+        // process lifetime. Past the horizon they go out again even though nothing changed.
+
+        @Test
+        fun `unchanged hash past the horizon is rewritten`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val module = createModule(powerModuleId, "static-data")
+            sm.updatePayload(module)
+            connectorSyncState.setHash(connectorId1, powerModuleId, module.payload.sha256().hex())
+
+            timeSource += SyncManager.MODULE_REWRITE_HORIZON
+
+            sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val cmdSlot = slot<ConnectorCommand>()
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
+            cmdSlot.syncOptions().writePayload.single().module.moduleId shouldBe powerModuleId
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `unchanged hash inside the horizon is skipped`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val module = createModule(powerModuleId, "static-data")
+            sm.updatePayload(module)
+            connectorSyncState.setHash(connectorId1, powerModuleId, module.payload.sha256().hex())
+
+            timeSource += SyncManager.MODULE_REWRITE_HORIZON - 1.minutes
+
+            sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val cmdSlot = slot<ConnectorCommand>()
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
+            cmdSlot.syncOptions().writePayload shouldBe emptyList()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `changed hash is written regardless of age`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            connectorSyncState.setHash(connectorId1, powerModuleId, "some-other-hash")
+            sm.updatePayload(createModule(powerModuleId, "fresh-data"))
+
+            sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val cmdSlot = slot<ConnectorCommand>()
+            coVerify { connector1.submitExclusive(capture(cmdSlot)) }
+            cmdSlot.syncOptions().writePayload.single().module.payload shouldBe "fresh-data".encodeUtf8()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `repeated triggers within the horizon do not rewrite again`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val module = createModule(powerModuleId, "static-data")
+            sm.updatePayload(module)
+
+            // First sync writes, connector records the hash on success.
+            sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+            connectorSyncState.setHash(connectorId1, powerModuleId, module.payload.sha256().hex())
+
+            // Minute-cadence background triggers for the rest of the hour.
+            repeat(5) {
+                timeSource += 10.minutes
+                sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+            }
+
+            val all = mutableListOf<ConnectorCommand>()
+            coVerify(exactly = 6) { connector1.submitExclusive(capture(all)) }
+            (all.first() as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
+            all.drop(1).forEach { (it as ConnectorCommand.Sync).options.writePayload shouldBe emptyList() }
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `only the connector whose record expired rewrites`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            connectorsFlow.value = listOf(connector1, connector2)
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val module = createModule(powerModuleId, "static-data")
+            sm.updatePayload(module)
+            val hash = module.payload.sha256().hex()
+
+            connectorSyncState.setHash(connectorId1, powerModuleId, hash)
+            timeSource += SyncManager.MODULE_REWRITE_HORIZON
+            connectorSyncState.setHash(connectorId2, powerModuleId, hash)
+
+            sm.sync(SyncOptions(writeData = true, readData = false, stats = false))
+            advanceUntilIdle()
+
+            val cmd1 = slot<ConnectorCommand>()
+            coVerify { connector1.submitExclusive(capture(cmd1)) }
+            (cmd1.captured as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
+
+            val cmd2 = slot<ConnectorCommand>()
+            coVerify { connector2.submitExclusive(capture(cmd2)) }
+            (cmd2.captured as ConnectorCommand.Sync).options.writePayload shouldBe emptyList()
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
+        @Test
+        fun `merged batch options still evaluate the horizon`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            val module = createModule(powerModuleId, "static-data")
+            sm.updatePayload(module)
+            connectorSyncState.setHash(connectorId1, powerModuleId, module.payload.sha256().hex())
+
+            // Hold the first run inside await() so the next two requests accumulate into one batch.
+            val gate = CompletableDeferred<Unit>()
+            var callCount = 0
+            coEvery { connector1.await(any()) } coAnswers {
+                callCount++
+                if (callCount == 1) gate.await()
+                ConnectorOperation.Succeeded(
+                    id = OperationId.create(),
+                    command = ConnectorCommand.Sync(),
+                    submittedAt = Clock.System.now(),
+                    startedAt = Clock.System.now(),
+                    finishedAt = Clock.System.now(),
+                )
+            }
+
+            val blocking = launch { sm.sync(SyncOptions(writeData = false, readData = true, stats = false)) }
+            advanceUntilIdle()
+
+            timeSource += SyncManager.MODULE_REWRITE_HORIZON
+
+            val readOnly = launch { sm.sync(SyncOptions(writeData = false, readData = true, stats = false)) }
+            val writing = launch { sm.sync(SyncOptions(writeData = true, readData = false, stats = false)) }
+            advanceUntilIdle()
+
+            gate.complete(Unit)
+            advanceUntilIdle()
+            blocking.join()
+            readOnly.join()
+            writing.join()
+
+            val all = mutableListOf<ConnectorCommand>()
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(all)) }
+            // The blocking read-only batch never carries a payload…
+            (all.first() as ConnectorCommand.Sync).options.writePayload shouldBe emptyList()
+            // …while the merged batch inherits writeData and rewrites the expired module.
+            val merged = (all.last() as ConnectorCommand.Sync).options
+            merged.readData shouldBe true
+            merged.writePayload.single().module.moduleId shouldBe powerModuleId
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+    }
+
+    @Nested
     inner class `sync failure` {
+        @Test
+        fun `a failed write leaves no record — module retried inside the horizon`() = runTest2 {
+            val timeSource = TestTimeSource()
+            connectorSyncState.timeSource = timeSource
+            val (sm, job) = createSyncManager()
+            advanceUntilIdle()
+
+            sm.updatePayload(createModule(powerModuleId, "data"))
+
+            connector1.wireSubmitFailure(RuntimeException("Network error"))
+            runCatching { sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false)) }
+
+            // Well inside the horizon — only the missing record can put the module back on the wire.
+            connector1.wireProcessorSideEffects()
+            timeSource += 1.minutes
+            sm.sync(connectorId1, SyncOptions(writeData = true, readData = false, stats = false))
+
+            val all = mutableListOf<ConnectorCommand>()
+            coVerify(exactly = 2) { connector1.submitExclusive(capture(all)) }
+            (all.last() as ConnectorCommand.Sync).options.writePayload.size shouldBe 1
+
+            job.cancel()
+            advanceUntilIdle()
+        }
+
         @Test
         fun `sync failure does not update hashes — module resent next sync`() = runTest2 {
             val (sm, job) = createSyncManager()

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -322,6 +322,9 @@ class GDriveAppDataConnector @AssistedInject constructor(
                     file.deleteAll()
                 }
         }
+        // Our device directory is gone, so the next write has to recreate _device.json. Without
+        // this the content-equality check below would still consider it written and skip it.
+        lastWrittenDeviceInfo = null
         syncState.clearConnector(identifier)
         _state.updateBlocking { copy(deviceMetadata = emptyList(), lastFullReadAt = null) }
         syncCache.removeDeviceMetadata(identifier)
@@ -343,6 +346,8 @@ class GDriveAppDataConnector @AssistedInject constructor(
             if (deviceId == syncSettings.deviceId) {
                 log(TAG, WARN) { "We just deleted ourselves, this connector is dead now" }
                 clearPathCaches()
+                // Same reason as handleReset(): our _device.json no longer exists.
+                lastWrittenDeviceInfo = null
                 _state.updateBlocking { copy(isDead = true) }
             }
         }
@@ -562,18 +567,21 @@ class GDriveAppDataConnector @AssistedInject constructor(
         deviceDirs.map { dir ->
             async(dispatcherProvider.IO) {
                 val deviceId = DeviceId(id = dir.name)
+                val infoFile = index.child(dir, DEVICE_INFO_FILE)?.also {
+                    deviceInfoFileIdCache[deviceId] = it.id
+                }
                 val info = try {
-                    index.child(dir, DEVICE_INFO_FILE)?.also {
-                        deviceInfoFileIdCache[deviceId] = it.id
-                    }?.readData()?.let {
+                    infoFile?.readData()?.let {
                         json.decodeFromString<GDriveDeviceInfo>(it.utf8())
                     }
                 } catch (e: Exception) {
                     log(TAG, WARN) { "readDeviceMetadata(): Failed to read $DEVICE_INFO_FILE for ${dir.name}: ${e.message}" }
                     null
                 }
+                // The manifest counts too: a peer that only touched _device.json (label change,
+                // capability update) was just as much "seen" as one that wrote a module file.
                 val lastSeen = index.children(dir)
-                    .filter { it.name != DEVICE_INFO_FILE && !it.isDirectory }
+                    .filter { !it.isDirectory }
                     .maxOfOrNull { Instant.fromEpochMilliseconds(it.modifiedTime.value) }
                 val capabilities = info?.capabilities?.let {
                     try {
@@ -820,15 +828,19 @@ class GDriveAppDataConnector @AssistedInject constructor(
                 var wroteData = false
                 if (options.writeData && options.writePayload.isNotEmpty()) {
                     log(TAG) { "handleSync(): Writing ${options.writePayload.size} cached modules (batched)" }
-                    writeDrive(SyncWriteContainer(
-                        deviceId = syncSettings.deviceId,
-                        modules = options.writePayload.map { it.module },
-                    ))
+                    // Per module, not per batch: one failing upload must not discard the hashes of
+                    // the modules that already landed, or they rewrite on every following trigger.
+                    val expectedHashes = options.writePayload.associate { it.module.moduleId to it.expectedHash }
+                    writeDrive(
+                        data = SyncWriteContainer(
+                            deviceId = syncSettings.deviceId,
+                            modules = options.writePayload.map { it.module },
+                        ),
+                        onModuleWritten = { moduleId ->
+                            expectedHashes[moduleId]?.let { syncState.setHash(identifier, moduleId, it) }
+                        },
+                    )
                     wroteData = true
-                    // writeDrive returned without throwing — record hashes for all written modules
-                    options.writePayload.forEach { mw ->
-                        syncState.setHash(identifier, mw.module.moduleId, mw.expectedHash)
-                    }
                 }
 
                 try {
@@ -935,8 +947,16 @@ class GDriveAppDataConnector @AssistedInject constructor(
      * `withContext(NonCancellable)`, which makes any bound placed around the command inert: a
      * `withTimeout` around a non-cancellable body does not return until that body completes. Only
      * the state commit below stays non-cancellable, mirroring `OctiServerConnector.runServerAction`.
+     *
+     * [onModuleWritten] fires per module, as soon as that module's upload succeeded. Modules are
+     * uploaded in parallel and `awaitAll` rethrows the first failure, so anything reported only
+     * after this call returns would be lost for the modules that did land — and they would be
+     * rewritten on every subsequent trigger. Called from the upload coroutines: must be thread-safe.
      */
-    private suspend fun GDriveEnvironment.writeDrive(data: SyncWrite) {
+    private suspend fun GDriveEnvironment.writeDrive(
+        data: SyncWrite,
+        onModuleWritten: (ModuleId) -> Unit = {},
+    ) {
         log(TAG, DEBUG) { "writeDrive(): $data" }
 
         // TODO cache write data for when we are online again?
@@ -979,6 +999,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                         fileIdCache[cacheKey]?.let { cachedId ->
                             try {
                                 cachedDriveFile(cachedId, module.moduleId.id).writeData(module.payload)
+                                onModuleWritten(module.moduleId)
                                 return@withPermit
                             } catch (e: com.google.api.client.googleapis.json.GoogleJsonResponseException) {
                                 if (e.statusCode != 404) throw e
@@ -993,6 +1014,7 @@ class GDriveAppDataConnector @AssistedInject constructor(
                             }
                         cacheModuleFileId(data.deviceId, module.moduleId, moduleFile.id)
                         moduleFile.writeData(module.payload)
+                        onModuleWritten(module.moduleId)
                     }
                 }
             }.awaitAll()

--- a/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
+++ b/syncs-gdrive/src/main/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnector.kt
@@ -567,8 +567,15 @@ class GDriveAppDataConnector @AssistedInject constructor(
         deviceDirs.map { dir ->
             async(dispatcherProvider.IO) {
                 val deviceId = DeviceId(id = dir.name)
-                val infoFile = index.child(dir, DEVICE_INFO_FILE)?.also {
-                    deviceInfoFileIdCache[deviceId] = it.id
+                // Drive allows duplicate names, index.child(...) throws on those. A single broken
+                // device directory must not abort metadata for every other device.
+                val infoFile = try {
+                    index.child(dir, DEVICE_INFO_FILE)?.also {
+                        deviceInfoFileIdCache[deviceId] = it.id
+                    }
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "readDeviceMetadata(): Failed to resolve $DEVICE_INFO_FILE for ${dir.name}: ${e.message}" }
+                    null
                 }
                 val info = try {
                     infoFile?.readData()?.let {

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -1320,6 +1320,99 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
     }
 
     @Nested
+    inner class `device metadata resilience` {
+
+        private val deviceA = DeviceId("device-a")
+        private val deviceB = DeviceId("device-b")
+
+        private fun folder(fileId: String, fileName: String, parentId: String?) = GDriveFile().apply {
+            id = fileId
+            name = fileName
+            mimeType = "application/vnd.google-apps.folder"
+            parentId?.let { parents = listOf(it) }
+        }
+
+        private fun file(fileId: String, fileName: String, parentId: String, modifiedAt: Long) = GDriveFile().apply {
+            id = fileId
+            name = fileName
+            mimeType = "application/octet-stream"
+            parents = listOf(parentId)
+            modifiedTime = DateTime(modifiedAt)
+        }
+
+        /** Drive permits duplicate names: device-a's directory holds two `_device.json` entries. */
+        private fun setupListingWithDuplicateManifest() {
+            val root = folder("appDataFolder", "appDataFolder", null)
+            val entries = listOf(
+                folder("devices-dir-id", "devices", "appDataFolder"),
+                folder("device-a-dir-id", deviceA.id, "devices-dir-id"),
+                folder("device-b-dir-id", deviceB.id, "devices-dir-id"),
+                file("a-power-file-id", power.id, "device-a-dir-id", 1000L),
+                file("a-info-file-id-1", "_device.json", "device-a-dir-id", 1500L),
+                file("a-info-file-id-2", "_device.json", "device-a-dir-id", 1700L),
+                file("b-power-file-id", power.id, "device-b-dir-id", 2000L),
+                file("b-info-file-id", "_device.json", "device-b-dir-id", 2500L),
+            )
+            val payloads = mapOf(
+                "a-power-file-id" to "power-a",
+                "a-info-file-id-1" to """{"version":"1","platform":"android","label":"Device A"}""",
+                "a-info-file-id-2" to """{"version":"2","platform":"android","label":"Device A duplicate"}""",
+                "b-power-file-id" to "power-b",
+                "b-info-file-id" to """{"version":"3","platform":"android","label":"Device B"}""",
+            )
+
+            val rootGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns root
+            }
+            val getsById = entries.associate { entry ->
+                entry.id to mockk<Drive.Files.Get>(relaxed = true).also {
+                    every { it.setFields(any<String>()) } returns it
+                    every { it.execute() } returns entry
+                    every { it.executeMediaAndDownloadTo(any()) } answers {
+                        firstArg<java.io.OutputStream>().write(payloads[entry.id].orEmpty().toByteArray())
+                    }
+                }
+            }
+            every { mockFiles.get(any()) } answers {
+                when (val fileId = firstArg<String>()) {
+                    "appDataFolder" -> rootGet
+                    else -> getsById[fileId] ?: mockk(relaxed = true)
+                }
+            }
+            every { mockFilesList.execute() } returns FileList().apply { files = entries }
+        }
+
+        @Test
+        fun `a duplicate device manifest does not abort the metadata read`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupListingWithDuplicateManifest()
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            val metadata = connector.state.first().deviceMetadata
+            metadata shouldHaveSize 2
+
+            // The ambiguous manifest is skipped, not fatal.
+            val ambiguous = metadata.single { it.deviceId == deviceA }
+            ambiguous.version.shouldBeNull()
+            ambiguous.label.shouldBeNull()
+            ambiguous.platform.shouldBeNull()
+            ambiguous.capabilities.shouldBeNull()
+            // Both duplicates are ordinary files, so they still count towards lastSeen.
+            ambiguous.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(1700L)
+
+            // The other device is untouched by its neighbour's broken directory.
+            val healthy = metadata.single { it.deviceId == deviceB }
+            healthy.version shouldBe "3"
+            healthy.platform shouldBe "android"
+            healthy.label shouldBe "Device B"
+            healthy.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(2500L)
+        }
+    }
+
+    @Nested
     inner class `blob store cache` {
 
         private val blobDevice = DeviceId("blob-device")

--- a/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
+++ b/syncs-gdrive/src/test/java/eu/darken/octi/syncs/gdrive/core/GDriveAppDataConnectorSyncTest.kt
@@ -73,6 +73,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
     private lateinit var mockFilesGet: Drive.Files.Get
 
     private lateinit var syncSettings: SyncSettings
+    private lateinit var syncState: ConnectorSyncState
 
     @BeforeEach
     fun setup() {
@@ -99,6 +100,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
         every { mockFilesGet.setFields(any<String>()) } returns mockFilesGet
 
         syncSettings = mockk(relaxed = true)
+        syncState = ConnectorSyncState()
     }
 
     private fun TestScope.createConnector(
@@ -137,7 +139,7 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             networkStateProvider = mockNetworkState,
             supportedModuleIds = setOf(power, wifi),
             syncSettings = syncSettings,
-            syncState = ConnectorSyncState(),
+            syncState = syncState,
             syncCache = cache,
             json = json,
             capabilitiesProvider = DeviceCapabilitiesProvider(
@@ -824,7 +826,8 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             metadata.version shouldBe "1"
             metadata.platform shouldBe "android"
             metadata.label shouldBe "Device A"
-            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(1000L)
+            // _device.json (1500) is newer than the power module file (1000) and counts too.
+            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(1500L)
         }
 
         @Test
@@ -1087,6 +1090,232 @@ class GDriveAppDataConnectorSyncTest : BaseTest() {
             verify(exactly = 0) { mockFiles.get(any()) }
             verify(exactly = 1) { mockFiles.list() }
             verify(exactly = 0) { mockFiles.create(any<GDriveFile>()) }
+        }
+    }
+
+    @Nested
+    inner class `self device writes` {
+
+        private val selfDevice = DeviceId("test-device")
+        private val selfPowerFileId = "self-power-file-id"
+        private val selfWifiFileId = "self-wifi-file-id"
+        private val selfInfoFileId = "self-device-info-id"
+
+        private fun rootFile() = GDriveFile().apply {
+            id = "appDataFolder"
+            name = "appDataFolder"
+            mimeType = "application/vnd.google-apps.folder"
+        }
+
+        private fun devicesDir() = GDriveFile().apply {
+            id = "devices-dir-id"
+            name = "devices"
+            mimeType = "application/vnd.google-apps.folder"
+            parents = listOf("appDataFolder")
+        }
+
+        private fun deviceDir() = GDriveFile().apply {
+            id = "self-device-dir-id"
+            name = selfDevice.id
+            mimeType = "application/vnd.google-apps.folder"
+            parents = listOf("devices-dir-id")
+        }
+
+        private fun moduleFile(fileId: String, module: ModuleId, modifiedAt: Long) = GDriveFile().apply {
+            id = fileId
+            name = module.id
+            mimeType = "application/octet-stream"
+            parents = listOf("self-device-dir-id")
+            modifiedTime = DateTime(modifiedAt)
+        }
+
+        private fun infoFile(modifiedAt: Long) = GDriveFile().apply {
+            id = selfInfoFileId
+            name = "_device.json"
+            mimeType = "application/octet-stream"
+            parents = listOf("self-device-dir-id")
+            modifiedTime = DateTime(modifiedAt)
+        }
+
+        private fun stubFileGets(entries: List<GDriveFile>) {
+            val root = rootFile()
+            val rootGet = mockk<Drive.Files.Get>(relaxed = true).also {
+                every { it.setFields(any<String>()) } returns it
+                every { it.execute() } returns root
+            }
+            val getsById = entries.associate { entry ->
+                entry.id to mockk<Drive.Files.Get>(relaxed = true).also {
+                    every { it.setFields(any<String>()) } returns it
+                    every { it.execute() } returns entry
+                    every { it.executeMediaAndDownloadTo(any()) } answers {
+                        val payload = when (entry.name) {
+                            "_device.json" -> """{"version":"1","platform":"android","label":"Self"}"""
+                            else -> "payload-${entry.name}"
+                        }
+                        firstArg<java.io.OutputStream>().write(payload.toByteArray())
+                    }
+                }
+            }
+            every { mockFiles.get(any()) } answers {
+                when (val fileId = firstArg<String>()) {
+                    "appDataFolder" -> rootGet
+                    else -> getsById[fileId] ?: mockk(relaxed = true)
+                }
+            }
+        }
+
+        /** Flat app-data listing, the shape [listAppDataFiles] returns during a full read. */
+        private fun setupFullListing(
+            powerModifiedAt: Long = 1000L,
+            wifiModifiedAt: Long = 1000L,
+            infoModifiedAt: Long = 1500L,
+        ) {
+            val entries = listOf(
+                devicesDir(),
+                deviceDir(),
+                moduleFile(selfPowerFileId, power, powerModifiedAt),
+                moduleFile(selfWifiFileId, wifi, wifiModifiedAt),
+                infoFile(infoModifiedAt),
+            )
+            stubFileGets(entries)
+            every { mockFilesList.execute() } returns FileList().apply { files = entries }
+        }
+
+        /**
+         * The mock cannot filter a listing by the request's name query, and `child()` throws on more
+         * than one match — so hand out one result per lookup, in traversal order.
+         */
+        private fun setupChildLookups(vararg results: GDriveFile) {
+            var call = 0
+            every { mockFilesList.execute() } answers {
+                val next = results.getOrNull(call++)
+                FileList().apply { files = listOfNotNull(next) }
+            }
+        }
+
+        private fun setupUpdates(updateIds: MutableList<String>, failingIds: Set<String> = emptySet()) {
+            every {
+                mockFiles.update(
+                    any<String>(),
+                    any<GDriveFile>(),
+                    any<com.google.api.client.http.AbstractInputStreamContent>(),
+                )
+            } answers {
+                val fileId = firstArg<String>()
+                updateIds += fileId
+                mockk<Drive.Files.Update>(relaxed = true).also {
+                    every { it.setFields(any<String>()) } returns it
+                    if (fileId in failingIds) {
+                        every { it.execute() } throws RuntimeException("upload failed: $fileId")
+                    } else {
+                        every { it.execute() } returns GDriveFile().apply {
+                            id = fileId
+                            name = "updated"
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun moduleWrite(module: ModuleId, payloadText: String): SyncOptions.ModuleWrite {
+            val written = object : SyncWrite.Device.Module {
+                override val moduleId: ModuleId = module
+                override val payload = payloadText.encodeUtf8()
+            }
+            return SyncOptions.ModuleWrite(module = written, expectedHash = "hash-${module.id}")
+        }
+
+        private fun writeSync(vararg writes: SyncOptions.ModuleWrite) = SyncOptions(
+            stats = false,
+            readData = false,
+            writeData = true,
+            writePayload = writes.toList(),
+        )
+
+        @Test
+        fun `a failing module upload keeps the hashes of the ones that landed`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupFullListing()
+
+            // Warm the file id caches so the write goes straight to update().
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            io.mockk.clearMocks(
+                mockFiles,
+                mockFilesGet,
+                mockFilesList,
+                answers = false,
+                childMocks = false,
+                exclusionRules = false,
+            )
+            val updateIds = mutableListOf<String>()
+            setupUpdates(updateIds, failingIds = setOf(selfWifiFileId))
+
+            runCatching {
+                connector.sync(writeSync(moduleWrite(power, "power-written"), moduleWrite(wifi, "wifi-written")))
+            }.isFailure shouldBe true
+
+            updateIds.contains(selfPowerFileId) shouldBe true
+            syncState.getRecord(connector.identifier, power)?.hash shouldBe "hash-${power.id}"
+            syncState.getRecord(connector.identifier, wifi).shouldBeNull()
+        }
+
+        @Test
+        fun `device info is rewritten after a reset even when its content is unchanged`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupFullListing()
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            val firstWriteIds = mutableListOf<String>()
+            setupUpdates(firstWriteIds)
+            connector.sync(writeSync(moduleWrite(power, "v1")))
+            firstWriteIds.contains(selfInfoFileId) shouldBe true
+
+            // Reset deletes our device dir — this listing leaves nothing for the deletion walk.
+            setupEmptyDriveRead()
+            connector.execute(ConnectorCommand.Reset)
+
+            // Caches were cleared, so the next write walks the tree again.
+            stubFileGets(listOf(devicesDir(), deviceDir()))
+            setupChildLookups(
+                devicesDir(),
+                deviceDir(),
+                moduleFile(selfPowerFileId, power, 2000L),
+                infoFile(2000L),
+            )
+            val secondWriteIds = mutableListOf<String>()
+            setupUpdates(secondWriteIds)
+
+            connector.sync(writeSync(moduleWrite(power, "v1")))
+
+            secondWriteIds.contains(selfInfoFileId) shouldBe true
+        }
+
+        @Test
+        fun `lastSeen counts the device info manifest`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupFullListing(powerModifiedAt = 1000L, wifiModifiedAt = 1000L, infoModifiedAt = 4000L)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            val metadata = connector.state.first().deviceMetadata.single { it.deviceId == selfDevice }
+            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(4000L)
+        }
+
+        @Test
+        fun `lastSeen uses the newest module file when it beats the manifest`() = runTest {
+            val connector = createConnector()
+            setupStartPageToken("start-token")
+            setupFullListing(powerModifiedAt = 5000L, wifiModifiedAt = 1000L, infoModifiedAt = 1500L)
+
+            connector.sync(SyncOptions(stats = true, readData = true, writeData = false))
+
+            val metadata = connector.state.first().deviceMetadata.single { it.deviceId == selfDevice }
+            metadata.lastSeen shouldBe kotlin.time.Instant.fromEpochMilliseconds(5000L)
         }
     }
 


### PR DESCRIPTION
Device cards on the dashboard showed "last updated" times that grew into hours — matching the app's process uptime — even while sync was running every minute and the server saw the device seconds ago. Pressing refresh didn't help.

## Root cause

The card renders the meta module's last **write** time, and meta almost never gets written: the per-module hash dedup (from the single-path writes refactor) skips any module whose payload is unchanged, `MetaInfo` is fully static between reboots, and the hash store is in-memory. Net effect: meta is written exactly once per process lifetime, so the visible timestamp equals process uptime. Long-lived processes looked permanently stale; a restart "fixed" it by clearing the hash store.

## Changes

- **Age horizon** — `ConnectorSyncState` records the last-sent hash together with a monotonic write time (single atomic snapshot). `SyncManager` rewrites an unchanged module once that record is over an hour old, restoring hourly freshness for static payloads without giving up per-minute dedup. No jitter or claim machinery: the hourly burst is a handful of tiny modules, the same as every process start already produces.
- **Dashboard** — device cards now show "last seen or data last written, whichever is newer": the newest `DeviceMetadata.lastSeen` any connector reports (server-side on Octi Server; file timestamps on Google Drive), with the module write time as a lower bound so stale cached metadata can never move the card backwards. Staleness warnings stay driven purely by data age, so a genuine write-side failure still surfaces instead of being masked by a fresh sighting.
- **Google Drive fixes** —
  - hashes are recorded per module as each upload lands, not after the whole batch; one failed upload no longer causes every already-uploaded module to be rewritten on each subsequent sync.
  - a reset now clears the remembered `_device.json` state, so the manifest is recreated afterwards instead of being skipped as "already written".
  - `_device.json`'s own modification time counts toward a device's `lastSeen`, and a duplicate manifest in one device's folder no longer aborts the metadata read for every other device.

## Notes

- The `lastSeen` shown for Google Drive devices is derived from Drive file modification times, which are client-authored on write — device clock skew is bounded, pre-existing behavior, and display-clamped to "now".
- Verified in tests: horizon include/exclude/hash-priority under merged sync options, per-module hash recording under partial batch failure, manifest recreation after reset, duplicate-manifest resilience, and the card's no-backwards-movement guarantee.
