### PR TITLE
General: Show clearer errors when Google Play offers can't load

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/error/ErrorEventHandler.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/error/ErrorEventHandler.kt
@@ -1,7 +1,10 @@
 package eu.darken.octi.common.error
 
 import android.app.Activity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -10,9 +13,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import eu.darken.octi.common.R
+import eu.darken.octi.common.ca.CaString
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
@@ -42,7 +48,17 @@ private fun ComposeErrorDialog(
     val localizedError = throwable.localized(context)
     val activity = context as? Activity
 
-    fun dispatchAndDismiss(action: (Activity) -> Unit) {
+    // Keyed on the throwable, not the LocalizedError: the latter is rebuilt (with fresh action
+    // lambdas, so never equal) on every recomposition, which would wipe the message immediately.
+    var actionError by remember(throwable) { mutableStateOf<CaString?>(null) }
+
+    // errorMessage is per-dispatch, NOT read from localizedError: this function serves both the fix
+    // and the info button, and fixActionErrorMessage describes only the fix action's failure. Each
+    // call site passes its own copy (or none), so no button can ever surface another one's message.
+    fun dispatchAndDismiss(
+        action: (Activity) -> Unit,
+        errorMessage: CaString? = null,
+    ) {
         // Error actions are arbitrary third-party code (intent launches, deep links): a throw here
         // would crash the UI thread from inside a click handler, and skipping onDismiss() would
         // leave the dialog latched on the current error with no way out.
@@ -50,18 +66,41 @@ private fun ComposeErrorDialog(
             activity?.let { action(it) }
         } catch (e: Exception) {
             log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
-        } finally {
-            onDismiss()
+            // A dispatch that ships its own failure copy keeps the dialog open and shows it inline
+            // (no length cap, unlike a Toast). Never latched: the dismiss button stays available.
+            errorMessage?.let {
+                actionError = it
+                return
+            }
         }
+        onDismiss()
     }
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(text = localizedError.label.get(context)) },
-        text = { Text(text = localizedError.description.get(context)) },
+        text = {
+            Column {
+                Text(text = localizedError.description.get(context))
+                actionError?.let {
+                    Text(
+                        text = it.get(context),
+                        color = MaterialTheme.colorScheme.error,
+                        modifier = Modifier.padding(top = 8.dp),
+                    )
+                }
+            }
+        },
         confirmButton = {
             if (localizedError.fixAction != null && activity != null) {
-                TextButton(onClick = { dispatchAndDismiss(localizedError.fixAction) }) {
+                TextButton(
+                    onClick = {
+                        dispatchAndDismiss(
+                            action = localizedError.fixAction,
+                            errorMessage = localizedError.fixActionErrorMessage,
+                        )
+                    },
+                ) {
                     Text(
                         text = localizedError.fixActionLabel?.get(context)
                             ?: stringResource(android.R.string.ok)
@@ -83,7 +122,9 @@ private fun ComposeErrorDialog(
             }
             localizedError.infoAction != null && activity != null -> {
                 {
-                    TextButton(onClick = { dispatchAndDismiss(localizedError.infoAction) }) {
+                    // No errorMessage: the info action has no failure copy of its own, and it must
+                    // never borrow the fix action's.
+                    TextButton(onClick = { dispatchAndDismiss(action = localizedError.infoAction) }) {
                         Text(text = stringResource(R.string.general_show_details_action))
                     }
                 }

--- a/app-common/src/main/java/eu/darken/octi/common/error/LocalizedError.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/error/LocalizedError.kt
@@ -18,6 +18,8 @@ data class LocalizedError(
     val description: CaString,
     val fixActionLabel: CaString? = null,
     val fixAction: ((Activity) -> Unit)? = null,
+    /** Shown inline in the error dialog if the fix action fails, instead of a length-capped toast. */
+    val fixActionErrorMessage: CaString? = null,
     val infoAction: ((Activity) -> Unit)? = null,
 ) {
     fun asText() = caString { "${label.get(it)}:\n${description.get(it)}" }

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,11 +1,9 @@
 package eu.darken.octi.common.upgrade.core.billing
 
-import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
-import android.widget.Toast
 import eu.darken.octi.R
 import eu.darken.octi.common.ca.toCaString
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
@@ -30,18 +28,23 @@ class GplayServiceUnavailableException(cause: Throwable) :
             try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             } catch (e: SecurityException) {
                 // Play can be installed but unreachable: disabled app, work/restricted profile or a
                 // ROM that guards the settings screen. The launch is denied, not unresolvable.
-                onLaunchFailed(activity, e)
+                onLaunchFailed(e)
+                throw e
             }
-        }
+        },
+        // The failure is not presented here: it propagates to the dialog, which renders this inline.
+        // A Toast caps at 2 lines and clipped this message (in French mid-word, dropping a whole
+        // condition), so the container was the defect, not the wording.
+        fixActionErrorMessage = R.string.upgrades_gplay_not_installed_message.toCaString(),
     )
 
-    private fun onLaunchFailed(activity: Activity, e: Exception) {
+    private fun onLaunchFailed(e: Exception) {
         log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeViewModel.kt
@@ -18,6 +18,7 @@ import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.octi.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.octi.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -186,9 +187,22 @@ class UpgradeViewModel @Inject constructor(
 
         if (done != null) {
             if (iap == null && sub == null) {
-                val serviceUnavailableError = GplayServiceUnavailableException(
-                    done.iap.exceptionOrNull() ?: RuntimeException("IAP and SUB data request failed.")
-                )
+                val iapCause = done.iap.exceptionOrNull()
+                val subCause = done.sub.exceptionOrNull()
+                // Play answered fine and simply has nothing to sell here (region, account
+                // eligibility, pulled product): reporting that as a connectivity failure sends the
+                // user chasing futile advice (clear Play's cache, reboot). Only when BOTH causes
+                // are merchandising — a single connectivity failure can't rule out a real Play
+                // problem, so the conservative "can't reach Play" copy stays correct.
+                val queryError = if (
+                    iapCause is OfferUnavailableBillingException && subCause is OfferUnavailableBillingException
+                ) {
+                    iapCause
+                } else {
+                    GplayServiceUnavailableException(
+                        iapCause ?: RuntimeException("IAP and SUB data request failed.")
+                    )
+                }
                 // Grace users and owners are excluded: during an outage (exactly when grace
                 // matters) they must keep the Loaded presentation with their status/grace card,
                 // not an acquisition-style error state or dialog.
@@ -197,9 +211,9 @@ class UpgradeViewModel @Inject constructor(
                     // toggling) — emit once per failure episode, not once per recombination.
                     if (!hasShownServiceUnavailableError) {
                         hasShownServiceUnavailableError = true
-                        errorEvents.tryEmit(serviceUnavailableError)
+                        errorEvents.tryEmit(queryError)
                     }
-                    return@combine GplayUpgradeUiState.Unavailable(serviceUnavailableError)
+                    return@combine GplayUpgradeUiState.Unavailable(queryError)
                 }
             } else {
                 hasShownServiceUnavailableError = false

--- a/app/src/test/java/eu/darken/octi/common/error/ComposeErrorDialogGuardTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/error/ComposeErrorDialogGuardTest.kt
@@ -39,21 +39,29 @@ class ComposeErrorDialogGuardTest : BaseTest() {
         override val errorEvents = SingleEventFlow<Throwable>()
     }
 
-    private class ThrowingFixError(private val onFix: () -> Unit) : Exception("fix error"), HasLocalizedError {
+    private class ThrowingFixError(
+        private val onFix: () -> Unit,
+        private val fixErrorMessage: String? = null,
+    ) : Exception("fix error"), HasLocalizedError {
         override fun getLocalizedError(): LocalizedError = LocalizedError(
             throwable = this,
             label = "Fix error".toCaString(),
             description = "Something wants fixing".toCaString(),
             fixActionLabel = FIX_LABEL.toCaString(),
             fixAction = { onFix() },
+            fixActionErrorMessage = fixErrorMessage?.toCaString(),
         )
     }
 
-    private class InfoActionError(private val onInfo: () -> Unit) : Exception("info error"), HasLocalizedError {
+    private class InfoActionError(
+        private val onInfo: () -> Unit,
+        private val fixErrorMessage: String? = null,
+    ) : Exception("info error"), HasLocalizedError {
         override fun getLocalizedError(): LocalizedError = LocalizedError(
             throwable = this,
             label = "Info error".toCaString(),
             description = "Something needs a closer look".toCaString(),
+            fixActionErrorMessage = fixErrorMessage?.toCaString(),
             infoAction = { onInfo() },
         )
     }
@@ -110,6 +118,55 @@ class ComposeErrorDialogGuardTest : BaseTest() {
         infoClicks shouldBe 1
         composeRule.onAllNodesWithText(context.getString(android.R.string.ok)).assertCountEquals(0)
     }
+
+    @Test
+    fun `a throwing fix action with its own message keeps the dialog open and shows it inline`() {
+        // A Toast caps at 2 lines and clipped this kind of message; the dialog body has no cap.
+        showError(
+            ThrowingFixError(
+                onFix = { throw IllegalStateException("fix action exploded") },
+                fixErrorMessage = FIX_ERROR_MESSAGE,
+            )
+        )
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(FIX_ERROR_MESSAGE).assertExists()
+        composeRule.onNodeWithText(FIX_LABEL).assertExists()
+        // Not latched: the way out stays available while the message is shown.
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_dismiss_action)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(FIX_LABEL).assertCountEquals(0)
+        composeRule.onAllNodesWithText(FIX_ERROR_MESSAGE).assertCountEquals(0)
+    }
+
+    @Test
+    fun `a throwing info action never borrows the fix action's failure message`() {
+        // The failure copy belongs to the fix action's dispatch, not to the error: the info button
+        // dispatches without one and must keep the plain log-then-dismiss behaviour. Octi never
+        // renders both buttons at once, so the message rides on an info-only error here — which is
+        // exactly the shape that would break if the dialog read it off the error instead.
+        var infoClicks = 0
+        showError(
+            InfoActionError(
+                onInfo = {
+                    infoClicks++
+                    throw IllegalStateException("info action exploded")
+                },
+                fixErrorMessage = FIX_ERROR_MESSAGE,
+            )
+        )
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_show_details_action)).performClick()
+        composeRule.waitForIdle()
+
+        infoClicks shouldBe 1
+        composeRule.onAllNodesWithText(context.getString(android.R.string.ok)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(FIX_ERROR_MESSAGE).assertCountEquals(0)
+    }
 }
 
 private const val FIX_LABEL = "Boom"
+private const val FIX_ERROR_MESSAGE = "Fixing it did not work"

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/core/billing/GplayFixActionTest.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import eu.darken.octi.R
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.Test
@@ -17,7 +18,8 @@ import testhelpers.TestApplication
 
 /**
  * The error dialog's "Google Play" button runs on an activity context: a device where the launch is
- * refused - or where there is nothing to launch - must get a toast, not a crash.
+ * refused - or where there is nothing to launch - must get the failure reported through the dialog
+ * (which can show the full message), not a clipped toast and not a crash.
  */
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
@@ -39,20 +41,33 @@ class GplayFixActionTest : BaseTest() {
 
     private fun <T : Activity> activityOf(clazz: Class<T>): T = Robolectric.buildActivity(clazz).setup().get()
 
-    private fun assertToastInsteadOfCrash(activity: Activity) {
-        fixAction.invoke(activity)
+    @Test
+    fun `a denied launch reports through the dialog instead of a toast`() {
+        val activity = activityOf(DeniedLaunchActivity::class.java)
 
-        ShadowToast.getTextOfLatestToast() shouldBe
-            activity.getString(R.string.upgrades_gplay_not_installed_message)
+        shouldThrow<SecurityException> { fixAction.invoke(activity) }
+
+        // A toast caps at 2 lines and clipped this message (French lost a whole condition
+        // mid-word) — the dialog renders it inline instead.
+        ShadowToast.getLatestToast() shouldBe null
     }
 
     @Test
-    fun `a denied launch shows the not-installed toast instead of crashing`() {
-        assertToastInsteadOfCrash(activityOf(DeniedLaunchActivity::class.java))
+    fun `an unresolvable launch reports through the dialog instead of a toast`() {
+        val activity = activityOf(UnresolvedLaunchActivity::class.java)
+
+        shouldThrow<ActivityNotFoundException> { fixAction.invoke(activity) }
+
+        ShadowToast.getLatestToast() shouldBe null
     }
 
     @Test
-    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
-        assertToastInsteadOfCrash(activityOf(UnresolvedLaunchActivity::class.java))
+    fun `the failure message travels with the error for the dialog to show`() {
+        val activity = activityOf(Activity::class.java)
+
+        val message = GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError().fixActionErrorMessage.shouldNotBeNull()
+
+        message.get(activity) shouldBe activity.getString(R.string.upgrades_gplay_not_installed_message)
     }
 }

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -10,6 +10,7 @@ import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.UpgradeRepoGplay
 import eu.darken.octi.common.upgrade.core.billing.BillingData
 import eu.darken.octi.common.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.octi.common.upgrade.core.billing.OfferUnavailableBillingException
 import eu.darken.octi.common.upgrade.core.billing.Sku
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -115,6 +116,67 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         loaded.await().shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
         coVerify(exactly = 4) { repo.querySkus(any()) }
+    }
+
+    @Test
+    fun `both product types unavailable surfaces the merchandising error, not a connectivity one`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Play answered OK and simply has no sellable offer here (region, account eligibility,
+        // pulled product). Reporting that as "can't connect to Google Play" tells the user to
+        // clear Play's cache and reboot, which cannot help.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Sub.PRO_UPGRADE, null)
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<OfferUnavailableBillingException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<OfferUnavailableBillingException>()
+    }
+
+    @Test
+    fun `a mixed failure keeps the conservative connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // One sku failed for a non-merchandising reason: a real Play problem can't be ruled out,
+        // so the conservative "can't reach Play" copy stays.
+        val repo = mockRepo()
+        coEvery { repo.querySkus(OurSku.Iap.PRO_UPGRADE) } throws
+            OfferUnavailableBillingException(OurSku.Iap.PRO_UPGRADE, null)
+        coEvery { repo.querySkus(OurSku.Sub.PRO_UPGRADE) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
+    }
+
+    @Test
+    fun `a connectivity failure on both product types stays a connectivity error`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val unavailableState = async { vm.state.first { it is GplayUpgradeUiState.Unavailable } }
+        val forwardedError = async { vm.errorEvents.first() }
+        advanceUntilIdle()
+
+        forwardedError.await().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        val state = unavailableState.await().shouldBeInstanceOf<GplayUpgradeUiState.Unavailable>()
+        state.error.shouldBeInstanceOf<GplayServiceUnavailableException>()
     }
 
     @Test


### PR DESCRIPTION
## What changed

Two fixes to how the upgrade screen reports Google Play problems, both found during a device QA pass.

**The app no longer blames your connection when Google Play simply has nothing to offer.** If Play answers normally but returns no purchasable products — because there is no pricing for your region, a product was withdrawn, or your account isn't eligible — the app used to say it "can't connect to Google Play" and suggest clearing the Play Store cache and rebooting. That advice couldn't help, because nothing was wrong with the device or with Play. Those cases now show the existing "offer unavailable" message instead. A genuine connection problem still reports as one.

**Error messages are no longer cut off.** When the "Google Play" button on an error dialog couldn't open the Play Store page, the explanation was shown as a toast — and Android limits toasts to two lines. The end of the sentence was clipped in English, and in translated languages an entire clause could disappear: a French user saw "it may be missing, disabled or r…" and never learned that *restricted* was one of the possible causes. The message now appears inside the dialog itself, where it fits at any length, and the dialog stays open so the wording is readable.

## Technical Context

- The billing layer already threw a typed `OfferUnavailableBillingException` for the merchandising case, specifically so it would surface as user copy rather than a bug report. The upgrade ViewModel discarded that typing, wrapping *any* both-queries-failed outcome into `GplayServiceUnavailableException`. It now inspects both causes and only downgrades to the merchandising error when **both** are merchandising — a single connectivity failure can't rule out a real Play problem, so the conservative copy stays correct in mixed cases.
- The failure message moved out of `Toast` and into the error dialog. `LocalizedError` gained an optional `fixActionErrorMessage`; the exception now logs and rethrows instead of presenting, and the dialog renders the message inline and skips its dismiss.
- The dialog's dispatch helper takes the message **per dispatch** rather than reading it off the error. That helper serves both the fix and the info buttons, so reading it off the error would let a failing info action surface the fix action's copy. Call sites use named arguments so any future third dispatch site has to make that choice explicitly.
- Review guidance: the inline-message state is keyed on the *throwable*, not the `LocalizedError` — the latter is rebuilt with fresh action lambdas on every recomposition, so equality never holds and the message would be wiped the instant it was set.
- Unchanged on purpose: the once-per-failure-episode emission guard, the carve-out that keeps owners and grace-period users on their normal presentation during an outage, and the wording of the message itself.
