### PR TITLE
Declare the upgraded title template once, in app-common

### DIFF
--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Fout</string>
     <string name="general_error_no_compatible_app_found_msg">Geen versoenbare toepassing gevind om hierdie versoek te hanteer nie.</string>
     <string name="general_share_action">Deel</string>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">أوكتي</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">خطأ</string>
     <string name="general_error_no_compatible_app_found_msg">لم يتم العثور على تطبيق متوافق لمعالجة هذا الطلب.</string>
     <string name="general_share_action">مشاركة</string>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Error</string>
     <string name="general_error_no_compatible_app_found_msg">No s\'ha trobat cap aplicació compatible per gestionar aquesta sol·licitud.</string>
     <string name="general_share_action">Comparteix</string>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Chyba</string>
     <string name="general_error_no_compatible_app_found_msg">Nebyla nalezena žádná kompatibilní aplikace, která by tento požadavek zpracovala.</string>
     <string name="general_share_action">Sdílet</string>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Fejl</string>
     <string name="general_error_no_compatible_app_found_msg">Ingen kompatibel app fundet til at håndtere denne forespørgsel.</string>
     <string name="general_share_action">Del</string>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Fehler</string>
     <string name="general_error_no_compatible_app_found_msg">Keine kompatible App gefunden, um diese Anfrage zu bearbeiten.</string>
     <string name="general_share_action">Teilen</string>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Σφάλμα</string>
     <string name="general_error_no_compatible_app_found_msg">Δεν βρέθηκε συμβατή εφαρμογή για να χειριστεί αυτό το αίτημα.</string>
     <string name="general_share_action">Κοινοποίηση</string>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Error</string>
     <string name="general_error_no_compatible_app_found_msg">No se encontró ninguna aplicación compatible para manejar esta solicitud.</string>
     <string name="general_share_action">Compartir</string>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Virhe</string>
     <string name="general_error_no_compatible_app_found_msg">Yhteensopivaa sovellusta ei löytynyt tämän pyynnön käsittelemiseksi.</string>
     <string name="general_share_action">Jaa</string>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Erreur</string>
     <string name="general_error_no_compatible_app_found_msg">Aucune application compatible trouvée pour traiter cette demande.</string>
     <string name="general_share_action">Partager</string>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Hiba</string>
     <string name="general_error_no_compatible_app_found_msg">Nem található kompatibilis alkalmazás ehhez a kéréshez.</string>
     <string name="general_share_action">Megosztás</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Errore</string>
     <string name="general_error_no_compatible_app_found_msg">Non è stata trovata nessuna app per soddisfare la richiesta.</string>
     <string name="general_share_action">Condividi</string>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">שגיאה</string>
     <string name="general_error_no_compatible_app_found_msg">לא נמצאה אפליקציה תואמת לטיפול בבקשה זו.</string>
     <string name="general_share_action">שיתוף</string>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">エラー</string>
     <string name="general_error_no_compatible_app_found_msg">このリクエストを処理する互換性のあるアプリが見つかりませんでした。</string>
     <string name="general_share_action">共有</string>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">오류</string>
     <string name="general_error_no_compatible_app_found_msg">이 요청을 처리할 호환 가능한 앱을 찾을 수 없습니다.</string>
     <string name="general_share_action">공유</string>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Feil</string>
     <string name="general_error_no_compatible_app_found_msg">Ingen kompatibel app ble funnet for å håndtere denne forespørselen.</string>
     <string name="general_share_action">Del</string>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Fout</string>
     <string name="general_error_no_compatible_app_found_msg">Er is geen compatibele app gevonden om dit verzoek te verwerken.</string>
     <string name="general_share_action">Delen</string>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Błąd</string>
     <string name="general_error_no_compatible_app_found_msg">Nie znaleziono kompatybilnej aplikacji do obsługi tego żądania.</string>
     <string name="general_share_action">Udostępnij</string>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Erro</string>
     <string name="general_error_no_compatible_app_found_msg">Nenhum aplicativo compatível encontrado para lidar com esta solicitação.</string>
     <string name="general_share_action">Compartilhar</string>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Erro</string>
     <string name="general_error_no_compatible_app_found_msg">Nenhum aplicativo compatível encontrado para lidar com esta solicitação.</string>
     <string name="general_share_action">Compartilhar</string>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Eroare</string>
     <string name="general_error_no_compatible_app_found_msg">Nu a fost găsită nicio aplicație compatibilă pentru a gestiona această solicitare.</string>
     <string name="general_share_action">Partajează</string>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Ошибка</string>
     <string name="general_error_no_compatible_app_found_msg">Не найдено совместимое приложение для обработки этого запроса.</string>
     <string name="general_share_action">Поделиться</string>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Грешка</string>
     <string name="general_error_no_compatible_app_found_msg">Није пронађена компатибилна апликација за обраду овог захтева.</string>
     <string name="general_share_action">Дели</string>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Fel</string>
     <string name="general_error_no_compatible_app_found_msg">Ingen kompatibel app hittades för att hantera denna begäran.</string>
     <string name="general_share_action">Dela</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Hata</string>
     <string name="general_error_no_compatible_app_found_msg">Bu isteği işlemek için uyumlu bir uygulama bulunamadı.</string>
     <string name="general_share_action">Paylaş</string>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Помилка</string>
     <string name="general_error_no_compatible_app_found_msg">Не знайдено сумісного додатку для обробки цього запиту.</string>
     <string name="general_share_action">Поділитися</string>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Lỗi</string>
     <string name="general_error_no_compatible_app_found_msg">Không tìm thấy ứng dụng tương thích để xử lý yêu cầu này.</string>
     <string name="general_share_action">Chia sẻ</string>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">错误</string>
     <string name="general_error_no_compatible_app_found_msg">未找到可处理该请求的应用程序。</string>
     <string name="general_share_action">分享</string>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">錯誤</string>
     <string name="general_error_no_compatible_app_found_msg">找不到可處理此請求的相容應用程式。</string>
     <string name="general_share_action">分享</string>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <string name="app_name">Octi</string>
+    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro" or "FOSS"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
+    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="general_error_label">Error</string>
     <string name="general_error_no_compatible_app_found_msg">No compatible app found to handle this request.</string>
     <string name="general_share_action">Share</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("FOSS"). -->
-    <string name="app_name_upgraded_template" translatable="false">%1$s %2$s</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requires Octi Pro</string>
 

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is nie beskikbaar nie</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en op datum? Is jou Google-rekening aangemeld? Probeer die kasgeheue van die Google Play-toepassing skoonmaak en jou toestel herlaai.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">احترافي</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">جوجل بلاي غير متوفر</string>
     <string name="upgrades_gplay_unavailable_error_description">لا يمكن لأوكتي الاتصال بـ جوجل بلاي. هل جوجل بلاي مثبت ومحدث؟ هل حساب جوجل الخاص بك مسجل الدخول؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق جوجل بلاي وأعد تشغيل جهازك.</string>
     <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على مشتريات. هل تستخدم الحساب الصحيح؟</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">El Google Play no està disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">L\'Octi no es pot connectar al Google Play. El Google Play està instal·lat i actualitzat? Heu iniciat sessió amb el vostre compte de Google? Proveu d\'esborrar la memòria cau de l\'aplicació Google Play i reinicieu el dispositiu.</string>
     <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu utilitzant el compte correcte?</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Služba Google Play není k dispozici</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se nemůže připojit k Google Play. Je Google Play nainstalován a aktuální? Je váš účet Google přihlášen? Zkuste vyčistit mezipaměť aplikace Google Play a restartovat zařízení.</string>
     <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgængelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prøv at rydde cachen for Google Play-appen og genstart din enhed.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Keine Verbindung zu Google Play</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kann sich nicht mit Google Play verbinden. Ist Google Play installiert und aktuell? Bist du angemeldet bei Google Play? Versuche den Cache von der Google Play App zu bereinigen und starte dein Gerät neu.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Zahlung gefunden. Benutzt du den richtigen Account?</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Το Google Play δεν είναι διαθέσιμο</string>
     <string name="upgrades_gplay_unavailable_error_description">Το Octi δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό σας Google; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi no puede conectarse a Google Play. ¿Está instalada y actualizada Google Play? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ei ole käytettävissä</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautuneena? Kokeile tyhjentää Google Play -sovelluksen välimuisti ja käynnistää laite uudelleen.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play est inaccessible</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l’appli Google Play et de redémarrer votre appareil.</string>
     <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">A Google Play nem elérhető</string>
     <string name="upgrades_gplay_unavailable_error_description">Az Octi nem tud csatlakozni a Google Playhez. Telepítve és naprakész a Google Play? Be vagy jelentkezve Google-fiókkal? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
     <string name="upgrades_no_purchases_found_check_account">Nem találhatók vásárlások. Biztosan a megfelelő fiókot használod?</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non disponibile</string>
     <string name="upgrades_gplay_unavailable_error_description">Opti non può connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a svuotare la cache dell\'app Google Play e riavviare il dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account corretto?</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">פרו</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">גוגל פליי לא זמין</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi לא יכול להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולאתחל את המכשיר שלך.</string>
     <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play は利用できません</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi が Google Play に接続できません。Google Play はインストールされている環境ですか？Google アカウントにログインをしていますか？その他に Google Play アプリのキャッシュを削除して、デバイスの再起動をお試しください。</string>
     <string name="upgrades_no_purchases_found_check_account">購入履歴が見つかりません。正しいアカウントを使用していますか？</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">프로</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play를 사용할 수 없음</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 상태입니까? Google 계정에 로그인되어 있습니까? Google Play 앱의 캐시를 지우고 기기를 재시작해 보세요.</string>
     <string name="upgrades_no_purchases_found_check_account">구매 내역이 없습니다. 올바른 계정을 사용 중인가요?</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgjengelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din pålogget? Prøv å tømme hurtigbufferen for Google Play-appen og start enheten på nytt.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is niet beschikbaar</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account aangemeld? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je het juiste account?</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play jest niedostępne</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nie może połączyć się z Google Play. Czy Google Play jest zainstalowane i aktualne? Czy jesteś zalogowany na swoim koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Octi não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta correta?</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Octi não pode conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta correta?</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play indisponibil</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nu se poate conecta la Google Play. Este Google Play instalat și actualizat? Contul tău Google este conectat? Încearcă să ștergi memoria cache a aplicației Google Play și să repornești dispozitivul.</string>
     <string name="upgrades_no_purchases_found_check_account">Nu au fost găsite achiziții. Folosiți contul corect?</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступен</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не может подключиться к Google Play. Установлен и обновлен ли Google Play? Вошли ли Вы в аккаунт Google? Попробуйте очистить кэш приложения Google Play и перезагрузить устройство.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Используете ли Вы правильный аккаунт?</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play није доступан</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може да се повеже са Google Play-ом. Да ли је Google Play инсталиран и ажуриран? Да ли сте пријављени на свој Google налог? Покушајте да очистите кеширање апликације Google Play и поново покренете уређај.</string>
     <string name="upgrades_no_purchases_found_check_account">Нису пронађене куповине. Користите ли прави налог?</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Expert</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play är inte tillgängligt</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Prova att rensa cacheminnet för Google Play-appen och starta om enheten.</string>
     <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play kullanılamıyor</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
     <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступний</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може підключитися до Google Play. Чи встановлено і оновлено Google Play? Ви ввійшли у свій обліковий запис Google? Спробуйте очистити кеш застосунку Google Play і перезапустити пристрій.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play không khả dụng</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Bạn đã đăng nhập tài khoản Google chưa? Hãy thử xóa bộ nhớ cache của ứng dụng Google Play và khởi động lại thiết bị.</string>
     <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch mua nào. Bạn có dùng đúng tài khoản không?</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">专业版</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play不可用</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi 无法连接到 Google Play。Google Play 是否已安装并更新？您的 Google 帐户是否已登录？尝试清除 Google Play 应用的缓存并重新启动您的设备。</string>
     <string name="upgrades_no_purchases_found_check_account">未找到任何购买记录。您使用的是正确的帐户吗？</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">專業版</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到任何購買記錄。您是否使用了正確的帳戶？</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -2,8 +2,6 @@
 <resources>
     <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
-    <!-- Upgraded app title. %1$s is the app name, %2$s the tier qualifier ("Pro"). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
-    <string name="app_name_upgraded_template">%1$s %2$s</string>
 
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>

--- a/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/octi/common/upgrade/ui/UpgradeContent.kt
@@ -107,7 +107,7 @@ internal fun brandTitle(includeQualifier: Boolean, highlightQualifier: Boolean):
     }
     return spliceTitleTemplate(
         formatted = stringResource(
-            R.string.app_name_upgraded_template,
+            CommonR.string.app_name_upgraded_template,
             BRAND_TITLE_MARKER,
             BRAND_QUALIFIER_MARKER,
         ),

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleLocaleSweepTest.kt
@@ -45,7 +45,7 @@ class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
             RuntimeEnvironment.setQualifiers("+$locale")
 
             withClue(locale) {
-                val template = context.getString(R.string.app_name_upgraded_template)
+                val template = context.getString(CommonR.string.app_name_upgraded_template)
 
                 // `%%` is an escaped literal percent and is legitimate punctuation for a translator
                 // to use, so it is removed before the leftover-percent check rather than failing it.
@@ -83,11 +83,11 @@ class BrandTitleLocaleSweepTest : BaseComposeRobolectricTest() {
             withClue(locale) {
                 val name = context.getString(CommonR.string.app_name)
                 val qualifier = context.getString(R.string.app_name_upgrade_postfix)
-                val composed = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+                val composed = context.getString(CommonR.string.app_name_upgraded_template, name, qualifier)
 
                 val result = spliceTitleTemplate(
                     formatted = context.getString(
-                        R.string.app_name_upgraded_template,
+                        CommonR.string.app_name_upgraded_template,
                         BRAND_TITLE_MARKER,
                         BRAND_QUALIFIER_MARKER,
                     ),

--- a/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/octi/common/upgrade/ui/BrandTitleTest.kt
@@ -32,7 +32,7 @@ class BrandTitleTest : BaseComposeRobolectricTest() {
         get() = context.getString(R.string.app_name_upgrade_postfix)
 
     private val composed: String
-        get() = context.getString(R.string.app_name_upgraded_template, name, qualifier)
+        get() = context.getString(CommonR.string.app_name_upgraded_template, name, qualifier)
 
     private fun capture(block: @Composable () -> AnnotatedString): AnnotatedString {
         lateinit var captured: AnnotatedString

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -168,19 +168,24 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
      * counts: the branch this replaced coloured the second of exactly two space-separated tokens,
      * so a locale that composed its title differently either lost the flavor name entirely or put
      * the highlight on the wrong word while still rendering correct-looking text.
+     *
+     * The expected text is *derived* from the resolved template rather than hardcoded. Arrangement
+     * is a language property, not a flavor one — the template lives in `app-common` and is
+     * translatable, so a locale may legitimately reorder or repunctuate the title, and FOSS
+     * inherits that. What must not vary is the qualifier itself.
      */
     @Test
     @Config(qualifiers = "fr")
     fun `the flavor qualifier is not translated in french`() {
-        context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
-        context.getString(R.string.app_name_upgraded_template) shouldBe "%1\$s %2\$s"
+        val qualifier = context.getString(R.string.app_name_upgrade_postfix)
+        qualifier shouldBe "FOSS"
 
         val result = captureBrandTitle()
 
-        result.text shouldBe "Octi FOSS"
+        result.text shouldBe composedTitle(qualifier)
         result.spanStyles.size shouldBe 1
         val span = result.spanStyles.single()
-        result.text.substring(span.start, span.end) shouldBe "FOSS"
+        result.text.substring(span.start, span.end) shouldBe qualifier
     }
 
     /**
@@ -192,16 +197,25 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     @Test
     @Config(qualifiers = "ar")
     fun `the flavor qualifier is not translated in arabic`() {
-        context.getString(R.string.app_name_upgrade_postfix) shouldBe "FOSS"
-        context.getString(R.string.app_name_upgraded_template) shouldBe "%1\$s %2\$s"
+        val qualifier = context.getString(R.string.app_name_upgrade_postfix)
+        qualifier shouldBe "FOSS"
+        // The reason this locale is worth its own case: it is the only one that localizes the brand.
+        context.getString(CommonR.string.app_name) shouldBe "أوكتي"
 
         val result = captureBrandTitle()
 
-        result.text shouldBe "أوكتي FOSS"
+        result.text shouldBe composedTitle(qualifier)
         result.spanStyles.size shouldBe 1
         val span = result.spanStyles.single()
-        result.text.substring(span.start, span.end) shouldBe "FOSS"
+        result.text.substring(span.start, span.end) shouldBe qualifier
     }
+
+    /** The title the current locale's template composes — whatever order it puts the parts in. */
+    private fun composedTitle(qualifier: String): String = context.getString(
+        CommonR.string.app_name_upgraded_template,
+        context.getString(CommonR.string.app_name),
+        qualifier,
+    )
 
     private fun captureBrandTitle(): AnnotatedString {
         lateinit var captured: AnnotatedString


### PR DESCRIPTION
## Why

`app_name_upgraded_template` was declared **twice per app** — once in `foss` (`translatable="false"`) and once in `gplay` (translatable). That split was copied from `app_name_upgrade_postfix`'s placement without asking whether arrangement is a flavour property.

It isn't. How a language orders and punctuates *name + qualifier* varies by **language**, not by build flavour. Each key belongs where its variation actually lives:

| key | varies by | belongs in |
|---|---|---|
| `app_name` | language | `app-common`, translated |
| `app_name_upgrade_postfix` | **flavour** | flavour-specific — foss pinned, gplay translated |
| `app_name_upgraded_template` | **language** | **`app-common`, translated** ← this PR |

## What changed

- **Added** `app_name_upgraded_template` to `app-common/src/main/res/values/strings.xml`, the module that already owns `app_name`, translatable, with the translator comment.
- **Deleted** both flavour copies — base declarations **and all 29 gplay locale overrides**. A surviving locale override would silently win over the shared one for gplay builds: harmless while the values agree, a divergence the moment a translator edits one. That is exactly the duplication this removes.
- **Repointed 7 references** from `R.string.` to `CommonR.string.` (see below).

`app_name_upgrade_postfix` and `upgrade_badge_label` are deliberately untouched. They genuinely differ per flavour, and moving the postfix into a shared file is what broke FOSS branding in `94d7ac9a`. That failure mode requires a flavour override for a shared entry to defeat — the template has none, so it doesn't apply here.

## The compile trap

Under **non-transitive R classes** (AGP 9.0.1), the app module's R is generated from app-module declarations only; library resources are reachable solely via the owning library's R. Resource *merging* still resolves the key by name at runtime — but the app module's R *symbol* disappears the moment the app-module declaration is deleted.

So the move does not compile until every app-module reference is repointed to `CommonR`. Seven of them: `UpgradeContent.kt:110`, `BrandTitleLocaleSweepTest.kt:48,86,90`, `BrandTitleTest.kt:35`, `FossUpgradeScreenTest.kt:176,196`. Verified empirically — the app module's `R.txt` carries no symbol for `app_name` either. All `app_name_upgrade_postfix` references correctly stay on bare `R`, since that key remains app-module-owned.

## Accepted consequence

FOSS now inherits the language's arrangement instead of being frozen at `%1$s %2$s`. In any locale whose template reorders, the FOSS title reorders too. For octi this is currently theoretical — all 29 pulled templates are the plain default, so **no rendered title changes in this PR**.

It does make two FOSS locale assertions unsound, though: they pinned the template literal and the resulting word order, which the resource's own comment now explicitly invites translators to change. They now **derive** the expected title from the resolved template and pin only what must not vary — the qualifier stays `FOSS`, and the highlight covers exactly it.

## Verification

Staged Crowdin migration (add to `main` → upload → translate → pull → verify → delete flavour copies → upload → pull), so translations transfer rather than being orphaned by an add-and-remove in one sync.

**Every pulled value read individually, not just counted.** Placeholder cardinality alone would pass `%1$s JUNK %2$s` and would also pass a wrongly-reordered template. All 29 came back as the plain default `%1$s %2$s` — no invented reorder, no injected content, and no sibling disagreement (`zh-rCN`/`zh-rTW` and `pt`/`pt-rBR` all agree). Nothing needed correcting on Crowdin.

Pulled with `--skip-untranslated-strings`, under which a locale lacking a real translation record exports nothing rather than falling back to source text. All 29 target locales export it, so every one has a genuine record.

**End state asserted explicitly**: `grep` finds zero occurrences of `app_name_upgraded_template` anywhere under `app/src/foss` or `app/src/gplay`, and it exists in exactly 30 `app-common` files (base + 29 locales). No bare-`R` reference to it remains.

`testGplayDebugUnitTest`, `testFossDebugUnitTest`, `assembleGplayDebug`, `assembleFossDebug` all pass.
