### PR TITLE
Rework the FOSS upgrade screen and improve billing reliability

### DIFF
--- a/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
@@ -46,13 +46,13 @@ class UpgradeRepoFoss @Inject constructor(
     }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
 
-    fun openSponsorsPage() {
-        log(TAG) { "openSponsorsPage()" }
+    fun openGithubSponsorsPage() {
+        log(TAG) { "openGithubSponsorsPage()" }
         appScope.launch { webpageTool.open(upgradeSite) }
     }
 
-    fun unlockUpgrade() {
-        log(TAG) { "unlockUpgrade()" }
+    fun persistUpgrade() {
+        log(TAG) { "persistUpgrade()" }
         fossCache.upgrade.valueBlocking = FossUpgrade(
             upgradedAt = Clock.System.now(),
             upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeNavigation.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
-        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(forced = key.forced, manage = key.manage) }
+        entry<Nav.Main.Upgrade> { key -> UpgradeScreenHost(route = key) }
     }
 
     @Module

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -1,287 +1,330 @@
 package eu.darken.octi.common.upgrade.ui
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import android.widget.Toast
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.AutoAwesome
+import androidx.compose.material.icons.twotone.Favorite
+import androidx.compose.material.icons.twotone.Info
+import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.octi.R
-import eu.darken.octi.common.compose.OctiMascot
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.error.ErrorEventHandler
+import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 import kotlin.time.Instant
 
+// Which presentation the FOSS upgrade screen shows: the classic support pitch, or one of the
+// status views behind the settings "upgrade status" entry.
+internal enum class FossUpgradeView {
+    PITCH,
+    STATUS_FREE,
+    STATUS_UPGRADED,
+}
+
 @Composable
 fun UpgradeScreenHost(
-    forced: Boolean = false,
-    manage: Boolean = false,
+    route: Nav.Main.Upgrade = Nav.Main.Upgrade(),
     vm: UpgradeViewModel = hiltViewModel(),
 ) {
-    vm.initialize(forced = forced, manage = manage)
-
+    LaunchedEffect(route) { vm.bindRoute(route) }
     ErrorEventHandler(vm)
     NavigationEventHandler(vm)
 
-    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.onResumed() }
-
+    val context = LocalContext.current
     val snackbarHostState = remember { SnackbarHostState() }
-    val tooFastMsg = stringResource(R.string.upgrade_screen_sponsor_too_fast_msg)
-
-    LaunchedEffect(Unit) {
-        vm.snackbarEvents.collect { snackbarHostState.showSnackbar(tooFastMsg) }
+    // Seeded from the ViewModel's handle-backed pending launch: after a process death while the
+    // sponsor page was open, a blank tracker would swallow the very first return. The handle is the
+    // authority on whether a return is still expected, so it reconstructs the tracker's state.
+    val sponsorReturnTracker = remember(vm) {
+        SponsorReturnTracker(wentToBackground = vm.hasPendingSponsorLaunch())
     }
 
-    val state by vm.state.collectAsState()
+    LaunchedEffect(Unit) {
+        vm.snackbarEvents.collect { stringRes ->
+            snackbarHostState.showSnackbar(context.getString(stringRes))
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        vm.toastEvents.collect { stringRes ->
+            Toast.makeText(context, context.getString(stringRes), Toast.LENGTH_LONG).show()
+        }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        sponsorReturnTracker.onStop()
+    }
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (sponsorReturnTracker.consumeResumeReturn()) {
+            vm.checkSponsorReturn()
+        }
+    }
+
+    val state by vm.state.collectAsStateWithLifecycle()
+
     UpgradeScreen(
-        state = state,
+        // Until the route binding lands (one frame): the default route keeps rendering the pitch
+        // exactly as before, only the manage route waits for the status decision.
+        view = state.view ?: FossUpgradeView.PITCH.takeIf { !route.manage },
+        supporterSince = state.supporterSince,
         snackbarHostState = snackbarHostState,
-        onNavigateUp = { vm.navUp() },
-        onSponsor = { vm.goGithubSponsors() },
-        onOpenSponsors = { vm.openSponsors() },
-        onSeeUpgradeOptions = { vm.onSeeUpgradeOptions() },
+        onGithubSponsors = vm::goGithubSponsors,
+        onOpenSponsors = vm::openSponsors,
+        onShowUpgradeOptions = vm::onShowUpgradeOptions,
+        onNavigateUp = vm::navUp,
     )
 }
 
 @Composable
-fun UpgradeScreen(
-    state: UpgradeViewModel.State?,
+internal fun UpgradeScreen(
+    view: FossUpgradeView? = FossUpgradeView.PITCH,
+    supporterSince: Instant? = null,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
-    onNavigateUp: () -> Unit,
-    onSponsor: () -> Unit,
-    onOpenSponsors: () -> Unit,
-    onSeeUpgradeOptions: () -> Unit,
+    onGithubSponsors: () -> Unit = {},
+    onOpenSponsors: () -> Unit = {},
+    onShowUpgradeOptions: () -> Unit = {},
+    onNavigateUp: () -> Unit = {},
 ) {
-    Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.upgrade_screen_title),
-                        modifier = Modifier.fillMaxWidth(),
-                        textAlign = TextAlign.Center,
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateUp) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = null,
-                        )
-                    }
-                },
-            )
+    UpgradeScreenScaffold(
+        // Status views describe the existing install, not a support ask — they get the composed
+        // flavor title, with the postfix highlighted for supporters like the dashboard does it.
+        title = if (view == FossUpgradeView.PITCH) {
+            AnnotatedString(stringResource(R.string.upgrade_screen_title))
+        } else {
+            upgradeScreenTitle(upgraded = view == FossUpgradeView.STATUS_UPGRADED)
         },
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .padding(horizontal = 32.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Spacer(modifier = Modifier.height(8.dp))
-            OctiMascot(modifier = Modifier.size(96.dp))
-            Spacer(modifier = Modifier.height(8.dp))
+        onNavigateUp = onNavigateUp,
+        snackbarHostState = snackbarHostState,
+    ) { paddingValues ->
+        when (view) {
+            null -> Unit // Route not bound yet (single frame); content lands with the next state.
+            FossUpgradeView.PITCH -> UpgradePitchContent(
+                paddingValues = paddingValues,
+                onGithubSponsors = onGithubSponsors,
+            )
 
-            when {
-                // DataStore hasn't answered yet — render nothing rather than flashing the sales
-                // pitch (with its armable unlock heuristic) at an existing supporter.
-                state == null -> Unit
+            FossUpgradeView.STATUS_FREE -> UpgradeStatusFreeContent(
+                paddingValues = paddingValues,
+                onShowUpgradeOptions = onShowUpgradeOptions,
+            )
 
-                state.isPro -> SupporterStatus(
-                    upgradedAt = state.upgradedAt,
-                    onOpenSponsors = onOpenSponsors,
-                )
-
-                state.showFreeStatus -> FreeStatus(onSeeUpgradeOptions = onSeeUpgradeOptions)
-
-                else -> SponsorPitch(onSponsor = onSponsor)
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
+            FossUpgradeView.STATUS_UPGRADED -> UpgradeStatusUpgradedContent(
+                paddingValues = paddingValues,
+                supporterSince = supporterSince,
+                onOpenSponsors = onOpenSponsors,
+            )
         }
     }
 }
 
 @Composable
-private fun SupporterStatus(
-    upgradedAt: Instant?,
+private fun UpgradePitchContent(
+    paddingValues: PaddingValues,
+    onGithubSponsors: () -> Unit,
+) {
+    UpgradeScreenContent(
+        paddingValues = paddingValues,
+    ) {
+        UpgradeHeader(
+            mascotSize = 104.dp,
+        )
+
+        UpgradePreambleCard(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+            ),
+        )
+
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_why_title),
+            icon = Icons.TwoTone.AutoAwesome,
+        ) {
+            UpgradeFeatureList(text = stringResource(R.string.upgrade_screen_benefits_body))
+        }
+
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_how_title),
+            icon = Icons.TwoTone.Favorite,
+        ) {
+            UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_how_body))
+        }
+
+        UpgradeActionCard(
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            ),
+        ) {
+            Button(
+                onClick = onGithubSponsors,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(UpgradeScreenTags.FOSS_SPONSOR),
+            ) {
+                Text(stringResource(R.string.upgrade_screen_sponsor_action))
+            }
+
+            UpgradeHintText(text = stringResource(R.string.upgrade_screen_sponsor_action_hint))
+        }
+    }
+}
+
+@Composable
+private fun UpgradeStatusFreeContent(
+    paddingValues: PaddingValues,
+    onShowUpgradeOptions: () -> Unit,
+) {
+    UpgradeScreenContent(
+        paddingValues = paddingValues,
+    ) {
+        UpgradeHeader(
+            mascotSize = 104.dp,
+        )
+
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_free_status_title),
+            icon = Icons.TwoTone.Info,
+            modifier = Modifier.testTag(UpgradeScreenTags.FOSS_STATUS_FREE),
+        ) {
+            UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_free_status_body))
+            Button(
+                onClick = onShowUpgradeOptions,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS),
+            ) {
+                Text(stringResource(R.string.upgrade_screen_see_options_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun UpgradeStatusUpgradedContent(
+    paddingValues: PaddingValues,
+    supporterSince: Instant? = null,
     onOpenSponsors: () -> Unit,
 ) {
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        ),
+    UpgradeScreenContent(
+        paddingValues = paddingValues,
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_supporter_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
+        UpgradeHeader(
+            mascotSize = 104.dp,
+        )
+
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_supporter_title),
+            icon = Icons.TwoTone.Verified,
+            modifier = Modifier.testTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED),
+            colors = CardDefaults.elevatedCardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+        ) {
             Text(
                 text = stringResource(R.string.upgrade_screen_supporter_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
-            upgradedAt?.let { instant ->
-                Spacer(modifier = Modifier.height(4.dp))
-                val formatted = remember(instant) {
-                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
-                        .withZone(ZoneId.systemDefault())
-                        .format(java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds()))
+            supporterSince?.let { since ->
+                val formatter = remember {
+                    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
                 }
+                val formatted = formatter.format(java.time.Instant.ofEpochMilli(since.toEpochMilliseconds()))
                 Text(
                     text = stringResource(R.string.upgrade_screen_supporter_since, formatted),
-                    style = MaterialTheme.typography.labelMedium,
+                    style = MaterialTheme.typography.bodySmall,
                 )
             }
         }
-    }
 
-    Spacer(modifier = Modifier.height(24.dp))
-
-    OutlinedButton(onClick = onOpenSponsors, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.upgrade_screen_open_sponsors_action))
-    }
-}
-
-@Composable
-private fun FreeStatus(onSeeUpgradeOptions: () -> Unit) {
-    ElevatedCard(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.elevatedCardColors(
-            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
-        ),
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = stringResource(R.string.upgrade_screen_free_status_title),
-                style = MaterialTheme.typography.titleMedium,
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.upgrade_screen_free_status_body),
-                style = MaterialTheme.typography.bodyMedium,
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            Button(onClick = onSeeUpgradeOptions, modifier = Modifier.fillMaxWidth()) {
-                Text(text = stringResource(R.string.upgrade_screen_see_options_action))
+        UpgradeSectionCard(
+            title = stringResource(R.string.upgrade_screen_recurring_title),
+            icon = Icons.TwoTone.Favorite,
+        ) {
+            UpgradeSectionBody(text = stringResource(R.string.upgrade_screen_recurring_body))
+            OutlinedButton(
+                // Deliberately the UNARMED entrypoint: a recurring-donation visit must not re-run
+                // the unlock heuristic and rewrite the supporter-since date shown right above.
+                onClick = onOpenSponsors,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(UpgradeScreenTags.FOSS_DONATE),
+            ) {
+                Text(stringResource(R.string.upgrade_screen_open_sponsors_action))
             }
         }
     }
 }
 
+internal class SponsorReturnTracker(
+    private var wentToBackground: Boolean = false,
+) {
+
+    fun onStop() {
+        wentToBackground = true
+    }
+
+    fun consumeResumeReturn(): Boolean {
+        return if (wentToBackground) {
+            wentToBackground = false
+            true
+        } else {
+            false
+        }
+    }
+}
+
+@Preview2
 @Composable
-private fun SponsorPitch(onSponsor: () -> Unit) {
-    ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-        Text(
-            text = stringResource(R.string.upgrade_screen_preamble),
-            style = MaterialTheme.typography.bodyMedium,
-            modifier = Modifier.padding(16.dp),
+private fun UpgradeScreenPreview() {
+    PreviewWrapper {
+        UpgradeScreen()
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenStatusFreePreview() {
+    PreviewWrapper {
+        UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenStatusUpgradedPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.fromEpochMilliseconds(1_700_000_000_000L),
         )
     }
-
-    Spacer(modifier = Modifier.height(32.dp))
-
-    Text(
-        text = stringResource(R.string.upgrade_screen_how_title),
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-    Text(
-        text = stringResource(R.string.upgrade_screen_how_body),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-
-    Spacer(modifier = Modifier.height(32.dp))
-
-    Text(
-        text = stringResource(R.string.upgrade_screen_why_title),
-        style = MaterialTheme.typography.titleMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-    Text(
-        text = stringResource(R.string.upgrade_screen_benefits_body),
-        style = MaterialTheme.typography.bodyMedium,
-        modifier = Modifier.fillMaxWidth(),
-    )
-
-    Spacer(modifier = Modifier.height(32.dp))
-
-    Button(onClick = onSponsor, modifier = Modifier.fillMaxWidth()) {
-        Text(text = stringResource(R.string.upgrade_screen_sponsor_action))
-    }
-    Text(
-        text = stringResource(R.string.upgrade_screen_sponsor_action_hint),
-        style = MaterialTheme.typography.labelSmall,
-        textAlign = TextAlign.Center,
-        modifier = Modifier.fillMaxWidth(),
-    )
-}
-
-@Preview2
-@Composable
-private fun UpgradeScreenSponsorPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeViewModel.State(isPro = false),
-        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
-    )
-}
-
-@Preview2
-@Composable
-private fun UpgradeScreenSupporterPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeViewModel.State(isPro = true, upgradedAt = Instant.fromEpochMilliseconds(1704067200000L)),
-        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
-    )
-}
-
-@Preview2
-@Composable
-private fun UpgradeScreenFreeStatusPreview() = PreviewWrapper {
-    UpgradeScreen(
-        state = UpgradeViewModel.State(isPro = false, manageMode = true, viewingOffers = false),
-        onNavigateUp = {}, onSponsor = {}, onOpenSponsors = {}, onSeeUpgradeOptions = {},
-    )
 }

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -51,7 +51,10 @@ class UpgradeViewModel @Inject constructor(
     ) { route, info, showOptions ->
         val view = when {
             route == null -> null
-            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            // Forced routes (widget configuration) never auto-close, so an upgraded user has to land
+            // on the status view — leaving them on the pitch would let its ARMED sponsor button
+            // rewrite the supporter-since date on a later long visit.
+            info.isPro && (route.manage || route.forced) -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -1,32 +1,25 @@
 package eu.darken.octi.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.octi.R
 import eu.darken.octi.common.coroutine.DispatcherProvider
-import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.SingleEventFlow
+import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
-import eu.darken.octi.common.upgrade.core.FossUpgrade
 import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
-import eu.darken.octi.common.widget.WidgetManager
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.take
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
 @HiltViewModel
@@ -34,125 +27,131 @@ class UpgradeViewModel @Inject constructor(
     private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoFoss,
-    private val widgetManagers: Set<@JvmSuppressWildcards WidgetManager>,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
-    val snackbarEvents = SingleEventFlow<Unit>()
+    // Route is bound from the Host via bindRoute(); SavedStateHandle.toRoute<>() crashes under Nav3.
+    private val routeFlow = MutableStateFlow<Nav.Main.Upgrade?>(null)
 
-    private var initialized = false
-    private var forced = false
-    private var manage = false
-    private val widgetsRefreshedForUpgrade = AtomicBoolean(false)
-
-    private val manageRoute = MutableStateFlow<Boolean?>(null)
-    private val viewingOffers = MutableStateFlow(handle.get<Boolean>(KEY_SHOW_OFFERS) ?: false)
-
-    data class State(
-        val isPro: Boolean = false,
-        val upgradedAt: Instant? = null,
-        val upgradeType: FossUpgrade.Type? = null,
-        val manageMode: Boolean = false,
-        val viewingOffers: Boolean = false,
-    ) {
-        // Free user opening the status row: show the calm status page first, revealing the sponsor
-        // pitch only when asked.
-        val showFreeStatus: Boolean get() = !isPro && manageMode && !viewingOffers
+    fun bindRoute(route: Nav.Main.Upgrade) {
+        if (routeFlow.value != null) return
+        routeFlow.value = route
     }
 
-    // Null until DataStore answered: a defaulted isPro=false would flash the sales pitch (and its
-    // armable unlock heuristic) at an existing supporter opening their status.
-    val state: StateFlow<State?> = combine(
+    val snackbarEvents = SingleEventFlow<Int>()
+    val toastEvents = SingleEventFlow<Int>()
+
+    // Which presentation the screen shows. The manage route (settings "upgrade status" entry)
+    // gets a status view first; the pitch only appears once a free user asks for the upgrade
+    // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
+    // land on the upgraded status, not back on the ask. null until the route is bound.
+    internal val state: StateFlow<State> = combine(
+        routeFlow,
         upgradeRepo.upgradeInfo,
-        manageRoute.filterNotNull(),
-        viewingOffers,
-    ) { info, isManage, offers ->
-        val fossInfo = info as? UpgradeRepoFoss.Info
-        State(
-            isPro = info.isPro,
-            upgradedAt = info.upgradedAt,
-            upgradeType = fossInfo?.fossUpgradeType,
-            manageMode = isManage,
-            viewingOffers = offers,
-        )
-    }.stateIn(vmScope, SharingStarted.WhileSubscribed(5_000), null)
+        handle.getStateFlow(KEY_SHOW_UPGRADE_OPTIONS, false),
+    ) { route, info, showOptions ->
+        val view = when {
+            route == null -> null
+            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
+            else -> FossUpgradeView.PITCH
+        }
+        // Derived in the same emission as the view on purpose: a sibling flow would let the
+        // upgraded status render for a frame without the date it is supposed to carry.
+        State(view = view, supporterSince = info.upgradedAt)
+    }.safeStateIn(
+        initialValue = State(),
+        onError = { State(view = FossUpgradeView.PITCH) },
+    )
 
-    fun initialize(forced: Boolean, manage: Boolean) {
-        if (initialized) return
-        initialized = true
-        this.forced = forced
-        this.manage = manage
-        manageRoute.value = manage
+    // internal like FossUpgradeView: the view enum is a screen-local presentation detail.
+    internal data class State(
+        val view: FossUpgradeView? = null,
+        val supporterSince: Instant? = null,
+    )
 
-        // Sales route: close once the user is Pro. Manage/forced route: never auto-close.
-        if (forced || manage) return
-        upgradeRepo.upgradeInfo
-            .filter { it.isPro }
+    init {
+        routeFlow
+            .filterNotNull()
             .take(1)
-            .onEach {
-                refreshWidgetsForUpgrade()
-                navUp()
+            .onEach { route ->
+                // The manage route is the settings "upgrade status" entry — upgraded users must
+                // not be bounced out. Forced routes keep their existing don't-auto-close semantics.
+                if (!route.forced && !route.manage) {
+                    upgradeRepo.upgradeInfo
+                        .filter { it.isPro }
+                        .take(1)
+                        .onEach { navUp() }
+                        .launchInViewModel()
+                }
+            }
+            .launchInViewModel()
+
+        upgradeRepo.upgradeInfo
+            .filter { !it.isPro && it.error != null }
+            .onEach { current ->
+                @Suppress("UNNECESSARY_NOT_NULL_ASSERTION")
+                errorEvents.tryEmit(current.error!!)
             }
             .launchInViewModel()
     }
 
-    fun onSeeUpgradeOptions() {
-        log(TAG) { "onSeeUpgradeOptions()" }
-        handle[KEY_SHOW_OFFERS] = true
-        viewingOffers.value = true
+    fun onShowUpgradeOptions() {
+        log(TAG) { "onShowUpgradeOptions()" }
+        // Handle-backed: surviving process recreation keeps the user on the pitch they asked for.
+        handle[KEY_SHOW_UPGRADE_OPTIONS] = true
     }
 
+    /** The pitch's sponsor button: arms the unlock heuristic, so a real visit unlocks on return. */
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
-        handle["browserOpenedAt"] = Clock.System.now().toEpochMilliseconds()
-        upgradeRepo.openSponsorsPage()
+        handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
+        upgradeRepo.openGithubSponsorsPage()
     }
 
-    // Plain sponsor link for existing supporters: must NOT arm the unlock heuristic — re-running it
-    // would rewrite the "supporter since" date and navigate away from the status view.
+    /**
+     * The recurring-donation link for existing supporters. Deliberately UNARMED: routing it through
+     * [goGithubSponsors] would re-run the unlock on return and rewrite the "supporter since" date
+     * that the status view exists to show.
+     */
     fun openSponsors() {
         log(TAG) { "openSponsors()" }
-        upgradeRepo.openSponsorsPage()
+        upgradeRepo.openGithubSponsorsPage()
     }
 
-    fun onResumed() {
-        val openedAt = handle.get<Long>("browserOpenedAt") ?: return
-        handle["browserOpenedAt"] = null
+    /**
+     * Whether a sponsor-page launch is still awaiting its return.
+     *
+     * Handle-backed, so it survives process recreation while the browser is in front — the screen's
+     * in-memory return tracker does not, and gating on that alone drops the first return after a
+     * recreation.
+     */
+    fun hasPendingSponsorLaunch(): Boolean = handle.contains(KEY_SPONSOR_PRESSED_AT)
 
-        val elapsed = Clock.System.now().toEpochMilliseconds() - openedAt
-        log(TAG) { "onResumed(): elapsed=${elapsed}ms" }
+    fun checkSponsorReturn() = launch {
+        val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+        val elapsed = SystemClock.elapsedRealtime() - pressedAt
+        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
-        if (elapsed.milliseconds < MIN_SPONSOR_TIME) {
-            log(TAG) { "onResumed(): too fast, showing snackbar" }
-            snackbarEvents.tryEmit(Unit)
+        if (elapsed < SPONSOR_DELAY_MS) {
+            // The nudge belongs to the unlock heuristic. An already upgraded user has nothing to
+            // unlock — peeking at the page needs no feedback.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(TAG) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
+            } else {
+                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast_msg)
+            }
         } else {
-            log(TAG) { "onResumed(): unlocking upgrade" }
-            launch {
-                upgradeRepo.unlockUpgrade()
-                refreshWidgetsForUpgrade()
-                // Sales route closes; manage/forced route stays to show the new supporter status.
-                if (!forced && !manage) navUp()
-            }
-        }
-    }
-
-    private suspend fun refreshWidgetsForUpgrade() {
-        if (!widgetsRefreshedForUpgrade.compareAndSet(false, true)) return
-
-        log(TAG) { "refreshWidgetsForUpgrade()" }
-        for (manager in widgetManagers) {
-            try {
-                manager.refreshWidgets()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "Failed to refresh widgets after upgrade: ${e.asLog()}" }
-            }
+            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+            upgradeRepo.persistUpgrade()
+            toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
         }
     }
 
     companion object {
-        private val MIN_SPONSOR_TIME = 5.seconds
-        private const val KEY_SHOW_OFFERS = "upgrade.manage.showOffers"
+        private const val KEY_SPONSOR_PRESSED_AT = "sponsor_pressed_at"
+        private const val KEY_SHOW_UPGRADE_OPTIONS = "show_upgrade_options"
+        private const val SPONSOR_DELAY_MS = 5_000L
         private val TAG = logTag("Upgrade", "Foss", "ViewModel")
     }
 }

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="upgrade_screen_supporter_title">You are a supporter ❤️</string>
     <string name="upgrade_screen_supporter_body">Thank you for supporting open-source development of Octi!</string>
     <string name="upgrade_screen_supporter_since">Supporter since %1$s</string>
+    <string name="upgrade_screen_recurring_title">Keep it going</string>
+    <string name="upgrade_screen_recurring_body">Octi keeps evolving through updates and fixes. If you\'d like to sustain that, consider a recurring donation via GitHub Sponsors.</string>
     <string name="upgrade_screen_open_sponsors_action">Open GitHub Sponsors</string>
     <string name="upgrade_screen_free_status_title">You are on the free version</string>
     <string name="upgrade_screen_free_status_body">Become a supporter to unlock extra features and sponsor continued development.</string>

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
@@ -11,19 +11,27 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.datastore.basicReader
 import eu.darken.octi.common.datastore.basicWriter
 import eu.darken.octi.common.datastore.createValue
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.billingCacheDataStore by preferencesDataStore(name = "settings_gplay")
+
 @Singleton
-class BillingCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class BillingCache internal constructor(
+    private val dataStore: DataStore<Preferences>,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_gplay")
+    @Inject constructor(@ApplicationContext context: Context) : this(context.billingCacheDataStore)
 
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    // Test seam: the bounded reads/writes below run on real dispatchers, so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var cacheTimeoutMs: Long = CACHE_TIMEOUT_MS
 
     // Raw keys shared between the DataStoreValues and stampLastProState's transaction — one
     // source of truth for key name and encoding.
@@ -60,8 +68,15 @@ class BillingCache @Inject constructor(
         val proUnconfirmedSince: Long,
     )
 
+    // Bounded on purpose: a wedged DataStore file lock would otherwise hang the caller forever.
+    // A timeout must NOT fall back to the default snapshot -- that would report "never bought"
+    // for an install whose evidence merely couldn't be read, which is the exact distinction the
+    // debug-log header exists to make.
     suspend fun snapshot(): Snapshot {
-        val prefs = dataStore.data.first()
+        val prefs = withTimeoutOrNull(cacheTimeoutMs) { dataStore.data.first() } ?: run {
+            log(TAG, WARN) { "snapshot() timed out after ${cacheTimeoutMs}ms" }
+            throw IOException("BillingCache snapshot timed out after ${cacheTimeoutMs}ms")
+        }
         return Snapshot(
             lastProStateAt = prefs[lastProStateAtKey] ?: 0L,
             lastProStateSku = prefs[lastProStateSkuKey] ?: "",
@@ -77,11 +92,19 @@ class BillingCache @Inject constructor(
     // entitlement layer out of order) opened a still-valid episode that this older confirmation must
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
-        dataStore.edit { prefs ->
-            prefs[lastProStateSkuKey] = skuId
-            prefs[lastProStateAtKey] = at
-            val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-            if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-        }
+        // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
+        withTimeoutOrNull(cacheTimeoutMs) {
+            dataStore.edit { prefs ->
+                prefs[lastProStateSkuKey] = skuId
+                prefs[lastProStateAtKey] = at
+                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+            }
+        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+    }
+
+    companion object {
+        private const val CACHE_TIMEOUT_MS = 2_000L
+        private val TAG = logTag("Upgrade", "Gplay", "BillingCache")
     }
 }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -17,10 +17,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -31,8 +31,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.octi.R
 import eu.darken.octi.common.compose.Preview2
@@ -56,15 +55,9 @@ fun UpgradeScreenHost(
 
     // Octi has no app-level activity-resume refresh of the upgrade repo, so the screen heals the
     // renewal state itself on resume — returning from Play's subscription-management page must
-    // reflect a just-cancelled renewal promptly.
-    val lifecycleOwner = LocalLifecycleOwner.current
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) vm.onResume()
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
-        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
-    }
+    // reflect a just-cancelled renewal promptly. It also re-runs a failed SKU query, so a transient
+    // Play outage doesn't leave the retry card up until it's tapped by hand.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { vm.onResume() }
 
     // rememberSaveable, not remember: these are driven by one-shot events that are already consumed
     // from the flow, so a rotation while a dialog is up would drop it for good.
@@ -402,14 +395,24 @@ private fun UpgradeOffersBox(
         when (state) {
             GplayUpgradeUiState.Loading -> UpgradeActionCard { UpgradeLoadingBlock() }
             is GplayUpgradeUiState.Unavailable -> UpgradeInlineStateCard(
-                title = stringResource(R.string.upgrades_gplay_unavailable_error_title),
-                body = stringResource(R.string.upgrades_gplay_unavailable_error_description),
+                title = stringResource(R.string.upgrade_screen_offers_unavailable_title),
+                body = stringResource(R.string.upgrade_screen_offers_unavailable_message),
                 icon = Icons.TwoTone.WarningAmber,
             ) {
                 // Play can be slow rather than broken (cold store, first sign-in): let
                 // the user re-run the offer queries instead of leaving a dead screen.
+                // No reset needed: this composable unmounts the moment the state leaves Unavailable.
+                var retryTapped by remember { mutableStateOf(false) }
                 OutlinedButton(
-                    onClick = onRetry,
+                    // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
+                    // after recomposition, so two taps in the same frame would both fire.
+                    onClick = {
+                        if (!retryTapped) {
+                            retryTapped = true
+                            onRetry()
+                        }
+                    },
+                    enabled = !retryTapped,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -369,7 +369,17 @@ class UpgradeViewModel @Inject constructor(
     // Octi has no app-level activity-resume refresh: returning from Play's subscription-management
     // page must heal the renewal state here, otherwise a disabled switch button (it can't re-run
     // its own gate) would stay locked against a just-cancelled renewal.
+    //
+    // Dual purpose — the two states are mutually exclusive: returning to the screen is also the
+    // user's own "try again", so a transient Play outage doesn't leave the retry card up until it's
+    // tapped by hand. Only re-queries from the unavailable state — a loaded or still-loading screen
+    // has nothing to retry.
     fun onResume() {
+        log(TAG) { "onResume()" }
+        if (state.value is GplayUpgradeUiState.Unavailable) {
+            retrySkuQuery()
+            return
+        }
         val current = state.value as? GplayUpgradeUiState.Loaded
         if (current?.ownership?.subscription == null) return
         launch {

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -49,6 +49,8 @@
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
     <!-- Offers box -->
     <string name="upgrade_screen_offers_title">Upgrade options</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prices unavailable</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prices couldn\'t be loaded right now. Check Google Play and try again in a moment.</string>
     <string name="upgrade_screen_offers_or">or</string>
     <string name="upgrade_screen_offers_body">Both unlock the same features — pick whichever pricing you prefer. Cancel anytime.</string>
     <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">Octi Pro</string>
-    <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
-    <string name="app_name_upgrade_postfix">Pro</string>
 
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
@@ -30,8 +28,6 @@
     </plurals>
 
     <string name="upgrade_screen_title">Get Octi Pro</string>
-    <string name="upgrade_screen_navigate_up">Navigate up</string>
-    <string name="upgrade_screen_progress_loading">Loading…</string>
     <string name="upgrade_screen_preamble">Octi has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_benefits_title">Benefits</string>
     <string name="upgrade_screen_benefits_body">• More than 3 devices 💯\n• Different themes 🎨\n• More options ⚙️\n• Extra sync servers🖥️️\n• Continued development ☕\n• A motivated developer 🧙</string>

--- a/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
@@ -28,6 +28,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -57,6 +59,11 @@ internal object UpgradeScreenTags {
     const val ACTIONS = "upgrade_actions"
     const val MASCOT_HAPPY = "upgrade_mascot_happy"
     const val MASCOT_GRUMPY = "upgrade_mascot_grumpy"
+    const val FOSS_SPONSOR = "upgrade_foss_sponsor"
+    const val FOSS_STATUS_FREE = "upgrade_foss_status_free"
+    const val FOSS_STATUS_UPGRADED = "upgrade_foss_status_upgraded"
+    const val FOSS_SHOW_OPTIONS = "upgrade_foss_show_options"
+    const val FOSS_DONATE = "upgrade_foss_donate"
     const val GPLAY_SUBSCRIPTION = "upgrade_gplay_subscription"
     const val GPLAY_SUBSCRIPTION_SPINNER = "upgrade_gplay_subscription_spinner"
     const val GPLAY_IAP = "upgrade_gplay_iap"
@@ -95,6 +102,7 @@ internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = buildAnnot
 internal fun UpgradeScreenScaffold(
     title: AnnotatedString,
     onNavigateUp: () -> Unit,
+    snackbarHostState: SnackbarHostState? = null,
     content: @Composable (PaddingValues) -> Unit,
 ) {
     val topAppBarState = rememberTopAppBarState()
@@ -115,6 +123,9 @@ internal fun UpgradeScreenScaffold(
                 },
                 scrollBehavior = scrollBehavior,
             )
+        },
+        snackbarHost = {
+            snackbarHostState?.let { SnackbarHost(it) }
         },
         content = content,
     )

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/support/ContactSupportVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/support/ContactSupportVM.kt
@@ -276,7 +276,10 @@ class ContactSupportVM @Inject constructor(
     companion object {
         private val TAG = logTag("Settings", "Support", "Contact", "VM")
         private const val MAX_PICKER_SESSIONS = 3
-        private val DIAGNOSTICS_TIMEOUT = 2.seconds
+        // Must stay above the diagnostics' own internal bounds (BillingCache reads are bounded at 2s,
+        // the pro-state history read follows) — an outer budget that expires first would cancel the
+        // read and drop the diagnostic instead of carrying its "unavailable" verdict into the email.
+        private val DIAGNOSTICS_TIMEOUT = 5.seconds
 
         fun wordCount(text: String): Int {
             return text.trim().split("\\s+".toRegex()).filter { it.isNotEmpty() }.size

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,4 +300,10 @@
     <string name="dashboard_device_remove_picker_title">Choose sync service</string>
     <string name="dashboard_device_remove_picker_message">This device is synced through multiple services. Pick which one to remove it from — you\'ll confirm on the next screen.</string>
 
+    <!-- Shared upgrade screen chrome (used by both flavors' upgrade screens). -->
+    <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
+    <string name="app_name_upgrade_postfix">Pro</string>
+    <string name="upgrade_screen_navigate_up">Navigate up</string>
+    <string name="upgrade_screen_progress_loading">Loading…</string>
+
 </resources>

--- a/app/src/test/java/eu/darken/octi/main/ui/settings/support/ContactSupportVMDiagnosticsTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/settings/support/ContactSupportVMDiagnosticsTest.kt
@@ -116,7 +116,7 @@ class ContactSupportVMDiagnosticsTest {
         val cv = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory }
         val diag = mockk<UpgradeDiagnostics>().apply {
             coEvery { debugInfo() } coAnswers {
-                delay(30_000) // far longer than the 2s diagnostics timeout
+                delay(30_000) // far longer than the diagnostics timeout
                 "TOO-SLOW"
             }
         }

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFossTest.kt
@@ -1,0 +1,36 @@
+package eu.darken.octi.common.upgrade.core
+
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Instant
+
+// Serialization of the persisted upgrade is covered by FossUpgradeSerializationTest.
+class UpgradeRepoFossTest : BaseTest() {
+
+    @Test
+    fun `test upgrade info pro status mapping`() {
+        UpgradeRepoFoss.Info(
+            isPro = false,
+            upgradedAt = null,
+        ).apply {
+            type shouldBe UpgradeRepo.Type.FOSS
+            isPro shouldBe false
+            // A local cache read is authoritative from the first emission, there is no billing
+            // handshake to wait out.
+            isSettled shouldBe true
+            error shouldBe null
+        }
+
+        UpgradeRepoFoss.Info(
+            isPro = true,
+            upgradedAt = Instant.fromEpochMilliseconds(0L),
+            fossUpgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+        ).apply {
+            isPro shouldBe true
+            upgradedAt shouldBe Instant.fromEpochMilliseconds(0L)
+            fossUpgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        }
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -1,0 +1,103 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import java.time.Duration
+
+/**
+ * Host-level counterpart to the ViewModel's sponsor-return tests: those prove the ViewModel reacts,
+ * they cannot prove the screen actually bridges the lifecycle to it. Only a real STOP/RESUME
+ * round-trip catches a missing or mis-scoped lifecycle effect, or a tracker that isn't seeded from
+ * the handle after a recreation.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var persisted = 0
+
+    private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        every { persistUpgrade() } answers { persisted++ }
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoFoss,
+        handle: SavedStateHandle = SavedStateHandle(),
+    ) = UpgradeViewModel(
+        handle = handle,
+        dispatcherProvider = TestDispatcherProvider(),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `a stop-resume round-trip after a sponsor launch runs the return check`() {
+        val repo = mockRepo()
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve here.
+        val vm = buildVm(repo)
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        // CREATED, not STARTED: only that far down does the activity emit ON_STOP, which is what
+        // "the browser took the foreground" looks like to the return tracker.
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.CREATED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        vm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    @Test
+    fun `a recreated screen consumes the pending sponsor launch on the first resume`() {
+        // Process death while the browser was in front: the fresh screen's tracker never saw the
+        // ON_STOP, so it has to be seeded from the handle or the first return is swallowed.
+        val handle = SavedStateHandle()
+        buildVm(mockRepo(), handle).goGithubSponsors()
+
+        val repo = mockRepo()
+        val recreatedVm = buildVm(repo, handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = recreatedVm)
+            }
+        }
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { persisted == 1 }
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -1,0 +1,171 @@
+package eu.darken.octi.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import kotlin.time.Instant
+import eu.darken.octi.common.R as CommonR
+
+class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val upgradedTitle: String
+        get() = "${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}"
+
+    @Test
+    fun `renders the pitch content without duplicated app bar title`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen()
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_why_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(firstFeatureLine(context, R.string.upgrade_screen_benefits_body))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_sponsor_action_hint))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(1)
+    }
+
+    @Test
+    fun `sponsor button invokes callback`() {
+        var clicked = false
+
+        composeRule.setUpgradeContent {
+            UpgradeScreen(onGithubSponsors = { clicked = true })
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_SPONSOR).performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle { clicked shouldBe true }
+    }
+
+    @Test
+    fun `free status view shows the status without any pitch content`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_FREE).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `upgrade options button invokes callback`() {
+        var clicked = false
+
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_FREE, onShowUpgradeOptions = { clicked = true })
+        }
+
+        composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS)
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle { clicked shouldBe true }
+    }
+
+    @Test
+    fun `upgraded status view thanks the supporter and offers a recurring donation`() {
+        val since = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
+        }
+
+        composeRule.onAllNodesWithText(upgradedTitle).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_supporter_body))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(
+            context.getString(R.string.upgrade_screen_supporter_since, formatted(since))
+        ).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the supporter-since line stays away without a date`() {
+        // UpgradeRepoFoss can report an upgrade whose timestamp predates the field: no date line
+        // instead of a bogus one.
+        composeRule.setUpgradeContent {
+            UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = null)
+        }
+
+        composeRule.onAllNodesWithText(
+            context.getString(
+                R.string.upgrade_screen_supporter_since,
+                formatted(Instant.fromEpochMilliseconds(0L)),
+            )
+        ).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the recurring donation button is wired to the unarmed sponsors entrypoint`() {
+        // Arming it would re-run the unlock on return and rewrite the supporter-since date shown
+        // right above it.
+        var armed = false
+        var unarmed = false
+
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                view = FossUpgradeView.STATUS_UPGRADED,
+                onGithubSponsors = { armed = true },
+                onOpenSponsors = { unarmed = true },
+            )
+        }
+
+        composeRule.onNodeWithTag(UpgradeScreenTags.FOSS_DONATE)
+            .performSemanticsAction(SemanticsActions.OnClick)
+
+        composeRule.runOnIdle {
+            unarmed shouldBe true
+            armed shouldBe false
+        }
+    }
+}
+
+private fun formatted(instant: Instant): String = DateTimeFormatter
+    .ofLocalizedDate(FormatStyle.MEDIUM)
+    .withZone(ZoneId.systemDefault())
+    .format(java.time.Instant.ofEpochMilli(instant.toEpochMilliseconds()))
+
+private fun ComposeContentTestRule.setUpgradeContent(
+    content: @Composable () -> Unit,
+) {
+    setContent {
+        PreviewWrapper {
+            content()
+        }
+    }
+}
+
+private fun firstFeatureLine(context: Context, resId: Int): String = context.getString(resId)
+    .lineSequence()
+    .map { it.trim() }
+    .first { it.startsWith("•") }
+    .removePrefix("•")
+    .trim()

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -71,6 +71,8 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(upgradedTitle).assertCountEquals(0)
     }
 
     @Test

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -179,6 +179,35 @@ class FossUpgradeViewModelTest : BaseTest() {
         upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
     }
 
+    /**
+     * Forced routes (widget configuration) never auto-close, so an upgraded user has to land on the
+     * status view — leaving them on the pitch would let its ARMED sponsor button rewrite the
+     * supporter-since date on a later long visit.
+     */
+    @Test
+    fun `forced route switches an upgrading user to the upgraded status without navigating`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        val pitchView = async { vm.state.first { it.view != null } }
+        vm.bindRoute(Nav.Main.Upgrade(forced = true))
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it.view == FossUpgradeView.STATUS_UPGRADED } }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+        navEvents.shouldBeEmpty()
+        collector.cancel()
+    }
+
     @Test
     fun `default route bounces an upgraded user out of the screen`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,0 +1,317 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.R
+import eu.darken.octi.common.navigation.Nav
+import eu.darken.octi.common.navigation.NavEvent
+import eu.darken.octi.common.upgrade.core.FossUpgrade
+import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import kotlin.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossUpgradeViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val upgradedAt = Instant.fromEpochMilliseconds(1_700_000_000_000L)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun upgradedInfo() = UpgradeRepoFoss.Info(
+        isPro = true,
+        upgradedAt = upgradedAt,
+        fossUpgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+    )
+
+    private fun mockRepo(
+        info: MutableStateFlow<UpgradeRepoFoss.Info> = MutableStateFlow(UpgradeRepoFoss.Info()),
+    ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
+        every { upgradeInfo } returns info
+    }
+
+    private fun buildVm(
+        repo: UpgradeRepoFoss = mockRepo(),
+        handle: SavedStateHandle = SavedStateHandle(),
+    ) = UpgradeViewModel(
+        handle = handle,
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        upgradeRepo = repo,
+    )
+
+    @Test
+    fun `manage route shows the free status to non-upgraded users`() = runTest2(context = testDispatcher) {
+        val vm = buildVm()
+
+        val view = async { vm.state.first { it.view != null } }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        view.await().view shouldBe FossUpgradeView.STATUS_FREE
+    }
+
+    @Test
+    fun `manage route shows the upgraded status to supporters`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val view = async { vm.state.first { it.view != null } }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        view.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `supporterSince reflects the repo's upgradedAt`() = runTest2(context = testDispatcher) {
+        // Derived in the same emission as the view: the upgraded status must never render a frame
+        // without the date it is supposed to carry.
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val state = async { vm.state.first { it.view != null } }
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        state.await() shouldBe UpgradeViewModel.State(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = upgradedAt,
+        )
+    }
+
+    @Test
+    fun `default and forced routes show the pitch`() = runTest2(context = testDispatcher) {
+        val defaultVm = buildVm()
+        val defaultView = async { defaultVm.state.first { it.view != null } }
+        defaultVm.bindRoute(Nav.Main.Upgrade())
+
+        val forcedVm = buildVm()
+        val forcedView = async { forcedVm.state.first { it.view != null } }
+        forcedVm.bindRoute(Nav.Main.Upgrade(forced = true))
+        advanceUntilIdle()
+
+        defaultView.await().view shouldBe FossUpgradeView.PITCH
+        forcedView.await().view shouldBe FossUpgradeView.PITCH
+    }
+
+    @Test
+    fun `asking for upgrade options switches the free status to the pitch`() = runTest2(context = testDispatcher) {
+        val vm = buildVm()
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+
+        val freeView = async { vm.state.first { it.view != null } }
+        advanceUntilIdle()
+        freeView.await().view shouldBe FossUpgradeView.STATUS_FREE
+
+        val pitchView = async { vm.state.first { it.view == FossUpgradeView.PITCH } }
+        vm.onShowUpgradeOptions()
+        advanceUntilIdle()
+
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+    }
+
+    @Test
+    fun `the upgrade-options choice survives process recreation`() = runTest2(context = testDispatcher) {
+        val handle = SavedStateHandle()
+        val firstVm = buildVm(handle = handle)
+        firstVm.bindRoute(Nav.Main.Upgrade(manage = true))
+        firstVm.onShowUpgradeOptions()
+        advanceUntilIdle()
+
+        // Same handle, fresh ViewModel — as after the process was killed on the pitch.
+        val recreatedVm = buildVm(handle = handle)
+        val view = async { recreatedVm.state.first { it.view != null } }
+        recreatedVm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        view.await().view shouldBe FossUpgradeView.PITCH
+    }
+
+    @Test
+    fun `completing the upgrade lands on the upgraded status even from the pitch`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        vm.onShowUpgradeOptions()
+
+        val pitchView = async { vm.state.first { it.view != null } }
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it.view == FossUpgradeView.STATUS_UPGRADED } }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+    }
+
+    @Test
+    fun `default route bounces an upgraded user out of the screen`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        vm.bindRoute(Nav.Main.Upgrade())
+        advanceUntilIdle()
+
+        navEvents shouldBe listOf(NavEvent.Up)
+        collector.cancel()
+    }
+
+    @Test
+    fun `manage route keeps an upgraded user on the screen`() = runTest2(context = testDispatcher) {
+        val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
+
+        val navEvents = mutableListOf<NavEvent>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.navEvents.collect { navEvents.add(it) } }
+
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+        advanceUntilIdle()
+
+        navEvents.shouldBeEmpty()
+        collector.cancel()
+    }
+
+    @Test
+    fun `a too-quick sponsor return only nudges, it does not upgrade`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val nudge = async { vm.snackbarEvents.first() }
+        vm.goGithubSponsors()
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        nudge.await() shouldBe R.string.upgrade_screen_sponsor_too_fast_msg
+        verify(exactly = 0) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a too-quick sponsor return stays silent for already upgraded users`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.snackbarEvents.collect { nudges.add(it) } }
+
+        vm.goGithubSponsors()
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        nudges.shouldBeEmpty()
+        verify(exactly = 0) { repo.persistUpgrade() }
+        collector.cancel()
+    }
+
+    @Test
+    fun `a sponsor return after the delay persists the upgrade`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = async { vm.toastEvents.first() }
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
+        verify(exactly = 1) { repo.persistUpgrade() }
+    }
+
+    /**
+     * Process death between the sponsor launch and the return: the screen's in-memory return
+     * tracker is gone, so the handle-backed pending launch has to carry the state across. Without
+     * it the very first return after a recreation is dropped and the supporter never gets unlocked.
+     */
+    @Test
+    fun `a sponsor return after process recreation still persists the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val handle = SavedStateHandle()
+        val firstVm = buildVm(handle = handle)
+        firstVm.goGithubSponsors()
+        advanceUntilIdle()
+
+        // Same handle, fresh ViewModel — as after the process was killed while the browser was up.
+        val repo = mockRepo()
+        val recreatedVm = buildVm(repo = repo, handle = handle)
+        recreatedVm.hasPendingSponsorLaunch() shouldBe true
+
+        val thanks = async { recreatedVm.toastEvents.first() }
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        recreatedVm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
+        verify(exactly = 1) { repo.persistUpgrade() }
+        // Consumed: a later resume must not re-run the unlock.
+        recreatedVm.hasPendingSponsorLaunch() shouldBe false
+    }
+
+    /**
+     * The recurring-donation entrypoint on the upgraded status is deliberately UNARMED. Routing it
+     * through the armed one would re-run the unlock on return and rewrite the "supporter since"
+     * date the status view exists to show — even for a long, genuine visit.
+     */
+    @Test
+    fun `a long unarmed sponsors visit leaves the supporter-since date alone`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+        vm.bindRoute(Nav.Main.Upgrade(manage = true))
+
+        val before = async { vm.state.first { it.view != null } }
+        advanceUntilIdle()
+        before.await().supporterSince shouldBe upgradedAt
+
+        vm.openSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        verify(exactly = 0) { repo.persistUpgrade() }
+
+        val after = async { vm.state.first { it.view != null } }
+        advanceUntilIdle()
+        after.await().supporterSince shouldBe upgradedAt
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/SponsorReturnTrackerTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/SponsorReturnTrackerTest.kt
@@ -1,0 +1,34 @@
+package eu.darken.octi.common.upgrade.ui
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class SponsorReturnTrackerTest : BaseTest() {
+
+    @Test
+    fun `resume only counts after background transition`() {
+        val tracker = SponsorReturnTracker()
+
+        tracker.consumeResumeReturn() shouldBe false
+
+        tracker.onStop()
+
+        tracker.consumeResumeReturn() shouldBe true
+        tracker.consumeResumeReturn() shouldBe false
+    }
+
+    /**
+     * The process can be killed while the sponsor page is in front, i.e. between the launch and the
+     * return. The recomposed screen gets a brand-new tracker that never saw the ON_STOP, so gating
+     * on in-memory state alone would swallow that first return for good. The handle-backed pending
+     * launch is the authority and seeds the tracker instead.
+     */
+    @Test
+    fun `a tracker seeded from a pending launch counts the first resume`() {
+        val tracker = SponsorReturnTracker(wentToBackground = true)
+
+        tracker.consumeResumeReturn() shouldBe true
+        tracker.consumeResumeReturn() shouldBe false
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
@@ -1,15 +1,25 @@
 package eu.darken.octi.common.upgrade.core
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.octi.common.datastore.value
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -20,50 +30,76 @@ class BillingCacheTest : BaseTest() {
     // would crash, not exercise anything real.
     @Test
     fun `stampLastProState round-trips through the DataStoreValues`() = runTest {
-        // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
-        // atomic stamp transaction writes and the keys/types the DataStoreValues read.
-        val cache = BillingCache(ApplicationProvider.getApplicationContext())
+        // Real time on purpose: the reads/writes below are bounded by cacheTimeoutMs, and the real
+        // DataStore does its I/O off the test scheduler -- under virtual time the bound would fire
+        // instantly while nothing else is scheduled.
+        withContext(Dispatchers.IO) {
+            // Real DataStore, no mocks: this catches an encoding mismatch between the raw keys the
+            // atomic stamp transaction writes and the keys/types the DataStoreValues read.
+            val cache = BillingCache(ApplicationProvider.getApplicationContext<Context>())
 
-        cache.lastProStateAt.value() shouldBe 0L
-        cache.lastProStateSku.value() shouldBe ""
+            cache.lastProStateAt.value() shouldBe 0L
+            cache.lastProStateSku.value() shouldBe ""
 
-        // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
-        // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
-        // install from one whose entitlement went missing.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 0L,
-            lastProStateSku = "",
-            proUnconfirmedSince = 0L,
-        )
+            // Defaults on a never-Pro install: this exact triple is what the debug-log header reports
+            // as "never / unknown-legacy / none", and it's the signal that separates a never-bought
+            // install from one whose entitlement went missing.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 0L,
+                lastProStateSku = "",
+                proUnconfirmedSince = 0L,
+            )
 
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
 
-        cache.lastProStateAt.value() shouldBe 1234L
-        cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 1234L
+            cache.lastProStateSku.value() shouldBe OurSku.Iap.PRO_UPGRADE.id
 
-        cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
+            cache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, 5678L)
 
-        cache.lastProStateAt.value() shouldBe 5678L
-        cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
+            cache.lastProStateAt.value() shouldBe 5678L
+            cache.lastProStateSku.value() shouldBe OurSku.Sub.PRO_UPGRADE.id
 
-        // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
-        // it, but must leave a NEWER episode intact — a connection failure that occurred after this
-        // confirmation but was processed out of order opened a still-valid episode.
-        cache.proUnconfirmedSince.value(4_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
-        cache.proUnconfirmedSince.value() shouldBe 0L
+            // Occurrence-aware episode clear: a confirmation closes an episode that began at or before
+            // it, but must leave a NEWER episode intact — a connection failure that occurred after this
+            // confirmation but was processed out of order opened a still-valid episode.
+            cache.proUnconfirmedSince.value(4_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 5_000L) // confirmation newer than episode
+            cache.proUnconfirmedSince.value() shouldBe 0L
 
-        cache.proUnconfirmedSince.value(9_000L)
-        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
-        cache.proUnconfirmedSince.value() shouldBe 9_000L
+            cache.proUnconfirmedSince.value(9_000L)
+            cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 8_000L) // confirmation older than episode
+            cache.proUnconfirmedSince.value() shouldBe 9_000L
 
-        // snapshot() must agree with the individual reads. It exists so the debug-log header reads
-        // all three in ONE DataStore emission: three separate reads can straddle a concurrent
-        // stampLastProState and report a combination that never existed.
-        cache.snapshot() shouldBe BillingCache.Snapshot(
-            lastProStateAt = 8_000L,
-            lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
-            proUnconfirmedSince = 9_000L,
-        )
+            // snapshot() must agree with the individual reads. It exists so the debug-log header reads
+            // all three in ONE DataStore emission: three separate reads can straddle a concurrent
+            // stampLastProState and report a combination that never existed.
+            cache.snapshot() shouldBe BillingCache.Snapshot(
+                lastProStateAt = 8_000L,
+                lastProStateSku = OurSku.Iap.PRO_UPGRADE.id,
+                proUnconfirmedSince = 9_000L,
+            )
+        }
     }
+
+    @Test
+    fun `a wedged datastore is bounded, reads fail loudly and writes fail soft`() = runTest {
+        // Fake store, no file: a second real DataStore on the same file would crash this process.
+        val cache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L }
+
+        // A timeout must not masquerade as a default snapshot -- "never bought" and "couldn't read
+        // the evidence" are the two things the debug-log header exists to tell apart.
+        shouldThrow<IOException> { cache.snapshot() }
+
+        // The write only decorates the entitlement path, it must never block it.
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+    }
+}
+
+/** DataStore that never answers -- stands in for a wedged file lock. */
+internal class HangingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { awaitCancellation() }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        awaitCancellation()
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -1,9 +1,12 @@
 package eu.darken.octi.common.upgrade.core
 
 import eu.darken.octi.main.core.CurriculumVitae
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -103,5 +106,53 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
 
         info shouldContain "lastProStateSku=${OurSku.Iap.PRO_UPGRADE.id}"
         info shouldContain "ProHistory=unavailable"
+    }
+
+    @Test
+    fun `a cancelled billing cache read is not swallowed`() = runTest {
+        val diag = UpgradeDiagnosticsGplay(
+            billingCache = mockk<BillingCache>().apply {
+                coEvery { snapshot() } throws CancellationException("scope died")
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+        )
+
+        shouldThrow<CancellationException> { diag.debugInfo() }
+    }
+
+    @Test
+    fun `a cancelled history read is not swallowed`() = runTest {
+        // Symmetric to the cache read: cancellation is not a diagnostics failure, it means the
+        // caller's scope died and the header read must unwind with it.
+        val diag = UpgradeDiagnosticsGplay(
+            billingCache = mockk<BillingCache>().apply {
+                coEvery { snapshot() } returns BillingCache.Snapshot(
+                    lastProStateAt = 0L,
+                    lastProStateSku = "",
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply {
+                coEvery { proHistory() } throws CancellationException("scope died")
+            },
+        )
+
+        shouldThrow<CancellationException> { diag.debugInfo() }
+    }
+
+    @Test
+    fun `a wedged billing cache is reported as unavailable, not as a never-pro install`() = runTest {
+        // End-to-end over a real BillingCache whose store never answers: the bounded read throws,
+        // and the header must say the evidence is missing instead of claiming "never bought".
+        val diag = UpgradeDiagnosticsGplay(
+            billingCache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+        )
+
+        val info = diag.debugInfo()
+
+        info shouldContain "BillingCache=unavailable"
+        info shouldNotContain "lastProStateAt=never"
+        info shouldContain "ProHistory=$proHistory"
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -1,0 +1,75 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
+import eu.darken.octi.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.octi.common.upgrade.core.billing.Sku
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+
+/**
+ * Host-level counterpart to the ViewModel's `onResume` tests: those prove the ViewModel re-queries,
+ * they cannot prove the screen actually asks it to. Only a real lifecycle round-trip catches a
+ * missing or mis-scoped ON_RESUME effect.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayUpgradeScreenHostTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null, isSettled = true))
+        every { wasEverPro } returns MutableStateFlow(false)
+        every { proUnconfirmedSince } returns MutableStateFlow(0L)
+        every { autoRestoreBusy } returns MutableStateFlow(false)
+        every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `returning to the screen re-runs a failed offers query`() {
+        val repo = mockRepo()
+        var queries = 0
+        coEvery { repo.querySkus(any()) } coAnswers {
+            queries++
+            throw GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        }
+        val vm = UpgradeViewModel(
+            handle = SavedStateHandle(),
+            dispatcherProvider = TestDispatcherProvider(),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        // The real ViewModel instance, passed explicitly: hiltViewModel() has nothing to resolve here.
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(vm = vm)
+            }
+        }
+
+        composeRule.waitUntil { vm.state.value is GplayUpgradeUiState.Unavailable }
+        val baseline = queries
+
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.STARTED)
+        composeRule.activityRule.scenario.moveToState(Lifecycle.State.RESUMED)
+        composeRule.waitForIdle()
+
+        composeRule.waitUntil { queries > baseline }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -154,8 +154,15 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_IAP).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_UNAVAILABLE).assertCountEquals(1)
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error_description)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_message))
+            .assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_benefits_title)).assertCountEquals(1)
+        // The card is about the prices, not about Play as a whole -- the generic service-unavailable
+        // title contradicted its own body.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_offers_unavailable_title))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error_title))
+            .assertCountEquals(0)
     }
 
     @Test
@@ -305,6 +312,26 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // would silently miss the button.
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo().performClick()
         composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+    }
+
+    @Test
+    fun `the retry latches after the first tap`() {
+        var retryClicks = 0
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Unavailable(
+                    error = RuntimeException("Google Play services unavailable"),
+                ),
+                onRetry = { retryClicks++ },
+            )
+        }
+
+        val retry = composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).performScrollTo()
+        retry.performClick()
+        retry.performClick()
+
+        composeRule.runOnIdle { check(retryClicks == 1) { "expected 1 retry click, got $retryClicks" } }
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RETRY).assertIsNotEnabled()
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -118,6 +118,117 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `onResume retries the query after a failure`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Octi has no app-level resume refresh -- coming back to the screen after a Play outage has
+        // to re-run the screen-local SKU query.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        val vm = buildVm(repo)
+
+        // WhileSubscribed: without a live subscriber the retry has no upstream to re-run.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 1) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Sub.PRO_UPGRADE) }
+    }
+
+    @Test
+    fun `onResume does not re-query when offers are already loaded`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `onResume refreshes the subscription of a loaded owner`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The octi-specific half of the dual-purpose resume: returning from Play's management page
+        // must heal a just-cancelled renewal, otherwise the switch button stays locked.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
+        )
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.queryCurrentSubscriptions() }
+    }
+
+    @Test
+    fun `onResume does not refresh the subscription of a loaded non-owner`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // No subscription to heal -- a Play round-trip here would be pure noise.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = buildVm(repo)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+    }
+
+    @Test
+    fun `onResume in the unavailable state retries the skus without a subscription refresh`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The two branches are mutually exclusive: there is no ownership data to refresh while the
+        // screen couldn't even load its offers.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+        val vm = buildVm(repo)
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+
+        vm.onResume()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.querySkus(OurSku.Iap.PRO_UPGRADE) }
+        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+    }
+
+    @Test
     fun `a single failed product type keeps the screen loaded and surfaces the error once`() = runTest2(
         context = testDispatcher,
     ) {

--- a/app/src/testGplay/java/eu/darken/octi/main/ui/settings/support/ContactSupportVMDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/main/ui/settings/support/ContactSupportVMDiagnosticsGplayTest.kt
@@ -1,0 +1,92 @@
+package eu.darken.octi.main.ui.settings.support
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.WebpageTool
+import eu.darken.octi.common.debug.recording.core.DebugSessionManager
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.core.BillingCache
+import eu.darken.octi.common.upgrade.core.HangingPreferencesDataStore
+import eu.darken.octi.common.upgrade.core.UpgradeDiagnosticsGplay
+import eu.darken.octi.main.core.CurriculumVitae
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import kotlin.time.Instant
+
+// Robolectric: sendEmail() builds an Intent and calls context.startActivity, which we capture via
+// the shadow application to assert what reached the support email body.
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class ContactSupportVMDiagnosticsGplayTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val proHistory = CurriculumVitae.ProHistory(
+        lastState = CurriculumVitae.ProState.PURCHASED,
+        graceEngagedCount = 3,
+        graceEngagedLast = null,
+        proLostCount = 0,
+        proLostLast = null,
+    )
+
+    private fun info(isPro: Boolean = true) = object : UpgradeRepo.Info {
+        override val type = UpgradeRepo.Type.GPLAY
+        override val isPro = isPro
+        override val isSettled = true
+        override val upgradedAt: Instant? = null
+        override val error: Throwable? = null
+    }
+
+    private fun sentBody(): String? {
+        val chooser = Shadows.shadowOf(context as Application).nextStartedActivity ?: return null
+        val send = chooser.getParcelableExtra<Intent>(Intent.EXTRA_INTENT) ?: chooser
+        return send.getStringExtra(Intent.EXTRA_TEXT)
+    }
+
+    @Test
+    fun `a wedged billing cache reaches the support email as unavailable`() = runTest(testDispatcher) {
+        // The diagnostics bound its own billing cache read; the VM's outer budget must be wide
+        // enough to let that verdict come back. If the outer budget expires first, the email
+        // silently ships without the diagnostic instead of with "BillingCache=unavailable".
+        val vm = ContactSupportVM(
+            dispatcherProvider = TestDispatcherProvider(testDispatcher),
+            sessionManager = mockk<DebugSessionManager>(relaxed = true).apply {
+                every { state } returns emptyFlow()
+            },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+                every { upgradeInfo } returns MutableStateFlow(info())
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+            upgradeDiagnostics = UpgradeDiagnosticsGplay(
+                billingCache = BillingCache(HangingPreferencesDataStore()).apply { cacheTimeoutMs = 50L },
+                curriculumVitae = mockk<CurriculumVitae>().apply { coEvery { proHistory() } returns proHistory },
+            ),
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+            context = context,
+        )
+
+        vm.sendEmail()
+        advanceUntilIdle()
+
+        val body = sentBody()!!
+        body shouldContain "BillingCache=unavailable"
+        body shouldNotContain "lastProStateAt=never"
+    }
+}


### PR DESCRIPTION
## What changed

FOSS version: the upgrade and supporter-status screens were rebuilt on the shared design used across the app family — a clear sponsor pitch, a calm free-status page, and a supporter-status page that now shows since when you've been a supporter. Completing a GitHub Sponsors donation is no longer lost if Android killed the app in the background while the browser was open, and upgrading from the widget-configuration flow now lands on the supporter status instead of back on the sales pitch.

Google Play version: if prices couldn't be loaded, simply returning to the upgrade screen now retries automatically, the error card says "Prices unavailable" instead of a generic connection error, and the retry button can no longer be double-triggered.

For support: debug logs can no longer stall or silently lose the billing diagnostic when the billing cache is slow — a wedged cache is reported as unavailable instead of looking like a never-bought install.

## Technical Context

- Continues the family-wide convergence on the shared canonical billing/upgrade implementation: `UpgradeContent.kt` moves to `src/main` so both flavors compose from the same building blocks, and the FOSS screen/ViewModel are the canonical port (view-state combine, return tracker seeded from the SavedStateHandle-backed pending launch so it survives process death, supporter-since derived atomically with the view).
- Deliberate deviations from the canonical source, each defect-driven: the armed/unarmed sponsor-entrypoint split is kept — routing the recurring-donation button through the armed unlock path would rewrite the "supporter since" date on a later long visit; forced routes (widget configuration) select the upgraded-status view because they never auto-close; widget refresh stays solely owned by the app-scope entitlement observer rather than gaining a duplicate ViewModel-local path.
- Billing cache reads/writes are bounded (2s). A timed-out snapshot throws instead of returning defaults, so the debug-log header reports `BillingCache=unavailable` rather than misreporting a wedged cache as never-Pro. The constructor now takes the DataStore directly — same `settings_gplay` backing file, no data migration. The support-email diagnostics budget rose from 2s to 5s so the outer timeout can no longer cancel the inner one before it renders its verdict.
- The gplay screen's resume handling is dual-purpose: it retries the offers query when the screen sits in the unavailable state (octi has no activity-level resume refresh), and keeps the existing subscription-renewal refresh for owners returning from Play.
- Review guidance: FOSS supporter records keep the existing serialization schema — legacy upgrade types decode unchanged and existing supporters keep Pro. The repo method renames are call-site-complete. Two new host-level lifecycle tests (first of their kind in this repo) prove the ON_RESUME wiring and the recreation seeding actually fire, rather than only testing the ViewModel directly.
