### PR TITLE
Keep the review prompt working when Google Play hangs

### DIFF
--- a/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/review/GplayReviewTool.kt
@@ -14,13 +14,13 @@ import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.replayingShare
-import eu.darken.octi.common.flow.setupCommonEventHandlers
 import eu.darken.octi.common.flow.throttleLatest
 import eu.darken.octi.common.upgrade.UpgradeRepo
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -28,7 +28,9 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.system.measureTimeMillis
@@ -36,6 +38,7 @@ import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
 
@@ -51,6 +54,23 @@ class GplayReviewTool @Inject constructor(
     // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
     internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
 
+    // Test seam: same reason, the cooldown between failed probe rounds is a production sized wait.
+    internal var probeFailureCooldown: Duration = PROBE_FAILURE_COOLDOWN
+
+    // Test seam: the launch duration is wall-clock measured, so a virtual-time test cannot reach
+    // the production bound either.
+    internal var reviewMinDuration: Duration = REVIEW_MIN_DURATION
+
+    // Test seam: a hung Play call would otherwise have to be waited out for the production bound.
+    internal var requestTimeout: Duration = REQUEST_TIMEOUT
+
+    // Test seam: same reason, the review sheet bound is minutes long.
+    internal var launchTimeout: Duration = LAUNCH_TIMEOUT
+
+    // Test seam: eligibility is a function of wall-clock time, a virtual-time test needs to be able
+    // to move "now" itself. Only used for eligibility, the persisted timestamps stay real.
+    internal var nowProvider: () -> Instant = { Clock.System.now() }
+
     // Local bookkeeping only: decided without talking to Play, so an ineligible user never
     // triggers a Play round-trip.
     private val isLocallyEligible: Flow<Boolean> = combine(
@@ -58,64 +78,134 @@ class GplayReviewTool @Inject constructor(
         settings.reviewedAt.flow,
         upgradeRepo.upgradeInfo,
     ) { lastDismissed, reviewedAt, upgradeInfo ->
-        val now = Clock.System.now()
-
-        // Free trial is 14 days, only ask for review after the user has paid something
-        val hasPaidForPro = (now - (upgradeInfo.upgradedAt ?: now)) > 21.days
-        val isSnoozed = (now - (lastDismissed ?: Instant.DISTANT_PAST)) < 14.days
-        val hasReviewed = reviewedAt != null
-
-        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
-        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
-
-        hasPaidForPro && !isSnoozed && !hasReviewed
+        EligibilityInputs(
+            lastDismissed = lastDismissed,
+            reviewedAt = reviewedAt,
+            upgradedAt = upgradeInfo.upgradedAt,
+        )
     }
+        // Eligibility depends on time, not just on the inputs: a snooze that runs out while the
+        // process is alive has to flip the verdict, otherwise the card only reappears after a
+        // restart. Re-evaluated at the upcoming boundaries, an input change restarts the whole
+        // schedule via flatMapLatest.
+        .flatMapLatest { inputs ->
+            flow {
+                var wakes = 0
+                while (true) {
+                    val now = nowProvider()
+                    emit(inputs.isEligibleAt(now))
+
+                    val nextBoundary = inputs.boundariesAfter(now).minOrNull()
+                    if (nextBoundary == null || wakes == MAX_BOUNDARY_WAKES) break
+
+                    wakes++
+                    val wakeIn = (nextBoundary - now) + BOUNDARY_WAKE_MARGIN
+                    log(TAG) { "Eligibility: Re-evaluating in $wakeIn (boundary $nextBoundary)" }
+                    delay(wakeIn)
+                }
+            }
+        }
         .distinctUntilChanged()
-        // Has to sit upstream of the shares below: a failure there would kill the sharing
-        // coroutine on AppScope (no handler = process crash) instead of reaching any collector.
+        // Upstream of the shares below: an exception there would kill the sharing coroutine on
+        // AppScope (crashing the process) instead of reaching any downstream `catch`.
         .catch { e ->
             if (e is CancellationException) throw e
             log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
             emit(false)
         }
 
+    // Play's definitive answers are worth exactly one round-trip per process: quota is limited and
+    // the verdict doesn't change while the app runs. Survives eligibility flips, unlike the share.
+    @Volatile private var cachedVerdict: Verdict? = null
+
+    // Process-wide on purpose: the eligibility flatMapLatest below restarts this branch on every
+    // input change (a billing flicker flipping upgradedAt is enough), and a restart must not hand
+    // out a fresh round budget.
+    @Volatile private var probeRoundsStarted: Int = 0
+
     // Only probed once the user is eligible: Play counts requests against the app's quota, and an
     // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
-    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+    // `null` means no probe ran (not eligible), which is not a Play answer and is never cached.
+    // No setupCommonEventHandlers here, deliberately breaking the repo's always-chain convention:
+    // its catch swallows CancellationException instead of rethrowing it, and a swallowed
+    // cancellation would complete this Lazily shared flow for the rest of the process.
+    private val reviewAvailability: Flow<Verdict?> = isLocallyEligible
         .flatMapLatest { eligible ->
-            if (!eligible) return@flatMapLatest flowOf(false)
+            if (!eligible) return@flatMapLatest flowOf<Verdict?>(null)
 
             flow {
-                for (attempt in 1..PROBE_ATTEMPTS) {
-                    val info = try {
-                        manager.requestReview()
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
-                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay)
-                        continue
-                    }
-                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
-                    emit(info.canShow)
+                cachedVerdict?.let {
+                    log(TAG) { "Reusing cached probe verdict: $it" }
+                    emit(it)
                     return@flow
                 }
-                // Re-probed when eligibility changes or on the next process start
-                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
-                emit(false)
+
+                while (true) {
+                    if (probeRoundsStarted == FAILURE_RETRY_ROUNDS + 1) {
+                        log(TAG, WARN) { "Probe failed in all ${FAILURE_RETRY_ROUNDS + 1} rounds, giving up" }
+                        emit(Verdict.TRANSIENT_FAILURE)
+                        return@flow
+                    }
+                    if (probeRoundsStarted > 0) delay(probeFailureCooldown)
+
+                    val round = probeRoundsStarted
+                    probeRoundsStarted++
+
+                    val verdict = probeRound(round)
+                    emit(verdict)
+
+                    if (verdict != Verdict.TRANSIENT_FAILURE) {
+                        // Play answered, that answer holds for the rest of the process
+                        cachedVerdict = verdict
+                        return@flow
+                    }
+                }
             }
         }
-        .setupCommonEventHandlers(TAG) { "isReviewAvailable" }
-        .replayingShare(appScope)
+        // Lazily, not WhileSubscribed: a re-subscription must not spend another Play request on a
+        // question that was already answered (or given up on) in this process.
+        .shareIn(appScope, SharingStarted.Lazily, replay = 1)
 
+    private suspend fun probeRound(round: Int): Verdict {
+        for (attempt in 1..PROBE_ATTEMPTS) {
+            val info = try {
+                // withTimeoutOrNull, never withTimeout: TimeoutCancellationException IS-A
+                // CancellationException and would escape through the rethrow below.
+                withTimeoutOrNull(requestTimeout) { manager.requestReview() }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay)
+                continue
+            }
+
+            if (info == null) {
+                // Our timeout does not cancel the underlying Play Task: an immediate retry would
+                // stack concurrent quota-consuming requests against an already hung service, so the
+                // whole round is abandoned. The orphaned Task is tolerated, its completion resumes
+                // a cancelled continuation and is discarded.
+                log(TAG, WARN) { "Probe $round:$attempt/$PROBE_ATTEMPTS timed out, abandoning the round" }
+                return Verdict.TRANSIENT_FAILURE
+            }
+
+            log(TAG) { "Probe $round:$attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+            return if (info.canShow) Verdict.AVAILABLE else Verdict.UNAVAILABLE_BY_PLAY
+        }
+        log(TAG, WARN) { "Probe round $round gave up after $PROBE_ATTEMPTS attempts" }
+        return Verdict.TRANSIENT_FAILURE
+    }
+
+    // No setupCommonEventHandlers here either, for the same reason as reviewAvailability above:
+    // cancellation has to propagate through this flow instead of being logged and swallowed.
     override val state: Flow<ReviewTool.State> = combine(
         isLocallyEligible,
-        isReviewAvailable,
+        reviewAvailability,
         settings.reviewedAt.flow,
-    ) { eligible, available, reviewedAt ->
-        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+    ) { eligible, verdict, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, verdict=$verdict, reviewedAt=$reviewedAt" }
         ReviewTool.State(
-            shouldAskForReview = eligible && available,
+            shouldAskForReview = eligible && verdict == Verdict.AVAILABLE,
             hasReviewed = reviewedAt != null,
         )
     }
@@ -126,15 +216,21 @@ class GplayReviewTool @Inject constructor(
             log(TAG, ERROR) { "State failed: ${e.asLog()}" }
             emit(ReviewTool.State())
         }
-        .setupCommonEventHandlers(TAG) { "state" }
         .replayingShare(appScope)
 
     // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
     // launched again the moment the user returns from it.
     private val reviewLock = Mutex()
 
+    // Tap race backstop: a dismiss can land while a reviewNow is waiting on Play. In-memory on
+    // purpose, re-reading the persisted timestamp would race the write it is supposed to observe.
+    @Volatile private var dismissGeneration: Int = 0
+
     override suspend fun dismiss() {
         log(TAG, INFO) { "dismiss()" }
+        // Bumped before the write: an in-flight reviewNow has to see the dismiss immediately,
+        // not once DataStore has persisted it.
+        dismissGeneration++
         settings.lastDismissed.value(Clock.System.now())
     }
 
@@ -147,10 +243,12 @@ class GplayReviewTool @Inject constructor(
         }
 
         try {
+            val generation = dismissGeneration
+
             // ReviewInfo is short lived, Google wants it requested shortly before the launch,
             // a token cached at process start is likely stale by the time the user taps.
             val reviewInfo = try {
-                manager.requestReview()
+                withTimeoutOrNull(requestTimeout) { manager.requestReview() }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -158,7 +256,18 @@ class GplayReviewTool @Inject constructor(
                 log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
                 return
             }
+
+            if (reviewInfo == null) {
+                // A hang is not user intent either: persist nothing, the next tap retries
+                log(TAG, ERROR) { "Timed out requesting a fresh ReviewInfo" }
+                return
+            }
             log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed while we were requesting a fresh ReviewInfo, aborting" }
+                return
+            }
 
             if (!reviewInfo.canShow) {
                 // Play's quota verdict, asking again right away would be pointless
@@ -172,19 +281,34 @@ class GplayReviewTool @Inject constructor(
                 return
             }
 
+            if (dismissGeneration != generation) {
+                log(TAG, WARN) { "Dismissed before we could launch, aborting" }
+                return
+            }
+
             val reviewTime = measureTimeMillis {
-                try {
-                    manager.launchReview(activity, reviewInfo)
+                val launched = try {
+                    // withTimeoutOrNull for the same reason as the probe: a withTimeout would be
+                    // rethrown as cancellation by the branch below.
+                    withTimeoutOrNull(launchTimeout) { manager.launchReview(activity, reviewInfo) }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
                     return
                 }
+
+                if (launched == null) {
+                    // Far beyond any real review session: the sheet's Task is hung and must not hold
+                    // the single-flight lock forever. The outcome is unknown, so nothing is persisted
+                    // and the duration heuristic below is skipped.
+                    log(TAG, WARN) { "Timed out waiting for the review flow to finish" }
+                    return
+                }
             }
             log(TAG) { "Review completed after ${reviewTime}ms" }
 
-            if (reviewTime >= REVIEW_MIN_DURATION.inWholeMilliseconds) {
+            if (reviewTime.milliseconds >= reviewMinDuration) {
                 log(TAG, INFO) { "Marking review as completed" }
                 settings.reviewedAt.value(Clock.System.now())
             } else {
@@ -196,6 +320,29 @@ class GplayReviewTool @Inject constructor(
         }
     }
 
+    private data class EligibilityInputs(
+        val lastDismissed: Instant?,
+        val reviewedAt: Instant?,
+        val upgradedAt: Instant?,
+    )
+
+    private fun EligibilityInputs.isEligibleAt(now: Instant): Boolean {
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = (now - (upgradedAt ?: now)) > PRO_GRACE_PERIOD
+        val isSnoozed = (now - (lastDismissed ?: Instant.DISTANT_PAST)) < SNOOZE_PERIOD
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro ($upgradedAt)" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        return hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+
+    private fun EligibilityInputs.boundariesAfter(now: Instant): List<Instant> = listOfNotNull(
+        lastDismissed?.plus(SNOOZE_PERIOD),
+        upgradedAt?.plus(PRO_GRACE_PERIOD),
+    ).filter { it > now }
+
     private val ReviewInfo.canShow: Boolean
         get() = when {
             toString().contains("isNoOp=true") -> false
@@ -206,10 +353,29 @@ class GplayReviewTool @Inject constructor(
         return "ReviewInfo(canShow=$canShow, ${toString()})"
     }
 
+    private enum class Verdict {
+        // Play answered with a usable ReviewInfo
+        AVAILABLE,
+
+        // Play answered with an isNoOp ReviewInfo, i.e. a deliberate "no"
+        UNAVAILABLE_BY_PLAY,
+
+        // No answer: attempts exhausted by exceptions, or the round was abandoned on a timeout
+        TRANSIENT_FAILURE,
+    }
+
     companion object {
         private val TAG = logTag("Review", "Tool", "Gplay")
         private const val PROBE_ATTEMPTS = 3
+        private const val FAILURE_RETRY_ROUNDS = 3
         private val PROBE_RETRY_DELAY = 30.seconds
+        private val PROBE_FAILURE_COOLDOWN = 15.minutes
         private val REVIEW_MIN_DURATION = 2.seconds
+        private val REQUEST_TIMEOUT = 10.seconds
+        private val LAUNCH_TIMEOUT = 10.minutes
+        private val SNOOZE_PERIOD = 14.days
+        private val PRO_GRACE_PERIOD = 21.days
+        private const val MAX_BOUNDARY_WAKES = 4
+        private val BOUNDARY_WAKE_MARGIN = 1.seconds
     }
 }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1365,6 +1365,13 @@ private fun ReviewCard(
     onLater: () -> Unit,
     onReview: () -> Unit,
 ) {
+    // The card only disappears with the next state emission, so the tap targets need a latch. It is
+    // asymmetric on purpose: the harmful orderings are a dismiss after a review (which overwrites
+    // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
+    // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
+    // card whenever a Play request fails and nothing gets persisted.
+    var dismissLocked by rememberSaveable { mutableStateOf(false) }
+    var fullyLatched by rememberSaveable { mutableStateOf(false) }
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()
@@ -1388,10 +1395,27 @@ private fun ReviewCard(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
             ) {
-                TextButton(onClick = onLater) {
+                TextButton(
+                    onClick = {
+                        if (!fullyLatched && !dismissLocked) {
+                            dismissLocked = true
+                            fullyLatched = true
+                            onLater()
+                        }
+                    },
+                    enabled = !fullyLatched && !dismissLocked,
+                ) {
                     Text(stringResource(CommonR.string.general_maybe_later_action))
                 }
-                TextButton(onClick = onReview) {
+                TextButton(
+                    onClick = {
+                        if (!fullyLatched) {
+                            dismissLocked = true
+                            onReview()
+                        }
+                    },
+                    enabled = !fullyLatched,
+                ) {
                     Text(stringResource(R.string.review_app_review_action))
                 }
             }

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1370,8 +1370,11 @@ private fun ReviewCard(
     // the review bookkeeping with a snooze) and a review after a dismiss. A repeated review tap is
     // harmless, the tool's single-flight lock absorbs it, and blocking it here would leave a dead
     // card whenever a Play request fails and nothing gets persisted.
-    var dismissLocked by rememberSaveable { mutableStateOf(false) }
-    var fullyLatched by rememberSaveable { mutableStateOf(false) }
+    // Plain remember, not rememberSaveable: the lazy grid host retains saveable state for a removed
+    // item key and would re-add the card still latched. Disposal-on-removal is the intended reset,
+    // and the latch only guards a sub-second window, so surviving recreation is not worth that.
+    var dismissLocked by remember { mutableStateOf(false) }
+    var fullyLatched by remember { mutableStateOf(false) }
     ElevatedCard(
         modifier = Modifier
             .fillMaxWidth()

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
@@ -2,6 +2,8 @@ package eu.darken.octi.main.ui.dashboard
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
@@ -98,7 +100,7 @@ class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `both review card actions report back`() {
+    fun `a dismissed card ignores a later review tap`() {
         var laterTaps = 0
         var reviewTaps = 0
         composeRule.setContent {
@@ -110,12 +112,70 @@ class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
             }
         }
 
+        // The card only disappears with the next state emission, so both targets are still on
+        // screen: a review after a dismiss would re-open what the user just closed.
         composeRule.onNodeWithText(laterAction).performClick()
+        composeRule.runOnIdle { laterTaps shouldBe 1 }
+
+        composeRule.onNodeWithText(reviewAction).assertIsNotEnabled()
         composeRule.onNodeWithText(reviewAction).performClick()
 
         composeRule.runOnIdle {
             laterTaps shouldBe 1
+            reviewTaps shouldBe 0
+        }
+    }
+
+    @Test
+    fun `a reviewed card ignores a later dismiss tap`() {
+        var laterTaps = 0
+        var reviewTaps = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewDashboard(
+                    onReviewLater = { laterTaps++ },
+                    onReview = { reviewTaps++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(reviewAction).performClick()
+        composeRule.runOnIdle { reviewTaps shouldBe 1 }
+
+        // A dismiss after a review would overwrite the completed-review bookkeeping with a snooze.
+        composeRule.onNodeWithText(laterAction).assertIsNotEnabled()
+        composeRule.onNodeWithText(laterAction).performClick()
+
+        composeRule.runOnIdle {
             reviewTaps shouldBe 1
+            laterTaps shouldBe 0
+        }
+    }
+
+    @Test
+    fun `repeated review taps are not absorbed by the card`() {
+        var laterTaps = 0
+        var reviewTaps = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewDashboard(
+                    onReviewLater = { laterTaps++ },
+                    onReview = { reviewTaps++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(reviewAction).performClick()
+        composeRule.runOnIdle { reviewTaps shouldBe 1 }
+
+        // A failed Play request persists nothing and leaves the card up, so the retry has to work.
+        // Duplicates are the tool's problem, it holds a single-flight lock for exactly this.
+        composeRule.onNodeWithText(reviewAction).assertIsEnabled()
+        composeRule.onNodeWithText(reviewAction).performClick()
+
+        composeRule.runOnIdle {
+            reviewTaps shouldBe 2
+            laterTaps shouldBe 0
         }
     }
 }

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DashboardReviewCardRenderTest.kt
@@ -2,6 +2,9 @@ package eu.darken.octi.main.ui.dashboard
 
 import android.content.Context
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithText
@@ -40,6 +43,7 @@ class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
 
     @Composable
     private fun ReviewDashboard(
+        showReviewCard: Boolean = true,
         onReviewLater: () -> Unit = {},
         onReview: () -> Unit = {},
     ) {
@@ -56,7 +60,7 @@ class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
                 update = null,
                 upgradeInfo = upgradeInfo,
                 deviceLimitReached = false,
-                showReviewCard = true,
+                showReviewCard = showReviewCard,
             ),
             onRefresh = {},
             onSyncServices = {},
@@ -150,6 +154,35 @@ class DashboardReviewCardRenderTest : BaseComposeRobolectricTest() {
             reviewTaps shouldBe 1
             laterTaps shouldBe 0
         }
+    }
+
+    @Test
+    fun `the latch resets when the card leaves and returns`() {
+        var laterTaps = 0
+        var reviewTaps = 0
+        var visible by mutableStateOf(true)
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewDashboard(
+                    showReviewCard = visible,
+                    onReviewLater = { laterTaps++ },
+                    onReview = { reviewTaps++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(laterAction).performClick()
+        composeRule.runOnIdle { laterTaps shouldBe 1 }
+
+        // A transient gate (update banner, sync setup, permissions) can pull the card out of the
+        // lazy grid and put it back within the same process. The latch protects a sub-second
+        // window, so it must not survive that: the card would come back permanently dead.
+        composeRule.runOnIdle { visible = false }
+        composeRule.onNodeWithText(laterAction).assertDoesNotExist()
+        composeRule.runOnIdle { visible = true }
+
+        composeRule.onNodeWithText(laterAction).assertIsEnabled()
+        composeRule.onNodeWithText(reviewAction).assertIsEnabled()
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/review/GplayReviewToolTest.kt
@@ -17,6 +17,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -24,15 +27,19 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.SerializationException
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.Instant
@@ -44,10 +51,17 @@ class GplayReviewToolTest : BaseTest() {
     private val upgradeRepo = mockk<UpgradeRepo>()
     private lateinit var lastDismissedMock: DataStoreValue<Instant?>
     private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+    private lateinit var lastDismissedFlow: MutableStateFlow<Instant?>
 
     // Relaxed so the `.value(new)` writes (which go through `update`) succeed and can be verified.
     private fun <T> rwSetting(initial: T): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
         every { flow } returns flowOf(initial)
+    }
+
+    // Hot variant: a value written after the tool started collecting has to reach the pipeline,
+    // which a one-shot `flowOf` can't do.
+    private fun <T> hotSetting(source: Flow<T>): DataStoreValue<T> = mockk<DataStoreValue<T>>(relaxed = true).apply {
+        every { flow } returns source
     }
 
     // Stored data that can't be decoded: the settings are created without a default fallback, so
@@ -64,8 +78,14 @@ class GplayReviewToolTest : BaseTest() {
         lastDismissed: Instant? = null,
         reviewedAt: Instant? = null,
         reviewedAtError: Throwable? = null,
+        minDuration: Duration? = null,
+        hotSettings: Boolean = false,
     ): GplayReviewTool {
-        lastDismissedMock = rwSetting(lastDismissed)
+        lastDismissedFlow = MutableStateFlow(lastDismissed)
+        lastDismissedMock = when {
+            hotSettings -> hotSetting(lastDismissedFlow)
+            else -> rwSetting(lastDismissed)
+        }
         reviewedAtMock = when (reviewedAtError) {
             null -> rwSetting(reviewedAt)
             else -> unreadableSetting(reviewedAtError)
@@ -82,7 +102,13 @@ class GplayReviewToolTest : BaseTest() {
             settings = settings,
             manager = manager,
             upgradeRepo = upgradeRepo,
-        ).apply { probeRetryDelay = 1.seconds }
+        ).apply {
+            probeRetryDelay = PROBE_RETRY_DELAY
+            probeFailureCooldown = PROBE_FAILURE_COOLDOWN
+            requestTimeout = REQUEST_TIMEOUT
+            launchTimeout = LAUNCH_TIMEOUT
+            minDuration?.let { reviewMinDuration = it }
+        }
     }
 
     private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
@@ -102,8 +128,29 @@ class GplayReviewToolTest : BaseTest() {
 
     private fun launchOk(): Task<Void?> = Tasks.forResult(null)
 
+    // A Play call that never comes back: the ktx wrapper suspends on the listeners it registers
+    // with the Task, and a relaxed mock never invokes them.
+    private fun <T> hangingTask(): Task<T> = mockk<Task<T>>(relaxed = true).apply {
+        every { isComplete } returns false
+    }
+
     // The `onStart` seed is not a computed state, every assertion has to await the first real one.
     private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    // Live view of everything the tool emitted so far, for assertions that have to move the clock
+    // between emissions instead of awaiting a single one.
+    private fun TestScope.collectStates(tool: GplayReviewTool): List<ReviewTool.State> {
+        val states = mutableListOf<ReviewTool.State>()
+        backgroundScope.launch { tool.state.collect { states += it } }
+        return states
+    }
+
+    // The tool's flows all run on the background scope, and `advanceUntilIdle` only advances while
+    // there is foreground work, so every wait has to name the span it is waiting for.
+    private fun TestScope.advanceBy(duration: Duration) {
+        advanceTimeBy(duration.inWholeMilliseconds)
+        runCurrent()
+    }
 
     @Test fun `an eligible user is asked for a review`() = runTest2 {
         // The happy path: nothing local blocks the ask and Play says the prompt can be shown.
@@ -130,6 +177,18 @@ class GplayReviewToolTest : BaseTest() {
 
         tool(lastDismissed = Clock.System.now() - 3.days)
             .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a user who already reviewed is never asked or probed again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(reviewedAt = Clock.System.now() - 200.days).computedState().apply {
+            shouldAskForReview shouldBe false
+            // The card is gone for good, but the fact stays readable for anything else that asks.
+            hasReviewed shouldBe true
+        }
 
         verify(exactly = 0) { manager.requestReviewFlow() }
     }
@@ -190,6 +249,33 @@ class GplayReviewToolTest : BaseTest() {
         coVerify(exactly = 0) { reviewedAtMock.update(any()) }
     }
 
+    @Test fun `a launch the user dismissed instantly counts as a snooze`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        // Play returns immediately when it decides not to show anything, that is not a review.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a launch the user stayed in counts as a completed review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        // Real sleep on purpose: the heuristic measures wall clock, virtual time cannot reach it.
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            Thread.sleep(150)
+            launchOk()
+        }
+        val tool = tool(minDuration = 50.milliseconds)
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 1) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+    }
+
     @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
         every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
         every { manager.launchReviewFlow(any(), any()) } returns launchOk()
@@ -220,8 +306,10 @@ class GplayReviewToolTest : BaseTest() {
         val tool = tool()
         val activity = activity()
 
+        // runCurrent, not advanceUntilIdle: the first call has to be parked on the request when the
+        // second tap arrives, an unbounded time advance would trip the request timeout first.
         val first = launch { tool.reviewNow(activity) }
-        advanceUntilIdle()
+        runCurrent()
 
         tool.reviewNow(activity)
 
@@ -251,6 +339,15 @@ class GplayReviewToolTest : BaseTest() {
         tool().computedState().shouldAskForReview shouldBe false
 
         verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp probe answer is accepted instead of retried`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        // isNoOp is an answer, not a failure: burning the retry budget on it would just cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
     }
 
     @Test fun `unreadable settings fall back to the default state`() = runTest2 {
@@ -286,5 +383,293 @@ class GplayReviewToolTest : BaseTest() {
         computed shouldBe null
         // The general failure path would have burned all 3 attempts and settled on "unavailable".
         verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that times out abandons the whole round`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(REQUEST_TIMEOUT * 2)
+
+        // Our timeout does not cancel the Play Task: an in-round retry would stack concurrent
+        // quota-consuming requests against a service that is already hung.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        hanging = false
+        advanceBy(PROBE_FAILURE_COOLDOWN * 2)
+
+        // Recovery comes from the next cooldown round, not from the abandoned one.
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a probe exception is still retried inside the round`() = runTest2 {
+        // Only a timeout abandons the round, the exception path keeps its 3 attempt budget.
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_RETRY_DELAY * 4)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a hanging fresh request releases the lock without persisting`() = runTest2 {
+        var hanging = true
+        every { manager.requestReviewFlow() } answers {
+            if (hanging) hangingTask() else Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // A hang is not user intent: no launch, no bookkeeping, the next tap has to be able to retry.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        // Without the timeout the single-flight lock would still be held by the first tap.
+        verify(exactly = 1) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a hanging launch releases the lock without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var hanging = true
+        every { manager.launchReviewFlow(any(), any()) } answers {
+            if (hanging) hangingTask() else launchOk()
+        }
+        val tool = tool()
+        val activity = activity()
+
+        tool.reviewNow(activity)
+
+        // The outcome is unknown, so neither the review nor the snooze may be recorded, and the
+        // duration heuristic must not treat the timeout as a completed review.
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+
+        hanging = false
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.launchReviewFlow(activity, any()) }
+    }
+
+    @Test fun `a dismiss racing the fresh request aborts the launch`() = runTest2 {
+        val tool = tool()
+        every { manager.requestReviewFlow() } answers {
+            // The user hits "maybe later" while Play is still answering the review tap.
+            runBlocking { tool.dismiss() }
+            Tasks.forResult(reviewInfo())
+        }
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // Only the dismiss' own write, reviewNow must not add bookkeeping on top of it.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a definitive probe answer is not requested twice`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(1.seconds)
+        first.last().shouldAskForReview shouldBe true
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(1.seconds)
+        second.last().shouldAskForReview shouldBe true
+        secondJob.cancelAndJoin()
+
+        // Play's answer holds for the rest of the process, a re-subscription must not cost quota.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `an isNoOp answer is not requested twice either`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        val first = mutableListOf<ReviewTool.State>()
+        val firstJob = backgroundScope.launch { tool.state.collect { first += it } }
+        advanceBy(1.seconds)
+        first.last().shouldAskForReview shouldBe false
+        firstJob.cancelAndJoin()
+
+        val second = mutableListOf<ReviewTool.State>()
+        val secondJob = backgroundScope.launch { tool.state.collect { second += it } }
+        advanceBy(1.seconds)
+        second.last().shouldAskForReview shouldBe false
+        secondJob.cancelAndJoin()
+
+        // isNoOp is a verdict, not a failure: it is cached like any other answer.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a transient probe failure is retried after the cooldown`() = runTest2 {
+        var healthy = false
+        every { manager.requestReviewFlow() } answers {
+            if (healthy) Tasks.forResult(reviewInfo()) else Tasks.forException(RuntimeException("Play unavailable"))
+        }
+        val tool = tool()
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN / 2)
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        healthy = true
+        advanceBy(PROBE_FAILURE_COOLDOWN)
+
+        // A failure is not an answer, so Play gets asked again once the cooldown is over.
+        verify(exactly = 4) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the probe retry rounds are bounded`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool(hotSettings = true)
+        val states = collectStates(tool)
+
+        advanceBy(PROBE_FAILURE_COOLDOWN * 4)
+
+        // The initial round plus 3 cooldown rounds, 3 attempts each, then the process gives up.
+        verify(exactly = 12) { manager.requestReviewFlow() }
+        states.last().shouldAskForReview shouldBe false
+
+        advanceBy(PROBE_FAILURE_COOLDOWN * 20)
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+
+        // The budget is spent for the process: an eligibility flicker restarts the probe branch,
+        // but it must not hand out a fresh set of rounds.
+        lastDismissedFlow.value = Clock.System.now()
+        advanceBy(1.seconds)
+        lastDismissedFlow.value = null
+        advanceBy(PROBE_FAILURE_COOLDOWN * 10)
+
+        verify(exactly = 12) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a snooze running out flips the card on without a restart`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW - 60.days,
+            lastDismissed = BASE_NOW - 13.days,
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(1.seconds)
+        states.last().shouldAskForReview shouldBe false
+
+        // The snooze ends a day later: the scheduled re-evaluation has to re-read the clock.
+        fakeNow = BASE_NOW + 2.days
+        advanceBy(2.days)
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `the pro grace period boundary is strict`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val upgradedAt = BASE_NOW - 21.days
+
+        val atBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val atBoundaryStates = collectStates(atBoundary)
+        advanceBy(1.seconds)
+        // 21 days have to have passed, not just been reached
+        atBoundaryStates.last().shouldAskForReview shouldBe false
+
+        // A second instance because nothing is pending on the first one: the wake schedule only
+        // keeps boundaries strictly after "now", and this one is exactly "now".
+        fakeNow = BASE_NOW + 1.seconds
+        val pastBoundary = tool(upgradedAt = upgradedAt).apply { nowProvider = { fakeNow } }
+        val pastBoundaryStates = collectStates(pastBoundary)
+        advanceBy(1.seconds)
+
+        pastBoundaryStates.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a new dismiss reschedules the boundary re-evaluation`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW - 60.days,
+            lastDismissed = BASE_NOW - 13.days,
+            hotSettings = true,
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(1.seconds)
+        states.last().shouldAskForReview shouldBe false
+
+        // Dismissed again while the old snooze end was still scheduled
+        lastDismissedFlow.value = BASE_NOW
+        advanceBy(1.seconds)
+
+        fakeNow = BASE_NOW + 2.days
+        advanceBy(3.days)
+        // The stale boundary must not flip the card back on, the new snooze governs now
+        states.last().shouldAskForReview shouldBe false
+
+        fakeNow = BASE_NOW + 15.days
+        advanceBy(15.days)
+
+        states.last().shouldAskForReview shouldBe true
+    }
+
+    @Test fun `a clock that moved backwards re-evaluates instead of flipping`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        var fakeNow = BASE_NOW
+        val tool = tool(
+            upgradedAt = BASE_NOW - 60.days,
+            lastDismissed = BASE_NOW - 13.days,
+        ).apply { nowProvider = { fakeNow } }
+        val states = collectStates(tool)
+
+        advanceBy(1.seconds)
+        states.last().shouldAskForReview shouldBe false
+
+        // The device clock moved back: the wake fires on schedule, but the snooze is still running
+        fakeNow = BASE_NOW - 5.days
+        advanceBy(30.days)
+
+        states.last().shouldAskForReview shouldBe false
+        verify(exactly = 0) { manager.requestReviewFlow() }
+
+        // Rescheduling is capped, so a backwards clock cannot keep the process waking forever
+        fakeNow = BASE_NOW + 2.days
+        advanceBy(30.days)
+
+        states.last().shouldAskForReview shouldBe false
+    }
+
+    companion object {
+        private val BASE_NOW: Instant = Instant.parse("2024-06-01T12:00:00Z")
+        private val PROBE_RETRY_DELAY: Duration = 1.seconds
+        private val PROBE_FAILURE_COOLDOWN: Duration = 5.minutes
+        private val REQUEST_TIMEOUT: Duration = 5.seconds
+        private val LAUNCH_TIMEOUT: Duration = 1.minutes
     }
 }


### PR DESCRIPTION
## What changed

Hardens the Google Play review prompt, ported from the same hardening that just landed in SD Maid SE. If Play hung while the app was checking review availability or launching the review sheet, the review feature could silently stop working until the next app restart — those calls now time out and the next tap simply retries. Fast conflicting taps on the review card can no longer trigger contradictory actions, and a card that briefly leaves the dashboard (an update banner, sync setup) no longer comes back with dead buttons. The app also asks Play about review availability only once per app start instead of on every dashboard visit, and the card appears on time when the snooze or the post-purchase waiting period runs out while the app is open.

## Technical Context

- Port of the reviewed donor change in SD Maid SE (d4rken-org/sdmaid-se#2619), kotlin.time-adapted (`withTimeoutOrNull(Duration)`, `Instant`/`Clock.System` seams, `DISTANT_PAST` floor kept).
- Root cause of the headline fix: the `ReviewManager` suspend calls are unbounded over Play IPC — a hang stalls the availability probe or leaves `reviewNow` holding its single-flight mutex, dropping every later tap until process death. All three call sites now use `withTimeoutOrNull` (10s requests, generous 10min sheet); a probe timeout abandons the whole round since our timeout cannot cancel the underlying Play Task.
- Definitive availability verdicts are cached for the process lifetime under `Lazily` sharing with a process-wide retry budget; transient failures retry on a 15-minute cooldown and are never cached.
- `setupCommonEventHandlers` was deliberately removed from the two review flows (comment in-code): its catch swallows `CancellationException`, which under process-lifetime sharing would silently terminate availability for the whole session. The hand-written catch guards remain.
- The card latch is asymmetric (review taps stay retryable; a dismissal locks everything) and uses plain `remember` — during review it was found that `rememberSaveable` inside the keyed lazy grid item is retained across item removal, so a latched card that left the dashboard came back with disabled buttons. The regression test was written first and reproduced exactly that before the fix.
- Tool test suite brought to parity with the donor's 31 tests; the eligibility boundary logic is driven by a `nowProvider` seam under virtual time.
