### PR TITLE
Keep the debug log usable when a recording fails to start

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/debug/logging/FileLogger.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/debug/logging/FileLogger.kt
@@ -13,6 +13,11 @@ import kotlin.time.Clock
 class FileLogger(private val logFile: File) : Logging.Logger {
     private var logWriter: OutputStreamWriter? = null
 
+    /**
+     * Throws if the writer could not be initialized. Swallowing the failure here would install a
+     * logger that silently writes nowhere, and the recorder would report a successful start for a
+     * recording that can never produce a log file.
+     */
     @SuppressLint("SetWorldReadable")
     @Synchronized
     fun start() {
@@ -26,19 +31,31 @@ class FileLogger(private val logFile: File) : Logging.Logger {
             Log.i(TAG, "Debug run log read permission set")
         }
 
-        try {
-            logWriter = OutputStreamWriter(FileOutputStream(logFile, true))
-            logWriter!!.write("=== BEGIN ===\n")
-            logWriter!!.write("Logfile: $logFile\n")
-            logWriter!!.flush()
-            Log.i(TAG, "File logger started.")
+        val writer = try {
+            OutputStreamWriter(FileOutputStream(logFile, true))
         } catch (e: IOException) {
-            e.printStackTrace()
-
+            Log.e(TAG, "File logger could not open $logFile", e)
             logFile.delete()
-            if (logWriter != null) logWriter!!.close()
+            throw e
         }
 
+        try {
+            writer.write("=== BEGIN ===\n")
+            writer.write("Logfile: $logFile\n")
+            writer.flush()
+        } catch (e: IOException) {
+            Log.e(TAG, "File logger could not write to $logFile", e)
+            try {
+                writer.close()
+            } catch (closeError: IOException) {
+                e.addSuppressed(closeError)
+            }
+            logFile.delete()
+            throw e
+        }
+
+        logWriter = writer
+        Log.i(TAG, "File logger started.")
     }
 
     @Synchronized

--- a/app-common/src/main/java/eu/darken/octi/common/debug/logging/FileLogger.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/debug/logging/FileLogger.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.common.debug.logging
 
 import android.annotation.SuppressLint
 import android.util.Log
+import eu.darken.octi.common.error.addSuppressedSafely
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -24,7 +25,11 @@ class FileLogger(private val logFile: File) : Logging.Logger {
         if (logWriter != null) return
 
         logFile.parentFile!!.mkdirs()
-        if (logFile.createNewFile()) {
+        // Only a log file THIS attempt created may be deleted again when the start fails: a session
+        // being resumed already holds the recording the user made, and dropping it on a failed
+        // restart destroys the very data they were collecting.
+        val createdHere = logFile.createNewFile()
+        if (createdHere) {
             Log.i(TAG, "File logger writing to " + logFile.path)
         }
         if (logFile.setReadable(true, false)) {
@@ -35,7 +40,7 @@ class FileLogger(private val logFile: File) : Logging.Logger {
             OutputStreamWriter(FileOutputStream(logFile, true))
         } catch (e: IOException) {
             Log.e(TAG, "File logger could not open $logFile", e)
-            logFile.delete()
+            if (createdHere) logFile.delete()
             throw e
         }
 
@@ -48,9 +53,9 @@ class FileLogger(private val logFile: File) : Logging.Logger {
             try {
                 writer.close()
             } catch (closeError: IOException) {
-                e.addSuppressed(closeError)
+                e.addSuppressedSafely(closeError)
             }
-            logFile.delete()
+            if (createdHere) logFile.delete()
             throw e
         }
 

--- a/app-common/src/main/java/eu/darken/octi/common/debug/logging/Logging.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/debug/logging/Logging.kt
@@ -54,8 +54,10 @@ object Logging {
     }
 
     fun remove(logger: Logger) {
-        log { "Removing: $logger" }
+        // Deregister first: a logger that is being torn down is still a receiver for anything we
+        // log before that, and if it fails on that line it would stay installed forever.
         synchronized(internalLoggers) { internalLoggers.remove(logger) }
+        log { "Removed: $logger" }
     }
 
     fun logInternal(

--- a/app-common/src/main/java/eu/darken/octi/common/error/ThrowableExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/error/ThrowableExtensions.kt
@@ -40,3 +40,12 @@ fun Throwable.getStackTraceString(): String {
 
 fun Throwable.tryUnwrap(kClass: KClass<RuntimeException> = RuntimeException::class): Throwable =
     if (!kClass.isInstance(this)) this else cause ?: this
+
+/**
+ * Suppressing a throwable on itself is an [IllegalArgumentException], which would replace the
+ * failure we are trying to report with one from the cleanup path. Cleanup that rethrows the very
+ * error it is cleaning up after is exactly where that happens.
+ */
+fun Throwable.addSuppressedSafely(other: Throwable) {
+    if (this !== other) addSuppressed(other)
+}

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/Recorder.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/Recorder.kt
@@ -25,40 +25,64 @@ class Recorder @Inject constructor() {
     var path: File? = null
         private set
 
-    suspend fun start(sessionDir: File) = mutex.withLock {
+    /**
+     * Nothing is published and no logger is installed until the writer is live: a failing
+     * [FileLogger.start] would otherwise leave this recorder claiming to record into a file that
+     * receives nothing.
+     */
+    suspend fun start(sessionDir: File): Unit = mutex.withLock {
         if (fileLogger != null) return@withLock
-        this.sessionDir = sessionDir
         sessionDir.mkdirs()
         val logFile = File(sessionDir, "core.log")
+
+        val logger = FileLogger(logFile)
+        logger.start()
+
+        this.sessionDir = sessionDir
         this.path = logFile
-        fileLogger = FileLogger(logFile)
-        fileLogger?.let { logger ->
-            if (Logging.loggers.none { it is LogCatLogger }) {
-                log(TAG, INFO) { "Adding LogCatLogger: $this" }
-                LogCatLogger().apply {
-                    Logging.install(this)
-                    logcatLogger = this
-                }
+        fileLogger = logger
+
+        if (Logging.loggers.none { it is LogCatLogger }) {
+            log(TAG, INFO) { "Adding LogCatLogger: $this" }
+            LogCatLogger().apply {
+                Logging.install(this)
+                logcatLogger = this
             }
-            logger.start()
-            Logging.install(logger)
-            log(TAG, INFO) { "Now logging to file in $sessionDir" }
         }
+        Logging.install(logger)
+        log(TAG, INFO) { "Now logging to file in $sessionDir" }
     }
 
-    suspend fun stop() = mutex.withLock {
-        fileLogger?.let {
-            log(TAG, INFO) { "Stopping file-logger-tree: $it" }
-            Logging.remove(it)
-            it.stop()
-            fileLogger = null
-            this.path = null
-            this.sessionDir = null
-        }
-        logcatLogger?.let {
-            log(TAG, INFO) { "Stopping LogCatLogger: $it" }
-            Logging.remove(it)
-            logcatLogger = null
+    /**
+     * Uninstalling the loggers, closing the writer and clearing the published state are guarded
+     * independently: whatever fails, this recorder must not stay globally installed while the
+     * module reports it as stopped.
+     */
+    suspend fun stop(): Unit = mutex.withLock {
+        try {
+            fileLogger?.let { logger ->
+                log(TAG, INFO) { "Stopping file-logger-tree: $logger" }
+                try {
+                    Logging.remove(logger)
+                } finally {
+                    try {
+                        logger.stop()
+                    } finally {
+                        fileLogger = null
+                        this.path = null
+                        this.sessionDir = null
+                    }
+                }
+            }
+        } finally {
+            logcatLogger?.let { logger ->
+                log(TAG, INFO) { "Stopping LogCatLogger: $logger" }
+                try {
+                    Logging.remove(logger)
+                } finally {
+                    logcatLogger = null
+                }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/Recorder.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/Recorder.kt
@@ -6,6 +6,7 @@ import eu.darken.octi.common.debug.logging.Logging
 import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.error.addSuppressedSafely
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
@@ -54,36 +55,45 @@ class Recorder @Inject constructor() {
     }
 
     /**
-     * Uninstalling the loggers, closing the writer and clearing the published state are guarded
-     * independently: whatever fails, this recorder must not stay globally installed while the
+     * Every teardown step runs, no matter what the ones before it did: the loggers leave the
+     * registry BEFORE any diagnostic that they would still receive themselves, the published state
+     * is cleared in the outermost finally, and only then is the first failure rethrown with the
+     * later ones suppressed onto it. This recorder must never stay globally installed while the
      * module reports it as stopped.
      */
     suspend fun stop(): Unit = mutex.withLock {
-        try {
-            fileLogger?.let { logger ->
-                log(TAG, INFO) { "Stopping file-logger-tree: $logger" }
-                try {
-                    Logging.remove(logger)
-                } finally {
-                    try {
-                        logger.stop()
-                    } finally {
-                        fileLogger = null
-                        this.path = null
-                        this.sessionDir = null
-                    }
-                }
-            }
-        } finally {
-            logcatLogger?.let { logger ->
-                log(TAG, INFO) { "Stopping LogCatLogger: $logger" }
-                try {
-                    Logging.remove(logger)
-                } finally {
-                    logcatLogger = null
-                }
+        val file = fileLogger
+        val logcat = logcatLogger
+        var failure: Throwable? = null
+
+        fun step(block: () -> Unit) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                val previous = failure
+                if (previous == null) failure = e else previous.addSuppressedSafely(e)
             }
         }
+
+        try {
+            if (file != null) {
+                step { Logging.remove(file) }
+                step { log(TAG, INFO) { "Stopped file-logger-tree: $file" } }
+                step { file.stop() }
+            }
+            if (logcat != null) {
+                step { Logging.remove(logcat) }
+                step { log(TAG, INFO) { "Stopped LogCatLogger: $logcat" } }
+            }
+        } finally {
+            fileLogger = null
+            logcatLogger = null
+            this.path = null
+            this.sessionDir = null
+        }
+
+        val settled = failure
+        if (settled != null) throw settled
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
@@ -14,6 +14,7 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.error.addSuppressedSafely
 import eu.darken.octi.common.flow.DynamicStateFlow
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.currentCoroutineContext
@@ -159,7 +160,7 @@ class RecorderModule @Inject constructor(
                             // observes it instead of waiting forever.
                             copy(
                                 shouldRecord = false,
-                                startFailure = e,
+                                startFailure = asStartFailure(e),
                                 recorder = null,
                                 recordingStartedAt = null,
                                 recordingStartedAtMonotonic = null,
@@ -200,6 +201,24 @@ class RecorderModule @Inject constructor(
                 }
             }
             .launchIn(appScope)
+    }
+
+    /**
+     * A start failure that arrived as a [CancellationException] while this module's own scope was
+     * still alive - a bounded read inside the start sequence timing out, for example. Stored and
+     * rethrown unchanged it makes every caller treat it as their OWN cancellation: the launch that
+     * requested the start ends "normally" and the error handler that would have surfaced the
+     * failure never runs.
+     */
+    class RecorderStartFailedException(cause: Throwable) : IllegalStateException("Failed to start recording", cause)
+
+    /**
+     * Runs AFTER [ensureActive] has confirmed the scope is alive, so a cancellation seen here can
+     * only be a foreign one. Everything else is committed unchanged.
+     */
+    private fun asStartFailure(error: Throwable): Throwable = when (error) {
+        is CancellationException -> RecorderStartFailedException(error)
+        else -> error
     }
 
     private fun getPreferredLogDir(): File {

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
@@ -12,6 +12,7 @@ import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.error.addSuppressedSafely
 import eu.darken.octi.common.flow.DynamicStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
@@ -120,7 +121,7 @@ class RecorderModule @Inject constructor(
                                     try {
                                         orphan.stop()
                                     } catch (stopError: Throwable) {
-                                        e.addSuppressed(stopError)
+                                        e.addSuppressedSafely(stopError)
                                     }
                                 }
                                 // Only a trigger this attempt created: one that was already there
@@ -131,7 +132,7 @@ class RecorderModule @Inject constructor(
                                             log(TAG, ERROR) { "Failed to delete trigger file after failed start" }
                                         }
                                     } catch (cleanupError: Throwable) {
-                                        e.addSuppressed(cleanupError)
+                                        e.addSuppressedSafely(cleanupError)
                                     }
                                 }
                                 // Resumed session dirs are the user's existing log and are kept.
@@ -141,7 +142,7 @@ class RecorderModule @Inject constructor(
                                             log(TAG, ERROR) { "Failed to delete session dir after failed start: $dir" }
                                         }
                                     } catch (cleanupError: Throwable) {
-                                        e.addSuppressed(cleanupError)
+                                        e.addSuppressedSafely(cleanupError)
                                     }
                                 }
                             }
@@ -223,21 +224,47 @@ class RecorderModule @Inject constructor(
         }
     }
 
-    private fun createSessionDir(): File {
+    /**
+     * [created] is what the rollback of a failed start keys off, so it reports what actually
+     * happened on disk, never the intent: a directory that was already there belongs to an earlier
+     * session and deleting it would take that session's logs with it.
+     */
+    private data class NewSessionDir(
+        val dir: File,
+        val created: Boolean,
+    )
+
+    private fun createSessionDir(): NewSessionDir {
         val sanitizedVersion = BuildConfigWrap.VERSION_NAME.replace(Regex("[^A-Za-z0-9._-]"), "_")
-        val dirName = "${BuildConfigWrap.APPLICATION_ID}_${sanitizedVersion}_${Clock.System.now().toEpochMilliseconds()}"
+        val dirName = "${BuildConfigWrap.APPLICATION_ID}_${sanitizedVersion}_${wallClock()}"
 
         val baseDir = getPreferredLogDir()
-        val sessionDir = File(baseDir, dirName)
+        createUniqueDir(baseDir, dirName)?.let { return NewSessionDir(it, created = true) }
 
-        if (!sessionDir.mkdirs() && !sessionDir.isDirectory) {
-            log(TAG, WARN) { "Failed to create session dir at $sessionDir, trying fallback" }
-            val fallbackDir = File(File(context.cacheDir, "debug/logs"), dirName)
-            fallbackDir.mkdirs()
-            return fallbackDir
+        log(TAG, WARN) { "Failed to create session dir for $dirName in $baseDir, trying fallback" }
+        val fallbackBase = File(context.cacheDir, "debug/logs")
+        createUniqueDir(fallbackBase, dirName)?.let { return NewSessionDir(it, created = true) }
+
+        // Nothing was created, so nothing may be rolled back either; the start attempt fails on the
+        // unusable directory further down instead.
+        log(TAG, ERROR) { "Failed to create a session dir for $dirName in $fallbackBase" }
+        return NewSessionDir(File(fallbackBase, dirName), created = false)
+    }
+
+    /**
+     * mkdirs() reports false for a directory that already exists, so the candidate that wins is
+     * always one this call brought into existence. A name collision (two starts within the same
+     * millisecond, or a leftover directory of that name) walks to a suffixed name rather than
+     * adopting - and later deleting - somebody else's session.
+     */
+    private fun createUniqueDir(baseDir: File, dirName: String): File? {
+        for (attempt in 0..NAME_COLLISION_LIMIT) {
+            val candidate = File(baseDir, if (attempt == 0) dirName else "${dirName}_$attempt")
+            if (candidate.mkdirs()) return candidate
+            // Not a collision but an unusable base directory: further suffixes cannot help.
+            if (!candidate.exists()) return null
         }
-
-        return sessionDir
+        return null
     }
 
     internal fun writeTriggerFile(sessionDir: File, startedAt: Long) {
@@ -263,8 +290,8 @@ class RecorderModule @Inject constructor(
     }
 
     /**
-     * [isNewDir] separates a directory this call created from one it resumed into: only the former
-     * may be deleted again when the start sequence fails.
+     * [isNewDir] separates a directory this call actually created from one it resumed into or found
+     * already present: only the former may be deleted again when the start sequence fails.
      */
     internal data class SessionTarget(
         val sessionDir: File,
@@ -291,7 +318,8 @@ class RecorderModule @Inject constructor(
             return SessionTarget(existingDir, startedAt, isNewDir = false)
         }
 
-        return SessionTarget(createSessionDir(), wallClock(), isNewDir = true)
+        val fresh = createSessionDir()
+        return SessionTarget(fresh.dir, wallClock(), isNewDir = fresh.created)
     }
 
     internal fun findExistingSessionDir(lastSession: LogSession? = null): File? {
@@ -343,31 +371,39 @@ class RecorderModule @Inject constructor(
         LogSession(sessionDir)
     }
 
-    suspend fun stopRecorder(): LogSession? = requestMutex.withLock {
+    suspend fun stopRecorder(): LogSession? = requestMutex.withLock { stopRecorderLocked() }
+
+    /**
+     * Requires [requestMutex]. Reading the current session, publishing the request and observing
+     * the stop have to happen without another caller in between, or two callers report having
+     * stopped the same session - or a session that is still running.
+     */
+    private suspend fun stopRecorderLocked(): LogSession? {
         val currentState = internalState.value()
-        val sessionDir = currentState.recorder?.sessionDir ?: return@withLock null
+        val sessionDir = currentState.recorder?.sessionDir ?: return null
 
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
         internalState.flow.first { !it.isRecording }
-        LogSession(sessionDir)
+        return LogSession(sessionDir)
     }
 
-    suspend fun requestStopRecorder(): StopResult {
+    suspend fun requestStopRecorder(): StopResult = requestMutex.withLock {
         val currentState = internalState.value()
-        if (!currentState.isRecording) return StopResult.NotRecording
+        if (!currentState.isRecording) return@withLock StopResult.NotRecording
 
-        val sessionDir = currentState.recorder?.sessionDir ?: return StopResult.NotRecording
         val elapsed = currentState.recordingStartedAtMonotonic
             ?.let { monotonicClock() - it }             // live session: immune to wall-clock adjustments
             ?: (wallClock() - (currentState.recordingStartedAt ?: 0L))  // resumed: persisted/derived wall start only
         // Negative = wall clock moved backward across a resume; fail open (no warning) rather than
         // trap the user in TooShort.
-        if (elapsed in 0 until MIN_RECORDING.inWholeMilliseconds) return StopResult.TooShort
+        if (elapsed in 0 until MIN_RECORDING.inWholeMilliseconds) return@withLock StopResult.TooShort
 
-        stopRecorder()
-        return StopResult.Stopped(LogSession(sessionDir))
+        // The delegated stop decides what was stopped: reporting the session read above would claim
+        // a stop that a concurrent caller had already performed on a different one.
+        val stopped = stopRecorderLocked() ?: return@withLock StopResult.NotRecording
+        StopResult.Stopped(stopped)
     }
 
     sealed class StopResult {
@@ -404,6 +440,13 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "force_debug_run"
+
+        /**
+         * Suffixes tried when the timestamped session dir name is already taken. A handful is
+         * plenty: the name is millisecond-stamped, so a collision means a leftover directory or a
+         * second start in the same millisecond, not a long run of them.
+         */
+        private const val NAME_COLLISION_LIMIT = 8
 
         /**
          * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped

--- a/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/octi/common/debug/recording/core/RecorderModule.kt
@@ -14,14 +14,19 @@ import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.DynamicStateFlow
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -49,6 +54,14 @@ class RecorderModule @Inject constructor(
     internal var wallClock: () -> Long = { Clock.System.now().toEpochMilliseconds() }
     internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
 
+    // Test seam for the recorder itself: a failing stop() has no reachable production trigger, so
+    // the guarantee that a failed stop still completes cannot be driven without substituting one.
+    internal var recorderFactory: () -> Recorder = { Recorder() }
+
+    // Serializes the public request surface: without it two concurrent callers can observe each
+    // other's start failure, or a stale one, instead of their own attempt's outcome.
+    private val requestMutex = Mutex()
+
     private val internalState = DynamicStateFlow(TAG, appScope + dispatcherProvider.IO) {
         val triggerFileExists = triggerFile.exists()
         State(shouldRecord = triggerFileExists)
@@ -72,27 +85,106 @@ class RecorderModule @Inject constructor(
                         // case with no usable monotonic base.
                         val isProcessResume = triggerFile.exists()
 
-                        val (sessionDir, startedAt) = findOrCreateSession(lastSession)
-                        val newRecorder = Recorder()
-                        newRecorder.start(sessionDir)
-                        writeTriggerFile(sessionDir, startedAt)
+                        // Rollback bookkeeping: a start that throws half-way must leave nothing
+                        // behind that this module can no longer reach - neither a running recorder
+                        // with globally installed loggers, nor a trigger file that re-runs the
+                        // failing start on every process launch.
+                        var pendingRecorder: Recorder? = null
+                        var createdSessionDir: File? = null
+                        var triggerWriteStarted = false
 
-                        copy(
-                            recorder = newRecorder,
-                            recordingStartedAt = startedAt,
-                            // A fresh start that reuses an old session dir gets BOTH bases: the
-                            // scanned wall stamp above and this monotonic one. The heuristic prefers
-                            // the monotonic base, so the stale mtime never decides a live recording.
-                            recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
-                        )
+                        try {
+                            val target = findOrCreateSession(lastSession)
+                            if (target.isNewDir) createdSessionDir = target.sessionDir
+
+                            // Bound BEFORE start() so a throw from inside start() still has
+                            // something to roll back.
+                            val newRecorder = recorderFactory().also { pendingRecorder = it }
+                            newRecorder.start(target.sessionDir)
+
+                            triggerWriteStarted = true
+                            writeTriggerFile(target.sessionDir, target.startedAt)
+
+                            copy(
+                                recorder = newRecorder,
+                                recordingStartedAt = target.startedAt,
+                                // A fresh start that reuses an old session dir gets BOTH bases: the
+                                // scanned wall stamp above and this monotonic one. The heuristic prefers
+                                // the monotonic base, so the stale mtime never decides a live recording.
+                                recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
+                                startFailure = null,
+                            )
+                        } catch (e: Throwable) {
+                            withContext(NonCancellable) {
+                                pendingRecorder?.let { orphan ->
+                                    try {
+                                        orphan.stop()
+                                    } catch (stopError: Throwable) {
+                                        e.addSuppressed(stopError)
+                                    }
+                                }
+                                // Only a trigger this attempt created: one that was already there
+                                // belongs to the session we were resuming.
+                                if (triggerWriteStarted && !isProcessResume) {
+                                    try {
+                                        if (triggerFile.exists() && !triggerFile.delete()) {
+                                            log(TAG, ERROR) { "Failed to delete trigger file after failed start" }
+                                        }
+                                    } catch (cleanupError: Throwable) {
+                                        e.addSuppressed(cleanupError)
+                                    }
+                                }
+                                // Resumed session dirs are the user's existing log and are kept.
+                                createdSessionDir?.let { dir ->
+                                    try {
+                                        if (dir.isDirectory && !dir.deleteRecursively()) {
+                                            log(TAG, ERROR) { "Failed to delete session dir after failed start: $dir" }
+                                        }
+                                    } catch (cleanupError: Throwable) {
+                                        e.addSuppressed(cleanupError)
+                                    }
+                                }
+                            }
+
+                            log(TAG, ERROR) { "Failed to start recording: ${e.asLog()}" }
+
+                            // Our own scope being cancelled must propagate; a CancellationException
+                            // that merely came out of the start sequence must not, it would kill
+                            // this collector and leave every future request unanswered.
+                            currentCoroutineContext().ensureActive()
+
+                            // shouldRecord is reset so the edge-triggered collector is re-armed for
+                            // a retry, and the failure is committed so a waiting startRecorder()
+                            // observes it instead of waiting forever.
+                            copy(
+                                shouldRecord = false,
+                                startFailure = e,
+                                recorder = null,
+                                recordingStartedAt = null,
+                                recordingStartedAtMonotonic = null,
+                            )
+                        }
                     } else if (!shouldRecord && isRecording) {
                         val recorderSessionDir = recorder?.sessionDir
                             ?: return@updateBlocking this
                         val session = LogSession(recorderSessionDir)
-                        recorder.stop()
 
-                        if (triggerFile.exists() && !triggerFile.delete()) {
-                            log(TAG, ERROR) { "Failed to delete trigger file" }
+                        // Both steps are best-effort: a stop that cannot complete is logged, but the
+                        // cleared state is committed regardless so a waiting stopRecorder() returns.
+                        try {
+                            recorder.stop()
+                        } catch (e: Throwable) {
+                            currentCoroutineContext().ensureActive()
+                            log(TAG, ERROR) { "Failed to stop the recorder: ${e.asLog()}" }
+                        }
+
+                        try {
+                            if (triggerFile.exists() && !triggerFile.delete()) {
+                                log(TAG, ERROR) { "Failed to delete trigger file" }
+                            }
+                        } catch (e: Throwable) {
+                            currentCoroutineContext().ensureActive()
+                            log(TAG, ERROR) { "Failed to delete trigger file: ${e.asLog()}" }
                         }
 
                         copy(
@@ -170,14 +262,24 @@ class RecorderModule @Inject constructor(
         return sessionDir to startedAt
     }
 
-    internal fun findOrCreateSession(lastSession: LogSession? = null): Pair<File, Long> {
+    /**
+     * [isNewDir] separates a directory this call created from one it resumed into: only the former
+     * may be deleted again when the start sequence fails.
+     */
+    internal data class SessionTarget(
+        val sessionDir: File,
+        val startedAt: Long,
+        val isNewDir: Boolean,
+    )
+
+    internal fun findOrCreateSession(lastSession: LogSession? = null): SessionTarget {
         val triggerData = readTriggerFile()
         if (triggerData != null) {
             val (sessionDir, startedAt) = triggerData
             val coreLog = File(sessionDir, "core.log")
             if (sessionDir.isDirectory && coreLog.exists()) {
                 log(TAG, INFO) { "Resuming session: ${sessionDir.name}, startedAt=$startedAt" }
-                return sessionDir to startedAt
+                return SessionTarget(sessionDir, startedAt, isNewDir = false)
             }
             log(TAG, WARN) { "Trigger references missing session: $sessionDir, creating new" }
         }
@@ -186,10 +288,10 @@ class RecorderModule @Inject constructor(
         if (existingDir != null) {
             val startedAt = existingDir.lastModified().takeIf { it > 0 } ?: wallClock()
             log(TAG, INFO) { "Legacy resume from scan: ${existingDir.name}" }
-            return existingDir to startedAt
+            return SessionTarget(existingDir, startedAt, isNewDir = false)
         }
 
-        return createSessionDir() to wallClock()
+        return SessionTarget(createSessionDir(), wallClock(), isNewDir = true)
     }
 
     internal fun findExistingSessionDir(lastSession: LogSession? = null): File? {
@@ -228,24 +330,28 @@ class RecorderModule @Inject constructor(
         return dirs
     }
 
-    suspend fun startRecorder(): LogSession {
+    suspend fun startRecorder(): LogSession = requestMutex.withLock {
+        // Clearing the failure is what keeps a STALE one from satisfying this attempt's await.
         internalState.updateBlocking {
-            copy(shouldRecord = true)
+            copy(shouldRecord = true, startFailure = null)
         }
-        val recordingState = internalState.flow.filter { it.isRecording }.first()
-        val sessionDir = checkNotNull(recordingState.recorder?.sessionDir) { "Recorder started but sessionDir is null" }
-        return LogSession(sessionDir)
+
+        val settled = internalState.flow.first { it.isRecording || it.startFailure != null }
+        settled.startFailure?.let { throw it }
+
+        val sessionDir = checkNotNull(settled.recorder?.sessionDir) { "Recorder started but sessionDir is null" }
+        LogSession(sessionDir)
     }
 
-    suspend fun stopRecorder(): LogSession? {
+    suspend fun stopRecorder(): LogSession? = requestMutex.withLock {
         val currentState = internalState.value()
-        val sessionDir = currentState.recorder?.sessionDir ?: return null
+        val sessionDir = currentState.recorder?.sessionDir ?: return@withLock null
 
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
-        internalState.flow.filter { !it.isRecording }.first()
-        return LogSession(sessionDir)
+        internalState.flow.first { !it.isRecording }
+        LogSession(sessionDir)
     }
 
     suspend fun requestStopRecorder(): StopResult {
@@ -280,6 +386,13 @@ class RecorderModule @Inject constructor(
         // previous process or boot is meaningless. Nullable rather than 0L — 0 is a legal
         // elapsedRealtime near boot.
         val recordingStartedAtMonotonic: Long? = null,
+        /**
+         * The exception that ended the last start attempt, cleared when a new one is requested.
+         * Identity is per-attempt on purpose: the state flow is distinctUntilChanged, so a failure
+         * has to produce a value distinct from its predecessor or a waiting [startRecorder] never
+         * wakes up. Throwable's reference equality provides that.
+         */
+        val startFailure: Throwable? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null

--- a/app/src/test/java/eu/darken/octi/common/debug/logging/FileLoggerTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/logging/FileLoggerTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.octi.common.debug.logging
+
+import android.app.Application
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.io.File
+import java.io.IOException
+
+/**
+ * A start that cannot open its writer removes the log file again - which used to include the log of
+ * a session being RESUMED, so a restart that failed threw away the recording the user had already
+ * collected. Only a file this attempt created may be removed.
+ *
+ * Robolectric because the logger uses android.util.Log (app-common has no test runner of its own).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class FileLoggerTest : BaseTest() {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun `a failed start keeps a log it did not create`() {
+        val logFile = File(tempFolder.newFolder("session"), "core.log")
+        logFile.writeText("=== BEGIN ===\nthe recording the user already made\n")
+        logFile.setWritable(false, false)
+        // A root test runner ignores the permission bit, and then there is no failure to observe.
+        assumeTrue("Log file is still writable", !logFile.canWrite())
+
+        try {
+            shouldThrow<IOException> { FileLogger(logFile).start() }
+
+            logFile.exists() shouldBe true
+            logFile.readText() shouldContain "the recording the user already made"
+        } finally {
+            logFile.setWritable(true, true)
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.debug.logging.Logging
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -14,6 +15,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -373,6 +375,46 @@ class RecorderModuleDurationTest : BaseTest() {
             state.isRecording shouldBe false
             state.shouldRecord shouldBe false
             state.startFailure.shouldBeInstanceOf<FileNotFoundException>()
+        }
+    }
+
+    /**
+     * A cancellation coming out of the start sequence is not necessarily OUR cancellation - a
+     * dependency can let one escape while the module's scope is perfectly alive. Stored and
+     * rethrown unchanged, it reaches the caller as their own cancellation: the requesting launch
+     * ends "normally" and the error handler that would have shown the failure never runs. It has to
+     * arrive as an ordinary exception instead, with the original kept as the cause.
+     */
+    @Test
+    fun `a foreign cancellation during start surfaces as an ordinary failure`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        val recorder = spyk(Recorder())
+        coEvery { recorder.start(any()) } throws CancellationException("dependency cancelled mid-start")
+
+        withModule(clocks, recorderOverride = recorder) { module ->
+            val error = shouldThrow<RecorderModule.RecorderStartFailedException> { module.startRecorder() }
+            // Walked along the chain rather than read off error.cause directly: stack-trace recovery
+            // may hand back a copy that wraps the wrapper.
+            generateSequence(error.cause) { it.cause }
+                .filterIsInstance<CancellationException>()
+                .map { it.message }
+                .toList() shouldContain "dependency cancelled mid-start"
+
+            val failed = module.state.first()
+            failed.isRecording shouldBe false
+            failed.shouldRecord shouldBe false
+            failed.startFailure.shouldBeInstanceOf<RecorderModule.RecorderStartFailedException>()
+
+            // A fresh real recorder for the retry - the double's start stays broken. The collector
+            // survived the foreign cancellation, so this request is answered instead of wedged.
+            module.recorderFactory = { Recorder() }
+
+            val session = module.startRecorder()
+            session.sessionDir.isDirectory shouldBe true
+
+            val started = module.state.first()
+            started.isRecording shouldBe true
+            started.startFailure.shouldBeNull()
         }
     }
 

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.every
@@ -16,7 +17,10 @@ import io.mockk.spyk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
@@ -398,6 +402,73 @@ class RecorderModuleDurationTest : BaseTest() {
                 // installed are uninstalled here. Recorder.stop() itself guarantees that removal
                 // even when a step fails, but that guarantee cannot be driven through this double.
                 (Logging.loggers - loggersBefore).forEach { Logging.remove(it) }
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent stop requests stop the session exactly once`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(clocks) { module ->
+            module.startRecorder()
+            clocks.monotonic += 30_000L
+
+            val results = coroutineScope {
+                (1..4).map { async(Dispatchers.IO) { module.requestStopRecorder() } }.awaitAll()
+            }
+
+            // Deciding outside the request lock let every caller read "recording" and then report a
+            // stop that only one of them performed.
+            results.count { it is RecorderModule.StopResult.Stopped } shouldBe 1
+            results.count { it == RecorderModule.StopResult.NotRecording } shouldBe 3
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a force stop racing a stop request stops the session exactly once`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(clocks) { module ->
+            module.startRecorder()
+            clocks.monotonic += 30_000L
+
+            val (forced, requested) = coroutineScope {
+                val force = async(Dispatchers.IO) { module.stopRecorder() }
+                val request = async(Dispatchers.IO) { module.requestStopRecorder() }
+                force.await() to request.await()
+            }
+
+            listOf(
+                forced != null,
+                requested is RecorderModule.StopResult.Stopped,
+            ).count { it } shouldBe 1
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a stop request racing a start never claims the live session`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(clocks) { module ->
+            module.startRecorder()
+            clocks.monotonic += 30_000L
+
+            val (requested, restarted) = coroutineScope {
+                val request = async(Dispatchers.IO) { module.requestStopRecorder() }
+                val start = async(Dispatchers.IO) { module.startRecorder() }
+                request.await() to start.await()
+            }
+
+            requested.shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            // Either order is legal, but the reported stop and a still-live session can never be
+            // the same one - that pairing is what an unsynchronized read produced.
+            if (module.state.first().isRecording) {
+                requested.session.sessionDir shouldNotBe restarted.sessionDir
+            } else {
+                requested.session.sessionDir shouldBe restarted.sessionDir
             }
         }
     }

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleDurationTest.kt
@@ -4,10 +4,15 @@ import android.app.Application
 import android.content.Context
 import eu.darken.octi.common.BuildConfigWrap
 import eu.darken.octi.common.debug.logging.Logging
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.spyk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -25,6 +30,8 @@ import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
 import kotlin.time.Clock
 
 /**
@@ -37,6 +44,9 @@ import kotlin.time.Clock
  *
  * Robolectric with the REAL [Recorder]: the module constructs it directly, and its FileLogger
  * needs android.util.Log.
+ *
+ * The start/stop failure cases live here too: they need exactly this harness — a real recorder
+ * whose globally installed loggers are accounted for, inside a hard timeout envelope.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE, application = Application::class)
@@ -63,10 +73,14 @@ class RecorderModuleDurationTest : BaseTest() {
      * construction, so seeding afterwards would race the init collector. The clock seams are
      * installed immediately after construction, so a resume's trigger validation may still see the
      * real clock — the resume cases anchor their timestamps near real time for exactly that reason.
+     *
+     * [recorderOverride] is installed after construction as well, so it only reaches attempts the
+     * test itself requests, not one a seeded trigger starts during construction.
      */
     private fun withModule(
         clocks: TestClocks,
         awaitRecording: Boolean = false,
+        recorderOverride: Recorder? = null,
         seed: (externalDir: File) -> Unit = {},
         block: suspend (RecorderModule) -> Unit,
     ) {
@@ -92,6 +106,7 @@ class RecorderModuleDurationTest : BaseTest() {
                 ).apply {
                     wallClock = { clocks.wall }
                     monotonicClock = { clocks.monotonic }
+                    recorderOverride?.let { override -> recorderFactory = { override } }
                 }
                 module = created
                 // Envelope: a wedged start or stop must fail in seconds, not hold the gradle worker.
@@ -259,6 +274,131 @@ class RecorderModuleDurationTest : BaseTest() {
 
             module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
             module.state.first().isRecording shouldBe true
+        }
+    }
+
+    /**
+     * A DIRECTORY at the trigger path: [RecorderModule.readTriggerFile] tolerates it (it reads as
+     * "no resumable session"), but the trigger write at the end of the start sequence cannot open
+     * it. That is the last step of the start branch, so the recorder is already live and globally
+     * installed when it throws — the orphan case.
+     *
+     * Note this also makes `triggerFile.exists()` true, so the module treats it as a process
+     * resume and starts recording during construction; [withModule] is therefore driven with
+     * awaitRecording=false.
+     */
+    private fun seedBlockedTrigger(externalDir: File): File =
+        File(externalDir, "force_debug_run").also { check(it.mkdirs()) { "Failed to seed trigger dir" } }
+
+    @Test
+    fun `a failed start surfaces the error instead of hanging`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(clocks, seed = { seedBlockedTrigger(it) }) { module ->
+            // Asserted INSIDE the envelope and on the concrete exception type: a wedged await
+            // fails with TimeoutCancellationException, which must not be able to satisfy this.
+            shouldThrow<FileNotFoundException> { module.startRecorder() }
+
+            val state = module.state.first()
+            state.isRecording shouldBe false
+            state.shouldRecord shouldBe false
+            state.startFailure.shouldBeInstanceOf<FileNotFoundException>()
+            // No leaked logger: the harness asserts it, and it is the proof that the recorder the
+            // failed attempt had already started was rolled back instead of orphaned.
+        }
+    }
+
+    @Test
+    fun `the recorder recovers after a failed start`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        var blockedTrigger: File? = null
+
+        withModule(clocks, seed = { blockedTrigger = seedBlockedTrigger(it) }) { module ->
+            shouldThrow<FileNotFoundException> { module.startRecorder() }
+
+            // The blocker was NOT created by the failed attempt, so its rollback left it alone.
+            blockedTrigger!!.delete() shouldBe true
+
+            // Collector still alive and re-armed: shouldRecord was reset by the failure, so this
+            // request is a fresh edge.
+            val session = module.startRecorder()
+            session.sessionDir.isDirectory shouldBe true
+
+            val started = module.state.first()
+            started.isRecording shouldBe true
+            started.startFailure.shouldBeNull()
+
+            module.stopRecorder().shouldNotBeNull()
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a boot trigger that cannot start settles instead of wedging`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(clocks, seed = { seedBlockedTrigger(it) }) { module ->
+            // Nobody is waiting on this attempt — it is the one the module makes on its own during
+            // construction. It has to settle rather than crash the app scope or spin.
+            val settled = module.state.first { it.startFailure != null }
+            settled.isRecording shouldBe false
+            settled.shouldRecord shouldBe false
+            settled.startFailure.shouldBeInstanceOf<FileNotFoundException>()
+        }
+    }
+
+    @Test
+    fun `a start that cannot open the log file surfaces the error`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+
+        withModule(
+            clocks,
+            seed = { externalDir ->
+                // An existing session whose core.log is a DIRECTORY: the file logger cannot open a
+                // writer for it. This fails inside the start operation itself, before the trigger
+                // write, and it used to be swallowed into a successful start with a logger that
+                // wrote nowhere.
+                val sessionDir = File(externalDir, "debug/logs/${BuildConfigWrap.APPLICATION_ID}_1.0_blocked")
+                    .also { it.mkdirs() }
+                check(File(sessionDir, "core.log").mkdirs()) { "Failed to seed core.log dir" }
+            },
+        ) { module ->
+            shouldThrow<FileNotFoundException> { module.startRecorder() }
+
+            val state = module.state.first()
+            state.isRecording shouldBe false
+            state.shouldRecord shouldBe false
+            state.startFailure.shouldBeInstanceOf<FileNotFoundException>()
+        }
+    }
+
+    @Test
+    fun `a stop that fails still completes`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        val loggersBefore = Logging.loggers.toSet()
+        val recorder = spyk(Recorder())
+
+        withModule(clocks, recorderOverride = recorder) { module ->
+            module.startRecorder()
+            module.state.first().isRecording shouldBe true
+
+            coEvery { recorder.stop() } throws IOException("Simulated stop failure")
+
+            try {
+                // Bounded by the envelope: a throwing stop must not strand the caller, and the
+                // module commits the cleared state anyway — the session is reported as stopped
+                // exactly once, which is what the compression downstream keys off.
+                module.stopRecorder().shouldNotBeNull()
+
+                val state = module.state.first()
+                state.isRecording shouldBe false
+                state.shouldRecord shouldBe false
+            } finally {
+                // The double throws INSTEAD of running the real stop, so the loggers the real start
+                // installed are uninstalled here. Recorder.stop() itself guarantees that removal
+                // even when a step fails, but that guarantee cannot be driven through this double.
+                (Logging.loggers - loggersBefore).forEach { Logging.remove(it) }
+            }
         }
     }
 

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderModuleTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
@@ -156,9 +157,11 @@ class RecorderModuleTest : BaseTest() {
             val startedAt = Clock.System.now().toEpochMilliseconds() - 120_000
             module.writeTriggerFile(sessionDir, startedAt)
 
-            val (resultDir, resultStartedAt) = module.findOrCreateSession()
-            resultDir shouldBe sessionDir
-            resultStartedAt shouldBe startedAt
+            val target = module.findOrCreateSession()
+            target.sessionDir shouldBe sessionDir
+            target.startedAt shouldBe startedAt
+            // Resumed, not created: a failed start must never roll this directory away.
+            target.isNewDir shouldBe false
         }
 
         @Test
@@ -201,10 +204,31 @@ class RecorderModuleTest : BaseTest() {
 
         @Test
         fun `creates fresh session when no trigger and no existing dirs`() {
-            val (resultDir, resultStartedAt) = module.findOrCreateSession()
-            resultDir.isDirectory shouldBe true
-            resultDir.name shouldContain BuildConfigWrap.APPLICATION_ID
-            resultStartedAt shouldBeGreaterThan 0L
+            val target = module.findOrCreateSession()
+            target.sessionDir.isDirectory shouldBe true
+            target.sessionDir.name shouldContain BuildConfigWrap.APPLICATION_ID
+            target.startedAt shouldBeGreaterThan 0L
+            // Actually created by this call, so its rollback may delete it again.
+            target.isNewDir shouldBe true
+        }
+
+        @Test
+        fun `a name collision takes a new dir instead of adopting the existing one`() {
+            val stamp = 1_700_000_000_000L
+            module.wallClock = { stamp }
+            val sanitizedVersion = BuildConfigWrap.VERSION_NAME.replace(Regex("[^A-Za-z0-9._-]"), "_")
+            val collidingName = "${BuildConfigWrap.APPLICATION_ID}_${sanitizedVersion}_$stamp"
+            // No core.log, so the scan skips it and the create path runs straight into the name.
+            val existing = File(logDir, collidingName).also { it.mkdirs() }
+
+            val target = module.findOrCreateSession()
+
+            // Adopting it would mark somebody else's directory as created-by-this-attempt, and a
+            // failed start would then delete it.
+            target.sessionDir shouldNotBe existing
+            target.sessionDir.name shouldBe "${collidingName}_1"
+            target.isNewDir shouldBe true
+            existing.isDirectory shouldBe true
         }
     }
 

--- a/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/debug/recording/core/RecorderTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.octi.common.debug.recording.core
+
+import android.app.Application
+import eu.darken.octi.common.debug.logging.Logging
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import java.io.File
+
+/**
+ * The REAL recorder with a fault injected into the logging its own teardown emits - no double, no
+ * manual cleanup. [Recorder.stop] has to run every teardown step regardless of what the ones before
+ * it did: the module commits "stopped" state around it, and a logger left installed keeps writing
+ * into a session everybody else considers finished.
+ *
+ * Robolectric because the file logger needs android.util.Log.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, application = Application::class)
+class RecorderTest : BaseTest() {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    /** Fails on every line it receives while armed - the loggers being torn down are receivers. */
+    private class Saboteur : Logging.Logger {
+        @Volatile
+        var armed = false
+
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            if (armed) throw IllegalStateException("Simulated logger failure")
+        }
+    }
+
+    @Test
+    fun `a stop whose logging fails still tears the recorder down`() {
+        val loggersBefore = Logging.loggers
+        val sessionDir = tempFolder.newFolder("session")
+        val recorder = Recorder()
+        val saboteur = Saboteur()
+
+        try {
+            runBlocking { recorder.start(sessionDir) }
+            Logging.install(saboteur)
+            saboteur.armed = true
+
+            // The first failure is reported, not swallowed - but only after everything ran.
+            shouldThrow<IllegalStateException> { runBlocking { recorder.stop() } }
+        } finally {
+            saboteur.armed = false
+            Logging.remove(saboteur)
+        }
+
+        // Nothing was uninstalled by hand in between: this is stop()'s own guarantee.
+        Logging.loggers shouldBe loggersBefore
+        recorder.isRecording shouldBe false
+        recorder.path.shouldBeNull()
+        recorder.sessionDir.shouldBeNull()
+        // The end marker is written by the file logger's own stop, so the writer was closed too
+        // instead of being left open on a session that is reported as finished.
+        File(sessionDir, "core.log").readText() shouldContain "=== END ==="
+    }
+}


### PR DESCRIPTION
## What changed

The debug log recorder no longer becomes permanently unusable when a recording fails to start (for example on full storage): the failure now appears as a normal error dialog, the running recorder is cleanly shut down instead of writing invisibly forever, and the next attempt works. A start that failed while opening the log file no longer pretends to record, and a failed restart can no longer delete a recording you already made.

## Technical Context

- The start branch had no guard at all: a throw between `Recorder().start()` and the state commit orphaned the live recorder (its global logger kept writing with no reachable stop path), killed the reactive collector for the process lifetime, left `startRecorder()` awaiting state forever (`shouldRecord` stuck true also blocked any retry), and rethrew onto the handler-less AppScope.
- Fix shape (shared with the sibling apps): failures are committed to state (`startFailure`, Throwable identity beats the flow's `distinctUntilChanged`), `shouldRecord` resets, rollback runs under `NonCancellable` with a pre-bound candidate recorder and deletes only attempt-created trigger files/dirs, and after rollback `ensureActive()` distinguishes real scope cancellation (propagates) from a dependency's `CancellationException` (wrapped in `RecorderStartFailedException` so ViewModel error handlers fire).
- `FileLogger.start()` used to swallow its IOException — a failed open committed an inert "recording". It now surfaces the failure and only deletes a log file it created itself (a failed resume previously deleted the existing recording).
- `Recorder.stop()` and `Logging.remove()` are exception-safe now (registry removal before fallible diagnostics, fields cleared in finally) — a throwing logger could previously leave itself installed while the session got compressed as "stopped".
- `startRecorder()`/`stopRecorder()`/`requestStopRecorder()` are serialized by a mutex; the stop-request previously read state outside it and could report a stop it never performed.
