### PR TITLE
Fix a misleading Google Play error message

### DIFF
--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play is currently not offering this upgrade option. Please try again later or check the Google Play Store.</string>
 
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
-    <string name="upgrades_gplay_not_installed_message">Google Play is not installed.</string>
+    <string name="upgrades_gplay_not_installed_message">Couldn\'t open Google Play. It may be missing, disabled or restricted on this device.</string>
 
     <string name="upgrades_dashcard_title">Get Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade to unlock additional features and support development!</string>


### PR DESCRIPTION
## What changed

Fixed a misleading error message: when the error dialog's "Google Play" button couldn't open Google Play, the app always claimed "Google Play is not installed" — even on devices where Play is installed but disabled or restricted (work profiles, some ROMs), telling those users to install an app they already have. The message is now neutral: "Couldn't open Google Play. It may be missing, disabled or restricted on this device."

## Technical Context

- One-line string-value change; the resource key is unchanged and had no translations yet, so there is no localization churn. The toast tests assert via the resource, so no test changes.
- Same change lands in the sibling apps to keep the shared billing surface source-identical.
