### PR TITLE
Fix release builds failing on a missing Play Core annotation

### DIFF
--- a/app/proguard/proguard-rules.pro
+++ b/app/proguard/proguard-rules.pro
@@ -11,3 +11,5 @@
 -dontwarn org.openjsse.javax.net.ssl.SSLParameters
 -dontwarn org.openjsse.javax.net.ssl.SSLSocket
 -dontwarn org.openjsse.net.ssl.OpenJSSE
+# Play Core KTX references this compile-time-only GMS annotation not on the runtime classpath
+-dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite


### PR DESCRIPTION
## Problem

Release builds fail during R8 minification:

```
ERROR: Missing classes detected while running R8.
ERROR: R8: Missing class com.google.android.gms.common.annotation.NoNullnessRewrite
       (referenced from: com.google.android.play.core.ktx.ReviewManagerKtxKt)
```

## Cause

`com.google.android.play:review-ktx:2.0.2` references a compile-time-only GMS annotation that is not on the runtime classpath. R8 reports it as a missing class.

This only affects release builds, since `gplayRelease` is the only variant that minifies — which is why no pull request check has ever caught it.

## Fix

A targeted `-dontwarn` for that single class, matching the rule SD Maid SE already carries. Deliberately narrow rather than a `com.google.android.gms.**` wildcard, so a genuine missing-class error still surfaces.

Verified with a full `assembleGplayRelease`.