### PR TITLE
Let translators own the upgraded app title's word order

### DIFF
--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded" translatable="false">Octi FOSS</string>
-
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("FOSS"). -->
+    <string name="app_name_upgraded_template" translatable="false">%1$s %2$s</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requires Octi Pro</string>
 

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is nie beskikbaar nie</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en op datum? Is jou Google-rekening aangemeld? Probeer die kasgeheue van die Google Play-toepassing skoonmaak en jou toestel herlaai.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">أوكتي احترافي</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">احترافي</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">جوجل بلاي غير متوفر</string>
     <string name="upgrades_gplay_unavailable_error_description">لا يمكن لأوكتي الاتصال بـ جوجل بلاي. هل جوجل بلاي مثبت ومحدث؟ هل حساب جوجل الخاص بك مسجل الدخول؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق جوجل بلاي وأعد تشغيل جهازك.</string>
     <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على مشتريات. هل تستخدم الحساب الصحيح؟</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е наличен</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може да се свърже с Google Play. Инсталиран и актуализиран ли е Google Play? Влезли ли сте с вашия Google акаунт? Опитайте да изчистите кеша на приложението Google Play и рестартирайте устройството си.</string>
     <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">El Google Play no està disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">L\'Octi no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat sessió amb el vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
     <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu utilitzant el compte correcte?</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Služba Google Play není k dispozici</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se nemůže připojit k Google Play. Je Google Play nainstalován a aktuální? Je váš účet Google přihlášen? Zkuste vyčistit mezipaměť aplikace Google Play a restartovat zařízení.</string>
     <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgængelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prøv at rydde cachen for Google Play-appen og genstart din enhed.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Keine Verbindung zu Google Play</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kann sich nicht mit Google Play verbinden. Ist Google Play installiert und aktuell? Bist du angemeldet bei Google Play? Versuche den Cache von der Google Play App zu bereinigen und starte dein Gerät neu.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Zahlung gefunden. Benutzt du den richtigen Account?</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Το Google Play δεν είναι διαθέσιμο</string>
     <string name="upgrades_gplay_unavailable_error_description">Το Octi δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό σας Google; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi no puede conectarse a Google Play. ¿Está instalada y actualizada Google Play? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>

--- a/app/src/gplay/res/values-et/strings.xml
+++ b/app/src/gplay/res/values-et/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play pole saadaval</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ei saa Google Playga ühendust. Kas Google Play on paigaldatud ja ajakohane? Kas Sinu Google\'i konto on sisse logitud? Proovi Google Play rakenduse vahemälu tühjendada ja seadme taaskäivitada.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostud ei leitud. Kas kasutad õiget kontot?</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ei ole käytettävissä</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautuneena? Kokeile tyhjentää Google Play -sovelluksen välimuisti ja käynnistää laite uudelleen.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play est inaccessible</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l’appli Google Play et de redémarrer votre appareil.</string>
     <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>

--- a/app/src/gplay/res/values-ga/strings.xml
+++ b/app/src/gplay/res/values-ga/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Níl Google Play ar fáil</string>
     <string name="upgrades_gplay_unavailable_error_description">Ní féidir le Octi nascadh le Google Play. An bhfuil Google Play suiteáilte agus cothrom le dáta? An bhfuil do Chuntas Google logáilte isteach? Bain triail as taisce an aipe Google Play a ghlanadh agus an gléas a atosú.</string>
     <string name="upgrades_no_purchases_found_check_account">Níor aimsíodh aon cheannacháin. An bhfuil tú ag úsáid an chuntais cheart?</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nije dostupan</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se ne može povezati s Google Playom. Je li Google Play instaliran i ažuriran? Jeste li prijavljeni na svoj Google račun? Pokušajte izbrisati predmemoriju aplikacije Google Play i ponovno pokrenuti uređaj.</string>
     <string name="upgrades_no_purchases_found_check_account">Nema pronađenih kupnji. Koristite li pravi račun?</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">A Google Play nem elérhető</string>
     <string name="upgrades_gplay_unavailable_error_description">Az Octi nem tud csatlakozni a Google Playhez. Telepítve és naprakész a Google Play? Be vagy jelentkezve Google-fiókkal? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
     <string name="upgrades_no_purchases_found_check_account">Nem találhatók vásárlások. Biztosan a megfelelő fiókot használod?</string>

--- a/app/src/gplay/res/values-id/strings.xml
+++ b/app/src/gplay/res/values-id/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi tidak dapat terhubung ke Google Play. Apakah Google Play sudah terinstal dan terbaru? Apakah akun Google Anda sudah masuk? Coba bersihkan cache aplikasi Google Play dan hidupkan ulang perangkat Anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Tidak ada pembelian yang ditemukan. Apakah Anda menggunakan akun yang benar?</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er ekki í boði</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Er Google-aðgangurinn þinn virkur? Prófaðu að hreinsa skyndiminni fyrir Google Play og endurræsa tækið.</string>
     <string name="upgrades_no_purchases_found_check_account">Engar kaupfundust. Ertu að nota rétta reikninginn?</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non disponibile</string>
     <string name="upgrades_gplay_unavailable_error_description">Opti non può connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a svuotare la cache dell\'app Google Play e riavviare il dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account corretto?</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi פרימיום</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">פרו</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">גוגל פליי לא זמין</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi לא יכול להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולאתחל את המכשיר שלך.</string>
     <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play は利用できません</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi が Google Play に接続できません。Google Play はインストールされている環境ですか？Google アカウントにログインをしていますか？その他に Google Play アプリのキャッシュを削除して、デバイスの再起動をお試しください。</string>
     <string name="upgrades_no_purchases_found_check_account">購入履歴が見つかりません。正しいアカウントを使用していますか？</string>

--- a/app/src/gplay/res/values-ka/strings.xml
+++ b/app/src/gplay/res/values-ka/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play მიუწვდომელია</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ვერ უკავშირდება Google Play-ს. Google Play არის დამყენებული და განახლებული? თქვენ შედიხართ Google ანგარიშით? სცადეთ Google Play აპის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
     <string name="upgrades_no_purchases_found_check_account">ვერ მოიძებნა შეძენილი პროდუქტები. ნამდვილად სწორ ანგარიშს იყენებთ?</string>

--- a/app/src/gplay/res/values-kk/strings.xml
+++ b/app/src/gplay/res/values-kk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play қолжетімсіз</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi Google Play қызметіне қосыла алмайды. Google Play орнатылған және жаңартылған ба? Google есептік жазбаңызға кіргенсіз бе? Google Play қолданбасының кэшін тазалап, құрылғыны қайта іске қосып көріңіз.</string>
     <string name="upgrades_no_purchases_found_check_account">Сатып алулар табылмады. Дұрыс есептік жазбаны пайдаланудасыз ба?</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">프로</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play를 사용할 수 없음</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 상태입니까? Google 계정에 로그인되어 있습니까? Google Play 앱의 캐시를 지우고 기기를 재시작해 보세요.</string>
     <string name="upgrades_no_purchases_found_check_account">구매 내역이 없습니다. 올바른 계정을 사용 중인가요?</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nepasiekiama</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nepavyksta prisijungti prie Google Play. Ar Google Play įdiegta ir atnaujinta? Ar jūsų Google paskyra yra prisijungusi? Pabandykite išvalyti Google Play programos podėlį ir paleisti įrenginį iš naujo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nerasta jokių pirkinių. Ar naudojate tinkamą paskyrą?</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nav pieejams</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai jūsu Google konts ir pieslēgts? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un restartēt ierīci.</string>
     <string name="upgrades_no_purchases_found_check_account">Netika atrasti pirkumi. Vai izmantojat pareizo kontu?</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi tidak dapat menyambung ke Google Play. Adakah Google Play telah dipasang dan dikemas kini? Adakah akaun Google anda telah log masuk? Cuba kosongkan cache aplikasi Google Play dan mulakan semula peranti anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Tiada pembelian dijumpai. Adakah anda menggunakan akaun yang betul?</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgjengelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din pålogget? Prøv å tømme hurtigbufferen for Google Play-appen og start enheten på nytt.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is niet beschikbaar</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account aangemeld? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je het juiste account?</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play jest niedostępne</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nie może połączyć się z Google Play. Czy Google Play jest zainstalowane i aktualne? Czy jesteś zalogowany na swoim koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Octi não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta correta?</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Octi não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta correta?</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponibil</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nu se poate conecta la Google Play. Este Google Play instalat și actualizat? Contul tău Google este conectat? Încearcă să ștergi memoria cache a aplicației Google Play și să repornești dispozitivul.</string>
     <string name="upgrades_no_purchases_found_check_account">Nu au fost găsite achiziții. Folosiți contul corect?</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступен</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не может подключиться к Google Play. Установлен и обновлен ли Google Play? Вошли ли Вы в аккаунт Google? Попробуйте очистить кэш приложения Google Play и перезагрузить устройство.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Используете ли Вы правильный аккаунт?</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nie je dostupný</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartovať zariadenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ni na voljo</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se ne more povezati z Google Play. Ali je Google Play nameščen in posodobljen? Ali ste prijavljeni v svoj Google račun? Poskusite počistiti predpomnilnik aplikacije Google Play in znova zagnati napravo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nakupi niso bili najdeni. Ali uporabljate pravi račun?</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play није доступан</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може да се повеже са Google Play-ом. Да ли је Google Play инсталиран и ажуриран? Да ли сте пријављени на свој Google налог? Покушајте да очистите кеширање апликације Google Play и поново покренете уређај.</string>
     <string name="upgrades_no_purchases_found_check_account">Нису пронађене куповине. Користите ли прави налог?</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Expert</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play är inte tillgängligt</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Prova att rensa cacheminnet för Google Play-appen och starta om enheten.</string>
     <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ไม่พร้อมใช้งาน</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ไม่สามารถเชื่อมต่อกับ Google Play ได้ ติดตั้งและอัปเดต Google Play แล้วหรือยัง? คุณเข้าสู่ระบบด้วยบัญชี Google หรือไม่? ลองล้างแคชของแอป Google Play และรีสตาร์ทอุปกรณ์ของคุณ</string>
     <string name="upgrades_no_purchases_found_check_account">ไม่พบการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play kullanılamıyor</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
     <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступний</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може підключитися до Google Play. Чи встановлено і оновлено Google Play? Ви ввійшли у свій обліковий запис Google? Спробуйте очистити кеш застосунку Google Play і перезапустити пристрій.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play không khả dụng</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Bạn đã đăng nhập tài khoản Google chưa? Hãy thử xóa bộ nhớ cache của ứng dụng Google Play và khởi động lại thiết bị.</string>
     <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch mua nào. Bạn có dùng đúng tài khoản không?</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">专业版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play不可用</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi 无法连接到 Google Play。Google Play 是否已安装并更新？您的 Google 帐户是否已登录？尝试清除 Google Play 应用的缓存并重新启动您的设备。</string>
     <string name="upgrades_no_purchases_found_check_account">未找到任何购买记录。您使用的是正确的帐户吗？</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">專業版</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到任何購買記錄。您是否使用了正確的帳戶？</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">Octi Pro</string>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
 
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>

--- a/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
@@ -88,22 +88,58 @@ internal object UpgradeScreenTags {
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"
 }
 
-// "Octi" + the flavor postfix, colored while Pro is active. The postfix is its own translatable
-// string (RTL/localized upgrade words reorder), so we never locate a substring inside a combined
-// name.
+// The app's brand title, composed through the flavor's title template so translators own the word
+// order and punctuation instead of the code assuming "name, space, qualifier".
+//
+// The two flags are deliberately separate. `includeQualifier` decides whether the tier word is part
+// of the title at all (the dashboard drops it while free); `highlightQualifier` only decides whether
+// it is colored. Collapsing them would tie "name the flavor" to "color it", which is the pair a
+// status-free view needs to hold apart.
 @Composable
-internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = buildAnnotatedString {
-    append(stringResource(CommonR.string.app_name))
-    append(" ")
-    if (upgraded) pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
-    append(stringResource(R.string.app_name_upgrade_postfix))
-    if (upgraded) pop()
+internal fun brandTitle(includeQualifier: Boolean, highlightQualifier: Boolean): AnnotatedString {
+    val name = AnnotatedString(stringResource(CommonR.string.app_name))
+    if (!includeQualifier) return name
+
+    val qualifier = buildAnnotatedString {
+        if (highlightQualifier) pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
+        append(stringResource(R.string.app_name_upgrade_postfix))
+        if (highlightQualifier) pop()
+    }
+    return spliceTitleTemplate(
+        formatted = stringResource(
+            R.string.app_name_upgraded_template,
+            BRAND_TITLE_MARKER,
+            BRAND_QUALIFIER_MARKER,
+        ),
+        name = name,
+        qualifier = qualifier,
+    )
 }
+
+// Same composition for call sites that need a plain String. Routed through brandTitle so the two
+// forms cannot drift apart.
+@Composable
+internal fun brandTitleText(includeQualifier: Boolean): String =
+    brandTitle(includeQualifier = includeQualifier, highlightQualifier = false).text
+
+// Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
+// active — the same treatment the dashboard title uses.
+@Composable
+internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = brandTitle(
+    // Unconditional: this title names the flavor even when the screen is showing the free state.
+    includeQualifier = true,
+    highlightQualifier = upgraded,
+)
 
 // Marker char for brand-title splicing: formatted into the translated pattern via the normal
 // Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
 // with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
 internal const val BRAND_TITLE_MARKER = "￼"
+
+// The title template's second slot. U+FFF9 (interlinear annotation anchor) is likewise absent from
+// real translations, and being distinct from BRAND_TITLE_MARKER is what lets the splice tell the
+// two slots apart after the formatter has reordered them.
+internal const val BRAND_QUALIFIER_MARKER = "￹"
 
 internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
     var rest = formatted
@@ -121,6 +157,64 @@ internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): Annota
         // Defensive: a translation that lost its placeholder still shows the brand.
         append(" ")
         append(brand)
+    }
+}
+
+// Splices the two title slots into an already-formatted template. Stricter than spliceBrandTitle on
+// purpose: that one splices a brand into a *sentence*, where a repeated marker is a legitimate (if
+// odd) translation. A *title* template has exactly two slots, so anything else is damage — and once
+// a slot is missing or doubled the template can no longer tell us the intended order or
+// punctuation, which is the whole reason it exists. So a broken template is discarded whole and the
+// default title is rebuilt from the parts; patching it up piecewise would emit a title no
+// translator wrote.
+internal fun spliceTitleTemplate(
+    formatted: String,
+    name: AnnotatedString,
+    qualifier: AnnotatedString,
+): AnnotatedString {
+    val slots = listOf(
+        BRAND_TITLE_MARKER to name,
+        BRAND_QUALIFIER_MARKER to qualifier,
+    ).map { (marker, value) -> Triple(formatted.indexOf(marker), marker, value) }
+
+    val intact = slots.all { (index, marker, _) ->
+        index >= 0 && formatted.indexOf(marker, index + marker.length) < 0
+    }
+    if (!intact) {
+        return buildAnnotatedString {
+            append(name)
+            append(" ")
+            append(qualifier)
+        }
+    }
+
+    return buildAnnotatedString {
+        var cursor = 0
+        slots.sortedBy { it.first }.forEach { (index, marker, value) ->
+            append(formatted.substring(cursor, index))
+            append(value)
+            cursor = index + marker.length
+        }
+        append(formatted.substring(cursor))
+    }
+}
+
+// All three flag combinations the app actually uses, in one place — the pair (true, false) is the
+// one that reads as a mistake at a glance, so seeing it render the flavor name in plain text is
+// what documents it.
+@Preview2
+@Composable
+private fun BrandTitlePreview() {
+    PreviewWrapper {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(text = brandTitle(includeQualifier = false, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = false))
+            Text(text = brandTitle(includeQualifier = true, highlightQualifier = true))
+            Text(text = brandTitleText(includeQualifier = true))
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -79,17 +79,13 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -110,6 +106,7 @@ import eu.darken.octi.common.permissions.Permission
 import eu.darken.octi.common.permissions.descriptionRes
 import eu.darken.octi.common.permissions.labelRes
 import eu.darken.octi.common.upgrade.UpgradeRepo
+import eu.darken.octi.common.upgrade.ui.brandTitle
 import eu.darken.octi.main.ui.dashboard.editor.TileEditorCard
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleId
@@ -1155,39 +1152,20 @@ private fun SyncDetailConnectorRow(
 
 @Composable
 private fun DashboardToolbarTitle(upgradeInfo: UpgradeRepo.Info) {
-    val appName = stringResource(CommonR.string.app_name)
-    val titleText = when {
-        upgradeInfo.isPro -> stringResource(R.string.app_name_upgraded)
-        else -> appName
-    }
+    val isPro = upgradeInfo.isPro
+    val titleText = brandTitle(includeQualifier = isPro, highlightQualifier = isPro)
     val buildChannelLabel = LocalDashboardBuildChannelLabel.current
-
-    val titleParts = titleText.split(" ").filter { it.isNotEmpty() }
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        if (titleParts.size == 2) {
-            Text(
-                text = buildAnnotatedString {
-                    append("${titleParts[0]} ")
-                    withStyle(SpanStyle(color = colorResource(R.color.colorUpgraded))) {
-                        append(titleParts[1])
-                    }
-                },
-                modifier = Modifier.weight(1f, fill = false),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        } else {
-            Text(
-                text = appName,
-                modifier = Modifier.weight(1f, fill = false),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-        }
+        Text(
+            text = titleText,
+            modifier = Modifier.weight(1f, fill = false),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
 
         if (buildChannelLabel != null) {
             BuildChannelChip(label = buildChannelLabel)

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
@@ -1,0 +1,115 @@
+package eu.darken.octi.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.R
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import testhelpers.compose.BaseComposeRobolectricTest
+import eu.darken.octi.common.R as CommonR
+
+/**
+ * Resolves the title template through the real resource merger for every locale the app ships,
+ * because a damaged template is a crash, not a cosmetic bug: a stray `%`, a `%3$s` or a `%1$d` in
+ * a pulled translation throws inside `getString` *before* `spliceTitleTemplate`'s fallback can run.
+ *
+ * The per-locale span assertion goes through `spliceTitleTemplate` directly rather than the
+ * composable, so all locales fit in one test — `composeRule.setContent` may only be called once.
+ * Ordering behaviour itself is covered exhaustively by [TitleTemplateSpliceTest]; what this adds is
+ * that the *shipped* templates are the ones being spliced.
+ */
+class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    // Every locale with a shipped strings.xml, plus "en" for the base resources. A new locale must
+    // be added here deliberately — that is the point, not an oversight.
+    private val locales = listOf(
+        "en",
+        "af-rZA", "ar", "bg", "ca", "cs", "da", "de", "el", "es", "et", "fi", "fr", "ga", "hr",
+        "hu", "id", "is", "it", "iw", "ja", "ka", "kk", "ko", "lt", "lv", "ms", "nb", "nl", "pl",
+        "pt", "pt-rBR", "ro", "ru", "sk", "sl", "sr", "sv", "th", "tr", "uk", "vi", "zh-rCN",
+        "zh-rTW",
+    )
+
+    @Test
+    fun `every shipped locale resolves a well-formed title template`() {
+        locales.forEach { locale ->
+            RuntimeEnvironment.setQualifiers("+$locale")
+
+            val template = context.getString(R.string.app_name_upgraded_template)
+
+            withClue(locale) {
+                // Exactly one of each slot, and nothing else that getString would try to expand.
+                Regex(Regex.escape("%1\$s")).findAll(template).count() shouldBe 1
+                Regex(Regex.escape("%2\$s")).findAll(template).count() shouldBe 1
+                template.replace("%1\$s", "").replace("%2\$s", "") shouldNotContain "%"
+            }
+        }
+    }
+
+    /**
+     * Guards the two tests above against passing vacuously. If `setQualifiers` silently stopped
+     * switching locales, every iteration would resolve the base resources and the sweep would still
+     * be green while testing exactly one locale.
+     */
+    @Test
+    fun `the sweep actually switches locales`() {
+        RuntimeEnvironment.setQualifiers("+ar")
+        context.getString(CommonR.string.app_name) shouldBe "أوكتي"
+
+        RuntimeEnvironment.setQualifiers("+en")
+        context.getString(CommonR.string.app_name) shouldBe "Octi"
+    }
+
+    @Test
+    fun `every shipped locale composes a title whose highlight covers the qualifier`() {
+        locales.forEach { locale ->
+            RuntimeEnvironment.setQualifiers("+$locale")
+
+            val name = context.getString(CommonR.string.app_name)
+            val qualifier = context.getString(R.string.app_name_upgrade_postfix)
+            val composed = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+            val result = spliceTitleTemplate(
+                formatted = context.getString(
+                    R.string.app_name_upgraded_template,
+                    BRAND_TITLE_MARKER,
+                    BRAND_QUALIFIER_MARKER,
+                ),
+                name = AnnotatedString(name),
+                qualifier = buildAnnotatedString {
+                    pushStyle(SpanStyle(color = Color.Red))
+                    append(qualifier)
+                    pop()
+                },
+            )
+
+            withClue(locale) {
+                name.isNotBlank() shouldBe true
+                qualifier.isNotBlank() shouldBe true
+                result.text shouldBe composed
+                result.text shouldNotContain BRAND_TITLE_MARKER
+                result.text shouldNotContain BRAND_QUALIFIER_MARKER
+                result.spanStyles.size shouldBe 1
+                val span = result.spanStyles.single()
+                result.text.substring(span.start, span.end) shouldBe qualifier
+            }
+        }
+    }
+
+    // Kotest's own withClue pulls in the assertions-core dependency; this keeps the failure message
+    // locale-tagged without adding one, since a bare failure in a 44-iteration loop is unreadable.
+    private inline fun withClue(clue: String, block: () -> Unit) = try {
+        block()
+    } catch (e: AssertionError) {
+        throw AssertionError("[locale=$clue] ${e.message}", e)
+    }
+}

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
@@ -44,13 +44,17 @@ class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
         locales.forEach { locale ->
             RuntimeEnvironment.setQualifiers("+$locale")
 
-            val template = context.getString(R.string.app_name_upgraded_template)
-
             withClue(locale) {
+                val template = context.getString(R.string.app_name_upgraded_template)
+
+                // `%%` is an escaped literal percent and is legitimate punctuation for a translator
+                // to use, so it is removed before the leftover-percent check rather than failing it.
+                val unescaped = template.replace("%%", "")
+
                 // Exactly one of each slot, and nothing else that getString would try to expand.
-                Regex(Regex.escape("%1\$s")).findAll(template).count() shouldBe 1
-                Regex(Regex.escape("%2\$s")).findAll(template).count() shouldBe 1
-                template.replace("%1\$s", "").replace("%2\$s", "") shouldNotContain "%"
+                Regex(Regex.escape("%1\$s")).findAll(unescaped).count() shouldBe 1
+                Regex(Regex.escape("%2\$s")).findAll(unescaped).count() shouldBe 1
+                unescaped.replace("%1\$s", "").replace("%2\$s", "") shouldNotContain "%"
             }
         }
     }
@@ -74,25 +78,27 @@ class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
         locales.forEach { locale ->
             RuntimeEnvironment.setQualifiers("+$locale")
 
-            val name = context.getString(CommonR.string.app_name)
-            val qualifier = context.getString(R.string.app_name_upgrade_postfix)
-            val composed = context.getString(R.string.app_name_upgraded_template, name, qualifier)
-
-            val result = spliceTitleTemplate(
-                formatted = context.getString(
-                    R.string.app_name_upgraded_template,
-                    BRAND_TITLE_MARKER,
-                    BRAND_QUALIFIER_MARKER,
-                ),
-                name = AnnotatedString(name),
-                qualifier = buildAnnotatedString {
-                    pushStyle(SpanStyle(color = Color.Red))
-                    append(qualifier)
-                    pop()
-                },
-            )
-
+            // Formatting is inside the clue on purpose: a malformed `%1$d` or `%3$s` throws out of
+            // getString rather than failing an assertion, and that throw has to name the locale too.
             withClue(locale) {
+                val name = context.getString(CommonR.string.app_name)
+                val qualifier = context.getString(R.string.app_name_upgrade_postfix)
+                val composed = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+                val result = spliceTitleTemplate(
+                    formatted = context.getString(
+                        R.string.app_name_upgraded_template,
+                        BRAND_TITLE_MARKER,
+                        BRAND_QUALIFIER_MARKER,
+                    ),
+                    name = AnnotatedString(name),
+                    qualifier = buildAnnotatedString {
+                        pushStyle(SpanStyle(color = Color.Red))
+                        append(qualifier)
+                        pop()
+                    },
+                )
+
                 name.isNotBlank() shouldBe true
                 qualifier.isNotBlank() shouldBe true
                 result.text shouldBe composed
@@ -107,9 +113,13 @@ class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
 
     // Kotest's own withClue pulls in the assertions-core dependency; this keeps the failure message
     // locale-tagged without adding one, since a bare failure in a 44-iteration loop is unreadable.
+    //
+    // Catches Throwable, not just AssertionError: the failure mode this sweep exists to catch is a
+    // malformed format specifier, which throws IllegalFormatException out of getString instead of
+    // failing an assertion. Narrowing to AssertionError would let exactly that case lose its locale.
     private inline fun withClue(clue: String, block: () -> Unit) = try {
         block()
-    } catch (e: AssertionError) {
-        throw AssertionError("[locale=$clue] ${e.message}", e)
+    } catch (e: Throwable) {
+        throw AssertionError("[locale=$clue] ${e::class.simpleName}: ${e.message}", e)
     }
 }

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.octi.common.upgrade.ui
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import eu.darken.octi.common.R as CommonR
+
+/**
+ * Resolves the real flavor resources rather than a sample pattern, so this also proves the two
+ * markers survive Android's format path and never reach the user.
+ *
+ * Flavor-agnostic on purpose: it asserts against whatever this variant's qualifier resource says
+ * ("Pro" on GPLAY, "FOSS" on FOSS) so the one test guards both. The resources are flavor-owned, so
+ * a variant that compiles proves nothing about the other.
+ */
+class BrandTitleTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val name: String
+        get() = context.getString(CommonR.string.app_name)
+
+    private val qualifier: String
+        get() = context.getString(R.string.app_name_upgrade_postfix)
+
+    private val composed: String
+        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+
+    private fun capture(block: @Composable () -> AnnotatedString): AnnotatedString {
+        lateinit var captured: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper { captured = block() }
+        }
+        composeRule.waitForIdle()
+        return captured
+    }
+
+    @Test
+    fun `without the qualifier the title is the bare app name`() {
+        val result = capture { brandTitle(includeQualifier = false, highlightQualifier = false) }
+
+        result.text shouldBe name
+        result.spanStyles.size shouldBe 0
+    }
+
+    // The regression guard for the two-flag split: the qualifier present but NOT colored.
+    // Collapsing the flags drops it; highlighting on `includeQualifier` alone colors it. Both would
+    // still produce plausible-looking text, so the span count is the assertion that matters.
+    @Test
+    fun `an included but unhighlighted qualifier is present and carries no span`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = false) }
+
+        result.text shouldBe composed
+        result.text.contains(qualifier) shouldBe true
+        result.spanStyles.size shouldBe 0
+    }
+
+    @Test
+    fun `a highlighted qualifier carries exactly one span covering the qualifier only`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldBe composed
+        result.spanStyles.size shouldBe 1
+        val span = result.spanStyles.single()
+        // Not just "a span exists" — the bug class this replaces put the highlight on the app name
+        // while rendering perfectly correct text.
+        result.text.substring(span.start, span.end) shouldBe qualifier
+    }
+
+    // The markers are injected as format arguments, so a template or formatter that mangled them
+    // would leak U+FFFC / U+FFF9 into the toolbar.
+    @Test
+    fun `neither splice marker survives into the rendered title`() {
+        val result = capture { brandTitle(includeQualifier = true, highlightQualifier = true) }
+
+        result.text shouldNotContain BRAND_TITLE_MARKER
+        result.text shouldNotContain BRAND_QUALIFIER_MARKER
+    }
+
+    @Test
+    fun `the string form matches the annotated form`() {
+        val result = capture { AnnotatedString(brandTitleText(includeQualifier = true)) }
+
+        result.text shouldBe composed
+    }
+}

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/TitleTemplateSpliceTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/TitleTemplateSpliceTest.kt
@@ -1,0 +1,157 @@
+package eu.darken.octi.common.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The title template lets translators own word order and punctuation, so the styled qualifier has
+ * to land on the right offsets wherever they put it. Assertions are on span boundaries, not just on
+ * the concatenated text: the failure this guards against renders the correct characters with the
+ * highlight sitting on the wrong word.
+ */
+class TitleTemplateSpliceTest : BaseTest() {
+
+    private val qualifierColor = Color.Red
+
+    private val name = AnnotatedString("Octi")
+
+    private val qualifier: AnnotatedString = buildAnnotatedString {
+        pushStyle(SpanStyle(color = qualifierColor))
+        append("Pro")
+        pop()
+    }
+
+    private fun template(pattern: String) = pattern
+        .replace("%1\$s", BRAND_TITLE_MARKER)
+        .replace("%2\$s", BRAND_QUALIFIER_MARKER)
+
+    @Test
+    fun `the default order highlights the trailing qualifier`() {
+        val result = spliceTitleTemplate(template("%1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+        result.text.substring(5, 8) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a reordered template highlights the leading qualifier`() {
+        val result = spliceTitleTemplate(template("%2\$s %1\$s"), name, qualifier)
+
+        result.text shouldBe "Pro Octi"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 0
+        result.spanStyles.single().end shouldBe 3
+        result.text.substring(0, 3) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a custom separator shifts the qualifier without entering the span`() {
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), name, qualifier)
+
+        result.text shouldBe "Octi – Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 7
+        result.spanStyles.single().end shouldBe 10
+        result.text.substring(7, 10) shouldBe "Pro"
+    }
+
+    // The shipped Arabic values, which are both multi-character and RTL: the span has to cover the
+    // whole qualifier, not the first word of it.
+    @Test
+    fun `a multi-word qualifier is highlighted whole`() {
+        val multiWord = buildAnnotatedString {
+            pushStyle(SpanStyle(color = qualifierColor))
+            append("احترافي")
+            pop()
+        }
+
+        val result = spliceTitleTemplate(template("%1\$s – %2\$s"), AnnotatedString("أوكتي"), multiWord)
+
+        result.text shouldBe "أوكتي – احترافي"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 8
+        result.spanStyles.single().end shouldBe 15
+        result.text.substring(8, 15) shouldBe "احترافي"
+    }
+
+    // Span offsets are UTF-16 indices, so a supplementary character ahead of a slot shifts it by
+    // two. Pins that the splice arithmetic counts code units and not code points.
+    @Test
+    fun `a supplementary character before the slots shifts the span by two`() {
+        val result = spliceTitleTemplate(template("🐙 %1\$s %2\$s"), name, qualifier)
+
+        result.text shouldBe "🐙 Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 8
+        result.spanStyles.single().end shouldBe 11
+        result.text.substring(8, 11) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a duplicated name marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+    }
+
+    @Test
+    fun `a duplicated qualifier marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate(
+            "$BRAND_TITLE_MARKER $BRAND_QUALIFIER_MARKER $BRAND_QUALIFIER_MARKER",
+            name,
+            qualifier,
+        )
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+    }
+
+    @Test
+    fun `a missing name marker falls back rather than rendering the qualifier alone`() {
+        val result = spliceTitleTemplate("Get $BRAND_QUALIFIER_MARKER", name, qualifier)
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+    }
+
+    @Test
+    fun `a missing qualifier marker falls back rather than dropping the tier`() {
+        val result = spliceTitleTemplate("Get $BRAND_TITLE_MARKER", name, qualifier)
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+    }
+
+    @Test
+    fun `a template with neither marker falls back to the complete default title`() {
+        val result = spliceTitleTemplate("Octi Pro", name, qualifier)
+
+        result.text shouldBe "Octi Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe qualifierColor
+        result.spanStyles.single().start shouldBe 5
+        result.spanStyles.single().end shouldBe 8
+    }
+}

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.text.AnnotatedString
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.octi.R
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -159,26 +160,56 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     }
 
     /**
-     * "FOSS" is the flavor's name, not prose. French and Arabic used to translate the upgraded app
-     * name, which also broke DashboardScreen's two-tone title: it colours the second of exactly two
-     * space-separated tokens, and "Octi, version libre" / the four-token Arabic variant fall out of
-     * that branch entirely. These resolve through the real resource merger, so a stray locale copy
-     * coming back would fail here.
+     * "FOSS" is the flavor's name, not prose, and the FOSS build must never pick up a translated
+     * copy of it — that regression shipped once already, when the postfix lived in the shared
+     * resource file and the merger handed FOSS a locale's translated value.
+     *
+     * These resolve through the real resource merger. They assert span boundaries rather than token
+     * counts: the branch this replaced coloured the second of exactly two space-separated tokens,
+     * so a locale that composed its title differently either lost the flavor name entirely or put
+     * the highlight on the wrong word while still rendering correct-looking text.
      */
     @Test
     @Config(qualifiers = "fr")
-    fun `the upgraded app name is not translated in french`() {
-        context.getString(R.string.app_name_upgraded) shouldBe "Octi FOSS"
+    fun `the flavor qualifier is not translated in french`() {
         context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
-        context.getString(R.string.app_name_upgraded).split(" ").size shouldBe 2
+        context.getString(R.string.app_name_upgraded_template) shouldBe "%1\$s %2\$s"
+
+        val result = captureBrandTitle()
+
+        result.text shouldBe "Octi FOSS"
+        result.spanStyles.size shouldBe 1
+        val span = result.spanStyles.single()
+        result.text.substring(span.start, span.end) shouldBe "FOSS"
     }
 
+    /**
+     * Arabic is the one locale that translates `app_name`, so the composed FOSS title localizes the
+     * brand while the flavor qualifier stays pinned to "FOSS". That is the title the FOSS upgrade
+     * screen already rendered here — the dashboard used to disagree with it by reading an atomic,
+     * non-translatable composed string.
+     */
     @Test
     @Config(qualifiers = "ar")
-    fun `the upgraded app name is not translated in arabic`() {
-        context.getString(R.string.app_name_upgraded) shouldBe "Octi FOSS"
+    fun `the flavor qualifier is not translated in arabic`() {
         context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
-        context.getString(R.string.app_name_upgraded).split(" ").size shouldBe 2
+        context.getString(R.string.app_name_upgraded_template) shouldBe "%1\$s %2\$s"
+
+        val result = captureBrandTitle()
+
+        result.text shouldBe "أوكتي FOSS"
+        result.spanStyles.size shouldBe 1
+        val span = result.spanStyles.single()
+        result.text.substring(span.start, span.end) shouldBe "FOSS"
+    }
+
+    private fun captureBrandTitle(): AnnotatedString {
+        lateinit var captured: AnnotatedString
+        composeRule.setUpgradeContent {
+            captured = brandTitle(includeQualifier = true, highlightQualifier = true)
+        }
+        composeRule.waitForIdle()
+        return captured
     }
 }
 


### PR DESCRIPTION
## Problem

`DashboardToolbarTitle` read the composed string `app_name_upgraded` ("Octi Pro"), split it on spaces, and required **exactly 2 tokens** to colour the second one — otherwise it fell back to rendering the bare app name, dropping the Pro identity entirely.

All 43 gplay overrides happen to be 2 tokens today, so this is **latent, not live**. It activates on the next sync that produces a one- or three-word name. capod's equivalent defect arrived exactly that way on 2026-07-22, and `FossUpgradeScreenTest` was actively *pinning* the fragile contract with `split(" ").size shouldBe 2`.

## Approach

Replace the composed key with a per-flavour template whose placeholders translators can reorder and repunctuate:

```xml
<!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
<string name="app_name_upgraded_template">%1$s %2$s</string>
```

`%1$s` = `CommonR.string.app_name`, `%2$s` = `app_name_upgrade_postfix`. Both already existed; no new qualifier key.

`spliceTitleTemplate` splices the styled qualifier into the already-formatted template, walking slots in index order so reordering and arbitrary separators both work. It is deliberately **stricter** than the pre-existing `spliceBrandTitle`: each marker must appear exactly once, else the template is discarded whole and the default title is rebuilt from the parts. A half-spliced title would be one no translator wrote. The two helpers are not merged — splicing a brand into a *sentence* tolerates a repeated marker; a *title* does not.

`brandTitle(includeQualifier, highlightQualifier)` keeps the two flags separate so "name the flavour" and "colour it" cannot be collapsed into one.

This mirrors the accepted implementation in sdmaid-se #2625.

## Six locales change

The composed key and the qualifier key already disagreed in these six, so the template's output differs from what shipped:

| locale | before | after | nature |
|---|---|---|---|
| `it` | `Octi pro` | `Octi Pro` | capitalisation |
| `iw` | `Octi פרימיום` | `Octi פרו` | **word change** — Premium → Pro |
| `ko` | `Octi Pro` | `Octi 프로` | was untranslated English |
| `sv` | `Octi Pro` | `Octi Expert` | was untranslated English |
| `zh-rCN` | `Octi Pro` | `Octi 专业版` | was untranslated English |
| `zh-rTW` | `Octi Pro` | `Octi 專業版` | was untranslated English |

The last four are strict improvements — the composed value was stale English while the postfix was properly translated. **`iw` and `it` are judgement calls** and are flagged here deliberately: `iw` changes the user-visible tier word from "Premium" to "Pro", and `it` changes case. Both follow the postfix key, which is the one translators actually maintain.

The other **38 of 44** locales are byte-identical.

## FOSS Arabic

FOSS's dashboard title moves from `Octi FOSS` to `أوكتي FOSS`. Arabic is the only locale that translates `app_name`. This is **convergence, not a regression**: the FOSS *upgrade screen* already composed `app_name + postfix` and so already rendered `أوكتي FOSS` there — the two surfaces disagreed because the dashboard read an atomic `translatable="false"` composed string. The FOSS qualifier stays pinned to `FOSS`, so the guarantee from #364's predecessor (`94d7ac9a`) is untouched.

## Verification

**Migration gate** — resolved every one of the 44 locales through real Android `Resources` (Robolectric) and compared against the pre-change `app_name_upgraded` captured at `d887143e`:

```
locales compared      : 44
byte-identical        : 38
changed               : 6      <- exactly the six above
```

**Translation completeness** — re-pulled with `--skip-untranslated-strings`, under which a locale lacking a real translation record exports nothing rather than falling back to source text. All **29/29** Crowdin-target locales still export the template, so every one has a genuine record. The 14 absent locales (`bg et ga hr id is ka kk lt lv ms sk sl th`) are not Crowdin target languages at all, so no record is possible; they inherit the base `%1$s %2$s`, and all 14 are among the 38 byte-identical.

**Pulled values read individually, not just checked for placeholder cardinality** — cardinality alone would pass `%1$s JUNK %2$s`. All 29 came back as the plain default `%1$s %2$s`, with no sibling disagreement (`zh-rCN`/`zh-rTW`, `pt`/`pt-rBR` all agree). Nothing needed correcting on Crowdin.

**Tests** — assertions are on **span boundaries**, not token counts: the bug class being replaced renders perfectly correct text with the highlight on the wrong word.

- `TitleTemplateSpliceTest` — default order, reordered, custom separator, multi-word RTL qualifier, a supplementary character before the slots, and all five marker-damage cases.
- `BrandTitleTest` — resolves real flavour resources; pins that `(true, false)` yields the qualifier with **zero** spans, which is the guard for the two-flag split.
- `BrandTitleLocaleSweepTest` — all 44 locales: exactly one `%1$s` and one `%2$s`, no other specifier, span covers exactly the qualifier. Includes a guard test proving locale switching actually happens, so the sweep cannot pass vacuously.
- `FossUpgradeScreenTest` — the two `split(" ").size shouldBe 2` assertions are replaced with span-boundary assertions.

Tests live in the shared `src/test` source set, so both `testGplayDebugUnitTest` and `testFossDebugUnitTest` run them — resources are flavour-owned, so one variant compiling proves nothing about the other.

`testGplayDebugUnitTest`, `testFossDebugUnitTest`, `assembleGplayDebug`, `assembleFossDebug` all pass.

## Known lint delta

One new `MissingTranslation` for `app_name_upgraded_template` in the 14 non-Crowdin locales. This is structurally identical to the pre-existing `MissingTranslation` for `app_name_upgrade_postfix` directly above it in the same file, which is already present on `main`. Not silenced by hand-writing values into those 14 files, which would falsely assert translations exist where none do.
