### PR TITLE
Add shared screenshot thumbnail workflow

### DIFF
--- a/.github/workflows/thumbnail-images.yml
+++ b/.github/workflows/thumbnail-images.yml
@@ -1,0 +1,26 @@
+name: Thumbnail images
+
+# Shrinks oversized screenshots in issues and comments into clickable
+# thumbnails. The logic lives in d4rken-org/.github so every app repo shares
+# one copy; this stub only supplies the triggers, because workflow_call cannot
+# be triggered by issue_comment directly.
+#
+# The shared workflow splits into an unprivileged parsing job and a privileged
+# job that only makes the API call, so issues:write below is the ceiling, not
+# what the parsing half receives.
+#
+# Add <!-- no-thumbnail --> to a body to opt it out.
+
+on:
+  issue_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited]
+
+permissions: {}
+
+jobs:
+  thumbnail:
+    permissions:
+      issues: write
+    uses: d4rken-org/.github/.github/workflows/thumbnail-images.yml@3756372c3c844e4817c03d27983691f9991a19f4


### PR DESCRIPTION
Shrinks oversized screenshots in issues and comments into clickable thumbnails, matching what sdmaid-se now runs.

The logic is shared from `d4rken-org/.github`. This stub only supplies the triggers, because `workflow_call` cannot be driven by `issue_comment` directly.

The shared workflow splits into an unprivileged job that parses the untrusted Markdown and probes image dimensions holding no token scopes, and a privileged job that only makes the API call. `issues: write` in the stub is the ceiling for that call, not what the parsing half receives. Pinned by commit SHA rather than a moving tag.

Only tall portrait images are touched; landscape shots, badges and icons are left alone. Add `<!-- no-thumbnail -->` to a body to opt it out.