### PR TITLE
Brand the FOSS supporter screens and harden the sponsor flow

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/WebpageTool.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/WebpageTool.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import javax.inject.Inject
 
@@ -14,14 +15,18 @@ class WebpageTool @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
 
-    fun open(address: String) {
+    // Returns whether an activity was actually started, so callers that gate behaviour on the page
+    // having opened (e.g. the FOSS sponsor unlock heuristic) don't fire when no browser handled it.
+    fun open(address: String): Boolean {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(address)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        try {
+        return try {
             context.startActivity(intent)
+            true
         } catch (e: Exception) {
-            log(ERROR) { "Failed to launch" }
+            log(ERROR) { "Failed to launch: ${e.asLog()}" }
+            false
         }
     }
 

--- a/app-common/src/test/java/eu/darken/octi/common/WebpageToolTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/WebpageToolTest.kt
@@ -1,0 +1,58 @@
+package eu.darken.octi.common
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The return value is a contract, not a convenience: the FOSS sponsor unlock heuristic only arms
+ * when the page actually opened. Every swallow point has to report the failure back.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WebpageToolTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a launched page reports success`() {
+        WebpageTool(application).open(URL) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data.toString() shouldBe URL
+    }
+
+    @Test
+    fun `a missing browser reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw ActivityNotFoundException("No browser")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    @Test
+    fun `a denied launch reports failure`() {
+        // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
+        // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw SecurityException("Permission Denial")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    companion object {
+        private const val URL = "https://github.com/sponsors/d4rken"
+    }
+}

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
@@ -1,17 +1,14 @@
 package eu.darken.octi.common.upgrade.core
 
 import eu.darken.octi.common.WebpageTool
-import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.datastore.valueBlocking
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.upgrade.UpgradeRepo
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -20,7 +17,6 @@ import kotlin.time.Instant
 
 @Singleton
 class UpgradeRepoFoss @Inject constructor(
-    @AppScope private val appScope: CoroutineScope,
     private val fossCache: FossCache,
     private val webpageTool: WebpageTool,
 ) : UpgradeRepo {
@@ -46,9 +42,11 @@ class UpgradeRepoFoss @Inject constructor(
     }
         .setupCommonEventHandlers(TAG) { "upgradeInfo" }
 
-    fun openGithubSponsorsPage() {
+    // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
+    // only arms on a successful launch, and a fire-and-forget coroutine can't report that back.
+    fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
-        appScope.launch { webpageTool.open(upgradeSite) }
+        return webpageTool.open(upgradeSite)
     }
 
     fun persistUpgrade() {

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -107,8 +107,17 @@ class UpgradeViewModel @Inject constructor(
     /** The pitch's sponsor button: arms the unlock heuristic, so a real visit unlocks on return. */
     fun goGithubSponsors() {
         log(TAG) { "goGithubSponsors()" }
+        if (hasPendingSponsorLaunch()) {
+            log(TAG) { "A sponsor launch is already awaiting its return" }
+            return
+        }
+        // Only arm the heuristic if the page actually opened; otherwise an unrelated later
+        // background/foreground round-trip would grant supporter status with no page ever shown.
+        if (!upgradeRepo.openGithubSponsorsPage()) {
+            log(TAG) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            return
+        }
         handle[KEY_SPONSOR_PRESSED_AT] = SystemClock.elapsedRealtime()
-        upgradeRepo.openGithubSponsorsPage()
     }
 
     /**
@@ -132,18 +141,21 @@ class UpgradeViewModel @Inject constructor(
 
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+
+        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
+        // resetting the "supporter since" date the status screen shows them.
+        if (upgradeRepo.upgradeInfo.first().isPro) {
+            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+            return@launch
+        }
+
         val elapsed = SystemClock.elapsedRealtime() - pressedAt
         log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
         if (elapsed < SPONSOR_DELAY_MS) {
-            // The nudge belongs to the unlock heuristic. An already upgraded user has nothing to
-            // unlock — peeking at the page needs no feedback.
-            if (upgradeRepo.upgradeInfo.first().isPro) {
-                log(TAG) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
-            } else {
-                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast_msg)
-            }
+            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast_msg)
         } else {
             log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
             upgradeRepo.persistUpgrade()

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Vereis Octi Pro</string>
     <string name="upgrades_dashcard_title">Kry Octi Pro</string>
     <string name="upgrades_dashcard_body">Ontsluit ekstra kenmerke en word \'n ondersteuner om voortdurende ontwikkeling te help!</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">أوكتي حر ومفتوح المصدر</string>
     <string name="upgrade_feature_requires_pro">يتطلب أوكتي احترافي</string>
     <string name="upgrades_dashcard_title">احصل على أوكتي احترافي</string>
     <string name="upgrades_dashcard_body">افتح ميزات إضافية وكن راعيًا لدعم التطوير المستمر!</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Cal l\'Octi Pro</string>
     <string name="upgrades_dashcard_title">Obtén l\'Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al desenvolupament continu!</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Vyžaduje Octi Pro</string>
     <string name="upgrades_dashcard_title">Získat Octi Pro</string>
     <string name="upgrades_dashcard_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Kræver Octi Pro</string>
     <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås op for ekstra funktioner og bliv en sponsor for at støtte fortsat udvikling!</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Erfordert Octi Pro</string>
     <string name="upgrades_dashcard_title">Hole dir Octi Pro</string>
     <string name="upgrades_dashcard_body">Schalte zusätzliche Funktionen frei und unterstütze die Weiterentwicklung!</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Απαιτεί το Octi Pro</string>
     <string name="upgrades_dashcard_title">Αποκτήστε το Octi Pro</string>
     <string name="upgrades_dashcard_body">Ξεκλειδώστε επιπλέον λειτουργίες και γίνετε υποστηρικτής για να ενισχύσετε τη συνεχή ανάπτυξη!</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere Octi Pro</string>
     <string name="upgrades_dashcard_title">Obtener Octi Pro</string>
     <string name="upgrades_dashcard_body">¡Desbloquea funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Vaatii Octi Pro:n</string>
     <string name="upgrades_dashcard_title">Hanki Octi Pro</string>
     <string name="upgrades_dashcard_body">Avaa lisäominaisuuksia ja auta tukemaan jatkuvaa kehitystä liittymällä tukijaksi!</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi, version libre</string>
     <string name="upgrade_feature_requires_pro">Seulement avec Octi Pro</string>
     <string name="upgrades_dashcard_title">Obtenir Octi Pro</string>
     <string name="upgrades_dashcard_body">Accédez à des fonctions supplémentaires et financez le développement permanent de l’appli</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Octi Pro szükséges</string>
     <string name="upgrades_dashcard_title">Szerezze be az Octi Pro-t</string>
     <string name="upgrades_dashcard_body">Oldjon fel további funkciókat és legyen támogató a folyamatos fejlesztéshez!</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Richiede Octi Pro</string>
     <string name="upgrades_dashcard_title">Ottieni Octi Pro</string>
     <string name="upgrades_dashcard_body">Sblocca funzionalità aggiuntive e diventa sostenitore dello sviluppo dell\'applicazione!</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">דורש Octi פרימיום</string>
     <string name="upgrades_dashcard_title">קבל את Octi פרמיום</string>
     <string name="upgrades_dashcard_body">פתח תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Octi Pro が必要です</string>
     <string name="upgrades_dashcard_title">Octi Pro を入手</string>
     <string name="upgrades_dashcard_body">追加機能の入手と支援者になって断続的な開発をサポートしましょう！</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Octi Pro가 필요합니다</string>
     <string name="upgrades_dashcard_title">Octi Pro 얻기</string>
     <string name="upgrades_dashcard_body">추가 기능을 잠금 해제하고 계속된 개발을 지원하는 후원자가 되어주세요!</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Krever Octi Pro</string>
     <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås opp flere funksjoner og bli en beskytter for å støtte videre utvikling!</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Octi Pro vereist</string>
     <string name="upgrades_dashcard_title">Krijg Octi Pro</string>
     <string name="upgrades_dashcard_body">Ontgrendel extra functies en word een sponsor om verdere ontwikkeling te steunen!</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Wymaga Octi Pro</string>
     <string name="upgrades_dashcard_title">Uzyskaj Octi Pro</string>
     <string name="upgrades_dashcard_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer Octi Pro</string>
     <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer Octi Pro</string>
     <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrocinador para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Necesită Octi Pro</string>
     <string name="upgrades_dashcard_title">Obține Octi Pro</string>
     <string name="upgrades_dashcard_body">Deblochează funcții suplimentare și devino patron pentru a susține dezvoltarea continuă!</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Требуется Octi Pro</string>
     <string name="upgrades_dashcard_title">Получить Octi Pro</string>
     <string name="upgrades_dashcard_body">Разблокируйте дополнительные функции и станьте спонсором для поддержки дальнейшей разработки!</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Zahteva Octi Pro</string>
     <string name="upgrades_dashcard_title">Dobijte Octi Pro</string>
     <string name="upgrades_dashcard_body">Otključajte dodatne funkcije i postanite pokrovitelj za podršku daljem razvoju!</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Kräver Octi Pro</string>
     <string name="upgrades_dashcard_title">Skaffa Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Octi Pro gereklidir</string>
     <string name="upgrades_dashcard_title">Octi Pro Al</string>
     <string name="upgrades_dashcard_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Потрібен Octi Pro</string>
     <string name="upgrades_dashcard_title">Отримати Octi Pro</string>
     <string name="upgrades_dashcard_body">Відкрийте додаткові функції та підтримайте подальший розвиток!</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">Yêu cầu Octi Pro</string>
     <string name="upgrades_dashcard_title">Nhận Octi Pro</string>
     <string name="upgrades_dashcard_body">Mở khóa các tính năng bổ sung và trở thành nhà bảo trợ để hỗ trợ phát triển liên tục!</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">请求Octi Pro</string>
     <string name="upgrades_dashcard_title">获取Octi Pro</string>
     <string name="upgrades_dashcard_body">解锁附加功能并成为赞助人以支持持续发展！</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 Octi Pro</string>
     <string name="upgrades_dashcard_title">取得 Octi Pro</string>
     <string name="upgrades_dashcard_body">解鎖額外功能並成為支持者，協助持續開發！</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi FOSS</string>
+    <string name="app_name_upgraded" translatable="false">Octi FOSS</string>
 
+    <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requires Octi Pro</string>
 

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/BillingCache.kt
@@ -12,8 +12,10 @@ import eu.darken.octi.common.datastore.basicReader
 import eu.darken.octi.common.datastore.basicWriter
 import eu.darken.octi.common.datastore.createValue
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
@@ -93,14 +95,24 @@ class BillingCache internal constructor(
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
-        withTimeoutOrNull(cacheTimeoutMs) {
-            dataStore.edit { prefs ->
-                prefs[lastProStateSkuKey] = skuId
-                prefs[lastProStateAtKey] = at
-                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-            }
-        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        // A wedged file lock (timeout) and a broken write (IOException, corrupt file, no disk space)
+        // are the same to the caller — the stamp is lost, the bookkeeping around it carries on.
+        try {
+            withTimeoutOrNull(cacheTimeoutMs) {
+                dataStore.edit { prefs ->
+                    prefs[lastProStateSkuKey] = skuId
+                    prefs[lastProStateAtKey] = at
+                    val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                    if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+                }
+            } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        } catch (e: CancellationException) {
+            // Caught before the general case on purpose: our caller going away is not a write
+            // failure, and swallowing it would break their structured concurrency.
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState($skuId, $at) failed, write skipped: ${e.asLog()}" }
+        }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -7,6 +7,7 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.upgrade.UpgradeDiagnostics
 import eu.darken.octi.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Instant
@@ -28,6 +29,10 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
+    // Test seam: the bounded read below runs on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var historyTimeoutMs: Long = HISTORY_TIMEOUT_MS
+
     override suspend fun debugInfo(): String {
         val cache = try {
             val snapshot = billingCache.snapshot()
@@ -48,7 +53,12 @@ class UpgradeDiagnosticsGplay @Inject constructor(
         // and the counters only cover installs new enough to have them. A failure to read one must
         // not suppress the other's independent evidence.
         val history = try {
-            curriculumVitae.proHistory().toString()
+            // Bounded like the cache read above: a wedged DataStore file lock would otherwise hold
+            // the debug-log header - and with it the start of the recording - forever.
+            withTimeoutOrNull(historyTimeoutMs) { curriculumVitae.proHistory().toString() } ?: run {
+                log(TAG, WARN) { "Pro history timed out after ${historyTimeoutMs}ms" }
+                "unavailable"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -59,6 +69,7 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     }
 
     companion object {
+        private const val HISTORY_TIMEOUT_MS = 2_000L
         private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -38,6 +38,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
 
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
+        every { openGithubSponsorsPage() } returns true
         every { persistUpgrade() } answers { persisted++ }
     }
 

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -14,6 +14,7 @@ import eu.darken.octi.R
 import eu.darken.octi.common.compose.PreviewWrapper
 import io.kotest.matchers.shouldBe
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -96,6 +97,9 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen(view = FossUpgradeView.STATUS_UPGRADED, supporterSince = since)
         }
 
+        // Literal on purpose: the resource-derived helper would follow a wrong postfix along. FOSS
+        // has no "Pro" to sell, so the upgraded title has to read "Octi FOSS".
+        composeRule.onAllNodesWithText("Octi FOSS").assertCountEquals(1)
         composeRule.onAllNodesWithText(upgradedTitle).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_STATUS_UPGRADED).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_supporter_body))
@@ -147,6 +151,29 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             unarmed shouldBe true
             armed shouldBe false
         }
+    }
+
+    /**
+     * "FOSS" is the flavor's name, not prose. French and Arabic used to translate the upgraded app
+     * name, which also broke DashboardScreen's two-tone title: it colours the second of exactly two
+     * space-separated tokens, and "Octi, version libre" / the four-token Arabic variant fall out of
+     * that branch entirely. These resolve through the real resource merger, so a stray locale copy
+     * coming back would fail here.
+     */
+    @Test
+    @Config(qualifiers = "fr")
+    fun `the upgraded app name is not translated in french`() {
+        context.getString(R.string.app_name_upgraded) shouldBe "Octi FOSS"
+        context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
+        context.getString(R.string.app_name_upgraded).split(" ").size shouldBe 2
+    }
+
+    @Test
+    @Config(qualifiers = "ar")
+    fun `the upgraded app name is not translated in arabic`() {
+        context.getString(R.string.app_name_upgraded) shouldBe "Octi FOSS"
+        context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
+        context.getString(R.string.app_name_upgraded).split(" ").size shouldBe 2
     }
 }
 

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -62,6 +62,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         info: MutableStateFlow<UpgradeRepoFoss.Info> = MutableStateFlow(UpgradeRepoFoss.Info()),
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
+        every { openGithubSponsorsPage() } returns true
     }
 
     private fun buildVm(
@@ -342,5 +343,93 @@ class FossUpgradeViewModelTest : BaseTest() {
         val after = async { vm.state.first { it.view != null } }
         advanceUntilIdle()
         after.await().supporterSince shouldBe upgradedAt
+    }
+
+    @Test
+    fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Persisting again would rewrite upgradedAt and visibly reset the "supporter since" date the
+        // status screen shows — and the thanks toast belongs to the unlock, which already happened.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        verify(exactly = 0) { repo.persistUpgrade() }
+        nudges.shouldBeEmpty()
+        thanks.shouldBeEmpty()
+        // Consumed even though nothing happened: a later resume must not re-run the unlock.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        verify(exactly = 0) { repo.persistUpgrade() }
+        nudges.shouldBeEmpty()
+        thanks.shouldBeEmpty()
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // A silently failed launch must not leave the heuristic armed: an unrelated later
+        // background round-trip would otherwise hand out supporter status for free.
+        val repo = mockRepo()
+        every { repo.openGithubSponsorsPage() } returns false
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // And the failure must not brick the button either — the next working attempt arms as usual.
+        every { repo.openGithubSponsorsPage() } returns true
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+    }
+
+    @Test
+    fun `a second sponsor tap while a launch is pending opens the page only once`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The suppressed tap must also leave the armed timestamp alone: rewriting it would restart
+        // the five second window, so a genuine long visit would come back as "too quick".
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        // Collected, not awaited: a regression must fail on the assertion below instead of hanging
+        // this test on a toast that never arrives.
+        val thanks = mutableListOf<Int>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(4))
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(2))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        // 6s since the FIRST tap: the second one neither reopened the page nor rearmed the clock.
+        verify(exactly = 1) { repo.persistUpgrade() }
+        verify(exactly = 1) { repo.openGithubSponsorsPage() }
+        thanks shouldBe listOf(R.string.upgrade_screen_thanks_toast)
+        toastCollector.cancel()
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/BillingCacheTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.octi.common.datastore.value
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +95,28 @@ class BillingCacheTest : BaseTest() {
         // The write only decorates the entitlement path, it must never block it.
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
     }
+
+    @Test
+    fun `a failing datastore write does not abort the entitlement bookkeeping`() = runTest {
+        // A broken write (corrupt file, no disk space) is not the same failure as a wedged lock, and
+        // the timeout alone doesn't cover it -- the exception would propagate straight through the
+        // stamp into the caller that was only decorating its entitlement work.
+        val cache = BillingCache(ThrowingPreferencesDataStore())
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        // Reads stay loud: a snapshot that can't be read must not look like "never bought".
+        shouldThrow<IOException> { cache.snapshot() }
+    }
+
+    @Test
+    fun `a cancelled stamp still cancels`() = runTest {
+        // Fail-soft must not extend to cancellation -- swallowing it would break the structured
+        // concurrency of whatever entitlement work is being torn down.
+        val cache = BillingCache(CancellingPreferencesDataStore())
+
+        shouldThrow<CancellationException> { cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L) }
+    }
 }
 
 /** DataStore that never answers -- stands in for a wedged file lock. */
@@ -102,4 +125,20 @@ internal class HangingPreferencesDataStore : DataStore<Preferences> {
 
     override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
         awaitCancellation()
+}
+
+/** DataStore whose I/O fails -- stands in for a corrupt file or a full disk. */
+internal class ThrowingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Preferences file is broken") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw IOException("Preferences file is broken")
+}
+
+/** DataStore whose write is cancelled from the outside. */
+internal class CancellingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw CancellationException("Torn down") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw CancellationException("Torn down")
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -2,12 +2,17 @@ package eu.darken.octi.common.upgrade.core
 
 import eu.darken.octi.main.core.CurriculumVitae
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
@@ -154,5 +159,39 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         info shouldContain "BillingCache=unavailable"
         info shouldNotContain "lastProStateAt=never"
         info shouldContain "ProHistory=$proHistory"
+    }
+
+    @Test
+    fun `a wedged history is reported as unavailable`() = runTest {
+        // Counterpart to the wedged cache above: a never-answering CurriculumVitae store would hold
+        // the debug-log header -- and with it the start of the recording -- forever.
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = mockk<BillingCache>().apply {
+                coEvery { snapshot() } returns BillingCache.Snapshot(
+                    lastProStateAt = 0L,
+                    lastProStateSku = "",
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply {
+                coEvery { proHistory() } coAnswers { awaitCancellation() }
+            },
+        ).apply { historyTimeoutMs = 50L }
+
+        // Real time on purpose: the bound below runs on real dispatchers, virtual time would skip it.
+        // The outer envelope is independent of the seam -- if the bound is ignored entirely, this
+        // fails as a timeout instead of hanging the suite.
+        withContext(Dispatchers.IO) {
+            val start = System.currentTimeMillis()
+            val info = withTimeout(10_000L) { diagnostics.debugInfo() }
+            val elapsed = System.currentTimeMillis() - start
+
+            // Materially below the 2s production bound: proves the seam was honoured, with plenty
+            // of CI margin over the 50ms it was set to.
+            elapsed shouldBeLessThan 1_000L
+            // The cache read is independent evidence and must still be reported.
+            info shouldContain "BillingCache(lastProStateAt=never"
+            info shouldContain "ProHistory=unavailable"
+        }
     }
 }


### PR DESCRIPTION
## What changed

FOSS version: the supporter screens now brand themselves "Octi FOSS" — previously the upgraded title said "Octi Pro" in every language, contradicting the flavor's own labels. The "Octi FOSS" name is also no longer translatable: French and Arabic had it translated into multi-word phrases, which silently disabled the two-tone brand coloring on the dashboard title. Supporter status is now only granted when the GitHub Sponsors page launch actually went through — if no browser could handle the link, coming back later no longer counts as a visit, a second tap while a visit is pending doesn't fire twice, and an existing supporter returning from the sponsors page can no longer accidentally reset their "supporter since" date.

For support: a wedged billing store can no longer stall the pro-history part of the support-email diagnostics — it degrades to "unavailable" while the rest still reports. A failed write to the purchase cache also no longer interrupts the surrounding entitlement bookkeeping.

## Technical Context

- Propagates the latest canonical billing/upgrade batch (follow-up to #350). Octi originated the armed/unarmed sponsor-button split; this completes the flow around it: `WebpageTool.open()` returns whether an activity was actually started (documented as "launch accepted", not "page rendered"), `openGithubSponsorsPage()` is synchronous so the return-after-5s heuristic arms only on success behind a single-flight guard, and `checkSponsorReturn()` consumes the pending key and returns quietly for already-Pro users before the duration check. The now-unused `appScope` was removed from `UpgradeRepoFoss`.
- `stampLastProState()` was fail-soft for timeouts only; thrown write exceptions now degrade to a logged skip (cancellation rethrown, covered by dedicated fakes). Reads stay loud.
- The GPlay diagnostics' pro-history read gets the same 2s bound its billing-cache read already had — per-source isolation, so a wedged history yields "cache reported, ProHistory=unavailable" instead of the whole diagnostic block timing out at the caller's envelope. The debug recorder needed no change here: octi's recorder writes no diagnostics header, and its support-email reader already bounds each source at 5s.
- Resources: the FOSS flavor gains its missing `app_name_upgrade_postfix` override ("FOSS", non-translatable — the string previously resolved to main's "Pro" everywhere), and `app_name_upgraded` is non-translatable with its 29 FOSS locale entries removed. GPlay resources are untouched.
- Review guidance: locale-qualified tests (fr/ar) assert both brand tokens resolve to the intended two-token values — exactly the condition the dashboard's split-coloring branch checks; the single-flight test proves a suppressed second tap preserves the original arm timestamp; the wedge test runs on real dispatchers with a 50ms seam, a sub-1s ceiling, and an independent 10s envelope.
