### PR TITLE
Fix rare crashes and back-navigation issues in the error dialog

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/error/ErrorEventHandler.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/error/ErrorEventHandler.kt
@@ -13,6 +13,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import eu.darken.octi.common.R
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 
 @Composable
 fun ErrorEventHandler(source: ErrorEventSource) {
@@ -38,16 +42,26 @@ private fun ComposeErrorDialog(
     val localizedError = throwable.localized(context)
     val activity = context as? Activity
 
+    fun dispatchAndDismiss(action: (Activity) -> Unit) {
+        // Error actions are arbitrary third-party code (intent launches, deep links): a throw here
+        // would crash the UI thread from inside a click handler, and skipping onDismiss() would
+        // leave the dialog latched on the current error with no way out.
+        try {
+            activity?.let { action(it) }
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
+        } finally {
+            onDismiss()
+        }
+    }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(text = localizedError.label.get(context)) },
         text = { Text(text = localizedError.description.get(context)) },
         confirmButton = {
             if (localizedError.fixAction != null && activity != null) {
-                TextButton(onClick = {
-                    localizedError.fixAction.invoke(activity)
-                    onDismiss()
-                }) {
+                TextButton(onClick = { dispatchAndDismiss(localizedError.fixAction) }) {
                     Text(
                         text = localizedError.fixActionLabel?.get(context)
                             ?: stringResource(android.R.string.ok)
@@ -69,10 +83,7 @@ private fun ComposeErrorDialog(
             }
             localizedError.infoAction != null && activity != null -> {
                 {
-                    TextButton(onClick = {
-                        localizedError.infoAction.invoke(activity)
-                        onDismiss()
-                    }) {
+                    TextButton(onClick = { dispatchAndDismiss(localizedError.infoAction) }) {
                         Text(text = stringResource(R.string.general_show_details_action))
                     }
                 }
@@ -81,3 +92,5 @@ private fun ComposeErrorDialog(
         },
     )
 }
+
+private val TAG = logTag("Error", "EventHandler")

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.common.upgrade.core.billing
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
@@ -21,20 +22,27 @@ class GplayServiceUnavailableException(cause: Throwable) :
         description = R.string.upgrades_gplay_unavailable_error_description.toCaString(),
         fixActionLabel = "Google Play".toCaString(),
         fixAction = { activity ->
-            try {
-                val intent = Intent().apply {
-                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                    data = Uri.fromParts("package", GPLAY_PKG, null)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
+            val intent = Intent().apply {
+                action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                data = Uri.fromParts("package", GPLAY_PKG, null)
+            }
 
+            try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-                Toast.makeText(activity, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+                onLaunchFailed(activity, e)
+            } catch (e: SecurityException) {
+                // Play can be installed but unreachable: disabled app, work/restricted profile or a
+                // ROM that guards the settings screen. The launch is denied, not unresolvable.
+                onLaunchFailed(activity, e)
             }
         }
     )
+
+    private fun onLaunchFailed(activity: Activity, e: Exception) {
+        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
+    }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="upgrades_gplay_offer_unavailable_title">Offer unavailable</string>
     <string name="upgrades_gplay_offer_unavailable_description">Google Play is currently not offering this upgrade option. Please try again later or check the Google Play Store.</string>
 
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play is not installed.</string>
+
     <string name="upgrades_dashcard_title">Get Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade to unlock additional features and support development!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>

--- a/app/src/test/java/eu/darken/octi/common/error/ComposeErrorDialogGuardTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/error/ComposeErrorDialogGuardTest.kt
@@ -1,0 +1,115 @@
+package eu.darken.octi.common.error
+
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.ca.toCaString
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.flow.SingleEventFlow
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import eu.darken.octi.common.R as CommonR
+
+/**
+ * The error dialog runs whatever action an error hands it: a throwing action must neither take the
+ * UI down with it nor leave the dialog latched on the error it was supposed to resolve.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ComposeErrorDialogGuardTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private class FakeErrorSource : ErrorEventSource {
+        override val errorEvents = SingleEventFlow<Throwable>()
+    }
+
+    private class ThrowingFixError(private val onFix: () -> Unit) : Exception("fix error"), HasLocalizedError {
+        override fun getLocalizedError(): LocalizedError = LocalizedError(
+            throwable = this,
+            label = "Fix error".toCaString(),
+            description = "Something wants fixing".toCaString(),
+            fixActionLabel = FIX_LABEL.toCaString(),
+            fixAction = { onFix() },
+        )
+    }
+
+    private class InfoActionError(private val onInfo: () -> Unit) : Exception("info error"), HasLocalizedError {
+        override fun getLocalizedError(): LocalizedError = LocalizedError(
+            throwable = this,
+            label = "Info error".toCaString(),
+            description = "Something needs a closer look".toCaString(),
+            infoAction = { onInfo() },
+        )
+    }
+
+    private fun showError(error: Throwable) {
+        val source = FakeErrorSource()
+        composeRule.setContent {
+            PreviewWrapper {
+                ErrorEventHandler(source)
+            }
+        }
+        // Buffered channel: the event survives until the handler's collector attaches.
+        source.errorEvents.tryEmit(error)
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a throwing fix action still dismisses the dialog`() {
+        var invoked = false
+        showError(
+            ThrowingFixError(
+                onFix = {
+                    // Flag first: the assertion below has to distinguish "action ran and threw" from
+                    // "action was never dispatched".
+                    invoked = true
+                    throw IllegalStateException("fix action exploded")
+                },
+            )
+        )
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        invoked shouldBe true
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a throwing info action still dismisses the dialog`() {
+        // The other dispatch site: no fix to offer, but the details action is just as arbitrary.
+        var infoClicks = 0
+        showError(
+            InfoActionError(
+                onInfo = {
+                    infoClicks++
+                    throw IllegalStateException("info action exploded")
+                },
+            )
+        )
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_show_details_action)).performClick()
+        composeRule.waitForIdle()
+
+        infoClicks shouldBe 1
+        composeRule.onAllNodesWithText(context.getString(android.R.string.ok)).assertCountEquals(0)
+    }
+}
+
+private const val FIX_LABEL = "Boom"

--- a/app/src/testGplay/java/eu/darken/octi/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/error/ComposeErrorDialogTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.common.error
 
 import android.content.Context
+import android.content.Intent
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertCountEquals
@@ -87,6 +88,9 @@ class ComposeErrorDialogTest : BaseTest() {
         val started = shadowOf(composeRule.activity).nextStartedActivity.shouldNotBeNull()
         started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
         started.data.toString() shouldBe "package:com.android.vending"
+        // NEW_TASK on an activity context detaches Play's app info from our task: the user loses the
+        // back path to the screen they came from and the settings screen lingers in recents.
+        (started.flags and Intent.FLAG_ACTIVITY_NEW_TASK) shouldBe 0
         // The user acted: leaving the dialog up would greet them again on the way back.
         composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
     }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -1,0 +1,58 @@
+package eu.darken.octi.common.upgrade.core.billing
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import eu.darken.octi.R
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The error dialog's "Google Play" button runs on an activity context: a device where the launch is
+ * refused - or where there is nothing to launch - must get a toast, not a crash.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayFixActionTest : BaseTest() {
+
+    /** Play is installed but unreachable: disabled app, restricted profile or a guarding ROM. */
+    class DeniedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw SecurityException("Permission Denial")
+    }
+
+    /** No app settings screen resolves the intent at all, e.g. a stripped-down ROM. */
+    class UnresolvedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw ActivityNotFoundException("No Activity found")
+    }
+
+    private val fixAction: (Activity) -> Unit
+        get() = GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError().fixAction.shouldNotBeNull()
+
+    private fun <T : Activity> activityOf(clazz: Class<T>): T = Robolectric.buildActivity(clazz).setup().get()
+
+    private fun assertToastInsteadOfCrash(activity: Activity) {
+        fixAction.invoke(activity)
+
+        ShadowToast.getTextOfLatestToast() shouldBe
+            activity.getString(R.string.upgrades_gplay_not_installed_message)
+    }
+
+    @Test
+    fun `a denied launch shows the not-installed toast instead of crashing`() {
+        assertToastInsteadOfCrash(activityOf(DeniedLaunchActivity::class.java))
+    }
+
+    @Test
+    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
+        assertToastInsteadOfCrash(activityOf(UnresolvedLaunchActivity::class.java))
+    }
+}


### PR DESCRIPTION
## What changed

The error dialog's buttons can no longer crash the app. If tapping "Google Play" (or the "Show details" action) hits something unexpected — Google Play missing, disabled, or blocked on the device — the app now shows a short notice instead of crashing, and the dialog closes properly. Google Play's app-info screen also opens inside the app's own task now, so pressing Back returns to the screen you came from instead of stranding you.

## Technical Context

- The "Google Play" fix action started its settings intent with `FLAG_ACTIVITY_NEW_TASK` from an activity context — that detaches the settings screen from our task (Back loses the way home, the screen lingers in recents). The flag is dropped; a test pins its absence.
- The launch was only guarded against `ActivityNotFoundException`; a `SecurityException` (disabled Play, work/restricted profile, guarding ROM) crashed the app. Both now route to one fallback: an error log plus a translatable toast (the toast text was previously hardcoded English).
- Dialog action dispatch (fix and info branches) is wrapped in try/catch/finally: error actions run arbitrary code, and a throw from a click handler would crash the UI thread and leave the dialog latched. Failures are logged, the dialog always dismisses.
- New guard tests live in `app/src/test` (the dialog is shared code, so both flavor test legs exercise them); the Google-Play-specific toast tests cover both exception paths.
