### PR TITLE
Protect the supporter date and improve the debug log warning

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/flow/DynamicStateFlow.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/flow/DynamicStateFlow.kt
@@ -5,7 +5,10 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.runBlocking
@@ -129,17 +132,27 @@ class DynamicStateFlow<T>(
      *
      * Any errors that occurred during [action] will be rethrown by this method.
      */
-    suspend fun updateBlocking(action: suspend T.() -> T): T {
+    suspend fun updateBlocking(action: suspend T.() -> T): T = coroutineScope {
         val update: Update<T> = Update(onModify = action)
+
+        // Subscribe BEFORE emitting: UNDISPATCHED runs the awaiter synchronously up to its first
+        // suspension inside first's collect, so the collector is registered on the shared flow
+        // before the update can be processed. Emitting first is a lost wakeup: a fast producer
+        // plus a reactive collector (RecorderModule reacts to shouldRecord changes with its own
+        // updates) can process our update AND a successor before we subscribe, displacing our
+        // State from the replay-1 cache — the await then never completes.
+        val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+            internalFlow.first { it.updatedBy == update }
+        }
         updateActions.emit(update)
 
         lTag?.let { log(it, VERBOSE) { "Waiting for update." } }
-        val ourUpdate = internalFlow.first { it.updatedBy == update }
+        val ourUpdate = awaiter.await()
         lTag?.let { log(it, VERBOSE) { "Finished waiting, got $ourUpdate" } }
 
         ourUpdate.error?.let { throw it }
 
-        return ourUpdate.value
+        ourUpdate.value
     }
 
     private data class Update<T>(

--- a/app-common/src/test/java/eu/darken/octi/common/flow/DynamicStateFlowTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/flow/DynamicStateFlowTest.kt
@@ -2,22 +2,30 @@ package eu.darken.octi.common.flow
 
 import eu.darken.octi.common.collections.mutate
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import testhelpers.flow.test
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.thread
 
 class DynamicStateFlowTest : BaseTest() {
@@ -274,6 +282,63 @@ class DynamicStateFlowTest : BaseTest() {
         testCollector.latestValues shouldBe listOf(2, 3, 0)
 
         testCollector.cancelAndJoin()
+    }
+
+    /**
+     * Pre-fix, [DynamicStateFlow.updateBlocking] emitted its update BEFORE subscribing to the
+     * shared flow. Under contention its awaited State could be displaced from the replay-1 cache
+     * by a successor update before the subscription existed, and the await then never completed
+     * (jstack-verified: the pre-fix suite wedged a CI runner until the 6h job timeout). This pins
+     * the subscribe-before-emit contract, and the timeout envelope turns any regression into a
+     * fast failure instead of another wedged runner.
+     */
+    @Test
+    fun `concurrent blocking updates survive a reactive collector`() {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val hotData = DynamicStateFlow(
+                loggingTag = "tag",
+                parentScope = scope,
+                startValueProvider = { 0 },
+            )
+
+            // Mirrors RecorderModule: a collector that reacts to every state with an update of its
+            // own, keeping the producer busy between the other callers' updates. The echo updates
+            // are value-neutral so the final count stays exact, and capped so the echo terminates.
+            val echoes = AtomicInteger(0)
+            val subscribed = CompletableDeferred<Unit>()
+            scope.launch {
+                hotData.flow.collect { value ->
+                    subscribed.complete(Unit)
+                    if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
+                        hotData.updateAsync { this + 0 }
+                    }
+                }
+            }
+
+            runBlocking {
+                withTimeout(20_000) {
+                    // The contention only means anything with the reactive collector actually
+                    // attached: its first received value proves the subscription exists.
+                    subscribed.await()
+
+                    val workers = (1..2).map {
+                        launch(Dispatchers.IO) {
+                            repeat(100) { hotData.updateBlocking { this + 1 } }
+                        }
+                    }
+                    workers.forEach { it.join() }
+                    workers.all { it.isCompleted } shouldBe true
+
+                    hotData.flow.first() shouldBe 200
+                    // Non-vacuity: without a single echo there was no successor update to displace
+                    // an awaited State, and the test would pass for the wrong reason.
+                    echoes.get() shouldBeGreaterThan 0
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 
     @Test

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/core/FossCache.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/core/FossCache.kt
@@ -10,16 +10,20 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.fossCacheDataStore by preferencesDataStore(name = "settings_foss")
+
 @Singleton
-class FossCache @Inject constructor(
-    @ApplicationContext private val context: Context,
+class FossCache internal constructor(
+    // Test seam: the store is handed in so a test can supply its own DataStore instead of the
+    // Context-bound production delegate.
+    private val dataStore: DataStore<Preferences>,
     json: Json,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_foss")
-
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        json: Json,
+    ) : this(context.fossCacheDataStore, json)
 
     val upgrade = dataStore.createValue<FossUpgrade?>(
         key = "foss.upgrade",

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFoss.kt
@@ -1,7 +1,7 @@
 package eu.darken.octi.common.upgrade.core
 
 import eu.darken.octi.common.WebpageTool
-import eu.darken.octi.common.datastore.valueBlocking
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.setupCommonEventHandlers
@@ -49,12 +49,36 @@ class UpgradeRepoFoss @Inject constructor(
         return webpageTool.open(upgradeSite)
     }
 
-    fun persistUpgrade() {
+    /**
+     * Create-only-if-absent inside the store transaction: an existing record (and its upgradedAt —
+     * the user-visible "supporter since" date) is never replaced. The VM-level isPro guard alone is
+     * not race-free: it reads a shareIn replay that can be stale. Note the kept record is still
+     * re-encoded through the current schema — decoded fields are preserved exactly.
+     *
+     * Caveat, verified for this app: the kotlinx `createValue` decode fallback DEFAULTS TO FALSE and
+     * [FossCache] passes nothing, so a stored record that fails to decode makes this transaction
+     * THROW instead of reading as absent. The persist then fails outright and the caller restores
+     * its pending-return marker for a later retry — there is NO clobber path here, unlike the
+     * fleet's leaves that enable the fallback.
+     *
+     * @return true if a new record was created, false if an existing record was kept.
+     */
+    suspend fun persistUpgrade(): Boolean {
         log(TAG) { "persistUpgrade()" }
-        fossCache.upgrade.valueBlocking = FossUpgrade(
-            upgradedAt = Clock.System.now(),
-            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
-        )
+        val updated = fossCache.upgrade.update { existing ->
+            existing ?: FossUpgrade(
+                upgradedAt = Clock.System.now(),
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+        }
+        // Cross-module property (app-common Updated.old): smart cast refused.
+        val previous = updated.old
+        return if (previous == null) {
+            true
+        } else {
+            log(TAG, WARN) { "persistUpgrade(): Record already exists (upgradedAt=${previous.upgradedAt}), keeping it" }
+            false
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -142,24 +142,45 @@ class UpgradeViewModel @Inject constructor(
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
-        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
-        // resetting the "supporter since" date the status screen shows them.
-        if (upgradeRepo.upgradeInfo.first().isPro) {
-            log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
-            return@launch
-        }
+        try {
+            // Evaluated before the duration: an already upgraded supporter (recurring donation
+            // button) has nothing left to unlock, so this fast path exists for the UX — return
+            // quietly, no redundant write attempt and no thanks toast for an unlock that already
+            // happened. Data integrity is not this guard's job: the repo's create-only transaction
+            // owns that.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(TAG) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+                return@launch
+            }
 
-        val elapsed = SystemClock.elapsedRealtime() - pressedAt
-        log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+            val elapsed = SystemClock.elapsedRealtime() - pressedAt
+            log(TAG) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
-        if (elapsed < SPONSOR_DELAY_MS) {
-            log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
-            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast_msg)
-        } else {
-            log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            upgradeRepo.persistUpgrade()
-            toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+            if (elapsed < SPONSOR_DELAY_MS) {
+                log(TAG) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast_msg)
+            } else {
+                log(TAG) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+                val created = upgradeRepo.persistUpgrade()
+                if (created) {
+                    toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+                } else {
+                    // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                    log(TAG) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                }
+            }
+        } catch (e: Exception) {
+            // The marker was consumed above; neither a failed entitlement read nor a failed write may
+            // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
+            // unlock. Conditional: the user may have armed a NEWER launch while this attempt was
+            // suspended, and that one must survive. The contains-check has a small check-then-act
+            // window against a concurrent new arm; accepted — the create-only transaction owns data
+            // integrity, a wrong winner only changes which REAL visit's timestamp gates the unlock.
+            // Rethrow unconditionally: cancellation is not swallowed.
+            if (!handle.contains(KEY_SPONSOR_PRESSED_AT)) {
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            }
+            throw e
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
@@ -26,7 +26,6 @@ import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Clock
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @Singleton
@@ -45,6 +44,11 @@ class RecorderModule @Inject constructor(
         )
     }
 
+    // Test seams for the two clocks the recording heuristics use: the durations are
+    // wall-clock/monotonic, so virtual time cannot drive them.
+    internal var wallClock: () -> Long = { Clock.System.now().toEpochMilliseconds() }
+    internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
+
     private val internalState = DynamicStateFlow(TAG, appScope + dispatcherProvider.IO) {
         val triggerFileExists = triggerFile.exists()
         State(shouldRecord = triggerFileExists)
@@ -60,6 +64,14 @@ class RecorderModule @Inject constructor(
 
                 internalState.updateBlocking {
                     if (shouldRecord && !isRecording) {
+                        // Keyed on the trigger file, NOT on directory reuse: leftover unzipped
+                        // session dirs from a failed compression are picked up again by LIVE
+                        // recordings, so their stale mtime must not decide a fresh recording's
+                        // duration. Only a trigger that already existed before this start sequence
+                        // means the process died mid-recording and we are resuming it — the one
+                        // case with no usable monotonic base.
+                        val isProcessResume = triggerFile.exists()
+
                         val (sessionDir, startedAt) = findOrCreateSession(lastSession)
                         val newRecorder = Recorder()
                         newRecorder.start(sessionDir)
@@ -68,6 +80,10 @@ class RecorderModule @Inject constructor(
                         copy(
                             recorder = newRecorder,
                             recordingStartedAt = startedAt,
+                            // A fresh start that reuses an old session dir gets BOTH bases: the
+                            // scanned wall stamp above and this monotonic one. The heuristic prefers
+                            // the monotonic base, so the stale mtime never decides a live recording.
+                            recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
                         )
                     } else if (!shouldRecord && isRecording) {
                         val recorderSessionDir = recorder?.sessionDir
@@ -83,6 +99,7 @@ class RecorderModule @Inject constructor(
                             recorder = null,
                             lastSession = session,
                             recordingStartedAt = null,
+                            recordingStartedAtMonotonic = null,
                         )
                     } else {
                         this
@@ -147,7 +164,9 @@ class RecorderModule @Inject constructor(
         if (lines.size < 2) return null
         val sessionDir = File(lines[0])
         val startedAt = lines[1].toLongOrNull() ?: return null
-        if (startedAt !in 1..Clock.System.now().toEpochMilliseconds()) return null
+        // The trigger file stores wall-clock timestamps: it has to survive reboots, which monotonic
+        // time does not.
+        if (startedAt !in 1..wallClock()) return null
         return sessionDir to startedAt
     }
 
@@ -165,12 +184,12 @@ class RecorderModule @Inject constructor(
 
         val existingDir = findExistingSessionDir(lastSession)
         if (existingDir != null) {
-            val startedAt = existingDir.lastModified().takeIf { it > 0 } ?: Clock.System.now().toEpochMilliseconds()
+            val startedAt = existingDir.lastModified().takeIf { it > 0 } ?: wallClock()
             log(TAG, INFO) { "Legacy resume from scan: ${existingDir.name}" }
             return existingDir to startedAt
         }
 
-        return createSessionDir() to Clock.System.now().toEpochMilliseconds()
+        return createSessionDir() to wallClock()
     }
 
     internal fun findExistingSessionDir(lastSession: LogSession? = null): File? {
@@ -234,8 +253,12 @@ class RecorderModule @Inject constructor(
         if (!currentState.isRecording) return StopResult.NotRecording
 
         val sessionDir = currentState.recorder?.sessionDir ?: return StopResult.NotRecording
-        val elapsed = Clock.System.now().toEpochMilliseconds() - (currentState.recordingStartedAt ?: 0L)
-        if (elapsed.milliseconds < MIN_RECORDING) return StopResult.TooShort
+        val elapsed = currentState.recordingStartedAtMonotonic
+            ?.let { monotonicClock() - it }             // live session: immune to wall-clock adjustments
+            ?: (wallClock() - (currentState.recordingStartedAt ?: 0L))  // resumed: persisted/derived wall start only
+        // Negative = wall clock moved backward across a resume; fail open (no warning) rather than
+        // trap the user in TooShort.
+        if (elapsed in 0 until MIN_RECORDING.inWholeMilliseconds) return StopResult.TooShort
 
         stopRecorder()
         return StopResult.Stopped(LogSession(sessionDir))
@@ -252,6 +275,11 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val lastSession: LogSession? = null,
         val recordingStartedAt: Long? = null,
+        // Monotonic base for the duration heuristic, null when there is none: a session resumed
+        // after process death has only the persisted wall-clock start, and a monotonic value from a
+        // previous process or boot is meaningless. Nullable rather than 0L — 0 is a legal
+        // elapsedRealtime near boot.
+        val recordingStartedAtMonotonic: Long? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null
@@ -263,6 +291,18 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "force_debug_run"
-        internal val MIN_RECORDING = 5.seconds
+
+        /**
+         * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped
+         * this quickly usually contains nothing but the recorder starting and stopping, which
+         * costs a support round-trip to re-request.
+         *
+         * It stays a prompt because short recordings can be perfectly valid: a crash is logged
+         * and flushed immediately, so the reproduction is already on disk. The
+         * [StopResult.TooShort] consumers (the Support and ContactSupport screens) turn it into
+         * their short-recording warning, and its "stop anyway" answer goes through the direct
+         * force-stop path, which has no duration check.
+         */
+        internal val MIN_RECORDING = 10.seconds
     }
 }

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -1,0 +1,271 @@
+package eu.darken.octi.common.debug.recording.core
+
+import android.app.Application
+import android.content.Context
+import eu.darken.octi.common.BuildConfigWrap
+import eu.darken.octi.common.debug.logging.Logging
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import kotlin.time.Clock
+
+/**
+ * The "that recording looks very short" prompt is a duration heuristic, and duration was measured
+ * against the wall clock. A clock adjustment mid-recording (NTP sync, the user changing the time)
+ * therefore either invented a long recording out of a short one or trapped a long recording in the
+ * warning. A live session now measures monotonically; only a session resumed after process death
+ * has to fall back to the wall-clock start the trigger file persisted, because monotonic time does
+ * not survive a reboot.
+ *
+ * Robolectric with the REAL [Recorder]: the module constructs it directly, and its FileLogger
+ * needs android.util.Log.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class RecorderModuleDurationTest : BaseTest() {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    // Test-controlled clocks, handed to the module's two seams. The durations under test are
+    // wall-clock/monotonic, so virtual time cannot drive them. Volatile: the seams are read on the
+    // module's own coroutines, the fields are written from the test thread.
+    private class TestClocks(
+        @Volatile var wall: Long,
+        @Volatile var monotonic: Long,
+    )
+
+    /**
+     * The recorder is stopped in a nested finally, before the scope goes: cancelling the scope alone
+     * does NOT uninstall a running recorder's globally installed loggers, and the forward-jump case
+     * deliberately ends still recording. The accounting covers loggers of ANY type — this recorder
+     * installs a LogCatLogger alongside the FileLogger.
+     *
+     * [seed] runs BEFORE the module is constructed: a trigger file makes the module resume during
+     * construction, so seeding afterwards would race the init collector. The clock seams are
+     * installed immediately after construction, so a resume's trigger validation may still see the
+     * real clock — the resume cases anchor their timestamps near real time for exactly that reason.
+     */
+    private fun withModule(
+        clocks: TestClocks,
+        awaitRecording: Boolean = false,
+        seed: (externalDir: File) -> Unit = {},
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val loggersBefore = Logging.loggers
+        val externalDir = tempFolder.newFolder("external")
+        val cacheRoot = tempFolder.newFolder("cache")
+        File(externalDir, "debug/logs").mkdirs()
+        File(cacheRoot, "debug/logs").mkdirs()
+
+        val context = mockk<Context>(relaxed = true)
+        every { context.getExternalFilesDir(null) } returns externalDir
+        every { context.cacheDir } returns cacheRoot
+        seed(externalDir)
+
+        val appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        var module: RecorderModule? = null
+        try {
+            try {
+                val created = RecorderModule(
+                    context = context,
+                    appScope = appScope,
+                    dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+                ).apply {
+                    wallClock = { clocks.wall }
+                    monotonicClock = { clocks.monotonic }
+                }
+                module = created
+                // Envelope: a wedged start or stop must fail in seconds, not hold the gradle worker.
+                runBlocking {
+                    withTimeout(TEST_ENVELOPE_MS) {
+                        if (awaitRecording) created.state.first { it.isRecording }
+                        block(created)
+                    }
+                }
+            } finally {
+                module?.let { runBlocking { withTimeoutOrNull(TEST_ENVELOPE_MS) { it.stopRecorder() } } }
+            }
+        } finally {
+            appScope.cancel()
+            // Remove stragglers after asserting so one failure can't cascade into later tests.
+            val leaked = Logging.loggers - loggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<Logging.Logger>()
+        }
+    }
+
+    private fun seedSession(externalDir: File, name: String): File {
+        val sessionDir = File(externalDir, "debug/logs/$name").also { it.mkdirs() }
+        check(File(sessionDir, "core.log").createNewFile()) { "Failed to seed core.log" }
+        return sessionDir
+    }
+
+    @Test
+    fun `an eight second recording warns`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 8_000L
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+
+            // "Stop anyway" is the user's own next step, and past the threshold it stops cleanly.
+            clocks.monotonic += 3_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a ten second recording stops`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 10_000L
+
+            val result = module.requestStopRecorder()
+            result.shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            result.session.sessionDir.isDirectory shouldBe true
+            result.session.coreLogFile.exists() shouldBe true
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a backward wall-clock jump does not warn on a long recording`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Twelve real seconds of recording, and an NTP sync that moves the wall clock an hour
+            // back. Wall-clock measurement would report a negative duration here.
+            clocks.monotonic += 12_000L
+            clocks.wall -= 3_600_000L
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a forward wall-clock jump does not skip the warning`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Three real seconds of recording, and a clock correction an hour forward. Wall-clock
+            // measurement would call this a one-hour recording and skip the prompt.
+            clocks.monotonic += 3_000L
+            clocks.wall += 3_600_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    @Test
+    fun `a resumed session measures from the persisted start time`() {
+        // Resumed after a process death: there is no monotonic base to measure against, so the wall
+        // time the trigger file persisted is all the module has. Anchored near real time because the
+        // trigger parser rejects future timestamps and may still run on the real clock.
+        val realNow = Clock.System.now().toEpochMilliseconds()
+        val startedAt = realNow - 8_000L
+        val clocks = TestClocks(wall = realNow, monotonic = 100_000L)
+
+        withModule(
+            clocks,
+            awaitRecording = true,
+            seed = { externalDir ->
+                val sessionDir = seedSession(externalDir, "${BuildConfigWrap.APPLICATION_ID}_1.0_resume")
+                File(externalDir, "force_debug_run").writeText("${sessionDir.absolutePath}\n$startedAt")
+            },
+        ) { module ->
+            // Proves the trigger path was taken, not an accidental directory scan.
+            module.state.first().recordingStartedAt shouldBe startedAt
+
+            clocks.wall = startedAt + 8_000L
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+
+            clocks.wall = startedAt + 10_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a clock rollback across a resume fails open`() {
+        // The wall clock moved backward after the recording started, so the persisted start time now
+        // lies in the future. A negative duration must not trap the user in the warning. (A trigger
+        // seeded with a future timestamp is undrivable: the parser rejects those outright.)
+        val realNow = Clock.System.now().toEpochMilliseconds()
+        val startedAt = realNow - 8_000L
+        val clocks = TestClocks(wall = realNow, monotonic = 100_000L)
+
+        withModule(
+            clocks,
+            awaitRecording = true,
+            seed = { externalDir ->
+                val sessionDir = seedSession(externalDir, "${BuildConfigWrap.APPLICATION_ID}_1.0_rollback")
+                File(externalDir, "force_debug_run").writeText("${sessionDir.absolutePath}\n$startedAt")
+            },
+        ) { module ->
+            module.state.first().recordingStartedAt shouldBe startedAt
+
+            clocks.wall = startedAt - 3_600_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a repeat recording reusing an old session stays monotonic`() {
+        // An unzipped session directory left behind by a failed compression is picked up again by
+        // the next ordinary recording. Keying the "no monotonic base" case on directory reuse
+        // instead of on the trigger file would route that live recording to the stale directory's
+        // mtime — a wall-clock measurement, and the wrong one at that.
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        var reusableDir: File? = null
+
+        withModule(
+            clocks,
+            seed = { externalDir ->
+                reusableDir = seedSession(externalDir, "${BuildConfigWrap.APPLICATION_ID}_1.0_leftover")
+            },
+        ) { module ->
+            // Non-vacuity: the leftover directory really is the one being recorded into again, so
+            // the assertion below is about which start time wins, not about a fresh directory.
+            module.startRecorder().sessionDir shouldBe reusableDir
+
+            clocks.monotonic += 3_000L
+            clocks.wall += 3_600_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    companion object {
+        // Independent of any production bound: a wedged wait has to fail the test, not hang the
+        // gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
+        private const val WALL_BASE = 1_800_000_000_000L
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/FossCacheWiringTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/FossCacheWiringTest.kt
@@ -1,0 +1,44 @@
+package eu.darken.octi.common.upgrade.core
+
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.datastore.value
+import eu.darken.octi.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.TestApplication
+import kotlin.time.Instant
+
+/**
+ * The persist tests drive [FossCache]'s constructor seam against temp files, so this is the one
+ * test that exercises the file-level `settings_foss` delegate the @Inject constructor actually
+ * wires up — a delegate that got moved out of the class body to make that seam possible.
+ *
+ * One test method on purpose: DataStore forbids two active instances on the same file, and
+ * FossCache is a @Singleton in production.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FossCacheWiringTest {
+
+    @Test
+    fun `the injected constructor reads and writes the settings_foss store`() = runTest {
+        // The real DI Json config: the same instance production hands FossCache.
+        val cache = FossCache(
+            context = ApplicationProvider.getApplicationContext(),
+            json = SerializationModule().json(),
+        )
+
+        cache.upgrade.value() shouldBe null
+
+        val record = FossUpgrade(
+            upgradedAt = Instant.fromEpochMilliseconds(0),
+            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+        )
+        cache.upgrade.value(record)
+        cache.upgrade.value() shouldBe record
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFossPersistTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/core/UpgradeRepoFossPersistTest.kt
@@ -1,0 +1,167 @@
+package eu.darken.octi.common.upgrade.core
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.octi.common.WebpageTool
+import eu.darken.octi.common.datastore.value
+import eu.darken.octi.common.serialization.SerializationModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+/**
+ * The FOSS supporter record is create-only-if-absent: the sponsor-return heuristic can fire again
+ * for someone who is already a supporter (the recurring-donation button, or a stale entitlement
+ * replay), and a rewrite would move their "supporter since" date — and, for the legacy records
+ * every existing supporter has, replace their stored reason too.
+ *
+ * Driven through a real DataStore on a temp file via [FossCache]'s test seam, because the guarantee
+ * is the store transaction's, not the caller's.
+ */
+class UpgradeRepoFossPersistTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    // One store scope per test: the DataStore keeps its own actor alive on it.
+    private var storeScope: CoroutineScope? = null
+
+    @AfterEach
+    fun teardown() {
+        storeScope?.cancel()
+        storeScope = null
+    }
+
+    private class Harness(
+        val dataStore: DataStore<Preferences>,
+        val cache: FossCache,
+        val repo: UpgradeRepoFoss,
+    )
+
+    private fun newStoreScope(): CoroutineScope =
+        CoroutineScope(Dispatchers.IO + SupervisorJob()).also { storeScope = it }
+
+    // Unique file name per test method: DataStore forbids two active instances on the same file.
+    private fun buildHarness(storeName: String): Harness {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = newStoreScope(),
+            produceFile = { File(tempDir, "$storeName.preferences_pb") },
+        )
+        val cache = FossCache(dataStore, SerializationModule().json())
+        val repo = UpgradeRepoFoss(
+            fossCache = cache,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+        )
+        return Harness(dataStore, cache, repo)
+    }
+
+    @Test
+    fun `persistUpgrade keeps an existing legacy record`() = runTest {
+        val harness = buildHarness("legacy_record")
+        // A legacy wire value: a rewrite would corrupt BOTH the date and the stored type.
+        harness.cache.upgrade.value(
+            FossUpgrade(
+                upgradedAt = Instant.fromEpochMilliseconds(0),
+                upgradeType = FossUpgrade.Type.LEGACY_NO_MONEY,
+            )
+        )
+
+        harness.repo.persistUpgrade() shouldBe false
+
+        harness.cache.upgrade.value() shouldBe FossUpgrade(
+            upgradedAt = Instant.fromEpochMilliseconds(0),
+            upgradeType = FossUpgrade.Type.LEGACY_NO_MONEY,
+        )
+        harness.repo.upgradeInfo.first().apply {
+            isPro shouldBe true
+            upgradedAt shouldBe Instant.fromEpochMilliseconds(0)
+        }
+    }
+
+    @Test
+    fun `persistUpgrade creates on an empty store`() = runTest {
+        val harness = buildHarness("empty_store")
+        harness.cache.upgrade.value() shouldBe null
+
+        // Plain, untruncated: the InstantSerializer is ISO-8601 and preserves sub-millisecond
+        // precision, so the stored value can be compared against a precise bracket.
+        val before = Clock.System.now()
+        harness.repo.persistUpgrade() shouldBe true
+        val after = Clock.System.now()
+
+        val created = harness.cache.upgrade.value()
+        created shouldNotBe null
+        created!!.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        (created.upgradedAt >= before) shouldBe true
+        (created.upgradedAt <= after) shouldBe true
+
+        // Boolean-proven keep: immune to a timestamp collision between the two writes.
+        harness.repo.persistUpgrade() shouldBe false
+        harness.cache.upgrade.value() shouldBe created
+    }
+
+    @Test
+    fun `concurrent persists elect exactly one creator`() = runTest {
+        val harness = buildHarness("concurrent")
+        harness.cache.upgrade.value() shouldBe null
+
+        val before = Clock.System.now()
+        val gate = CompletableDeferred<Unit>()
+        val racers = List(2) {
+            async(Dispatchers.IO) {
+                gate.await()
+                harness.repo.persistUpgrade()
+            }
+        }
+        gate.complete(Unit)
+        val results = racers.awaitAll()
+        val after = Clock.System.now()
+
+        // Exactly one creator: the loser must report the record it found, not a second creation.
+        results.sorted() shouldBe listOf(false, true)
+
+        val record = harness.cache.upgrade.value()
+        record shouldNotBe null
+        record!!.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        (record.upgradedAt >= before) shouldBe true
+        (record.upgradedAt <= after) shouldBe true
+    }
+
+    @Test
+    fun `an undecodable record fails the persist and stays untouched`() = runTest {
+        // [FossCache] leaves the kotlinx decode fallback at its `false` default, so an undecodable
+        // stored record does NOT read as absent — the transaction throws and the persist fails.
+        // That is the deliberate ground truth: there is no clobber path that could replace a
+        // supporter's record just because it failed to parse.
+        val harness = buildHarness("undecodable")
+        val rawKey = stringPreferencesKey("foss.upgrade")
+        val malformed = """{ not valid json }"""
+        harness.dataStore.edit { prefs -> prefs[rawKey] = malformed }
+
+        shouldThrow<SerializationException> { harness.repo.persistUpgrade() }
+
+        // Untouched: the raw string is still the one that failed to decode.
+        harness.dataStore.data.first()[rawKey] shouldBe malformed
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle
 import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,7 +40,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
         every { openGithubSponsorsPage() } returns true
-        every { persistUpgrade() } answers { persisted++ }
+        coEvery { persistUpgrade() } answers { persisted++; true }
     }
 
     private fun buildVm(

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.common.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.octi.R
 import eu.darken.octi.common.navigation.Nav
@@ -8,14 +9,21 @@ import eu.darken.octi.common.upgrade.core.FossUpgrade
 import eu.darken.octi.common.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -32,6 +40,7 @@ import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import kotlin.time.Instant
 
@@ -63,6 +72,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     ): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns info
         every { openGithubSponsorsPage() } returns true
+        // Explicit: a relaxed mock would answer the Boolean with false, i.e. "record already
+        // existed", silently turning every thanks-toast assertion below into a no-op.
+        coEvery { persistUpgrade() } returns true
     }
 
     private fun buildVm(
@@ -248,7 +260,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         nudge.await() shouldBe R.string.upgrade_screen_sponsor_too_fast_msg
-        verify(exactly = 0) { repo.persistUpgrade() }
+        coVerify(exactly = 0) { repo.persistUpgrade() }
     }
 
     @Test
@@ -266,7 +278,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         nudges.shouldBeEmpty()
-        verify(exactly = 0) { repo.persistUpgrade() }
+        coVerify(exactly = 0) { repo.persistUpgrade() }
         collector.cancel()
     }
 
@@ -282,7 +294,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
-        verify(exactly = 1) { repo.persistUpgrade() }
+        coVerify(exactly = 1) { repo.persistUpgrade() }
     }
 
     /**
@@ -310,15 +322,172 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         thanks.await() shouldBe R.string.upgrade_screen_thanks_toast
-        verify(exactly = 1) { repo.persistUpgrade() }
+        coVerify(exactly = 1) { repo.persistUpgrade() }
         // Consumed: a later resume must not re-run the unlock.
         recreatedVm.hasPendingSponsorLaunch() shouldBe false
     }
 
+    @Test
+    fun `a sponsor return whose record already existed stays quiet`() = runTest2(context = testDispatcher) {
+        // The isPro fast path reads a shareIn replay that can be stale, so a supporter's return can
+        // get past it. Only the store transaction knows the record is already there — it keeps it
+        // and reports "not created", and there is no unlock to thank anyone for.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } returns false
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // Consumed: the visit was evaluated, there is nothing left to retry.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed persist restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is consumed before the write. If the write then fails, dropping it would eat a
+        // valid sponsor visit for good — the next return/resume has to be able to retry the unlock.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } throws IOException("write failed")
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        // Rethrown, not swallowed: the failure still travels the normal error path.
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a thrown entitlement read restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The guard's entitlement read happens after the marker was consumed, so it can eat the
+        // sponsor visit just as a failed write can. Installed after arming: the ViewModel's own init
+        // collectors already hold the working flow, so the only failing read is the guard's. Octi's
+        // upgradeInfo is a PLAIN combine without shareIn, so a thrown cache read propagates straight
+        // into the guard's first() — the widened catch covers this app fully.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { throw IOException("read failed") }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a hung entitlement read releases the visit when the screen dies`() = runTest2(context = testDispatcher) {
+        // A read that never answers holds the check open with the marker already consumed. When the
+        // screen goes away the coroutine is cancelled — the catch's cancellation path has to hand
+        // the sponsor visit back, otherwise it is lost with nothing to retry from.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { awaitCancellation() }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Suspended inside the guard's read, marker already consumed.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // The ViewModel going away: vmScope shares viewModelScope's job, so this is the cleared VM.
+        vm.vmScope.cancel()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a newer sponsor launch survives a failed older attempt`() = runTest2(context = testDispatcher) {
+        // The restore must not clobber a launch armed while the old attempt was still suspended:
+        // the newer visit is the one the user is actually waiting on.
+        val repo = mockRepo()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repo.persistUpgrade() } coAnswers {
+            gate.await()
+            throw IOException("write failed")
+        }
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Consumed and parked in the write.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A second sponsor visit while the first attempt is still hanging.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(30))
+        val newerPressedAt = SystemClock.elapsedRealtime()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the newer timestamp must still be
+        // the one stored, the failed older attempt must not have written its own back over it.
+        handle.get<Long>("sponsor_pressed_at") shouldBe newerPressedAt
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        errorCollector.cancel()
+    }
+
     /**
-     * The recurring-donation entrypoint on the upgraded status is deliberately UNARMED. Routing it
-     * through the armed one would re-run the unlock on return and rewrite the "supporter since"
-     * date the status view exists to show — even for a long, genuine visit.
+     * The recurring-donation entrypoint on the upgraded status is deliberately UNARMED: a supporter
+     * browsing the sponsors page for a while must not run the unlock heuristic again — no write
+     * attempt, no toast.
      */
     @Test
     fun `a long unarmed sponsors visit leaves the supporter-since date alone`() = runTest2(
@@ -338,7 +507,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         verify(exactly = 1) { repo.openGithubSponsorsPage() }
-        verify(exactly = 0) { repo.persistUpgrade() }
+        coVerify(exactly = 0) { repo.persistUpgrade() }
 
         val after = async { vm.state.first { it.view != null } }
         advanceUntilIdle()
@@ -349,8 +518,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
         context = testDispatcher,
     ) {
-        // Persisting again would rewrite upgradedAt and visibly reset the "supporter since" date the
-        // status screen shows — and the thanks toast belongs to the unlock, which already happened.
+        // The armed path taken by a supporter who tapped the pitch's sponsor button again. The store
+        // transaction keeps the existing record either way, so this is about the feedback: no
+        // redundant write attempt, and no thanks toast for an unlock that already happened.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 
@@ -366,7 +536,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.checkSponsorReturn()
         advanceUntilIdle()
 
-        verify(exactly = 0) { repo.persistUpgrade() }
+        coVerify(exactly = 0) { repo.persistUpgrade() }
         nudges.shouldBeEmpty()
         thanks.shouldBeEmpty()
         // Consumed even though nothing happened: a later resume must not re-run the unlock.
@@ -375,7 +545,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         vm.checkSponsorReturn()
         advanceUntilIdle()
 
-        verify(exactly = 0) { repo.persistUpgrade() }
+        coVerify(exactly = 0) { repo.persistUpgrade() }
         nudges.shouldBeEmpty()
         thanks.shouldBeEmpty()
         snackbarCollector.cancel()
@@ -427,7 +597,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         // 6s since the FIRST tap: the second one neither reopened the page nor rearmed the clock.
-        verify(exactly = 1) { repo.persistUpgrade() }
+        coVerify(exactly = 1) { repo.persistUpgrade() }
         verify(exactly = 1) { repo.openGithubSponsorsPage() }
         thanks shouldBe listOf(R.string.upgrade_screen_thanks_toast)
         toastCollector.cancel()


### PR DESCRIPTION
## What changed

FOSS version: an existing supporter's "supporter since" date is now protected by the storage layer itself and can no longer be reset by re-visiting the sponsors page. The "thanks for supporting" toast only appears when supporter status was actually newly granted, and if checking or saving the status fails, the pending unlock is retried on the next return instead of being lost (without clobbering a newer visit started in the meantime).

Both versions: the "that debug log looks too short" warning now catches recordings up to 10 seconds (previously 5) and no longer misjudges the recording length when the device clock changes mid-recording — including when a new recording picks up the folder of an older interrupted one. Also fixed: a rare internal race that could hang state updates (it wedged a CI runner for 6 hours in a sibling project before being caught).

## Technical Context

- The race fix lands first: `DynamicStateFlow.updateBlocking` (app-common) emitted its update before subscribing to the replay-1 shared flow; a fast producer plus a reactive collector — exactly `RecorderModule`'s react-to-shouldRecord pattern — could displace the awaited emission before the subscription existed, suspending the caller forever. Fixed with an `UNDISPATCHED` awaiter registered before the emit; the regression test uses a subscription barrier so the contention is guaranteed rather than probabilistic.
- Root cause (supporter date): `persistUpgrade()` unconditionally overwrote the record (via a blocking setter). It is now a suspend create-only-if-absent transaction returning whether a record was created; legacy-schema records (the old `reason` wire values) are covered by the keep-branch test. Octi-specific and deliberate: the store value has no decode fallback, so an undecodable record makes the transaction throw — the marker is restored and no overwrite path exists at all; a test seeds malformed raw JSON and asserts the bytes stay untouched after the throw.
- The pending-return marker restore wraps everything after the marker consume and is conditional so a newer launch armed mid-failure survives; the small check-then-act window is documented as accepted (the transaction owns data integrity). Octi's `upgradeInfo` is a plain combine without `shareIn`, so a thrown cache read reaches the guard directly — the restore genuinely covers the read path here.
- Recording duration: live sessions now measure via `elapsedRealtime()`. The monotonic base is keyed on trigger-file pre-existence — only a trigger that survived a process death means a genuine resume. Notably NOT keyed on session-directory reuse: leftover unzipped directories (e.g. after failed compression) get picked up by live recordings, and their stale timestamps must not decide a fresh recording's duration (regression-tested). Resumed sessions keep the persisted wall start and fail open when the clock rolled back across the resume. `recordingStartedAt` stays wall-clock for the session-metadata consumers.
- Review guidance: the duration tests are Robolectric with the real recorder (octi constructs `Recorder()` directly and its logger needs Android APIs); leak accounting covers all newly installed logger types including the `LogCatLogger`. The persist tests run on `FossCache`'s new constructor seam against per-test temp stores; a one-method Robolectric test covers the moved real-file delegate. The constrained 2-core validation run explicitly executes app-common's contention test.
