### PR TITLE
Retire the hardcoded settings upgrade row title

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Raak \'n ondersteuner om ekstra funksies te ontgrendel en voortgesette ontwikkeling te ondersteun.</string>
     <string name="upgrade_screen_see_options_action">Sien opgraad-opsies</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Sien jou ondersteuner-status</string>
 </resources>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -33,6 +33,5 @@
     <string name="upgrade_screen_free_status_body">كن داعمًا لفتح ميزات إضافية ورعاية استمرار التطوير.</string>
     <string name="upgrade_screen_see_options_action">عرض خيارات الترقية</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">أوكتي حر ومفتوح المصدر</string>
     <string name="settings_upgrade_status_desc">اطّلع على حالة الدعم الخاصة بك</string>
 </resources>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Convertiu-vos en col·laborador per desbloquejar funcions addicionals i patrocinar el desenvolupament continu.</string>
     <string name="upgrade_screen_see_options_action">Consulteu les opcions d’actualització</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Consulteu el vostre estat de col·laborador</string>
 </resources>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -31,6 +31,5 @@
     <string name="upgrade_screen_free_status_body">Staňte se podporovatelem, abyste odemkli další funkce a podpořili pokračující vývoj.</string>
     <string name="upgrade_screen_see_options_action">Zobrazit možnosti upgradu</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Zobrazit stav podporovatele</string>
 </resources>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Bliv supporter for at få ekstra funktioner og sponsorere fortsat udvikling.</string>
     <string name="upgrade_screen_see_options_action">Se opgraderingsmuligheder</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Se din supporterstatus</string>
 </resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Werde ein Unterstützer, um zusätzliche Funktionen freizuschalten und die weitere Entwicklung zu unterstützen.</string>
     <string name="upgrade_screen_see_options_action">Upgrade-Optionen ansehen</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Schau dir deinen Unterstützer-Status an</string>
 </resources>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Γίνετε υποστηρικτής για να ξεκλειδώσετε επιπλέον δυνατότητες και να χορηγήσετε τη συνεχιζόμενη ανάπτυξη.</string>
     <string name="upgrade_screen_see_options_action">Δείτε τις επιλογές αναβάθμισης</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Δείτε την κατάστασή σας ως υποστηρικτής</string>
 </resources>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Conviértete en un colaborador para desbloquear funciones adicionales y patrocinar el desarrollo continuo.</string>
     <string name="upgrade_screen_see_options_action">Ver opciones de actualización</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Ver tu estado de colaborador</string>
 </resources>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Tule kannattajaksi lisäominaisuuksien avaamiseksi ja kehityksen jatkamisen tukemiseksi.</string>
     <string name="upgrade_screen_see_options_action">Näytä päivitysvaihtoehdot</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Näytä kannattajatilasi</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Devenez un soutien pour déverrouiller des fonctions supplémentaires et soutenir le développement continu.</string>
     <string name="upgrade_screen_see_options_action">Voir les options de mise à niveau</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi, version libre</string>
     <string name="settings_upgrade_status_desc">Voir votre statut de soutien</string>
 </resources>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Támogatóvá válva extra funkciókhoz juthatsz és támogathatod a fejlesztést.</string>
     <string name="upgrade_screen_see_options_action">Tekintsd meg a frissítési lehetőségeket</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Tekintsd meg a támogató státuszod</string>
 </resources>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Diventa un sostenitore per sbloccare funzioni extra e sponsorizzare lo sviluppo continuo.</string>
     <string name="upgrade_screen_see_options_action">Visualizza opzioni di aggiornamento</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Visualizza il tuo stato di sostenitore</string>
 </resources>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -31,6 +31,5 @@
     <string name="upgrade_screen_free_status_body">הפוך לתומך כדי לפתוח תכונות נוספות ולממן פיתוח מתמשך.</string>
     <string name="upgrade_screen_see_options_action">הצג אפשרויות שדרוג</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">הצג את סטטוס התומך שלך</string>
 </resources>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -28,6 +28,5 @@
     <string name="upgrade_screen_free_status_body">サポーターになって、追加機能を利用し、開発の継続をスポンサーしましょう。</string>
     <string name="upgrade_screen_see_options_action">アップグレードオプションを確認</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">あなたのサポーターステータスを確認</string>
 </resources>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -28,6 +28,5 @@
     <string name="upgrade_screen_free_status_body">후원자가 되어 추가 기능을 잠금 해제하고 지속적인 개발을 후원하세요.</string>
     <string name="upgrade_screen_see_options_action">업그레이드 옵션 보기</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">후원자 상태 보기</string>
 </resources>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Bli en støtter for å låse opp ekstra funksjoner og sponse fortsatt utvikling.</string>
     <string name="upgrade_screen_see_options_action">Se oppgraderingsalternativer</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Se støtterstatus din</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Word supporter om extra functies te ontgrendelen en de verdere ontwikkeling te steunen.</string>
     <string name="upgrade_screen_see_options_action">Bekijk upgrade-opties</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Bekijk je supporterstatus</string>
 </resources>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -31,6 +31,5 @@
     <string name="upgrade_screen_free_status_body">Zostań wspierającym, aby odblokować dodatkowe funkcje i sponsorować dalszy rozwój.</string>
     <string name="upgrade_screen_see_options_action">Zobacz opcje aktualizacji</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Zobacz swój status wspierającego</string>
 </resources>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Torne-se um apoiador para desbloquear recursos extras e patrocinar o desenvolvimento contínuo.</string>
     <string name="upgrade_screen_see_options_action">Ver opções de upgrade</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Veja seu status de apoiador</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Torne-se um apoiante para desbloquear funcionalidades adicionais e patrocinar o desenvolvimento contínuo.</string>
     <string name="upgrade_screen_see_options_action">Ver opções de atualização</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Veja o seu estado de apoiante</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -30,6 +30,5 @@
     <string name="upgrade_screen_free_status_body">Fii un susținător pentru a debloca funcții suplimentare și a sprijini dezvoltarea continuă.</string>
     <string name="upgrade_screen_see_options_action">Vezi opțiuni de upgrade</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Vezi starea ta de susținător</string>
 </resources>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -31,6 +31,5 @@
     <string name="upgrade_screen_free_status_body">Поддержите нас, чтобы разблокировать дополнительные функции и спонсировать дальнейшую разработку.</string>
     <string name="upgrade_screen_see_options_action">Посмотреть варианты обновления</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Статус Вашей поддержки</string>
 </resources>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -30,6 +30,5 @@
     <string name="upgrade_screen_free_status_body">Постаните подржавач да откључате додатне функције и спонзоришете наставак развоја.</string>
     <string name="upgrade_screen_see_options_action">Погледајте опције надградње</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Погледајте свој статус подржавача</string>
 </resources>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Bli en supporter för att låsa upp extra funktioner och sponsra fortsatt utveckling.</string>
     <string name="upgrade_screen_see_options_action">Se uppgraderingsalternativ</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Se din supporterstatus</string>
 </resources>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -29,6 +29,5 @@
     <string name="upgrade_screen_free_status_body">Ek özelliklerin kilidini açmak ve devam eden geliştirmeyi sponsorlamak için bir destekçi olun.</string>
     <string name="upgrade_screen_see_options_action">Yükseltme seçeneklerini görün</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Destekçi durumunuzu görün</string>
 </resources>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -31,6 +31,5 @@
     <string name="upgrade_screen_free_status_body">Станьте підтримувачем, щоб розблокувати додаткові функції та спонсорувати подальшу розробку.</string>
     <string name="upgrade_screen_see_options_action">Переглянути варіанти оновлення</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Переглянути статус підтримувача</string>
 </resources>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -28,6 +28,5 @@
     <string name="upgrade_screen_free_status_body">Trở thành người ủng hộ để mở khóa các tính năng bổ sung và ủng hộ phát triển tiếp tục.</string>
     <string name="upgrade_screen_see_options_action">Xem các tùy chọn nâng cấp</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">Xem trạng thái người ủng hộ của bạn</string>
 </resources>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -28,6 +28,5 @@
     <string name="upgrade_screen_free_status_body">成为支持者以解锁额外功能，并赞助持续开发。</string>
     <string name="upgrade_screen_see_options_action">查看升级选项</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者状态</string>
 </resources>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -28,6 +28,5 @@
     <string name="upgrade_screen_free_status_body">成為支持者以解鎖額外功能並贊助持續開發。</string>
     <string name="upgrade_screen_see_options_action">查看升級選項</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者狀態</string>
 </resources>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -33,6 +33,5 @@
     <string name="upgrade_screen_free_status_body">Become a supporter to unlock extra features and sponsor continued development.</string>
     <string name="upgrade_screen_see_options_action">See upgrade options</string>
     <!-- Settings status row (foss) -->
-    <string name="settings_upgrade_status_title">Octi FOSS</string>
     <string name="settings_upgrade_status_desc">See your supporter status</string>
 </resources>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Voer op tot Octi Pro om ekstra funksies te ontgrendel en ontwikkeling te ondersteun.</string>
     <string name="upgrade_screen_see_options_action">Sien opgraad-opsies</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Sien jou Pro-status en bestuur jou opgraad</string>
 </resources>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -105,6 +105,5 @@
     <string name="upgrade_screen_free_status_body">قم بالترقية إلى Octi Pro لفتح ميزات إضافية ودعم التطوير.</string>
     <string name="upgrade_screen_see_options_action">عرض خيارات الترقية</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">أوكتي احترافي</string>
     <string name="settings_upgrade_status_desc">اطّلع على حالة Pro الخاصة بك وأدر ترقيتك</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Actualitzeu a Octi Pro per desbloquejar funcions addicionals i donar suport al desenvolupament.</string>
     <string name="upgrade_screen_see_options_action">Veieu les opcions d’actualització</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Consulteu el vostre estat de Pro i gestioneu la vostra actualització</string>
 </resources>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -103,6 +103,5 @@
     <string name="upgrade_screen_free_status_body">Upgradujte na Octi Pro, abyste odemkli další funkce a podpořili vývoj.</string>
     <string name="upgrade_screen_see_options_action">Zobrazit možnosti upgradu</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Zobrazit stav Pro a spravovat upgrade</string>
 </resources>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Opgrader til Octi Pro for at få ekstra funktioner og støtte udvikling.</string>
     <string name="upgrade_screen_see_options_action">Se opgraderingsmuligheder</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Se din Pro-status og administrer din opgradering</string>
 </resources>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Upgrade zu Octi Pro, um zusätzliche Funktionen freizuschalten und die Entwicklung zu unterstützen.</string>
     <string name="upgrade_screen_see_options_action">Upgrade-Optionen ansehen</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Schau dir deinen Pro-Status an und verwalte dein Upgrade</string>
 </resources>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Αναβαθμίστε σε Octi Pro για να ξεκλειδώσετε επιπλέον δυνατότητες και να υποστηρίξετε την ανάπτυξη.</string>
     <string name="upgrade_screen_see_options_action">Δείτε τις επιλογές αναβάθμισης</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Δείτε την κατάσταση Pro και διαχειριστείτε την αναβάθμισή σας</string>
 </resources>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Actualiza a Octi Pro para desbloquear funciones adicionales y apoyar el desarrollo.</string>
     <string name="upgrade_screen_see_options_action">Ver opciones de actualización</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Ver tu estado Pro y administrar tu actualización</string>
 </resources>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Päivitä Octi Proon lisäominaisuuksien avaamiseksi ja kehityksen tukemiseksi.</string>
     <string name="upgrade_screen_see_options_action">Näytä päivitysvaihtoehdot</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Näytä Pro-statuksesi ja hallitse päivitystäsi</string>
 </resources>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -102,6 +102,5 @@ Mêmes fonctions, juste des modèles tarifaires différents.</string>
     <string name="upgrade_screen_free_status_body">Passez à Octi Pro pour débloquer des fonctions supplémentaires et financer le développement.</string>
     <string name="upgrade_screen_see_options_action">Voir les options de mise à niveau</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Consultez votre statut Pro et gérez votre mise à niveau</string>
 </resources>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Frissítsd az Octi Pro-ra az extra funkciók feloldásához és a fejlesztés támogatásához.</string>
     <string name="upgrade_screen_see_options_action">Tekintsd meg a frissítési lehetőségeket</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Tekintsd meg a Pro státuszod és kezeld a frissítésed</string>
 </resources>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -102,6 +102,5 @@
     <string name="upgrade_screen_free_status_body">Aggiorna a Octi Pro per sbloccare funzioni extra e supportare lo sviluppo.</string>
     <string name="upgrade_screen_see_options_action">Visualizza opzioni di aggiornamento</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi pro</string>
     <string name="settings_upgrade_status_desc">Visualizza il tuo stato Pro e gestisci il tuo aggiornamento</string>
 </resources>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -103,6 +103,5 @@
     <string name="upgrade_screen_free_status_body">שדרג ל-Octi Pro כדי לפתוח תכונות נוספות ולתמוך בפיתוח.</string>
     <string name="upgrade_screen_see_options_action">הצג אפשרויות שדרוג</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi פרימיום</string>
     <string name="settings_upgrade_status_desc">הצג את סטטוס Pro שלך ונהל את השדרוג שלך</string>
 </resources>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -100,6 +100,5 @@
     <string name="upgrade_screen_free_status_body">Octi Proにアップグレードして、追加機能を利用し、開発をサポートしましょう。</string>
     <string name="upgrade_screen_see_options_action">アップグレードオプションを確認</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Proステータスを確認し、アップグレードを管理</string>
 </resources>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -100,6 +100,5 @@
     <string name="upgrade_screen_free_status_body">Octi Pro로 업그레이드하면 추가 기능을 잠금 해제하고 개발을 지원할 수 있습니다.</string>
     <string name="upgrade_screen_see_options_action">업그레이드 옵션 보기</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Pro 상태 확인 및 업그레이드 관리</string>
 </resources>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -102,6 +102,5 @@ Samme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_free_status_body">Oppgrader til Octi Pro for å låse opp ekstra funksjoner og støtte utvikling.</string>
     <string name="upgrade_screen_see_options_action">Se oppgraderingsalternativer</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Se Pro-statusen din og administrer oppgraderingen din</string>
 </resources>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -102,6 +102,5 @@ Dezelfde functies, gewoon verschillende prijsmodellen.</string>
     <string name="upgrade_screen_free_status_body">Upgrade naar Octi Pro om extra functies te ontgrendelen en de ontwikkeling te ondersteunen.</string>
     <string name="upgrade_screen_see_options_action">Bekijk upgrade-opties</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Bekijk je Pro-status en beheer je upgrade</string>
 </resources>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -103,6 +103,5 @@
     <string name="upgrade_screen_free_status_body">Zaktualizuj do wersji Octi Pro, aby odblokować dodatkowe funkcje i wesprzeć rozwój.</string>
     <string name="upgrade_screen_see_options_action">Zobacz opcje aktualizacji</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Zobacz swój status Pro i zarządzaj aktualizacją</string>
 </resources>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -102,6 +102,5 @@ Os mesmos recursos, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_free_status_body">Faça upgrade para o Octi Pro para desbloquear recursos extras e apoiar o desenvolvimento.</string>
     <string name="upgrade_screen_see_options_action">Ver opções de upgrade</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Veja seu status de Pro e gerencie seu upgrade</string>
 </resources>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Atualize para Octi Pro para desbloquear funcionalidades adicionais e apoiar o desenvolvimento.</string>
     <string name="upgrade_screen_see_options_action">Ver opções de atualização</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Veja o seu estado Pro e faça a gestão da sua atualização</string>
 </resources>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -102,6 +102,5 @@
     <string name="upgrade_screen_free_status_body">Fă upgrade la Octi Pro pentru a debloca funcții suplimentare și a sprijini dezvoltarea.</string>
     <string name="upgrade_screen_see_options_action">Vezi opțiuni de upgrade</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Vezi starea ta Pro și gestionează upgradul</string>
 </resources>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -103,6 +103,5 @@
     <string name="upgrade_screen_free_status_body">Обновитесь до Octi Pro, чтобы получить дополнительные функции и поддержать разработку.</string>
     <string name="upgrade_screen_see_options_action">Посмотреть варианты обновления</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Смотрите Ваш статус Pro и управляйте обновлением</string>
 </resources>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -102,6 +102,5 @@
     <string name="upgrade_screen_free_status_body">Надградите се на Octi Pro да откључате додатне функције и подржите развој.</string>
     <string name="upgrade_screen_see_options_action">Погледајте опције надградње</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Погледајте свој Pro статус и управљајте својом надградњом</string>
 </resources>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">Uppgradera till Octi Pro för att låsa upp extra funktioner och stödja utvecklingen.</string>
     <string name="upgrade_screen_see_options_action">Se uppgraderingsalternativ</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Se din Pro-status och hantera din uppgradering</string>
 </resources>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -102,6 +102,5 @@ Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_free_status_body">Octi Pro\'ya yükseltin, ek özelliklerin kilidini açın ve geliştirmeyi destekleyin.</string>
     <string name="upgrade_screen_see_options_action">Yükseltme seçeneklerini görün</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Pro durumunuzu görün ve yükseltmenizi yönetin</string>
 </resources>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -103,6 +103,5 @@
     <string name="upgrade_screen_free_status_body">Оновіть до Octi Pro, щоб розблокувати додаткові функції та підтримати розробку.</string>
     <string name="upgrade_screen_see_options_action">Переглянути варіанти оновлення</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Перегляньте статус Pro та керуйте своїм оновленням</string>
 </resources>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -101,6 +101,5 @@ Các tính năng giống nhau, chỉ khác các mô hình giá.</string>
     <string name="upgrade_screen_free_status_body">Nâng cấp lên Octi Pro để mở khóa các tính năng bổ sung và hỗ trợ phát triển.</string>
     <string name="upgrade_screen_see_options_action">Xem các tùy chọn nâng cấp</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">Xem trạng thái Pro của bạn và quản lý nâng cấp của bạn</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -100,6 +100,5 @@
     <string name="upgrade_screen_free_status_body">升级到 Octi 专业版以解锁额外功能并支持开发。</string>
     <string name="upgrade_screen_see_options_action">查看升级选项</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">查看您的专业版状态并管理升级</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -101,6 +101,5 @@
     <string name="upgrade_screen_free_status_body">升級到 Octi Pro 以解鎖額外功能並支持開發。</string>
     <string name="upgrade_screen_see_options_action">查看升級選項</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">查看您的 Pro 狀態並管理您的升級</string>
 </resources>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -108,6 +108,5 @@
     <string name="upgrade_screen_free_status_body">Upgrade to Octi Pro to unlock extra features and support development.</string>
     <string name="upgrade_screen_see_options_action">See upgrade options</string>
     <!-- Settings status row (gplay) -->
-    <string name="settings_upgrade_status_title">Octi Pro</string>
     <string name="settings_upgrade_status_desc">See your Pro status and manage your upgrade</string>
 </resources>

--- a/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/settings/SettingsIndexScreen.kt
@@ -35,6 +35,7 @@ import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.common.settings.SettingsBaseItem
 import eu.darken.octi.common.settings.SettingsCategoryHeader
+import eu.darken.octi.common.upgrade.ui.brandTitleText
 
 @Composable
 fun SettingsIndexScreenHost(vm: SettingsIndexVM = hiltViewModel()) {
@@ -122,7 +123,7 @@ fun SettingsIndexScreen(
             }
             item {
                 SettingsBaseItem(
-                    title = stringResource(R.string.settings_upgrade_status_title),
+                    title = brandTitleText(includeQualifier = true),
                     subtitle = stringResource(R.string.settings_upgrade_status_desc),
                     icon = Icons.TwoTone.Stars,
                     onClick = onUpgradeStatus,

--- a/app/src/test/java/eu/darken/octi/main/ui/settings/SettingsUpgradeRowTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/settings/SettingsUpgradeRowTest.kt
@@ -1,0 +1,98 @@
+package eu.darken.octi.main.ui.settings
+
+import android.content.Context
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.text.AnnotatedString
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.octi.R
+import eu.darken.octi.common.compose.PreviewWrapper
+import eu.darken.octi.common.upgrade.ui.upgradeScreenTitle
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+import testhelpers.compose.BaseComposeRobolectricTest
+import eu.darken.octi.common.R as CommonR
+
+/**
+ * The Settings upgrade row used to render its own hardcoded per-flavor brand string, which
+ * drifted from the composed title the upgrade screen renders. Now both surfaces compose through
+ * the same template, and this test is the regression guard: the row must show exactly the text
+ * the upgrade screen's title resolves to.
+ *
+ * Expectations derive from the resolved template rather than pinned literals, so the test holds
+ * for both flavors and keeps holding when translations change the wording or word order.
+ *
+ * The base (English) values of the retired resource happened to equal the composed title, so a
+ * default-locale check alone could not catch a revert to a resource-backed row. The extra locale
+ * cases pick translations where the two visibly diverged — Swedish's qualifier is not "Pro" on
+ * GPLAY, and Arabic translates the app name itself — one `setContent` per test, since the rule
+ * allows only one per test method.
+ */
+class SettingsUpgradeRowTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val composed: String
+        get() = context.getString(
+            CommonR.string.app_name_upgraded_template,
+            context.getString(CommonR.string.app_name),
+            context.getString(R.string.app_name_upgrade_postfix),
+        )
+
+    private fun assertRowAgreesWithUpgradeTitle() {
+        lateinit var titleUpgraded: AnnotatedString
+        lateinit var titleFree: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper {
+                titleUpgraded = upgradeScreenTitle(upgraded = true)
+                titleFree = upgradeScreenTitle(upgraded = false)
+                SettingsIndexScreen(
+                    state = SettingsIndexVM.State(),
+                    onNavigateUp = {},
+                    onGeneralSettings = {},
+                    onSyncSettings = {},
+                    onModuleSettings = {},
+                    onSupport = {},
+                    onChangelog = {},
+                    onEcosystem = {},
+                    onHelpTranslate = {},
+                    onAcknowledgements = {},
+                    onPrivacyPolicy = {},
+                    onUpgradeStatus = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        // The upgrade screen's title is the composed template — in both of its states.
+        titleUpgraded.text shouldBe composed
+        titleFree.text shouldBe composed
+
+        // And the Settings row renders that same composition, exactly once. A row that re-grew its
+        // own literal would no longer match the resolved template and fail here.
+        composeRule.onAllNodesWithText(composed).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the upgrade row agrees with the upgrade screen title`() {
+        assertRowAgreesWithUpgradeTitle()
+    }
+
+    // Swedish translates the GPLAY qualifier to something other than "Pro", so this locale is one
+    // where the retired hardcoded row visibly disagreed with the composed title.
+    @Test
+    fun `the upgrade row agrees with the upgrade screen title in Swedish`() {
+        RuntimeEnvironment.setQualifiers("+sv")
+        assertRowAgreesWithUpgradeTitle()
+    }
+
+    // Arabic translates the app name itself, so agreement here proves the row composes from the
+    // localized brand rather than any Latin-script literal — in both flavors.
+    @Test
+    fun `the upgrade row agrees with the upgrade screen title in Arabic`() {
+        RuntimeEnvironment.setQualifiers("+ar")
+        assertRowAgreesWithUpgradeTitle()
+    }
+}


### PR DESCRIPTION
## Why

`settings_upgrade_status_title` was a second copy of the brand: the app name and tier qualifier baked together into one translatable value, per flavor, with 29 locale overrides each. It had drifted from the composed title the upgrade screen renders — the Settings row and the upgrade screen it opens named the same tier differently in eight locales.

## What

- The Settings row now composes its title through `brandTitleText(includeQualifier = true)` — the same template path (`app_name` + `app_name_upgraded_template` + `app_name_upgrade_postfix`) the upgrade-screen title uses. The two surfaces are now the same composition and cannot disagree.
- `settings_upgrade_status_title` is deleted from both flavors: base plus all 29 locale overrides each (60 lines). The key has also been removed from Crowdin (sources re-uploaded, string gone from the project).
- New regression guard `SettingsUpgradeRowTest` (shared `src/test`, runs in both variants): renders the real `SettingsIndexScreen` and asserts the row shows exactly the text `upgradeScreenTitle` resolves to, deriving expectations from the resolved template rather than pinned literals. Includes Swedish and Arabic locale cases — locales where the base English values would coincidentally mask a revert to a resource-backed row.

## Locales that visibly change (Settings row, before → after)

| Flavor | Locale | Before (settings row) | After (composed, matches upgrade title) |
|---|---|---|---|
| gplay | it | Octi pro | Octi Pro |
| gplay | iw | Octi פרימיום | Octi פרו |
| gplay | ko | Octi Pro | Octi 프로 |
| gplay | sv | Octi Pro | Octi Expert |
| gplay | zh-rCN | Octi Pro | Octi 专业版 |
| gplay | zh-rTW | Octi Pro | Octi 專業版 |
| foss | ar | أوكتي حر ومفتوح المصدر | أوكتي FOSS |
| foss | fr | Octi, version libre | Octi FOSS |

## Accepted cost

The foss `ar` and `fr` overrides carried bespoke prose — real translations of "free and open source" rather than the pinned `FOSS` qualifier. Retiring the key discards that deliberate translation work in favor of the flavor-pinned qualifier. This is a known, accepted trade for having a single source of truth for the brand title.

## Validation

- `testGplayDebugUnitTest`, `testFossDebugUnitTest`, `assembleGplayDebug`, `assembleFossDebug` all green.
- Zero occurrences of `settings_upgrade_status_title` in the repo; Crowdin string list returns empty for the key.
- Crowdin sync was staged in two uploads (code change first, key deletion second) so the removal could not obsolete the string mid-sync; unrelated pulled translation churn was restored to HEAD and not shipped.