### PR TITLE
Ask happy users for a Play Store review

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -198,6 +198,9 @@ dependencies {
     "gplayImplementation"("com.android.billingclient:billing:8.3.0")
     "gplayImplementation"("com.android.billingclient:billing-ktx:8.3.0")
 
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
+
     implementation("io.github.z4kn4fein:semver:1.4.2")
 
     "screenshotTestImplementation"(platform("androidx.compose:compose-bom:${Versions.Compose.bom}"))

--- a/app/src/foss/java/eu/darken/octi/common/review/FossReviewTool.kt
+++ b/app/src/foss/java/eu/darken/octi/common/review/FossReviewTool.kt
@@ -1,0 +1,30 @@
+package eu.darken.octi.common.review
+
+import android.app.Activity
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FossReviewTool @Inject constructor() : ReviewTool {
+
+    override val state: Flow<ReviewTool.State> = flowOf(ReviewTool.State())
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        // NOOP
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+        // NOOP
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "FOSS")
+    }
+}

--- a/app/src/foss/java/eu/darken/octi/common/review/ReviewModule.kt
+++ b/app/src/foss/java/eu/darken/octi/common/review/ReviewModule.kt
@@ -1,0 +1,16 @@
+package eu.darken.octi.common.review
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: FossReviewTool): ReviewTool
+}

--- a/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
@@ -1,0 +1,202 @@
+package eu.darken.octi.common.review
+
+import android.app.Activity
+import com.google.android.play.core.ktx.launchReview
+import com.google.android.play.core.ktx.requestReview
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.octi.common.coroutine.AppScope
+import eu.darken.octi.common.datastore.value
+import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.octi.common.debug.logging.Logging.Priority.INFO
+import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
+import eu.darken.octi.common.debug.logging.asLog
+import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.common.flow.replayingShare
+import eu.darken.octi.common.flow.setupCommonEventHandlers
+import eu.darken.octi.common.flow.throttleLatest
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.Mutex
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+@Singleton
+class GplayReviewTool @Inject constructor(
+    @AppScope private val appScope: CoroutineScope,
+    private val settings: ReviewSettings,
+    private val manager: ReviewManager,
+    upgradeRepo: UpgradeRepo,
+) : ReviewTool {
+
+    // Test seam: the probe backoff runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
+
+    // Local bookkeeping only: decided without talking to Play, so an ineligible user never
+    // triggers a Play round-trip.
+    private val isLocallyEligible: Flow<Boolean> = combine(
+        settings.lastDismissed.flow,
+        settings.reviewedAt.flow,
+        upgradeRepo.upgradeInfo,
+    ) { lastDismissed, reviewedAt, upgradeInfo ->
+        val now = Clock.System.now()
+
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = (now - (upgradeInfo.upgradedAt ?: now)) > 21.days
+        val isSnoozed = (now - (lastDismissed ?: Instant.DISTANT_PAST)) < 14.days
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+        .distinctUntilChanged()
+
+    // Only probed once the user is eligible: Play counts requests against the app's quota, and an
+    // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
+    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+        .flatMapLatest { eligible ->
+            if (!eligible) return@flatMapLatest flowOf(false)
+
+            flow {
+                for (attempt in 1..PROBE_ATTEMPTS) {
+                    val info = try {
+                        manager.requestReview()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay)
+                        continue
+                    }
+                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+                    emit(info.canShow)
+                    return@flow
+                }
+                // Re-probed when eligibility changes or on the next process start
+                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
+                emit(false)
+            }
+        }
+        .setupCommonEventHandlers(TAG) { "isReviewAvailable" }
+        .replayingShare(appScope)
+
+    override val state: Flow<ReviewTool.State> = combine(
+        isLocallyEligible,
+        isReviewAvailable,
+        settings.reviewedAt.flow,
+    ) { eligible, available, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+        ReviewTool.State(
+            shouldAskForReview = eligible && available,
+            hasReviewed = reviewedAt != null,
+        )
+    }
+        .throttleLatest(500.milliseconds)
+        .onStart { emit(ReviewTool.State()) }
+        .setupCommonEventHandlers(TAG) { "state" }
+        .replayingShare(appScope)
+
+    // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
+    // launched again the moment the user returns from it.
+    private val reviewLock = Mutex()
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        settings.lastDismissed.value(Clock.System.now())
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+
+        if (!reviewLock.tryLock()) {
+            log(TAG, WARN) { "reviewNow(...) is already in progress, skipping" }
+            return
+        }
+
+        try {
+            // ReviewInfo is short lived, Google wants it requested shortly before the launch,
+            // a token cached at process start is likely stale by the time the user taps.
+            val reviewInfo = try {
+                manager.requestReview()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure is not user intent: don't snooze the card, the next tap retries
+                log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
+                return
+            }
+            log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (!reviewInfo.canShow) {
+                // Play's quota verdict, asking again right away would be pointless
+                log(TAG, WARN) { "Play says we can't show the prompt, snoozing" }
+                settings.lastDismissed.value(Clock.System.now())
+                return
+            }
+
+            if (activity.isFinishing || activity.isDestroyed) {
+                log(TAG, WARN) { "Activity is gone, aborting: $activity" }
+                return
+            }
+
+            val reviewTime = measureTimeMillis {
+                try {
+                    manager.launchReview(activity, reviewInfo)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+            }
+            log(TAG) { "Review completed after ${reviewTime}ms" }
+
+            if (reviewTime >= REVIEW_MIN_DURATION.inWholeMilliseconds) {
+                log(TAG, INFO) { "Marking review as completed" }
+                settings.reviewedAt.value(Clock.System.now())
+            } else {
+                log(TAG, INFO) { "Review was too quick, counting as dismiss" }
+                settings.lastDismissed.value(Clock.System.now())
+            }
+        } finally {
+            reviewLock.unlock()
+        }
+    }
+
+    private val ReviewInfo.canShow: Boolean
+        get() = when {
+            toString().contains("isNoOp=true") -> false
+            else -> true
+        }
+
+    private fun ReviewInfo.desc(): String {
+        return "ReviewInfo(canShow=$canShow, ${toString()})"
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "Gplay")
+        private const val PROBE_ATTEMPTS = 3
+        private val PROBE_RETRY_DELAY = 30.seconds
+        private val REVIEW_MIN_DURATION = 2.seconds
+    }
+}

--- a/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -70,6 +71,13 @@ class GplayReviewTool @Inject constructor(
         hasPaidForPro && !isSnoozed && !hasReviewed
     }
         .distinctUntilChanged()
+        // Has to sit upstream of the shares below: a failure there would kill the sharing
+        // coroutine on AppScope (no handler = process crash) instead of reaching any collector.
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
+            emit(false)
+        }
 
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
@@ -113,6 +121,11 @@ class GplayReviewTool @Inject constructor(
     }
         .throttleLatest(500.milliseconds)
         .onStart { emit(ReviewTool.State()) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "State failed: ${e.asLog()}" }
+            emit(ReviewTool.State())
+        }
         .setupCommonEventHandlers(TAG) { "state" }
         .replayingShare(appScope)
 

--- a/app/src/gplay/java/eu/darken/octi/common/review/ReviewModule.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/review/ReviewModule.kt
@@ -1,0 +1,27 @@
+package eu.darken.octi.common.review
+
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: GplayReviewTool): ReviewTool
+
+    companion object {
+        @Provides
+        @Singleton
+        fun reviewManager(@ApplicationContext context: Context): ReviewManager = ReviewManagerFactory.create(context)
+    }
+}

--- a/app/src/gplay/java/eu/darken/octi/common/review/ReviewSettings.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/review/ReviewSettings.kt
@@ -1,0 +1,32 @@
+package eu.darken.octi.common.review
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.octi.common.datastore.createValue
+import eu.darken.octi.common.debug.logging.logTag
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Instant
+
+@Singleton
+class ReviewSettings @Inject constructor(
+    @ApplicationContext private val context: Context,
+    json: Json,
+) {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_review_gplay")
+
+    val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    val lastDismissed = dataStore.createValue<Instant?>("review.dismissedAt", null, json)
+    val reviewedAt = dataStore.createValue<Instant?>("review.reviewedAt", null, json)
+
+    companion object {
+        internal val TAG = logTag("Review", "Settings", "Gplay")
+    }
+}

--- a/app/src/main/java/eu/darken/octi/common/review/ReviewTool.kt
+++ b/app/src/main/java/eu/darken/octi/common/review/ReviewTool.kt
@@ -1,0 +1,18 @@
+package eu.darken.octi.common.review
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+
+interface ReviewTool {
+
+    val state: Flow<State>
+
+    data class State(
+        val shouldAskForReview: Boolean = false,
+        val hasReviewed: Boolean = false,
+    )
+
+    suspend fun dismiss()
+
+    suspend fun reviewNow(activity: Activity)
+}

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -157,7 +157,8 @@ fun DashboardScreenHost(vm: DashboardVM = hiltViewModel()) {
     NavigationEventHandler(vm)
 
     val context = LocalContext.current
-    val mainVm: MainActivityVM = hiltViewModel(context as androidx.activity.ComponentActivity)
+    val activity = context as androidx.activity.ComponentActivity
+    val mainVm: MainActivityVM = hiltViewModel(activity)
 
     val snackbarHostState = remember { SnackbarHostState() }
     val hostScope = rememberCoroutineScope()
@@ -336,6 +337,8 @@ fun DashboardScreenHost(vm: DashboardVM = hiltViewModel()) {
             onMoveDeviceUp = { vm.moveDeviceUp(it) },
             onMoveDeviceDown = { vm.moveDeviceDown(it) },
             onRemoveDevice = { connectorId, deviceId -> vm.goToDeviceDetails(connectorId, deviceId) },
+            onReviewLater = { vm.reviewDismiss() },
+            onReview = { vm.reviewNow(activity) },
             externalSheetTarget = externalSheetTarget,
             onExternalSheetHandled = { externalSheetTarget = null },
         )
@@ -379,6 +382,8 @@ fun DashboardScreen(
     onMoveDeviceUp: (String) -> Unit = {},
     onMoveDeviceDown: (String) -> Unit = {},
     onRemoveDevice: (ConnectorId, DeviceId) -> Unit = { _, _ -> },
+    onReviewLater: () -> Unit = {},
+    onReview: () -> Unit = {},
     externalSheetTarget: DashboardVM.ModuleItem? = null,
     onExternalSheetHandled: () -> Unit = {},
 ) {
@@ -603,6 +608,14 @@ fun DashboardScreen(
                     SyncedAloneCard(
                         onLater = onSnoozeSyncedAlone,
                         onAddDevice = onSetupSync,
+                    )
+                }
+            }
+            if (state.showReviewCard) {
+                item(key = "review", span = { GridItemSpan(maxLineSpan) }) {
+                    ReviewCard(
+                        onLater = onReviewLater,
+                        onReview = onReview,
                     )
                 }
             }
@@ -1341,6 +1354,45 @@ private fun SyncSetupCard(
                 }
                 TextButton(onClick = onSetup) {
                     Text(stringResource(R.string.dashboard_syncsetup_setup_action))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReviewCard(
+    onLater: () -> Unit,
+    onReview: () -> Unit,
+) {
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.Stars,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.review_app_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(onClick = onLater) {
+                    Text(stringResource(CommonR.string.general_maybe_later_action))
+                }
+                TextButton(onClick = onReview) {
+                    Text(stringResource(R.string.review_app_review_action))
                 }
             }
         }
@@ -2089,6 +2141,52 @@ private fun DashboardScreenEmptyPreview() = PreviewWrapper {
             update = null,
             upgradeInfo = PreviewUpgradeInfo(),
             deviceLimitReached = false,
+        ),
+        onRefresh = {},
+        onSyncServices = {},
+        onPlaceholderClick = {},
+        onIssueClick = {},
+        onConnectorDevices = {},
+        onUpgrade = {},
+        onSettings = {},
+        onSnoozeSyncSetup = {},
+        onSnoozeSyncedAlone = {},
+        onSetupSync = {},
+        onGrantPermission = {},
+        onDismissPermission = {},
+        onDismissUpdate = {},
+        onViewUpdate = {},
+        onStartUpdate = {},
+        onToggleSyncExpanded = {},
+        onToggleDeviceCollapsed = {},
+        onPowerAlerts = {},
+        onAppsList = {},
+        onInstallLatestApp = {},
+        onClearClipboard = {},
+        onShareClipboard = {},
+        onCopyClipboard = {},
+        onFileShareClicked = {},
+        onWifiPermissionGrant = {},
+    )
+}
+
+@Preview2
+@Composable
+private fun DashboardScreenReviewPreview() = PreviewWrapper {
+    DashboardScreen(
+        state = DashboardVM.State(
+            devices = emptyList(),
+            deviceCount = 0,
+            syncStatus = null,
+            isOffline = false,
+            showSyncSetup = false,
+            showSyncedAlone = false,
+            hasConnectors = true,
+            missingPermissions = emptyList(),
+            update = null,
+            upgradeInfo = PreviewUpgradeInfo(),
+            deviceLimitReached = false,
+            showReviewCard = true,
         ),
         onRefresh = {},
         onSyncServices = {},

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -1,6 +1,7 @@
 package eu.darken.octi.main.ui.dashboard
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import androidx.lifecycle.SavedStateHandle
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.WebpageTool
@@ -19,6 +20,7 @@ import eu.darken.octi.common.navigation.NavigationDestination
 import eu.darken.octi.common.network.NetworkStateProvider
 import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.PermissionState
+import eu.darken.octi.common.review.ReviewTool
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import eu.darken.octi.common.upgrade.isHardLocked
@@ -68,6 +70,7 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onStart
@@ -109,6 +112,7 @@ class DashboardVM @Inject constructor(
     private val storageStatusManager: StorageStatusManager,
     private val connectorContributions: Map<ConnectorType, @JvmSuppressWildcards ConnectorUiContribution>,
     private val cardSnoozer: DashboardCardSnoozer,
+    private val reviewTool: ReviewTool,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider) {
 
     init {
@@ -197,6 +201,7 @@ class DashboardVM @Inject constructor(
         val deviceLimitReached: Boolean,
         val deviceLimit: Int = DEVICE_LIMIT,
         val issues: List<ConnectorIssue> = emptyList(),
+        val showReviewCard: Boolean = false,
     )
 
     data class DeviceItem(
@@ -415,7 +420,7 @@ class DashboardVM @Inject constructor(
         val snoozedCards: Set<DashboardCardSnoozer.Card>,
     )
 
-    val state: Flow<State> = combine(
+    private val baseState: Flow<State> = combine(
         tickerUiRefresh,
         networkStateProvider.networkState,
         syncHintCtx,
@@ -497,6 +502,24 @@ class DashboardVM @Inject constructor(
             upgradeInfo = upgradeInfo,
             deviceLimitReached = orderedDeviceItems.size > DEVICE_LIMIT && entitlementLocked,
             issues = issues,
+        )
+    }
+
+    /**
+     * The review prompt is the lowest-priority card on the dashboard: it only appears once the user
+     * has nothing else to act on. Anything that asks for a decision (sync setup, a missing
+     * permission, a pending update) suppresses it, so we never interrupt a task to ask for a favor.
+     */
+    val state: Flow<State> = kotlinx.coroutines.flow.combine(
+        baseState,
+        // A failing review backend is a decoration failure: it must not take the dashboard down.
+        reviewTool.state.catch { emit(ReviewTool.State()) },
+    ) { state, review ->
+        state.copy(
+            showReviewCard = review.shouldAskForReview &&
+                !state.showSyncSetup &&
+                state.missingPermissions.isEmpty() &&
+                state.update == null,
         )
     }
         .setupCommonEventHandlers(TAG, logValues = false) { "state" }
@@ -677,6 +700,16 @@ class DashboardVM @Inject constructor(
 
     fun startUpdate() = launch {
         state.first().update?.let { updateService.startUpdate(it) }
+    }
+
+    fun reviewNow(activity: Activity) = launch {
+        log(TAG) { "reviewNow($activity)" }
+        reviewTool.reviewNow(activity)
+    }
+
+    fun reviewDismiss() = launch {
+        log(TAG) { "reviewDismiss()" }
+        reviewTool.dismiss()
     }
 
     private fun deviceItems(): Flow<List<DeviceItem>> = combine(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,6 +300,9 @@
     <string name="dashboard_device_remove_picker_title">Choose sync service</string>
     <string name="dashboard_device_remove_picker_message">This device is synced through multiple services. Pick which one to remove it from — you\'ll confirm on the next screen.</string>
 
+    <string name="review_app_review_action">Review</string>
+    <string name="review_app_body">Would you like to leave Octi a review? ❤️</string>
+
     <!-- Shared upgrade screen chrome (used by both flavors' upgrade screens). -->
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
@@ -1,0 +1,121 @@
+package eu.darken.octi.main.ui.dashboard
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import kotlin.time.Instant
+import eu.darken.octi.common.R as CommonR
+
+class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val bodyText: String
+        get() = context.getString(R.string.review_app_body)
+
+    private val laterAction: String
+        get() = context.getString(CommonR.string.general_maybe_later_action)
+
+    private val reviewAction: String
+        get() = context.getString(R.string.review_app_review_action)
+
+    private val upgradeInfo = object : UpgradeRepo.Info {
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.GPLAY
+        override val isPro: Boolean = true
+        override val isSettled: Boolean = true
+        override val upgradedAt: Instant? = null
+        override val error: Throwable? = null
+    }
+
+    @Composable
+    private fun ReviewDashboard(
+        onReviewLater: () -> Unit = {},
+        onReview: () -> Unit = {},
+    ) {
+        DashboardScreen(
+            state = DashboardVM.State(
+                devices = emptyList(),
+                deviceCount = 0,
+                syncStatus = null,
+                isOffline = false,
+                showSyncSetup = false,
+                showSyncedAlone = false,
+                hasConnectors = true,
+                missingPermissions = emptyList(),
+                update = null,
+                upgradeInfo = upgradeInfo,
+                deviceLimitReached = false,
+                showReviewCard = true,
+            ),
+            onRefresh = {},
+            onSyncServices = {},
+            onPlaceholderClick = {},
+            onIssueClick = {},
+            onConnectorDevices = {},
+            onUpgrade = {},
+            onSettings = {},
+            onSnoozeSyncSetup = {},
+            onSnoozeSyncedAlone = {},
+            onSetupSync = {},
+            onGrantPermission = {},
+            onDismissPermission = {},
+            onDismissUpdate = {},
+            onViewUpdate = {},
+            onStartUpdate = {},
+            onToggleSyncExpanded = {},
+            onToggleDeviceCollapsed = {},
+            onPowerAlerts = {},
+            onAppsList = {},
+            onInstallLatestApp = {},
+            onClearClipboard = {},
+            onShareClipboard = {},
+            onCopyClipboard = {},
+            onFileShareClicked = {},
+            onWifiPermissionGrant = {},
+            onReviewLater = onReviewLater,
+            onReview = onReview,
+        )
+    }
+
+    @Test
+    fun `the review card renders its body and both actions`() {
+        composeRule.setContent {
+            PreviewWrapper { ReviewDashboard() }
+        }
+
+        composeRule.onNodeWithText(bodyText).assertExists()
+        composeRule.onNodeWithText(laterAction).assertExists()
+        composeRule.onNodeWithText(reviewAction).assertExists()
+    }
+
+    @Test
+    fun `both review card actions report back`() {
+        var laterTaps = 0
+        var reviewTaps = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewDashboard(
+                    onReviewLater = { laterTaps++ },
+                    onReview = { reviewTaps++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(laterAction).performClick()
+        composeRule.onNodeWithText(reviewAction).performClick()
+
+        composeRule.runOnIdle {
+            laterTaps shouldBe 1
+            reviewTaps shouldBe 1
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardTest.kt
@@ -1,0 +1,178 @@
+package eu.darken.octi.main.ui.dashboard
+
+import androidx.lifecycle.SavedStateHandle
+import eu.darken.octi.common.WebpageTool
+import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.common.network.NetworkStateProvider
+import eu.darken.octi.common.permissions.PermissionState
+import eu.darken.octi.common.review.ReviewTool
+import eu.darken.octi.common.sync.ConnectorType
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.main.core.GeneralSettings
+import eu.darken.octi.main.core.updater.UpdateService
+import eu.darken.octi.module.core.ModuleManager
+import eu.darken.octi.modules.clipboard.ClipboardHandler
+import eu.darken.octi.modules.files.core.FileShareRepo
+import eu.darken.octi.modules.power.core.alert.PowerAlertManager
+import eu.darken.octi.sync.core.ConnectorIssueAggregator
+import eu.darken.octi.sync.core.ConnectorUiContribution
+import eu.darken.octi.sync.core.DeviceId
+import eu.darken.octi.sync.core.SyncConnector
+import eu.darken.octi.sync.core.SyncExecutor
+import eu.darken.octi.sync.core.SyncManager
+import eu.darken.octi.sync.core.SyncOrchestrator
+import eu.darken.octi.sync.core.SyncSettings
+import eu.darken.octi.sync.core.blob.BlobManager
+import eu.darken.octi.sync.core.blob.StorageStatusManager
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import kotlin.time.Instant
+
+/**
+ * The review prompt is the lowest-priority dashboard card: anything that asks the user for a
+ * decision has to win over asking them for a favor.
+ */
+class DashboardReviewCardTest : BaseTest() {
+
+    private val proInfo = object : UpgradeRepo.Info {
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.GPLAY
+        override val isPro: Boolean = true
+        override val isSettled: Boolean = true
+        override val upgradedAt: Instant? = null
+        override val error: Throwable? = null
+    }
+
+    private fun <T> setting(value: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(value)
+    }
+
+    private fun orchestratorState() = SyncOrchestrator.State(
+        quickSync = SyncOrchestrator.QuickSyncState(isActive = false, connectorModes = emptyMap()),
+        backgroundSync = SyncOrchestrator.BackgroundSyncState(
+            defaultWorker = SyncOrchestrator.BackgroundSyncState.WorkerInfo(
+                isEnabled = true,
+                isRunning = false,
+                isBlocked = false,
+                nextRunAt = null,
+            ),
+            chargingWorker = SyncOrchestrator.BackgroundSyncState.WorkerInfo(
+                isEnabled = false,
+                isRunning = false,
+                isBlocked = false,
+                nextRunAt = null,
+            ),
+        ),
+    )
+
+    private fun vm(
+        shouldAskForReview: Boolean,
+        hasConnector: Boolean,
+    ): DashboardVM {
+        val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
+            every { isOnboardingDone } returns setting(true)
+            every { dashboardConfig } returns setting(DashboardConfig())
+        }
+        val syncManager = mockk<SyncManager>(relaxed = true).apply {
+            every { allConnectors } returns flowOf(
+                if (hasConnector) listOf(mockk<SyncConnector>(relaxed = true)) else emptyList(),
+            )
+            every { connectors } returns flowOf(emptyList())
+            every { states } returns flowOf(emptyList())
+            every { allStates } returns flowOf(emptyList())
+            every { busyConnectorIds } returns flowOf(emptySet())
+        }
+        val moduleManager = mockk<ModuleManager>(relaxed = true).apply {
+            every { byDevice } returns flowOf(ModuleManager.ByDevice(emptyMap()))
+            every { moduleSyncStates } returns flowOf(emptyList())
+            every { syncingModules } returns flowOf(emptySet())
+        }
+        val networkStateProvider = mockk<NetworkStateProvider>(relaxed = true).apply {
+            every { networkState } returns flowOf(NetworkStateProvider.State.Fallback)
+        }
+        val permissionTool = mockk<PermissionTool>(relaxed = true).apply {
+            every { missingPermissions } returns flowOf(emptySet())
+        }
+        val syncSettings = mockk<SyncSettings>(relaxed = true).apply {
+            every { showDashboardCard } returns setting(false)
+            every { pausedConnectorIds } returns flowOf(emptySet())
+            every { deviceId } returns DeviceId("test-device")
+        }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            every { upgradeInfo } returns flowOf(proInfo)
+        }
+        val updateService = mockk<UpdateService>(relaxed = true).apply {
+            every { availableUpdate } returns emptyFlow()
+        }
+        val alertManager = mockk<PowerAlertManager>(relaxed = true).apply {
+            every { alerts } returns flowOf(emptyList())
+        }
+        val syncOrchestrator = mockk<SyncOrchestrator>(relaxed = true).apply {
+            every { state } returns flowOf(orchestratorState())
+        }
+        val issueAggregator = mockk<ConnectorIssueAggregator>(relaxed = true).apply {
+            every { issues } returns flowOf(emptyList())
+        }
+        val fileShareRepo = mockk<FileShareRepo>(relaxed = true).apply {
+            every { isEnabled } returns flowOf(false)
+        }
+        val storageStatusManager = mockk<StorageStatusManager>(relaxed = true).apply {
+            every { configuredConnectorIds } returns flowOf(emptySet())
+        }
+        val reviewTool = mockk<ReviewTool>().apply {
+            every { state } returns flowOf(ReviewTool.State(shouldAskForReview = shouldAskForReview))
+        }
+
+        return DashboardVM(
+            handle = SavedStateHandle(),
+            dispatcherProvider = TestDispatcherProvider(),
+            appScope = mockk<CoroutineScope>(relaxed = true),
+            generalSettings = generalSettings,
+            syncManager = syncManager,
+            moduleManager = moduleManager,
+            networkStateProvider = networkStateProvider,
+            permissionTool = permissionTool,
+            permissionState = mockk<PermissionState>(relaxed = true),
+            syncSettings = syncSettings,
+            upgradeRepo = upgradeRepo,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+            clipboardHandler = mockk<ClipboardHandler>(relaxed = true),
+            updateService = updateService,
+            alertManager = alertManager,
+            syncExecutor = mockk<SyncExecutor>(relaxed = true),
+            syncOrchestrator = syncOrchestrator,
+            issueAggregator = issueAggregator,
+            fileShareRepo = fileShareRepo,
+            blobManager = mockk<BlobManager>(relaxed = true),
+            storageStatusManager = storageStatusManager,
+            connectorContributions = emptyMap<ConnectorType, ConnectorUiContribution>(),
+            cardSnoozer = DashboardCardSnoozer(),
+            reviewTool = reviewTool,
+        )
+    }
+
+    @Test
+    fun `the sync setup card suppresses the review card`() = runTest2 {
+        val state = vm(shouldAskForReview = true, hasConnector = false).state.first()
+
+        state.showSyncSetup shouldBe true
+        // Asking for a favor must not compete with the setup step the user still has to do.
+        state.showReviewCard shouldBe false
+    }
+
+    @Test
+    fun `an otherwise quiet dashboard shows the review card`() = runTest2 {
+        val state = vm(shouldAskForReview = true, hasConnector = true).state.first()
+
+        state.showSyncSetup shouldBe false
+        state.showReviewCard shouldBe true
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
@@ -19,11 +19,15 @@ import io.mockk.verify
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -46,15 +50,26 @@ class GplayReviewToolTest : BaseTest() {
         every { flow } returns flowOf(initial)
     }
 
+    // Stored data that can't be decoded: the settings are created without a default fallback, so
+    // reading them throws (see ReviewSettingsTest).
+    private fun <T> unreadableSetting(error: Throwable): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>(relaxed = true).apply {
+            every { flow } returns flow { throw error }
+        }
+
     // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
     // state throttle would burn real time.
     private fun TestScope.tool(
         upgradedAt: Instant? = Clock.System.now() - 30.days,
         lastDismissed: Instant? = null,
         reviewedAt: Instant? = null,
+        reviewedAtError: Throwable? = null,
     ): GplayReviewTool {
         lastDismissedMock = rwSetting(lastDismissed)
-        reviewedAtMock = rwSetting(reviewedAt)
+        reviewedAtMock = when (reviewedAtError) {
+            null -> rwSetting(reviewedAt)
+            else -> unreadableSetting(reviewedAtError)
+        }
         every { settings.lastDismissed } returns lastDismissedMock
         every { settings.reviewedAt } returns reviewedAtMock
 
@@ -236,6 +251,16 @@ class GplayReviewToolTest : BaseTest() {
         tool().computedState().shouldAskForReview shouldBe false
 
         verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `unreadable settings fall back to the default state`() = runTest2 {
+        // `state` is shared on AppScope, which has no exception handler: an error escaping the
+        // pipeline would take the process down instead of reaching any collector, so a collector
+        // side `.catch` can never see it.
+        val tool = tool(reviewedAtError = SerializationException("Stored timestamp is corrupt"))
+
+        // The onStart seed plus the fallback the tool emits in place of the failure.
+        tool.state.take(2).toList() shouldBe listOf(ReviewTool.State(), ReviewTool.State())
     }
 
     @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
@@ -1,0 +1,265 @@
+package eu.darken.octi.common.review
+
+import android.app.Activity
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.octi.common.datastore.DataStoreValue
+import eu.darken.octi.common.upgrade.UpgradeRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
+
+class GplayReviewToolTest : BaseTest() {
+
+    private val manager = mockk<ReviewManager>()
+    private val settings = mockk<ReviewSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private lateinit var lastDismissedMock: DataStoreValue<Instant?>
+    private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+
+    // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
+    private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns flowOf(initial)
+    }
+
+    // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
+    // state throttle would burn real time.
+    private fun TestScope.tool(
+        upgradedAt: Instant? = Clock.System.now() - 30.days,
+        lastDismissed: Instant? = null,
+        reviewedAt: Instant? = null,
+    ): GplayReviewTool {
+        lastDismissedMock = rwSetting(lastDismissed)
+        reviewedAtMock = rwSetting(reviewedAt)
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns upgradedAt
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        return GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        ).apply { probeRetryDelay = 1.seconds }
+    }
+
+    private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
+        val info = mockk<ReviewInfo>()
+        // There is no public accessor for the isNoOp flag, the tool sniffs the toString().
+        every { info.toString() } returns when {
+            canShow -> "ReviewInfo{pendingIntent=PendingIntent{1}, isNoOp=false}"
+            else -> "ReviewInfo{pendingIntent=null, isNoOp=true}"
+        }
+        return info
+    }
+
+    private fun activity(finishing: Boolean = false, destroyed: Boolean = false) = mockk<Activity>().apply {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
+    }
+
+    private fun launchOk(): Task<Void?> = Tasks.forResult(null)
+
+    // The `onStart` seed is not a computed state, every assertion has to await the first real one.
+    private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    @Test fun `an eligible user is asked for a review`() = runTest2 {
+        // The happy path: nothing local blocks the ask and Play says the prompt can be shown.
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool().computedState().apply {
+            shouldAskForReview shouldBe true
+            hasReviewed shouldBe false
+        }
+    }
+
+    @Test fun `a user who has not paid for pro long enough is never probed`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(upgradedAt = Clock.System.now() - 3.days)
+            .computedState().shouldAskForReview shouldBe false
+
+        // Eligibility is decided locally first: Play's request quota is only spent on candidates.
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a recently dismissed card is not shown again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(lastDismissed = Clock.System.now() - 3.days)
+            .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `reviewNow launches with a freshly requested ReviewInfo`() = runTest2 {
+        // ReviewInfo is short lived, the token used for the launch must not be the one the
+        // availability probe obtained (potentially hours) earlier.
+        val probeInfo = reviewInfo()
+        val freshInfo = reviewInfo()
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forResult(probeInfo),
+            Tasks.forResult(freshInfo),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.computedState().shouldAskForReview shouldBe true
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(activity, freshInfo) }
+        verify(exactly = 0) { manager.launchReviewFlow(activity, probeInfo) }
+    }
+
+    @Test fun `a failed fresh request keeps the card and persists nothing`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // A transient failure is not user intent, the next tap has to be able to retry.
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a fresh isNoOp answer snoozes the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // isNoOp is Play's quota verdict, asking again right away would be pointless.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a failed launch persists nothing and does not escape`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns Tasks.forException(RuntimeException("launch failed"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        // The fresh request is a Play round-trip, the activity can be gone by the time it returns.
+        tool.reviewNow(activity(finishing = true))
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `overlapping reviewNow calls launch the flow only once`() = runTest2 {
+        // Park the first call on an unresolved Play request, so the second genuinely overlaps it.
+        val successListener = slot<OnSuccessListener<in ReviewInfo>>()
+        val pendingRequest = mockk<Task<ReviewInfo>>().apply {
+            every { isComplete } returns false
+            every { addOnSuccessListener(capture(successListener)) } returns this
+            every { addOnFailureListener(any<OnFailureListener>()) } returns this
+        }
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            pendingRequest,
+            // A second request would resolve instantly, so a broken guard shows up as a launch.
+            Tasks.forResult(reviewInfo()),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        val first = launch { tool.reviewNow(activity) }
+        advanceUntilIdle()
+
+        tool.reviewNow(activity)
+
+        successListener.captured.onSuccess(reviewInfo())
+        first.join()
+
+        // Without the single-flight guard the second tap would run its own request+launch, and
+        // Play's flow would pop up again the moment the user returned from the first one.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(any(), any()) }
+    }
+
+    @Test fun `a probe that fails once still resolves within the retry budget`() = runTest2 {
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+
+        tool().computedState().shouldAskForReview shouldBe true
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that keeps failing hides the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        shouldThrow<CancellationException> { tool.reviewNow(activity()) }
+
+        // A cancelled coroutine is not a Play failure: no launch, no bookkeeping.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        // Cancellation takes the probe down with its scope, no verdict is ever computed (virtual
+        // time, so the timeout costs nothing).
+        val computed = withTimeoutOrNull(1.minutes) { tool.computedState() }
+
+        computed shouldBe null
+        // The general failure path would have burned all 3 attempts and settled on "unavailable".
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/octi/common/review/ReviewSettingsTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/review/ReviewSettingsTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.octi.common.review
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.common.datastore.value
+import eu.darken.octi.common.serialization.SerializationModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import kotlin.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ReviewSettingsTest : BaseTest() {
+
+    // One test method on purpose: ReviewSettings owns its DataStore, and DataStore forbids two
+    // active instances on the same file — a second ReviewSettings in this process would crash,
+    // not exercise anything real.
+    @Test
+    fun `the review timestamps round-trip through the DataStore`() = runTest {
+        // Real time on purpose: the real DataStore does its I/O off the test scheduler.
+        withContext(Dispatchers.IO) {
+            // Real DataStore + the production Json, no mocks: this catches an encoding mismatch
+            // between what the settings write and what they read back.
+            val settings = ReviewSettings(
+                context = ApplicationProvider.getApplicationContext<Context>(),
+                json = SerializationModule().json(),
+            )
+
+            // A fresh install has never dismissed and never reviewed — both gates read "no".
+            settings.lastDismissed.value() shouldBe null
+            settings.reviewedAt.value() shouldBe null
+
+            val dismissedAt = Instant.parse("2024-01-01T00:00:00Z")
+            settings.lastDismissed.value(dismissedAt)
+            settings.lastDismissed.value() shouldBe dismissedAt
+
+            val reviewedAt = Instant.parse("2024-06-15T12:34:56Z")
+            settings.reviewedAt.value(reviewedAt)
+            settings.reviewedAt.value() shouldBe reviewedAt
+
+            // The two keys are independent: writing one must not disturb the other.
+            settings.lastDismissed.value() shouldBe dismissedAt
+
+            // Clearing goes back to the default instead of persisting a literal "null" payload.
+            settings.lastDismissed.value(null)
+            settings.lastDismissed.value() shouldBe null
+
+            // Pins the loud-failure behaviour: these values are created WITHOUT
+            // onErrorFallbackToDefault, so unreadable data surfaces instead of silently reading
+            // as "never reviewed" (which would re-ask a user who already left a review).
+            settings.dataStore.edit { prefs ->
+                prefs[stringPreferencesKey("review.reviewedAt")] = "not-an-instant"
+            }
+            shouldThrow<SerializationException> { settings.reviewedAt.value() }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Octi can now ask satisfied Pro users for a Play Store review. Users who have been Pro for more than 3 weeks may see a card on the dashboard asking for a review — only while the dashboard is otherwise quiet (no sync setup, missing permissions, or pending update). "Review" opens Google Play's own in-app review sheet, "Maybe later" hides the card for two weeks, and once a review was left the card never returns. FOSS builds are unaffected.

## Technical Context

- Port of SD Maid SE's review-prompt design (the fleet's canonical implementation): `ReviewTool` interface with a FOSS no-op and a gplay implementation, adapted to octi's `kotlin.time` types (`upgradedAt` is a `kotlin.time.Instant` here) and flow conventions (`setupCommonEventHandlers` on the shared flows).
- Eligibility is computed locally first; Play is only probed for eligible users (quota-friendly), and the launch always requests a fresh `ReviewInfo`. Review timestamps persist via the app's contextual `InstantSerializer` (same mechanism as `CurriculumVitae`).
- The dashboard's existing 10-flow combine is untouched; review state joins via a final pair-combine. The card deliberately does not use `DashboardCardSnoozer` (session-only) — the review tool owns its persistent snooze state.
- Hardened beyond the donor: corrupt review preferences used to terminate the shared state flow inside the app scope (a process crash no downstream `catch` can intercept — reproduced in a regression test); the tool now fails closed upstream of `replayingShare`. This fix is scheduled for backport to the donor.
- Strings are English-only for now and join the next translation pass. On the release carrying this, every Pro user past the 21-day mark becomes eligible at once — a one-time wave of review cards is expected.
