### PR TITLE
Stop naming the Play tier on screens where it does not apply

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetConfigScreen.kt
@@ -250,7 +250,7 @@ private fun WidgetConfigFooter(
         WidgetConfigAction.Upgrade -> {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = stringResource(R.string.widget_config_pro_required_label),
+                    text = stringResource(R.string.widget_config_upgrade_required_label),
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
@@ -258,7 +258,7 @@ private fun WidgetConfigFooter(
                     onClick = onUpgrade,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
-                    Text(stringResource(R.string.widget_config_upgrade_action))
+                    Text(stringResource(R.string.general_upgrade_action))
                 }
             }
         }
@@ -273,7 +273,7 @@ private fun WidgetConfigFooter(
                 CircularProgressIndicator(modifier = Modifier.size(20.dp))
                 Spacer(modifier = Modifier.size(12.dp))
                 Text(
-                    text = stringResource(R.string.widget_config_pro_checking_label),
+                    text = stringResource(R.string.widget_config_upgrade_checking_label),
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }
@@ -282,7 +282,7 @@ private fun WidgetConfigFooter(
         is WidgetConfigAction.ErrorRetry -> {
             Column(modifier = Modifier.padding(16.dp)) {
                 Text(
-                    text = action.message.ifBlank { stringResource(R.string.widget_config_pro_error_label) },
+                    text = action.message.ifBlank { stringResource(R.string.widget_config_upgrade_error_label) },
                     style = MaterialTheme.typography.bodyMedium,
                 )
                 Spacer(modifier = Modifier.height(12.dp))

--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Pas legstuk aan</string>
     <string name="widget_config_apply_action">Pas toe</string>
-    <string name="widget_config_upgrade_action">Opgradeer na Octi Pro</string>
-    <string name="widget_config_pro_required_label">Hierdie widget vereis Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Kontroleer jou Octi Pro-status…</string>
-    <string name="widget_config_pro_error_label">Kon nie jou Octi Pro-status verifieer nie.</string>
     <string name="widget_config_retry_action">Probeer weer</string>
     <string name="widget_config_presets_label">Voorkeure</string>
     <string name="widget_config_background_label">Agtergrondkleur</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Geen ooreenstemmende toestelle nie</string>
     <string name="widget_no_sync_devices_label">Nog geen sinchronisasie-toestelle nie</string>
     <string name="widget_more_items">+ %1$d meer</string>
-    <string name="widget_upgrade_required_title">Octi Pro nodig</string>
     <string name="widget_upgrade_required_action">Tik om op te gradeer</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Geen %1$s-data vir hierdie toestel nie</string>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -72,10 +72,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">تخصيص الأداة</string>
     <string name="widget_config_apply_action">تطبيق</string>
-    <string name="widget_config_upgrade_action">الترقية إلى أوكتي احترافي</string>
-    <string name="widget_config_pro_required_label">هذه الأداة تتطلب Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">جاري التحقق من حالة Octi Pro…</string>
-    <string name="widget_config_pro_error_label">لم نتمكن من التحقق من حالة Octi Pro.</string>
     <string name="widget_config_retry_action">أعد المحاولة</string>
     <string name="widget_config_presets_label">الإعدادات المسبقة</string>
     <string name="widget_config_background_label">لون الخلفية</string>
@@ -91,7 +87,6 @@
     <string name="widget_empty_label">لا توجد أجهزة مطابقة</string>
     <string name="widget_no_sync_devices_label">لا توجد أجهزة مزامنة بعد</string>
     <string name="widget_more_items">+ %1$d آخر</string>
-    <string name="widget_upgrade_required_title">Octi Pro مطلوب</string>
     <string name="widget_upgrade_required_action">اضغط للترقية</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">لا توجد بيانات %1$s لهذا الجهاز</string>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalitza el widget</string>
     <string name="widget_config_apply_action">Aplica</string>
-    <string name="widget_config_upgrade_action">Millora al Octi Pro</string>
-    <string name="widget_config_pro_required_label">Aquest widget requereix Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Comprovant l’estat d’Octi Pro…</string>
-    <string name="widget_config_pro_error_label">No s’ha pogut verificar l’estat d’Octi Pro.</string>
     <string name="widget_config_retry_action">Reintenta</string>
     <string name="widget_config_presets_label">Predefinits</string>
     <string name="widget_config_background_label">Color de fons</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Cap dispositiu coincident</string>
     <string name="widget_no_sync_devices_label">Encara no hi ha dispositius de sincronització</string>
     <string name="widget_more_items">+ %1$d més</string>
-    <string name="widget_upgrade_required_title">Octi Pro necessari</string>
     <string name="widget_upgrade_required_action">Toqueu per actualitzar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">No hi ha dades de %1$s per a aquest dispositiu</string>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -70,10 +70,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Přizpůsobit widget</string>
     <string name="widget_config_apply_action">Použít</string>
-    <string name="widget_config_upgrade_action">Upgradovat na Octi Pro</string>
-    <string name="widget_config_pro_required_label">Tento widget vyžaduje Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Ověřování vašeho stavu Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Nepodařilo se ověřit váš stav Octi Pro.</string>
     <string name="widget_config_retry_action">Opakovat</string>
     <string name="widget_config_presets_label">Předvolby</string>
     <string name="widget_config_background_label">Barva pozadí</string>
@@ -89,7 +85,6 @@
     <string name="widget_empty_label">Žádná odpovídající zařízení</string>
     <string name="widget_no_sync_devices_label">Zatím žádná zařízení k synchronizaci</string>
     <string name="widget_more_items">+ %1$d další</string>
-    <string name="widget_upgrade_required_title">Vyžaduje se Octi Pro</string>
     <string name="widget_upgrade_required_action">Klepněte pro upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Pro toto zařízení nejsou k dispozici žádná data %1$s</string>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tilpas widget</string>
     <string name="widget_config_apply_action">Anvend</string>
-    <string name="widget_config_upgrade_action">Opgrader til Octi Pro</string>
-    <string name="widget_config_pro_required_label">Denne widget kræver Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Kontrollerer din Octi Pro-status…</string>
-    <string name="widget_config_pro_error_label">Kunne ikke bekræfte din Octi Pro-status.</string>
     <string name="widget_config_retry_action">Prøv igen</string>
     <string name="widget_config_presets_label">Forudindstillinger</string>
     <string name="widget_config_background_label">Baggrundsfarve</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Ingen matchende enheder</string>
     <string name="widget_no_sync_devices_label">Ingen synkroniseringsenheder endnu</string>
     <string name="widget_more_items">+ %1$d mere</string>
-    <string name="widget_upgrade_required_title">Octi Pro påkrævet</string>
     <string name="widget_upgrade_required_action">Tryk for at opgradere</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ingen %1$s-data for denne enhed</string>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget anpassen</string>
     <string name="widget_config_apply_action">Anwenden</string>
-    <string name="widget_config_upgrade_action">Erweitere auf Octi Pro</string>
-    <string name="widget_config_pro_required_label">Dieses Widget benötigt Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Dein Octi Pro-Status wird überprüft…</string>
-    <string name="widget_config_pro_error_label">Dein Octi Pro-Status konnte nicht überprüft werden.</string>
     <string name="widget_config_retry_action">Erneut versuchen</string>
     <string name="widget_config_presets_label">Voreinstellungen</string>
     <string name="widget_config_background_label">Hintergrundfarbe</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Keine passenden Geräte</string>
     <string name="widget_no_sync_devices_label">Noch keine Synchronisierungsgeräte</string>
     <string name="widget_more_items">+ %1$d mehr</string>
-    <string name="widget_upgrade_required_title">Octi Pro erforderlich</string>
     <string name="widget_upgrade_required_action">Tippen zum Upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Keine %1$s-Daten für dieses Gerät</string>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Προσαρμογή Widget</string>
     <string name="widget_config_apply_action">Εφαρμογή</string>
-    <string name="widget_config_upgrade_action">Αναβαθμίστε στο Octi Pro</string>
-    <string name="widget_config_pro_required_label">Αυτό το widget απαιτεί Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Έλεγχος της κατάστασης Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Δεν ήταν δυνατή η επαλήθευση της κατάστασης Octi Pro.</string>
     <string name="widget_config_retry_action">Δοκιμάστε ξανά</string>
     <string name="widget_config_presets_label">Προεπιλογές</string>
     <string name="widget_config_background_label">Χρώμα φόντου</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Δεν υπάρχουν αντίστοιχες συσκευές</string>
     <string name="widget_no_sync_devices_label">Δεν υπάρχουν ακόμη συσκευές συγχρονισμού</string>
     <string name="widget_more_items">+ %1$d ακόμη</string>
-    <string name="widget_upgrade_required_title">Απαιτείται Octi Pro</string>
     <string name="widget_upgrade_required_action">Αγγίξτε για αναβάθμιση</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Δεν υπάρχουν δεδομένα %1$s για αυτή τη συσκευή</string>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
-    <string name="widget_config_upgrade_action">Actualizar a Octi Pro</string>
-    <string name="widget_config_pro_required_label">Este widget requiere Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Comprobando tu estado de Octi Pro…</string>
-    <string name="widget_config_pro_error_label">No se pudo verificar tu estado de Octi Pro.</string>
     <string name="widget_config_retry_action">Reintentar</string>
     <string name="widget_config_presets_label">Predeterminados</string>
     <string name="widget_config_background_label">Color de fondo</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">No hay dispositivos coincidentes</string>
     <string name="widget_no_sync_devices_label">Aún no hay dispositivos de sincronización</string>
     <string name="widget_more_items">+ %1$d más</string>
-    <string name="widget_upgrade_required_title">Se requiere Octi Pro</string>
     <string name="widget_upgrade_required_action">Toca para actualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sin datos de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Mukauta widgettiä</string>
     <string name="widget_config_apply_action">Käytä</string>
-    <string name="widget_config_upgrade_action">Päivitä Octi Pro:hon</string>
-    <string name="widget_config_pro_required_label">Tämä widget vaatii Octi Pro -versiota.</string>
-    <string name="widget_config_pro_checking_label">Tarkistetaan Octi Pro -tilaasi…</string>
-    <string name="widget_config_pro_error_label">Octi Pro -tilaasi tarkistaminen epäonnistui.</string>
     <string name="widget_config_retry_action">Yritä uudelleen</string>
     <string name="widget_config_presets_label">Esiasetukset</string>
     <string name="widget_config_background_label">Taustaväri</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Ei vastaavia laitteita</string>
     <string name="widget_no_sync_devices_label">Ei synkronoitavia laitteita vielä</string>
     <string name="widget_more_items">+ %1$d lisää</string>
-    <string name="widget_upgrade_required_title">Octi Pro vaaditaan</string>
     <string name="widget_upgrade_required_action">Napauta päivittyäksesi</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ei %1$s-tietoja tältä laitteelta</string>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personnaliser le widget</string>
     <string name="widget_config_apply_action">Appliquer</string>
-    <string name="widget_config_upgrade_action">Passer à Octi Pro</string>
-    <string name="widget_config_pro_required_label">Ce widget nécessite Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Vérification de votre statut Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Impossible de vérifier votre statut Octi Pro.</string>
     <string name="widget_config_retry_action">Réessayer</string>
     <string name="widget_config_presets_label">Préréglages</string>
     <string name="widget_config_background_label">Couleur d\'arrière-plan</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Aucun appareil correspondant</string>
     <string name="widget_no_sync_devices_label">Aucun appareil de synchronisation pour l\'instant</string>
     <string name="widget_more_items">+ %1$d autres</string>
-    <string name="widget_upgrade_required_title">Octi Pro requis</string>
     <string name="widget_upgrade_required_action">Appuyer pour mettre à niveau</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Aucune donnée %1$s pour cet appareil</string>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget testreszabása</string>
     <string name="widget_config_apply_action">Alkalmaz</string>
-    <string name="widget_config_upgrade_action">Frissítés Octi Pro-ra</string>
-    <string name="widget_config_pro_required_label">Ez a widget az Octi Pro verzióhoz szükséges.</string>
-    <string name="widget_config_pro_checking_label">Az Octi Pro státuszod ellenőrzése…</string>
-    <string name="widget_config_pro_error_label">Nem sikerült ellenőrizni az Octi Pro státuszod.</string>
     <string name="widget_config_retry_action">Újra</string>
     <string name="widget_config_presets_label">Előbeállítások</string>
     <string name="widget_config_background_label">Háttérszín</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Nincs egyező eszköz</string>
     <string name="widget_no_sync_devices_label">Még nincs szinkronizációs eszköz</string>
     <string name="widget_more_items">+ még %1$d</string>
-    <string name="widget_upgrade_required_title">Octi Pro szükséges</string>
     <string name="widget_upgrade_required_action">Koppints a frissítéshez</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nincs %1$s adat ennél az eszköznél</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizza Widget</string>
     <string name="widget_config_apply_action">Applica</string>
-    <string name="widget_config_upgrade_action">Aggiorna ad Octi Pro</string>
-    <string name="widget_config_pro_required_label">Questo widget richiede Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Verifica dello stato di Octi Pro in corso…</string>
-    <string name="widget_config_pro_error_label">Impossibile verificare lo stato di Octi Pro.</string>
     <string name="widget_config_retry_action">Ritenta</string>
     <string name="widget_config_presets_label">Predefiniti</string>
     <string name="widget_config_background_label">Colore di sfondo</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Nessun dispositivo corrispondente</string>
     <string name="widget_no_sync_devices_label">Nessun dispositivo di sincronizzazione ancora</string>
     <string name="widget_more_items">+ altri %1$d</string>
-    <string name="widget_upgrade_required_title">Octi Pro richiesto</string>
     <string name="widget_upgrade_required_action">Tocca per eseguire l’upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nessun dato %1$s per questo dispositivo</string>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -70,10 +70,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">התאם אישית את הווידג\'ט</string>
     <string name="widget_config_apply_action">החל</string>
-    <string name="widget_config_upgrade_action">שדרג ל-Octi פרמיום</string>
-    <string name="widget_config_pro_required_label">ווידג׳ט זה דורש Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">בדיקת סטטוס Octi Pro שלך…</string>
-    <string name="widget_config_pro_error_label">לא ניתן היה לאמת את סטטוס Octi Pro שלך.</string>
     <string name="widget_config_retry_action">נסה שוב</string>
     <string name="widget_config_presets_label">הגדרות קבועות מראש</string>
     <string name="widget_config_background_label">צבע רקע</string>
@@ -89,7 +85,6 @@
     <string name="widget_empty_label">אין מכשירים מתאימים</string>
     <string name="widget_no_sync_devices_label">עדיין אין מכשירי סנכרון</string>
     <string name="widget_more_items">+ עוד %1$d</string>
-    <string name="widget_upgrade_required_title">Octi Pro נדרש</string>
     <string name="widget_upgrade_required_action">הקש לשדרג</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">אין נתוני %1$s עבור מכשיר זה</string>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -67,10 +67,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">ウィジェットをカスタマイズ</string>
     <string name="widget_config_apply_action">適用</string>
-    <string name="widget_config_upgrade_action">Octi Pro にアップグレード</string>
-    <string name="widget_config_pro_required_label">このウィジェットはOcti Proが必要です。</string>
-    <string name="widget_config_pro_checking_label">Octi Proのステータスを確認中…</string>
-    <string name="widget_config_pro_error_label">Octi Proのステータスを確認できませんでした。</string>
     <string name="widget_config_retry_action">再試行</string>
     <string name="widget_config_presets_label">プリセット</string>
     <string name="widget_config_background_label">背景色</string>
@@ -86,7 +82,6 @@
     <string name="widget_empty_label">一致するデバイスがありません</string>
     <string name="widget_no_sync_devices_label">同期デバイスがまだありません</string>
     <string name="widget_more_items">+ %1$d 件</string>
-    <string name="widget_upgrade_required_title">Octi Pro が必要です</string>
     <string name="widget_upgrade_required_action">タップしてアップグレード</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">このデバイスの%1$sデータがありません</string>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -67,10 +67,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">위젯 맞춤 설정</string>
     <string name="widget_config_apply_action">적용</string>
-    <string name="widget_config_upgrade_action">Octi Pro로 업그레이드</string>
-    <string name="widget_config_pro_required_label">이 위젯을 사용하려면 Octi 프로가 필요합니다.</string>
-    <string name="widget_config_pro_checking_label">Octi 프로 상태 확인 중…</string>
-    <string name="widget_config_pro_error_label">Octi 프로 상태를 확인할 수 없습니다.</string>
     <string name="widget_config_retry_action">다시 시도</string>
     <string name="widget_config_presets_label">프리셋</string>
     <string name="widget_config_background_label">배경 색상</string>
@@ -86,7 +82,6 @@
     <string name="widget_empty_label">일치하는 기기 없음</string>
     <string name="widget_no_sync_devices_label">아직 동기화 기기 없음</string>
     <string name="widget_more_items">+ %1$d개 더</string>
-    <string name="widget_upgrade_required_title">Octi 프로 필요</string>
     <string name="widget_upgrade_required_action">탭하여 업그레이드</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">이 기기의 %1$s 데이터 없음</string>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tilpass widget</string>
     <string name="widget_config_apply_action">Bruk</string>
-    <string name="widget_config_upgrade_action">Oppgrader til Octi Pro</string>
-    <string name="widget_config_pro_required_label">Denne widgeten krever Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Kontrollerer din Octi Pro-status…</string>
-    <string name="widget_config_pro_error_label">Kunne ikke bekrefte din Octi Pro-status.</string>
     <string name="widget_config_retry_action">Prøv igjen</string>
     <string name="widget_config_presets_label">Forhåndsinnstillinger</string>
     <string name="widget_config_background_label">Bakgrunnsfarge</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Ingen samsvarende enheter</string>
     <string name="widget_no_sync_devices_label">Ingen synkroniseringsenheter ennå</string>
     <string name="widget_more_items">+ %1$d flere</string>
-    <string name="widget_upgrade_required_title">Octi Pro kreves</string>
     <string name="widget_upgrade_required_action">Trykk for å oppgradere</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ingen %1$s-data for denne enheten</string>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget aanpassen</string>
     <string name="widget_config_apply_action">Toepassen</string>
-    <string name="widget_config_upgrade_action">Upgrade naar Octi Pro</string>
-    <string name="widget_config_pro_required_label">Deze widget vereist Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Je Octi Pro-status controleren…</string>
-    <string name="widget_config_pro_error_label">Kon je Octi Pro-status niet verifiëren.</string>
     <string name="widget_config_retry_action">Opnieuw proberen</string>
     <string name="widget_config_presets_label">Voorinstellingen</string>
     <string name="widget_config_background_label">Achtergrondkleur</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Geen overeenkomende apparaten</string>
     <string name="widget_no_sync_devices_label">Nog geen synchronisatieapparaten</string>
     <string name="widget_more_items">+ %1$d meer</string>
-    <string name="widget_upgrade_required_title">Octi Pro vereist</string>
     <string name="widget_upgrade_required_action">Tik om te upgraden</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Geen %1$s-gegevens voor dit apparaat</string>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -70,10 +70,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Dostosuj widżet</string>
     <string name="widget_config_apply_action">Zastosuj</string>
-    <string name="widget_config_upgrade_action">Zaktualizuj do Octi Pro</string>
-    <string name="widget_config_pro_required_label">Ten widżet wymaga Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Sprawdzanie statusu Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Nie można zweryfikować twojego statusu Octi Pro.</string>
     <string name="widget_config_retry_action">Ponów</string>
     <string name="widget_config_presets_label">Ustawienia wstępne</string>
     <string name="widget_config_background_label">Kolor tła</string>
@@ -89,7 +85,6 @@
     <string name="widget_empty_label">Brak pasujących urządzeń</string>
     <string name="widget_no_sync_devices_label">Brak urządzeń do synchronizacji</string>
     <string name="widget_more_items">+ %1$d więcej</string>
-    <string name="widget_upgrade_required_title">Wymagany Octi Pro</string>
     <string name="widget_upgrade_required_action">Naciśnij, aby zaktualizować</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Brak danych %1$s dla tego urządzenia</string>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar Widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
-    <string name="widget_config_upgrade_action">Atualize para Octi Pro</string>
-    <string name="widget_config_pro_required_label">Este widget requer Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Verificando seu status do Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Não foi possível verificar seu status do Octi Pro.</string>
     <string name="widget_config_retry_action">Tentar novamente</string>
     <string name="widget_config_presets_label">Predefinições</string>
     <string name="widget_config_background_label">Cor de fundo</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Nenhum dispositivo correspondente</string>
     <string name="widget_no_sync_devices_label">Nenhum dispositivo de sincronização ainda</string>
     <string name="widget_more_items">+ %1$d mais</string>
-    <string name="widget_upgrade_required_title">Octi Pro obrigatório</string>
     <string name="widget_upgrade_required_action">Toque para atualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sem dados de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar Widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
-    <string name="widget_config_upgrade_action">Atualize para Octi Pro</string>
-    <string name="widget_config_pro_required_label">Este widget requer Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">A verificar o seu estado de Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Não foi possível verificar o seu estado de Octi Pro.</string>
     <string name="widget_config_retry_action">Tentar novamente</string>
     <string name="widget_config_presets_label">Predefinições</string>
     <string name="widget_config_background_label">Cor de fundo</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Nenhum dispositivo correspondente</string>
     <string name="widget_no_sync_devices_label">Ainda sem dispositivos de sincronização</string>
     <string name="widget_more_items">+ %1$d mais</string>
-    <string name="widget_upgrade_required_title">Octi Pro necessário</string>
     <string name="widget_upgrade_required_action">Toque para atualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sem dados de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -69,10 +69,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizare widget</string>
     <string name="widget_config_apply_action">Aplică</string>
-    <string name="widget_config_upgrade_action">Actualizează la Octi Pro</string>
-    <string name="widget_config_pro_required_label">Acest widget necesită Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Se verifică statutul Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Nu s-a putut verifica statutul Octi Pro.</string>
     <string name="widget_config_retry_action">Reîncercați</string>
     <string name="widget_config_presets_label">Presetări</string>
     <string name="widget_config_background_label">Culoare de fundal</string>
@@ -88,7 +84,6 @@
     <string name="widget_empty_label">Niciun dispozitiv corespunzător</string>
     <string name="widget_no_sync_devices_label">Niciun dispozitiv de sincronizare încă</string>
     <string name="widget_more_items">+ %1$d mai mult</string>
-    <string name="widget_upgrade_required_title">Octi Pro necesar</string>
     <string name="widget_upgrade_required_action">Atingeți pentru a face upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nu există date %1$s pentru acest dispozitiv</string>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -70,10 +70,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Настроить виджет</string>
     <string name="widget_config_apply_action">Применить</string>
-    <string name="widget_config_upgrade_action">Обновить до Octi Pro</string>
-    <string name="widget_config_pro_required_label">Этот виджет требует Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Проверка статуса Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Не удалось проверить статус Octi Pro.</string>
     <string name="widget_config_retry_action">Повторить</string>
     <string name="widget_config_presets_label">Предустановки</string>
     <string name="widget_config_background_label">Цвет фона</string>
@@ -89,7 +85,6 @@
     <string name="widget_empty_label">Нет подходящих устройств</string>
     <string name="widget_no_sync_devices_label">Нет синхронизированных устройств</string>
     <string name="widget_more_items">+ ещё %1$d</string>
-    <string name="widget_upgrade_required_title">Требуется Octi Pro</string>
     <string name="widget_upgrade_required_action">Нажмите для обновления</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Нет данных %1$s для этого устройства</string>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -69,10 +69,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Прилагоди виџет</string>
     <string name="widget_config_apply_action">Примени</string>
-    <string name="widget_config_upgrade_action">Nadogradite na Octi Pro</string>
-    <string name="widget_config_pro_required_label">Овај видгет захтева Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Проверавање статуса вашег Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Не могу да проверим статус вашег Octi Pro.</string>
     <string name="widget_config_retry_action">Поновити</string>
     <string name="widget_config_presets_label">Предефинисани изгледи</string>
     <string name="widget_config_background_label">Боја позадине</string>
@@ -88,7 +84,6 @@
     <string name="widget_empty_label">Нема уређаја који одговарају</string>
     <string name="widget_no_sync_devices_label">Још нема уређаја за синхронизацију</string>
     <string name="widget_more_items">+ %1$d више</string>
-    <string name="widget_upgrade_required_title">Потребан Octi Pro</string>
     <string name="widget_upgrade_required_action">Додирни да надоградиш</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Нема %1$s података за овај уређај</string>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Anpassa widget</string>
     <string name="widget_config_apply_action">Tillämpa</string>
-    <string name="widget_config_upgrade_action">Uppgradera till Octi Pro</string>
-    <string name="widget_config_pro_required_label">Den här widgeten kräver Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Kontrollerar din Octi Pro-status…</string>
-    <string name="widget_config_pro_error_label">Kunde inte verifiera din Octi Pro-status.</string>
     <string name="widget_config_retry_action">Försök igen</string>
     <string name="widget_config_presets_label">Förinställningar</string>
     <string name="widget_config_background_label">Bakgrundsfärg</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Inga matchande enheter</string>
     <string name="widget_no_sync_devices_label">Inga synkenheter ännu</string>
     <string name="widget_more_items">+ %1$d fler</string>
-    <string name="widget_upgrade_required_title">Octi Pro krävs</string>
     <string name="widget_upgrade_required_action">Tryck för att uppgradera</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Inga %1$s-data för den här enheten</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -68,10 +68,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget\'ı Özelleştir</string>
     <string name="widget_config_apply_action">Uygula</string>
-    <string name="widget_config_upgrade_action">Octi Pro\'ya Yükselt</string>
-    <string name="widget_config_pro_required_label">Bu widget Octi Pro gerektirir.</string>
-    <string name="widget_config_pro_checking_label">Octi Pro durumunuz kontrol ediliyor…</string>
-    <string name="widget_config_pro_error_label">Octi Pro durumunuz doğrulanamadı.</string>
     <string name="widget_config_retry_action">Yeniden dene</string>
     <string name="widget_config_presets_label">Ön Ayarlar</string>
     <string name="widget_config_background_label">Arka plan rengi</string>
@@ -87,7 +83,6 @@
     <string name="widget_empty_label">Eşleşen cihaz yok</string>
     <string name="widget_no_sync_devices_label">Henüz eşzamanlama cihazı yok</string>
     <string name="widget_more_items">+ %1$d daha</string>
-    <string name="widget_upgrade_required_title">Octi Pro gerekli</string>
     <string name="widget_upgrade_required_action">Yükseltmek için dokunun</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Bu cihaz için %1$s verisi yok</string>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -70,10 +70,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Налаштувати віджет</string>
     <string name="widget_config_apply_action">Застосувати</string>
-    <string name="widget_config_upgrade_action">Оновити до Octi Pro</string>
-    <string name="widget_config_pro_required_label">Цей віджет вимагає Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Перевірка вашого статусу Octi Pro…</string>
-    <string name="widget_config_pro_error_label">Не вдалось перевірити ваш статус Octi Pro.</string>
     <string name="widget_config_retry_action">Повторити спробу</string>
     <string name="widget_config_presets_label">Попередні налаштування</string>
     <string name="widget_config_background_label">Колір фону</string>
@@ -89,7 +85,6 @@
     <string name="widget_empty_label">Немає відповідних пристроїв</string>
     <string name="widget_no_sync_devices_label">Ще немає пристроїв синхронізації</string>
     <string name="widget_more_items">+ %1$d ще</string>
-    <string name="widget_upgrade_required_title">Octi Pro обов\'язковий</string>
     <string name="widget_upgrade_required_action">Тисніть, щоб оновити</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Немає даних %1$s для цього пристрою</string>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -67,10 +67,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tùy chỉnh Widget</string>
     <string name="widget_config_apply_action">Áp dụng</string>
-    <string name="widget_config_upgrade_action">Nâng cấp lên Octi Pro</string>
-    <string name="widget_config_pro_required_label">Tiện ích này yêu cầu Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Đang kiểm tra trạng thái Octi Pro của bạn…</string>
-    <string name="widget_config_pro_error_label">Không thể xác minh trạng thái Octi Pro của bạn.</string>
     <string name="widget_config_retry_action">Thử lại</string>
     <string name="widget_config_presets_label">Cài sẵn</string>
     <string name="widget_config_background_label">Màu nền</string>
@@ -86,7 +82,6 @@
     <string name="widget_empty_label">Không có thiết bị phù hợp</string>
     <string name="widget_no_sync_devices_label">Chưa có thiết bị đồng bộ</string>
     <string name="widget_more_items">+ %1$d thêm</string>
-    <string name="widget_upgrade_required_title">Yêu cầu Octi Pro</string>
     <string name="widget_upgrade_required_action">Nhấn để nâng cấp</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Không có dữ liệu %1$s cho thiết bị này</string>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -67,10 +67,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">自定义小部件</string>
     <string name="widget_config_apply_action">应用</string>
-    <string name="widget_config_upgrade_action">升级至 Octi Pro</string>
-    <string name="widget_config_pro_required_label">此小部件需要 Octi 专业版。</string>
-    <string name="widget_config_pro_checking_label">正在检查您的 Octi 专业版状态…</string>
-    <string name="widget_config_pro_error_label">无法验证您的 Octi 专业版状态。</string>
     <string name="widget_config_retry_action">重试</string>
     <string name="widget_config_presets_label">预设</string>
     <string name="widget_config_background_label">背景颜色</string>
@@ -86,7 +82,6 @@
     <string name="widget_empty_label">无匹配设备</string>
     <string name="widget_no_sync_devices_label">尚无同步设备</string>
     <string name="widget_more_items">+ %1$d 更多</string>
-    <string name="widget_upgrade_required_title">需要 Octi 专业版</string>
     <string name="widget_upgrade_required_action">点击升级</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">此设备没有 %1$s 数据</string>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -67,10 +67,6 @@
     <!-- Widget config -->
     <string name="widget_config_title">自訂小工具</string>
     <string name="widget_config_apply_action">套用</string>
-    <string name="widget_config_upgrade_action">升級至 Octi Pro</string>
-    <string name="widget_config_pro_required_label">此小工具需要 Octi 專業版。</string>
-    <string name="widget_config_pro_checking_label">正在檢查您的 Octi 專業版狀態…</string>
-    <string name="widget_config_pro_error_label">無法驗證您的 Octi 專業版狀態。</string>
     <string name="widget_config_retry_action">重試</string>
     <string name="widget_config_presets_label">預設</string>
     <string name="widget_config_background_label">背景顏色</string>
@@ -86,7 +82,6 @@
     <string name="widget_empty_label">沒有符合的裝置</string>
     <string name="widget_no_sync_devices_label">尚無同步裝置</string>
     <string name="widget_more_items">+ 還有 %1$d 個</string>
-    <string name="widget_upgrade_required_title">需要 Octi 專業版</string>
     <string name="widget_upgrade_required_action">點擊升級</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">此裝置沒有 %1$s 資料</string>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -70,10 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Customize Widget</string>
     <string name="widget_config_apply_action">Apply</string>
-    <string name="widget_config_upgrade_action">Upgrade to Octi Pro</string>
-    <string name="widget_config_pro_required_label">This widget requires Octi Pro.</string>
-    <string name="widget_config_pro_checking_label">Checking your Octi Pro status…</string>
-    <string name="widget_config_pro_error_label">Couldn\'t verify your Octi Pro status.</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">This widget requires an upgrade.</string>
+    <string name="widget_config_upgrade_checking_label">Checking your upgrade status…</string>
+    <string name="widget_config_upgrade_error_label">Couldn\'t verify your upgrade status.</string>
     <string name="widget_config_retry_action">Retry</string>
     <string name="widget_config_presets_label">Presets</string>
     <string name="widget_config_background_label">Background color</string>
@@ -90,7 +95,9 @@
     <string name="widget_empty_label">No matching devices</string>
     <string name="widget_no_sync_devices_label">No sync devices yet</string>
     <string name="widget_more_items">+ %1$d more</string>
-    <string name="widget_upgrade_required_title">Octi Pro required</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Upgrade required</string>
     <string name="widget_upgrade_required_action">Tap to upgrade</string>
 
     <!-- Widget deeplink -->

--- a/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/octi/common/upgrade/ui/UpgradeScreen.kt
@@ -116,7 +116,7 @@ internal fun UpgradeScreen(
         // composed flavor title, with the postfix highlighted like the dashboard does it.
         title = when (view) {
             FossUpgradeView.STATUS_UPGRADED -> upgradeScreenTitle(upgraded = true)
-            else -> AnnotatedString(stringResource(R.string.upgrade_screen_title))
+            else -> AnnotatedString(stringResource(R.string.upgrade_screen_support_title))
         },
         onNavigateUp = onNavigateUp,
         snackbarHostState = snackbarHostState,

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Vereis Octi Pro</string>
-    <string name="upgrades_dashcard_title">Kry Octi Pro</string>
     <string name="upgrades_dashcard_body">Ontsluit ekstra kenmerke en word \'n ondersteuner om voortdurende ontwikkeling te help!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgradeer</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Die gratis weergawe is beperk tot %1$d toestel.</item>
         <item quantity="other">Die gratis weergawe is beperk tot %1$d toestelle.</item>
     </plurals>
-    <string name="upgrade_screen_title">Opgradeer na Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi het geen advertensies en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️</string>
     <string name="upgrade_screen_how_title">Wat om te doen</string>
     <string name="upgrade_screen_how_body">Word \'n ondersteuner en borg ontwikkeling! Tik die knoppie hieronder om al die ekstra kenmerke te aktiveer en my GitHub Sponsors-profiel oop te maak.</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">يتطلب أوكتي احترافي</string>
-    <string name="upgrades_dashcard_title">احصل على أوكتي احترافي</string>
     <string name="upgrades_dashcard_body">افتح ميزات إضافية وكن راعيًا لدعم التطوير المستمر!</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -12,7 +10,6 @@
         <item quantity="many">النسخة المجانية مقتصرة على %1$d جهازًا.</item>
         <item quantity="other">النسخة المجانية مقتصرة على %1$d جهاز.</item>
     </plurals>
-    <string name="upgrade_screen_title">الترقية إلى أوكتي احترافي</string>
     <string name="upgrade_screen_preamble">أوكتي خالٍ من الإعلانات ولا يبيع بيانات المستخدمين. عملي يُموَّل بكم ❤️</string>
     <string name="upgrade_screen_how_title">الخطوات</string>
     <string name="upgrade_screen_how_body">كن راعيًا وادعم التطوير! انقر على الزر أدناه لتفعيل كل الميزات الإضافية وفتح صفحة رعاة جيثب الخاصة بي.</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Cal l\'Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obtén l\'Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al desenvolupament continu!</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">La versió gratuïta està limitada a %1$d dispositiu.</item>
         <item quantity="other">La versió gratuïta està limitada a %1$d dispositius.</item>
     </plurals>
-    <string name="upgrade_screen_title">Millora al Octi Pro</string>
     <string name="upgrade_screen_preamble">L\'Octi no té anuncis i no ven dades d\'usuari. El meu treball està finançat per usuaris com vós ❤️</string>
     <string name="upgrade_screen_how_title">Que fer?</string>
     <string name="upgrade_screen_how_body">Convertiu-vos en mecenes i patrocinadors del desenvolupament! Toqueu el botó següent per activar totes les funcions addicionals i obrir el meu perfil de patrocinadors del GitHub.</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Vyžaduje Octi Pro</string>
-    <string name="upgrades_dashcard_title">Získat Octi Pro</string>
     <string name="upgrades_dashcard_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -10,7 +8,6 @@
         <item quantity="many">Bezplatná verze je omezena na %1$d zařízení.</item>
         <item quantity="other">Bezplatná verze je omezena na %1$d zařízení.</item>
     </plurals>
-    <string name="upgrade_screen_title">Upgradovat na Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi neobsahuje žádné reklamy a neprodává data uživatelů. Moji práci financujete vy ❤️</string>
     <string name="upgrade_screen_how_title">Co dělat</string>
     <string name="upgrade_screen_how_body">Staňte se patronem a sponzorem vývoje! Klepnutím na tlačítko níže aktivujete všechny další funkce a otevřete můj profil sponzora na GitHubu.</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Kræver Octi Pro</string>
-    <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås op for ekstra funktioner og bliv en sponsor for at støtte fortsat udvikling!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Gratisversionen er begrænset til %1$d enhed.</item>
         <item quantity="other">Gratisversionen er begrænset til %1$d enheder.</item>
     </plurals>
-    <string name="upgrade_screen_title">Opgrader til Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi har ingen reklamer og sælger ikke brugerdata. Mit arbejde finansieres af dig ❤️</string>
     <string name="upgrade_screen_how_title">Hvad skal man gøre</string>
     <string name="upgrade_screen_how_body">Bliv sponsor og støt udviklingen! Tryk på knappen nedenfor for at aktivere alle ekstra funktioner og åbne min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Erfordert Octi Pro</string>
-    <string name="upgrades_dashcard_title">Hole dir Octi Pro</string>
     <string name="upgrades_dashcard_body">Schalte zusätzliche Funktionen frei und unterstütze die Weiterentwicklung!</string>
     <string name="upgrades_dashcard_upgrade_action">Erweitern</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Die kostenlose Version ist auf %1$d Gerät beschränkt.</item>
         <item quantity="other">Die kostenlose Version ist auf %1$d Geräte beschränkt.</item>
     </plurals>
-    <string name="upgrade_screen_title">Erweitere auf Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi hat keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️</string>
     <string name="upgrade_screen_how_title">Was ist zu tun</string>
     <string name="upgrade_screen_how_body">Werde ein Förderer und sponsere die Entwicklung! Tippe auf die Schaltfläche unten, um alle zusätzlichen Funktionen zu aktivieren und mein GitHub-Sponsorenprofil zu öffnen.</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Απαιτεί το Octi Pro</string>
-    <string name="upgrades_dashcard_title">Αποκτήστε το Octi Pro</string>
     <string name="upgrades_dashcard_body">Ξεκλειδώστε επιπλέον λειτουργίες και γίνετε υποστηρικτής για να ενισχύσετε τη συνεχή ανάπτυξη!</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Η δωρεάν έκδοση περιορίζεται σε %1$d συσκευή.</item>
         <item quantity="other">Η δωρεάν έκδοση περιορίζεται σε %1$d συσκευές.</item>
     </plurals>
-    <string name="upgrade_screen_title">Αναβαθμίστε στο Octi Pro</string>
     <string name="upgrade_screen_preamble">Το Octi δεν έχει διαφημίσεις και δεν πουλάει δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️</string>
     <string name="upgrade_screen_how_title">Τι να κάνετε</string>
     <string name="upgrade_screen_how_body">Γίνετε υποστηρικτής και σπόνσορας της ανάπτυξης! Πατήστε το παρακάτω κουμπί για να ενεργοποιήσετε όλες τις επιπλέον λειτουργίες και να ανοίξετε το προφίλ των χορηγιών μου στο GitHub.</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Requiere Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obtener Octi Pro</string>
     <string name="upgrades_dashcard_body">¡Desbloquea funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">%1$d dispositivo en la versión gratuita.</item>
         <item quantity="other">La versión gratuita está limitada a %1$d dispositivos.</item>
     </plurals>
-    <string name="upgrade_screen_title">Actualizar a Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi no tiene anuncios y no vende datos de usuario. Mi trabajo está financiado por ti ❤️</string>
     <string name="upgrade_screen_how_title">Qué hacer</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y apoya el desarrollo! Toca el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de GitHub Sponsors.</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Vaatii Octi Pro:n</string>
-    <string name="upgrades_dashcard_title">Hanki Octi Pro</string>
     <string name="upgrades_dashcard_body">Avaa lisäominaisuuksia ja auta tukemaan jatkuvaa kehitystä liittymällä tukijaksi!</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Ilmaisversio on rajoitettu %1$d laitteeseen.</item>
         <item quantity="other">Ilmaisversio on rajoitettu %1$d laitteeseen.</item>
     </plurals>
-    <string name="upgrade_screen_title">Päivitä Octi Pro:hon</string>
     <string name="upgrade_screen_preamble">Octi ei sisällä mainoksia eikä myy käyttäjätietoja. Työni rahoitetaan sinun avullasi ❤️</string>
     <string name="upgrade_screen_how_title">Mitä tehdä</string>
     <string name="upgrade_screen_how_body">Ryhdy tukijaksi ja sponsoroi kehitystä! Napauta alapuolella olevaa painiketta aktivoidaksesi kaikki lisäominaisuudet ja avataksesi GitHub Sponsorini profiilin.</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Seulement avec Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obtenir Octi Pro</string>
     <string name="upgrades_dashcard_body">Accédez à des fonctions supplémentaires et financez le développement permanent de l’appli</string>
     <string name="upgrades_dashcard_upgrade_action">Surclasser</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">La version gratuite est limitée à %1$d appareil.</item>
         <item quantity="other">La version gratuite est limitée à %1$d appareils.</item>
     </plurals>
-    <string name="upgrade_screen_title">Passer à Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi n’affiche pas de publicités et ne vend pas les données des utilisateurs. Vous financez mon travail ❤️.</string>
     <string name="upgrade_screen_how_title">Ce qu’il faut faire</string>
     <string name="upgrade_screen_how_body">Devenez mécène et commanditez le développement d’Octi. Touchez le bouton ci-dessous pour activer les fonctions supplémentaires et ouvrir mon profil « GitHub Sponsors ».</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Octi Pro szükséges</string>
-    <string name="upgrades_dashcard_title">Szerezze be az Octi Pro-t</string>
     <string name="upgrades_dashcard_body">Oldjon fel további funkciókat és legyen támogató a folyamatos fejlesztéshez!</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">%1$d eszközre korlátozódik az ingyenes verzió.</item>
         <item quantity="other">%1$d eszközre korlátozódik az ingyenes verzió.</item>
     </plurals>
-    <string name="upgrade_screen_title">Frissítés Octi Pro-ra</string>
     <string name="upgrade_screen_preamble">Az Octi nem tartalmaz hirdetéseket és nem árulja felhasználói adatokat. A munkámat te finanszírozod ❤️</string>
     <string name="upgrade_screen_how_title">Mit kell tenni</string>
     <string name="upgrade_screen_how_body">Légy támogató és szponzoráld a fejlesztést! Érintsd meg az alábbi gombot minden extra funkció aktiválásához és a GitHub Sponsors profilom megnyitásához.</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Richiede Octi Pro</string>
-    <string name="upgrades_dashcard_title">Ottieni Octi Pro</string>
     <string name="upgrades_dashcard_body">Sblocca funzionalità aggiuntive e diventa sostenitore dello sviluppo dell\'applicazione!</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">La versione gratuita è limitata a %1$d dispositivo.</item>
         <item quantity="other">La versione gratuita è limitata a %1$d dispositivi.</item>
     </plurals>
-    <string name="upgrade_screen_title">Aggiorna ad Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi non ha pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️</string>
     <string name="upgrade_screen_how_title">Cosa fare</string>
     <string name="upgrade_screen_how_body">Diventa sostenitore dello sviluppo! Clicca il bottone qui sotto per attivare funzionalità extra e vsualizza il mio profilo github sponsors.</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">דורש Octi פרימיום</string>
-    <string name="upgrades_dashcard_title">קבל את Octi פרמיום</string>
     <string name="upgrades_dashcard_body">פתח תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -10,7 +8,6 @@
         <item quantity="many">הגרסה החינמית מוגבלת ל-%1$d מכשירים</item>
         <item quantity="other">הגרסה החינמית מוגבלת ל-%1$d מכשירים</item>
     </plurals>
-    <string name="upgrade_screen_title">שדרג ל-Octi פרמיום</string>
     <string name="upgrade_screen_preamble">Octi לא מכילה מודעות ואיננו מוכרים נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️</string>
     <string name="upgrade_screen_how_title">מה לעשות</string>
     <string name="upgrade_screen_how_body">הפוך לפטרון ונותן חסות לפיתוח! הקש על הלחצן למטה כדי להפעיל את כל התכונות הנוספות ולפתוח את פרופיל התומכים ב- GitHub שלי.</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Octi Pro が必要です</string>
-    <string name="upgrades_dashcard_title">Octi Pro を入手</string>
     <string name="upgrades_dashcard_body">追加機能の入手と支援者になって断続的な開発をサポートしましょう！</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">無料版は%1$dデバイスまでに制限されています。</item>
     </plurals>
-    <string name="upgrade_screen_title">Octi Pro にアップグレード</string>
     <string name="upgrade_screen_preamble">Octi は無広告、ユーザーデータの販売もしません。あなたの支援で成り立っています ❤️</string>
     <string name="upgrade_screen_how_title">何をしますか</string>
     <string name="upgrade_screen_how_body">支援者になって開発者のスポンサーになりましょう！下のボタンをタップしてすべての追加機能を有効化し、私の GitHub スポンサープロフィールを開いてください。</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Octi Pro가 필요합니다</string>
-    <string name="upgrades_dashcard_title">Octi Pro 얻기</string>
     <string name="upgrades_dashcard_body">추가 기능을 잠금 해제하고 계속된 개발을 지원하는 후원자가 되어주세요!</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">무료 버전은 %1$d개의 기기로 제한됩니다.</item>
     </plurals>
-    <string name="upgrade_screen_title">Octi Pro로 업그레이드</string>
     <string name="upgrade_screen_preamble">Octi는 광고가 없고 사용자 데이터를 판매하지 않습니다. 제 작업은 여러분의 도움으로 이루어집니다 ❤️</string>
     <string name="upgrade_screen_how_title">해야 할 일</string>
     <string name="upgrade_screen_how_body">후원자가 되어 개발을 지원하세요! 아래 버튼을 터치하여 모든 추가 기능을 활성화하고 제 GitHub Sponsors 프로필을 여세요.</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Krever Octi Pro</string>
-    <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås opp flere funksjoner og bli en beskytter for å støtte videre utvikling!</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Gratisversjonen er begrenset til %1$d enhet.</item>
         <item quantity="other">Gratisversjonen er begrenset til %1$d enheter.</item>
     </plurals>
-    <string name="upgrade_screen_title">Oppgrader til Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi har ingen annonser og selger ikke brukerdata. Arbeidet mitt finansieres av deg ❤️</string>
     <string name="upgrade_screen_how_title">Hva du skal gjøre</string>
     <string name="upgrade_screen_how_body">Bli en beskytter og spons utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Octi Pro vereist</string>
-    <string name="upgrades_dashcard_title">Krijg Octi Pro</string>
     <string name="upgrades_dashcard_body">Ontgrendel extra functies en word een sponsor om verdere ontwikkeling te steunen!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">De gratis versie is beperkt tot %1$d apparaat.</item>
         <item quantity="other">De gratis versie is beperkt tot %1$d apparaten.</item>
     </plurals>
-    <string name="upgrade_screen_title">Upgrade naar Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi heeft geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️</string>
     <string name="upgrade_screen_how_title">Wat te doen</string>
     <string name="upgrade_screen_how_body">Word een sponsor en steun de ontwikkeling! Tik op de knop hieronder om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Wymaga Octi Pro</string>
-    <string name="upgrades_dashcard_title">Uzyskaj Octi Pro</string>
     <string name="upgrades_dashcard_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -10,7 +8,6 @@
         <item quantity="many">Darmowa wersja jest ograniczona do %1$d urządzeń.</item>
         <item quantity="other">Darmowa wersja jest ograniczona do %1$d urządzeń.</item>
     </plurals>
-    <string name="upgrade_screen_title">Uaktualnij do Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi nie wyświetla reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️</string>
     <string name="upgrade_screen_how_title">Co zrobić</string>
     <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Requer Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">A versão gratuita é limitada a %1$d dispositivo.</item>
         <item quantity="other">A versão gratuita é limitada a %1$d dispositivos.</item>
     </plurals>
-    <string name="upgrade_screen_title">Atualize para Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi não possui anúncios e não vende dados de usuário. Meu trabalho é financiado por você ❤️</string>
     <string name="upgrade_screen_how_title">O que fazer</string>
     <string name="upgrade_screen_how_body">Torne-se um patrono e patrocine o desenvolvimento! Toque no botão abaixo para ativar todos os recursos extras e abrir meu perfil no GitHub Sponsors.</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Requer Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Desbloqueie recursos adicionais e torne-se um patrocinador para apoiar o desenvolvimento contínuo!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">A versão gratuita está limitada a %1$d dispositivo.</item>
         <item quantity="other">A versão gratuita está limitada a %1$d dispositivos.</item>
     </plurals>
-    <string name="upgrade_screen_title">Atualize para Octi Pro</string>
     <string name="upgrade_screen_preamble">O Octi não tem anúncios e não vende dados de usuários. Meu trabalho é financiado por você ❤️</string>
     <string name="upgrade_screen_how_title">O que fazer</string>
     <string name="upgrade_screen_how_body">Torne-se um patrocinador e apoie o desenvolvimento! Toque no botão abaixo para ativar todos os recursos extras e abrir meu perfil do GitHub Sponsors.</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Necesită Octi Pro</string>
-    <string name="upgrades_dashcard_title">Obține Octi Pro</string>
     <string name="upgrades_dashcard_body">Deblochează funcții suplimentare și devino patron pentru a susține dezvoltarea continuă!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -9,7 +7,6 @@
         <item quantity="few">Versiunea gratuită este limitată la %1$d dispozitive.</item>
         <item quantity="other">Versiunea gratuită este limitată la %1$d de dispozitive.</item>
     </plurals>
-    <string name="upgrade_screen_title">Actualizează la Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi nu are reclame și nu vinde datele utilizatorului. Munca mea este finanțată de tine ❤️</string>
     <string name="upgrade_screen_how_title">Ce să faci</string>
     <string name="upgrade_screen_how_body">Devino patron și sponsorizează dezvoltarea! Atinge butonul de mai jos pentru a activa toate funcțiile suplimentare și a deschide profilul meu GitHub Sponsors.</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Требуется Octi Pro</string>
-    <string name="upgrades_dashcard_title">Получить Octi Pro</string>
     <string name="upgrades_dashcard_body">Разблокируйте дополнительные функции и станьте спонсором для поддержки дальнейшей разработки!</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -10,7 +8,6 @@
         <item quantity="many">Бесплатная версия ограничена %1$d устройствами.</item>
         <item quantity="other">Бесплатная версия ограничена %1$d устройствами.</item>
     </plurals>
-    <string name="upgrade_screen_title">Обновить до Octi Pro</string>
     <string name="upgrade_screen_preamble">В Octi нет рекламы, и он не продаёт данные пользователей. Моя работа финансируется вами ❤️</string>
     <string name="upgrade_screen_how_title">Что нужно сделать</string>
     <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Zahteva Octi Pro</string>
-    <string name="upgrades_dashcard_title">Dobijte Octi Pro</string>
     <string name="upgrades_dashcard_body">Otključajte dodatne funkcije i postanite pokrovitelj za podršku daljem razvoju!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradi</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -9,7 +7,6 @@
         <item quantity="few">Бесплатна верзија је ограничена на %1$d уређаја.</item>
         <item quantity="other">Бесплатна верзија је ограничена на %1$d уређаја.</item>
     </plurals>
-    <string name="upgrade_screen_title">Nadogradite na Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi nema reklame i ne prodaje korisničke podatke. Moj rad finansirate vi ❤️</string>
     <string name="upgrade_screen_how_title">Šta uraditi</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj i sponzorišite razvoj! Dodirnite dugme ispod da aktivirate sve dodatne funkcije i otvorite moj GitHub Sponsors profil.</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Kräver Octi Pro</string>
-    <string name="upgrades_dashcard_title">Skaffa Octi Pro</string>
     <string name="upgrades_dashcard_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">Gratisversionen är begränsad till %1$d enhet.</item>
         <item quantity="other">Gratisversionen är begränsad till %1$d enheter.</item>
     </plurals>
-    <string name="upgrade_screen_title">Uppgradera till Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️</string>
     <string name="upgrade_screen_how_title">Vad du ska göra</string>
     <string name="upgrade_screen_how_body">Bli beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,14 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Octi Pro gereklidir</string>
-    <string name="upgrades_dashcard_title">Octi Pro Al</string>
     <string name="upgrades_dashcard_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="one">%1$d cihaz</item>
         <item quantity="other">Ücretsiz sürüm %1$d cihazla sınırlıdır.</item>
     </plurals>
-    <string name="upgrade_screen_title">Octi Pro\'ya Yükselt</string>
     <string name="upgrade_screen_preamble">Octi\'de reklam yoktur ve kullanıcı verilerini satmaz. Çalışmalarım sizin tarafınızdan finanse edilmektedir ❤️</string>
     <string name="upgrade_screen_how_title">Ne yapmalı</string>
     <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Потрібен Octi Pro</string>
-    <string name="upgrades_dashcard_title">Отримати Octi Pro</string>
     <string name="upgrades_dashcard_body">Відкрийте додаткові функції та підтримайте подальший розвиток!</string>
     <string name="upgrades_dashcard_upgrade_action">Оновити</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -10,7 +8,6 @@
         <item quantity="many">Безкоштовна версія обмежена %1$d пристроями.</item>
         <item quantity="other">Безкоштовна версія обмежена %1$d пристроями.</item>
     </plurals>
-    <string name="upgrade_screen_title">Оновити до Octi Pro</string>
     <string name="upgrade_screen_preamble">В Octi немає реклами і він не продає дані користувачів. Моя робота фінансується вами ❤️</string>
     <string name="upgrade_screen_how_title">Що робити</string>
     <string name="upgrade_screen_how_body">Станьте патроном та підтримуйте розробку! Натисніть на кнопку нижче, щоб активувати всі додаткові функції та відкрити мій профіль GitHub Sponsors.</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">Yêu cầu Octi Pro</string>
-    <string name="upgrades_dashcard_title">Nhận Octi Pro</string>
     <string name="upgrades_dashcard_body">Mở khóa các tính năng bổ sung và trở thành nhà bảo trợ để hỗ trợ phát triển liên tục!</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">Phiên bản miễn phí bị giới hạn ở %1$d thiết bị.</item>
     </plurals>
-    <string name="upgrade_screen_title">Nâng cấp lên Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️</string>
     <string name="upgrade_screen_how_title">Nên làm gì</string>
     <string name="upgrade_screen_how_body">Trở thành nhà bảo trợ và tài trợ cho phát triển! Nhấn nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở trang hồ sơ GitHub Sponsors của tôi.</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">请求Octi Pro</string>
-    <string name="upgrades_dashcard_title">获取Octi Pro</string>
     <string name="upgrades_dashcard_body">解锁附加功能并成为赞助人以支持持续发展！</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">免费版最多支持 %1$d 台设备。</item>
     </plurals>
-    <string name="upgrade_screen_title">升级至 Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi 没有广告，也不会出售用户数据。我的工作由你资助 ❤️</string>
     <string name="upgrade_screen_how_title">该怎么办</string>
     <string name="upgrade_screen_how_body">成为赞助人并赞助开发！点击下面的按钮以激活所有额外功能并打开我的 GitHub 赞助商资料。</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="upgrade_feature_requires_pro">需要 Octi Pro</string>
-    <string name="upgrades_dashcard_title">取得 Octi Pro</string>
     <string name="upgrades_dashcard_body">解鎖額外功能並成為支持者，協助持續開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">免費版限制最多 %1$d 台裝置。</item>
     </plurals>
-    <string name="upgrade_screen_title">升級至 Octi Pro</string>
     <string name="upgrade_screen_preamble">Octi 沒有廣告，也不會販售使用者資料。我的工作由你贊助 ❤️</string>
     <string name="upgrade_screen_how_title">該怎麼做</string>
     <string name="upgrade_screen_how_body">成為支持者並贊助開發！點擊下方按鈕以啟用所有額外功能並打開我的 GitHub Sponsors 個人頁面。</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -2,9 +2,7 @@
 <resources>
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
-    <string name="upgrade_feature_requires_pro">Requires Octi Pro</string>
 
-    <string name="upgrades_dashcard_title">Get Octi Pro</string>
     <string name="upgrades_dashcard_body">Unlock additional features and become a patron to support continued development!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -12,7 +10,10 @@
         <item quantity="other">The free version is limited to %1$d devices.</item>
     </plurals>
 
-    <string name="upgrade_screen_title">Upgrade to Octi Pro</string>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Support Octi</string>
     <string name="upgrade_screen_preamble">Octi has no ads and doesn\'t sell user data. My work is financed by you ❤️</string>
     <string name="upgrade_screen_how_title">What to do</string>
     <string name="upgrade_screen_how_body">Become a patron and sponsor development! Tap the button below to activate all extra features and open my GitHub Sponsors profile.</string>

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/ui/UpgradeOwnership.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import eu.darken.octi.R
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import eu.darken.octi.common.R as CommonR
 
 // Ownership presentation for users who already own a Pro entitlement. Subscribers without the
 // one-time purchase always see the switch offer — but LOCKED while the subscription still
@@ -158,8 +157,9 @@ private fun UpgradeOwnedHero(
             Column(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
+                val brand = brandTitleText(includeQualifier = true)
                 Text(
-                    text = stringResource(R.string.upgrade_screen_owned_hero_title),
+                    text = stringResource(R.string.upgrade_screen_owned_hero_brand_title, brand),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -168,7 +168,7 @@ private fun UpgradeOwnedHero(
                     text = stringResource(
                         if (ownership.hasIap) R.string.upgrade_screen_owned_hero_iap_body
                         else R.string.upgrade_screen_owned_hero_sub_body,
-                        "${stringResource(CommonR.string.app_name)} ${stringResource(R.string.app_name_upgrade_postfix)}",
+                        brand,
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                 )

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play bied tans nie hierdie opgraad-opsie aan nie. Probeer asseblief later weer of kontroleer die Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kon nie Google Play oopmaak nie. Dit kan ontbreek, gedeaktiveer of beperk wees op hierdie toestel.</string>
-    <string name="upgrades_dashcard_title">Kry Octi Pro</string>
     <string name="upgrades_dashcard_body">Gradeer op om ekstra funksies te ontsluit en ontwikkeling te ondersteun!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgradeer</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Nog vasgevang? Kontak ondersteuning en ons sal help dit uitwerk.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Die kontrole met Google Play het nie op tyd klaar gemaak nie, daarom is jou aankoopstatus steeds onbekend. Niks het op jou rekening verander nie.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Jy is Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Dankie dat jy Octi ondersteun! Jou Pro-funksies is ontsluit.</string>
     <string name="upgrade_screen_owned_iap_title">Leeftydse aankoop</string>
     <string name="upgrade_screen_owned_iap_body">Jy eie die eenmalige Pro-aankoop. Dit verval nooit.</string>
     <string name="upgrade_screen_owned_sub_title">Inskrywing</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Jy eie albei</string>
     <string name="upgrade_screen_owned_both_warning">Jy eie beide die inskrywing en die eenmalige aankoop. Om dubbele betaling te vermy, kanselleer die inskrywing in Google Play — jy behou Pro deur die leeftydse aankoop.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Jy is Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dankie vir die aankoop van %1$s! Jou Pro-funksies is ontsluit en verval nooit.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dankie vir inskrywing op %1$s! Jou Pro-funksies is ontsluit.</string>
     <string name="upgrade_screen_manage_subscription_action">Bestuur inskrywing</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play لا يقدم حالياً خيار الترقية هذا. يرجى المحاولة لاحقاً أو التحقق من متجر Google Play.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">تعذر فتح Google Play. قد يكون التطبيق مفقوداً أو معطلاً أو مقيداً على هذا الجهاز.</string>
-    <string name="upgrades_dashcard_title">احصل على أوكتي احترافي</string>
     <string name="upgrades_dashcard_body">قم بالترقية لفتح ميزات إضافية ودعم التطوير!</string>
     <string name="upgrades_dashcard_upgrade_action">ترقية</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -72,8 +71,6 @@
     <string name="upgrade_screen_restore_contact_hint">لا تزال تواجه مشكلة؟ تواصل مع الدعم وسنساعدك في حلها.</string>
     <string name="upgrade_screen_restore_inconclusive_message">لم ينته التحقق مع Google Play في الوقت المناسب، لذا حالة شرائك لا تزال غير معروفة. لم يتغير شيء في حسابك.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">أنت مستخدم Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">شكرًا لدعمك Octi! ميزات Pro مفتوحة الآن.</string>
     <string name="upgrade_screen_owned_iap_title">شراء مدى الحياة</string>
     <string name="upgrade_screen_owned_iap_body">أنت تملك شراء Pro لمرة واحدة. لا تنتهي صلاحيته أبدًا.</string>
     <string name="upgrade_screen_owned_sub_title">اشتراك</string>
@@ -82,7 +79,6 @@
     <string name="upgrade_screen_owned_both_title">تملك كليهما</string>
     <string name="upgrade_screen_owned_both_warning">تملك كلاً من الاشتراك والشراء لمرة واحدة. لتجنب الدفع مرتين، ألغِ الاشتراك عبر Google Play — ستحتفظ بـ Pro من خلال الشراء مدى الحياة.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">أنت مستخدم Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">شكرًا لشرائك %1$s! ميزات Pro مفتوحة الآن ولن تنتهي أبدًا.</string>
     <string name="upgrade_screen_owned_hero_sub_body">شكرًا لاشتراكك في %1$s! ميزات Pro مفتوحة الآن.</string>
     <string name="upgrade_screen_manage_subscription_action">إدارة الاشتراك</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е наличен</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не може да се свърже с Google Play. Инсталиран и актуализиран ли е Google Play? Влезли ли сте с вашия Google акаунт? Опитайте да изчистите кеша на приложението Google Play и рестартирайте устройството си.</string>
     <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>
-    <string name="upgrades_dashcard_title">Вземете Octi Pro</string>
     <string name="upgrades_dashcard_body">Актуализирайте, за да отключите допълнителни функции и да подкрепите развитието!</string>
     <string name="upgrades_dashcard_upgrade_action">Актуализация</string>
     <string name="upgrade_screen_preamble">Octi няма реклами и не продава потребителски данни. Моята работа се финансира от вас ❤️.</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play actualment no ofereix aquesta opció de millora. Si us plau, torna a intentar més tard o consulta la Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Podria estar absent, desactivat o restringit en aquest dispositiu.</string>
-    <string name="upgrades_dashcard_title">Obtén l\'Octi Pro</string>
     <string name="upgrades_dashcard_body">Actualitzeu per desbloquejar funcions addicionals i donar suport al desenvolupament!</string>
     <string name="upgrades_dashcard_upgrade_action">Millora</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Seguiu tenint problemes? Contacteu amb el suport i us ajudarem a resoldre-ho.</string>
     <string name="upgrade_screen_restore_inconclusive_message">La verificació amb Google Play no s\'ha completat a temps, de manera que l\'estat de la teva compra és encara desconegut. Res ha canviat al teu compte.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Sou Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Gràcies per donar suport a Octi! Les vostres funcionalitats Pro estan desbloquejades.</string>
     <string name="upgrade_screen_owned_iap_title">Compra de per vida</string>
     <string name="upgrade_screen_owned_iap_body">Teniu la compra Pro d’una vegada. Mai no caduca.</string>
     <string name="upgrade_screen_owned_sub_title">Subscripció</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Posseïu ambdues</string>
     <string name="upgrade_screen_owned_both_warning">Posseïu tant la subscripció com la compra única. Per evitar pagar dues vegades, cancel·leu la subscripció a Google Play — manteniu l’accés Pro a través de la compra de per vida.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Sou Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Gràcies per comprar %1$s! Les vostres funcionalitats Pro estan desbloquejades i no caducaran mai.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Gràcies per subscriure-us a %1$s! Les vostres funcionalitats Pro estan desbloquejades.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestiona la subscripció</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play v současné době nenabízí tuto možnost upgradu. Prosím, zkuste to později nebo zkontrolujte obchod Google Play.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nelze otevřít Google Play. Aplikace chybí, je deaktivovaná nebo omezená na tomto zařízení.</string>
-    <string name="upgrades_dashcard_title">Získat Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgradujte a odemkněte další funkce a podpořte vývoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgradovat</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -70,8 +69,6 @@
     <string name="upgrade_screen_restore_contact_hint">Stále máte problém? Kontaktujte podporu a pomůžeme vám to vyřešit.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Kontrola s Google Play se nedokončila včas, takže stav vašeho nákupu je stále neznámý. Nic se na vašem účtu nezměnilo.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Jste Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Děkujeme za podporu Octi! Vaše funkce Pro jsou nyní dostupné.</string>
     <string name="upgrade_screen_owned_iap_title">Nákup na doživotí</string>
     <string name="upgrade_screen_owned_iap_body">Vlastníte jednorázový nákup Pro. Nikdy nevyprší.</string>
     <string name="upgrade_screen_owned_sub_title">Předplatné</string>
@@ -80,7 +77,6 @@
     <string name="upgrade_screen_owned_both_title">Vlastníte obojí</string>
     <string name="upgrade_screen_owned_both_warning">Vlastníte jak předplatné, tak jednorázový nákup. Abyste se vyhnuli zaplacení dvakrát, zrušte předplatné v Google Play — Pro si ponecháte díky nákupu na doživotí.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Jste Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Děkujeme za nákup %1$s! Vaše funkce Pro jsou odemčeny a nikdy nevyprší.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Děkujeme za přihlášení k odběru %1$s! Vaše funkce Pro jsou odemčeny.</string>
     <string name="upgrade_screen_manage_subscription_action">Spravovat předplatné</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbyder i øjeblikket ikke denne opgraderingsmulighed. Prøv igen senere eller tjek Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunne ikke åbne Google Play. Det kan være manglende, deaktiveret eller begrænset på denne enhed.</string>
-    <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Opgrader for at låse op for flere funktioner og støtte udviklingen!</string>
     <string name="upgrades_dashcard_upgrade_action">Opgrader</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Stadig fast? Kontakt support, og vi hjælper dig med at løse det.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play blev ikke færdig i tide, så din købestatus er stadig ukendt. Intet er ændret på din konto.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Du er Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Tak fordi du støtter Octi! Dine Pro-funktioner er låst op.</string>
     <string name="upgrade_screen_owned_iap_title">Livsvarigt køb</string>
     <string name="upgrade_screen_owned_iap_body">Du ejer engangskøbet af Pro. Det udløber aldrig.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnement</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Du ejer begge</string>
     <string name="upgrade_screen_owned_both_warning">Du ejer både abonnementet og engangskøbet. For at undgå at betale to gange, annuller abonnementet i Google Play – du beholder Pro gennem det livsvarige køb.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Du er Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tak for købet af %1$s! Dine Pro-funktioner er låst op og udløber aldrig.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tak for abonnementet på %1$s! Dine Pro-funktioner er låst op.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play bietet diese Upgrade-Option derzeit nicht an. Bitte versuche es später noch einmal oder überprüfe den Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Möglicherweise ist die App auf diesem Gerät nicht installiert, deaktiviert oder der Zugriff darauf wurde eingeschränkt.</string>
-    <string name="upgrades_dashcard_title">Hole dir Octi Pro</string>
     <string name="upgrades_dashcard_body">Freischalten für weitere Funktionen und Unterstützung des Entwicklers!</string>
     <string name="upgrades_dashcard_upgrade_action">Freischalten</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Immer noch festgefahren? Kontaktiere den Support und wir helfen dir, alles zu klären.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Die Überprüfung mit Google Play wurde nicht rechtzeitig abgeschlossen, daher ist dein Kaufstatus weiterhin unbekannt. An deinem Konto wurde nichts geändert.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Du bist Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Danke für deine Unterstützung bei Octi! Deine Pro-Funktionen sind freigeschaltet.</string>
     <string name="upgrade_screen_owned_iap_title">Lebenslanger Kauf</string>
     <string name="upgrade_screen_owned_iap_body">Du besitzt den Pro-Einmalkauf. Er verfällt nie.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnement</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Du besitzt beides</string>
     <string name="upgrade_screen_owned_both_warning">Du besitzt sowohl das Abonnement als auch den Einmalkauf. Um doppelte Zahlungen zu vermeiden, kündige das Abonnement in Google Play – du behältst Pro durch den Einmalkauf.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Du bist Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Danke, dass du %1$s gekauft hast! Deine Pro-Funktionen sind freigeschaltet und verfallen nie.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Danke, dass du %1$s abonniert hast! Deine Pro-Funktionen sind freigeschaltet.</string>
     <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Το Google Play δεν προσφέρει αυτή τη στιγμή αυτή την επιλογή αναβάθμισης. Δοκιμάστε ξανά αργότερα ή ελέγξτε το Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Δεν ήταν δυνατό να ανοιχθεί το Google Play. Ενδέχεται να λείπει, να είναι απενεργοποιημένο ή να είναι περιορισμένο σε αυτή τη συσκευή.</string>
-    <string name="upgrades_dashcard_title">Αποκτήστε το Octi Pro</string>
     <string name="upgrades_dashcard_body">Αναβαθμίστε για να ξεκλειδώσετε επιπλέον δυνατότητες και να στηρίξετε την ανάπτυξη!</string>
     <string name="upgrades_dashcard_upgrade_action">Αναβάθμιση</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Ακόμα έχετε πρόβλημα; Επικοινωνήστε με την υποστήριξη και θα σας βοηθήσουμε να το λύσουμε.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Ο έλεγχος με το Google Play δεν ολοκληρώθηκε εγκαίρως, επομένως η κατάσταση της αγοράς σας παραμένει άγνωστη. Τίποτα δεν έχει αλλάξει στο λογαριασμό σας.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Είστε Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Ευχαριστούμε που υποστηρίζετε το Octi! Οι δυνατότητες Pro είναι ξεκλειδωμένες.</string>
     <string name="upgrade_screen_owned_iap_title">Ισόβια αγορά</string>
     <string name="upgrade_screen_owned_iap_body">Κατέχετε την εφάπαξ αγορά Pro. Δεν λήγει ποτέ.</string>
     <string name="upgrade_screen_owned_sub_title">Συνδρομή</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Κατέχετε και τα δύο</string>
     <string name="upgrade_screen_owned_both_warning">Κατέχετε τόσο τη συνδρομή όσο και την εφάπαξ αγορά. Για να αποφύγετε τη διπλή χρέωση, ακυρώστε τη συνδρομή στο Google Play — διατηρείτε το Pro μέσω της ισόβιας αγοράς.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Είστε Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ευχαριστούμε που αγοράσατε %1$s! Οι δυνατότητες Pro είναι ξεκλειδωμένες και δεν λήγουν ποτέ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ευχαριστούμε που κάνατε εγγραφή στο %1$s! Οι δυνατότητες Pro είναι ξεκλειδωμένες.</string>
     <string name="upgrade_screen_manage_subscription_action">Διαχείριση συνδρομής</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play no está ofreciendo esta opción de actualización en este momento. Por favor, intenta de nuevo más tarde o consulta la Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Puede que esté ausente, deshabilitado o restringido en este dispositivo.</string>
-    <string name="upgrades_dashcard_title">Obtén Octi Pro</string>
     <string name="upgrades_dashcard_body">¡Actualiza para desbloquear funciones adicionales y apoyar el desarrollo!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">¿Aún con problemas? Ponte en contacto con soporte y te ayudaremos a resolverlo.</string>
     <string name="upgrade_screen_restore_inconclusive_message">La comprobación con Google Play no se completó a tiempo, por lo que tu estado de compra es aún desconocido. Nada ha cambiado en tu cuenta.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Eres Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">¡Gracias por apoyar Octi! Tus funciones Pro están desbloqueadas.</string>
     <string name="upgrade_screen_owned_iap_title">Compra de por vida</string>
     <string name="upgrade_screen_owned_iap_body">Posees la compra Pro única. Nunca caduca.</string>
     <string name="upgrade_screen_owned_sub_title">Suscripción</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Tienes ambas</string>
     <string name="upgrade_screen_owned_both_warning">Tienes tanto la suscripción como la compra única. Para evitar pagar dos veces, cancela la suscripción en Google Play — mantienes Pro a través de la compra de por vida.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Eres Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">¡Gracias por comprar %1$s! Tus funciones Pro están desbloqueadas y nunca caducan.</string>
     <string name="upgrade_screen_owned_hero_sub_body">¡Gracias por suscribirte a %1$s! Tus funciones Pro están desbloqueadas.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrar suscripción</string>

--- a/app/src/gplay/res/values-et/strings.xml
+++ b/app/src/gplay/res/values-et/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play pole saadaval</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ei saa Google Playga ühendust. Kas Google Play on paigaldatud ja ajakohane? Kas Sinu Google\'i konto on sisse logitud? Proovi Google Play rakenduse vahemälu tühjendada ja seadme taaskäivitada.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostud ei leitud. Kas kasutad õiget kontot?</string>
-    <string name="upgrades_dashcard_title">Hangi Octi Pro</string>
     <string name="upgrades_dashcard_body">Uuenda, et avada lisafunktsioone ja toetada arendust!</string>
     <string name="upgrades_dashcard_upgrade_action">Uuenda</string>
     <string name="upgrade_screen_preamble">Octil pole reklaame ega müü ta kasutajaandmeid. Minu tööd rahastad Sina ❤️.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play ei tällä hetkellä tarjoa tätä päivitysvaihtoehtoa. Yritä myöhemmin tai tarkista Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Ei voitu avata Google Playta. Se saattaa puuttua, olla poissa käytöstä tai rajoitettu tällä laitteella.</string>
-    <string name="upgrades_dashcard_title">Hanki Octi Pro</string>
     <string name="upgrades_dashcard_body">Päivitä avataksesi lisää ominaisuuksia ja tukeaksesi kehitystä!</string>
     <string name="upgrades_dashcard_upgrade_action">Päivitä</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Olet vielä jumissa? Ota yhteyttä tukeen ja autamme sinua.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Google Play -tarkistus ei valmistunut ajoissa, joten ostotilasi on edelleen tuntematon. Tilillä ei ole tapahtunut muutoksia.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Olet Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Kiitos Octin tukemisesta! Pro-ominaisuutesi on avattu.</string>
     <string name="upgrade_screen_owned_iap_title">Elinikäinen osto</string>
     <string name="upgrade_screen_owned_iap_body">Omistat kertaluonteisen Pro-osion. Se ei koskaan vanhene.</string>
     <string name="upgrade_screen_owned_sub_title">Tilaus</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Omistat molemmat</string>
     <string name="upgrade_screen_owned_both_warning">Omistat sekä tilauksen että kertaluonteisen osion. Kaksinkertaisen maksun välttämiseksi peruuta tilaus Google Playssa — säilytät Pro-tilan elinikäisen osion kautta.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Olet Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kiitos %1$s:n ostamisesta! Pro-ominaisuutesi on avattu eivätkä ne koskaan vanhene.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Kiitos %1$s:n tilaamisesta! Pro-ominaisuutesi on avattu.</string>
     <string name="upgrade_screen_manage_subscription_action">Hallitse tilausta</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play n\'offre actuellement pas cette option de mise à jour. Veuillez réessayer plus tard ou vérifier le Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Impossible d\'ouvrir Google Play. Il se peut qu\'il soit manquant, désactivé ou restreint sur cet appareil.</string>
-    <string name="upgrades_dashcard_title">Obtenir Octi Pro</string>
     <string name="upgrades_dashcard_body">Surclassez Octi pour débloquer des fonctions supplémentaires et financer le développement.</string>
     <string name="upgrades_dashcard_upgrade_action">Surclasser</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@ Mêmes fonctions, juste des modèles tarifaires différents.</string>
     <string name="upgrade_screen_restore_contact_hint">Toujours bloqué ? Contactez le support et nous vous aiderons à résoudre le problème.</string>
     <string name="upgrade_screen_restore_inconclusive_message">La vérification avec Google Play n\'a pas abouti à temps, votre statut d\'achat est donc toujours inconnu. Rien n\'a changé sur votre compte.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Vous êtes Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Merci de soutenir Octi ! Vos fonctionnalités Pro sont déverrouillées.</string>
     <string name="upgrade_screen_owned_iap_title">Achat unique</string>
     <string name="upgrade_screen_owned_iap_body">Vous possédez l’achat Pro unique. Il n’expire jamais.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnement</string>
@@ -79,7 +76,6 @@ Mêmes fonctions, juste des modèles tarifaires différents.</string>
     <string name="upgrade_screen_owned_both_title">Vous possédez les deux</string>
     <string name="upgrade_screen_owned_both_warning">Vous possédez à la fois l’abonnement et l’achat unique. Pour éviter de payer deux fois, annulez l’abonnement dans Google Play — vous conservez Pro grâce à l’achat unique.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Vous êtes Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Merci d’avoir acheté %1$s ! Vos fonctionnalités Pro sont déverrouillées et n’expirent jamais.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Merci de votre abonnement à %1$s ! Vos fonctionnalités Pro sont déverrouillées.</string>
     <string name="upgrade_screen_manage_subscription_action">Gérer l’abonnement</string>

--- a/app/src/gplay/res/values-ga/strings.xml
+++ b/app/src/gplay/res/values-ga/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Níl Google Play ar fáil</string>
     <string name="upgrades_gplay_unavailable_error_description">Ní féidir le Octi nascadh le Google Play. An bhfuil Google Play suiteáilte agus cothrom le dáta? An bhfuil do Chuntas Google logáilte isteach? Bain triail as taisce an aipe Google Play a ghlanadh agus an gléas a atosú.</string>
     <string name="upgrades_no_purchases_found_check_account">Níor aimsíodh aon cheannacháin. An bhfuil tú ag úsáid an chuntais cheart?</string>
-    <string name="upgrades_dashcard_title">Faigh Octi Pro</string>
     <string name="upgrades_dashcard_body">Uasghrádaigh chun gnéithe breise a dhíghlasáil agus tacú le forbairt!</string>
     <string name="upgrades_dashcard_upgrade_action">Uasghrádú</string>
     <string name="upgrade_screen_preamble">Níl fógraí ar Octi agus ní dhíoltar sonraí úsáideora. Maoiníonn tusa mo chuid oibre ❤️.</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play nije dostupan</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se ne može povezati s Google Playom. Je li Google Play instaliran i ažuriran? Jeste li prijavljeni na svoj Google račun? Pokušajte izbrisati predmemoriju aplikacije Google Play i ponovno pokrenuti uređaj.</string>
     <string name="upgrades_no_purchases_found_check_account">Nema pronađenih kupnji. Koristite li pravi račun?</string>
-    <string name="upgrades_dashcard_title">Nabavite Octi Pro</string>
     <string name="upgrades_dashcard_body">Nadogradite kako biste otključali dodatne značajke i podržali razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadogradi</string>
     <string name="upgrade_screen_preamble">Octi nema oglase i ne prodaje korisničke podatke. Moj rad financirate vi ❤️.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">A Google Play jelenleg nem kínálja ezt az upgrade opciót. Próbáld később vagy ellenőrizd a Google Play Store-t.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nem sikerült a Google Play megnyitása. Az alkalmazás hiányozhat, letiltott lehet vagy korlátozott ezen az eszközön.</string>
-    <string name="upgrades_dashcard_title">Szerezze be az Octi Pro-t</string>
     <string name="upgrades_dashcard_body">Frissíts további funkciók eléréséhez és a fejlesztés támogatásához!</string>
     <string name="upgrades_dashcard_upgrade_action">Frissítés</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Még mindig nem működik? Fordulj az ügyfélszolgálathoz, és segítünk rendezni.</string>
     <string name="upgrade_screen_restore_inconclusive_message">A Google Play-vel való ellenőrzés nem fejeződött be időben, ezért a vásárlási állapot továbbra sem ismert. Semmi sem változott a fiókodon.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Te vagy az Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Köszönjük az Octi támogatásáért! A Pro funkciók feloldottak.</string>
     <string name="upgrade_screen_owned_iap_title">Élettartam vásárlás</string>
     <string name="upgrade_screen_owned_iap_body">Megvetted az egyszeri Pro vásárlást. Soha nem jár le.</string>
     <string name="upgrade_screen_owned_sub_title">Előfizetés</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Mindkettőt birtoklod</string>
     <string name="upgrade_screen_owned_both_warning">Mindkettőt birtoklod: az előfizetést és az egyszeri vásárlást. Hogy ne fizess kétszer, mondj le az előfizetésről a Google Play-ben — az élettartam vásárlás révén megtartod a Pro-t.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Te vagy az Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Köszönjük a %1$s vásárlást! A Pro funkciók feloldottak és soha nem járnak le.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Köszönjük a %1$s-ra való feliratkozást! A Pro funkciók feloldottak.</string>
     <string name="upgrade_screen_manage_subscription_action">Előfizetés kezelése</string>

--- a/app/src/gplay/res/values-id/strings.xml
+++ b/app/src/gplay/res/values-id/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi tidak dapat terhubung ke Google Play. Apakah Google Play sudah terinstal dan terbaru? Apakah akun Google Anda sudah masuk? Coba bersihkan cache aplikasi Google Play dan hidupkan ulang perangkat Anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Tidak ada pembelian yang ditemukan. Apakah Anda menggunakan akun yang benar?</string>
-    <string name="upgrades_dashcard_title">Dapatkan Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade untuk membuka fitur tambahan dan dukung pengembangan!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>
     <string name="upgrade_screen_preamble">Octi tidak menampilkan iklan dan tidak menjual data pengguna. Karya saya didanai oleh Anda ❤️.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play er ekki í boði</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Er Google-aðgangurinn þinn virkur? Prófaðu að hreinsa skyndiminni fyrir Google Play og endurræsa tækið.</string>
     <string name="upgrades_no_purchases_found_check_account">Engar kaupfundust. Ertu að nota rétta reikninginn?</string>
-    <string name="upgrades_dashcard_title">Fá Octi Pro</string>
     <string name="upgrades_dashcard_body">Uppfærðu til að opna fleiri eiginleika og styðja við þróunina!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppfæra</string>
     <string name="upgrade_screen_preamble">Octi er án auglýsinga og selur ekki notendagögn. Verk mitt er fjármagnað af þér ❤️.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play attualmente non offre questa opzione di upgrade. Riprova più tardi o controlla Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Impossibile aprire Google Play. Potrebbe mancare, essere disabilitato o limitato su questo dispositivo.</string>
-    <string name="upgrades_dashcard_title">Ottieni Octi Pro</string>
     <string name="upgrades_dashcard_body">Aggiorna per sbloccare funzionalità aggiuntive e supportare lo sviluppo!</string>
     <string name="upgrades_dashcard_upgrade_action">Aggiorna</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@
     <string name="upgrade_screen_restore_contact_hint">Ancora bloccato? Contatta il supporto e ti aiuteremo a risolvere.</string>
     <string name="upgrade_screen_restore_inconclusive_message">La verifica con Google Play non è stata completata in tempo, quindi il tuo stato di acquisto è ancora sconosciuto. Nulla è cambiato sul tuo account.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Sei Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Grazie per aver supportato Octi! Le tue funzionalità Pro sono sbloccate.</string>
     <string name="upgrade_screen_owned_iap_title">Acquisto permanente</string>
     <string name="upgrade_screen_owned_iap_body">Possiedi l’acquisto Pro permanente. Non scade mai.</string>
     <string name="upgrade_screen_owned_sub_title">Abbonamento</string>
@@ -79,7 +76,6 @@
     <string name="upgrade_screen_owned_both_title">Possiedi entrambi</string>
     <string name="upgrade_screen_owned_both_warning">Possiedi sia l’abbonamento che l’acquisto una tantum. Per evitare di pagare due volte, annulla l’abbonamento in Google Play — manterrai Pro tramite l’acquisto a vita.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Sei Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Grazie per aver acquistato %1$s! Le tue funzioni Pro sono sbloccate e non scadono mai.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Grazie per aver sottoscritto %1$s! Le tue funzioni Pro sono sbloccate.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestisci l’abbonamento</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play כרגע לא מציעה אפשרות שדרוג זו. אנא נסה שוב מאוחר יותר או בדוק את Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">לא היה אפשר לפתוח את Google Play. ייתכן שהוא חסר, מבוטל או מוגבל בהתקן זה.</string>
-    <string name="upgrades_dashcard_title">קבל את Octi פרמיום</string>
     <string name="upgrades_dashcard_body">שדרג כדי לפתוח תכונות נוספות ולתמוך בפיתוח!</string>
     <string name="upgrades_dashcard_upgrade_action">שדרוג</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -70,8 +69,6 @@
     <string name="upgrade_screen_restore_contact_hint">עדיין תקוע? צור קשר עם התמיכה ואנחנו נעזור לסדר את זה.</string>
     <string name="upgrade_screen_restore_inconclusive_message">הבדיקה עם Google Play לא הושלמה בזמן, כך שמצב הרכישה שלך עדיין לא ידוע. שום דבר לא השתנה בחשבונך.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">אתה Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">תודה על תמיכתך ב-Octi! תכונות ה-Pro שלך פתוחות.</string>
     <string name="upgrade_screen_owned_iap_title">רכישה לחיים</string>
     <string name="upgrade_screen_owned_iap_body">אתה בעלים של רכישת Pro חד פעמית. היא לעולם לא תפוג.</string>
     <string name="upgrade_screen_owned_sub_title">מנוי</string>
@@ -80,7 +77,6 @@
     <string name="upgrade_screen_owned_both_title">יש לך שניהם</string>
     <string name="upgrade_screen_owned_both_warning">יש לך גם המנוי וגם את הרכישה החד-פעמית. כדי להימנע מתשלום כפול, בטל את המנוי ב-Google Play — אתה תשמור על Pro דרך הרכישה לכל החיים.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">אתה Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">תודה על קנייתך של %1$s! תכונות Pro שלך פתוחות ולא יפוגו לעולם.</string>
     <string name="upgrade_screen_owned_hero_sub_body">תודה על הרשמתך ל-%1$s! תכונות Pro שלך פתוחות.</string>
     <string name="upgrade_screen_manage_subscription_action">ניהול המנוי</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Playは現在、このアップグレードオプションを提供していません。後でもう一度試すか、Google Play Storeを確認してください。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play を開けませんでした。このデバイスでは見つからないか、無効になっているか、制限されている可能性があります。</string>
-    <string name="upgrades_dashcard_title">Octi Pro を入手</string>
     <string name="upgrades_dashcard_body">アップグレードで追加機能の入手と開発を支援します！</string>
     <string name="upgrades_dashcard_upgrade_action">アップグレード</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -67,8 +66,6 @@
     <string name="upgrade_screen_restore_contact_hint">まだ解決しませんか？サポートにご連絡ください。解決に向けてお手伝いします。</string>
     <string name="upgrade_screen_restore_inconclusive_message">Google Playでの確認がタイムアウトしました。購入ステータスはまだ不明です。アカウントには何も変わっていません。</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">あなたはOcti Proです 🎉</string>
-    <string name="upgrade_screen_owned_body">Octiをサポートしていただきありがとうございます！Pro機能がロック解除されました。</string>
     <string name="upgrade_screen_owned_iap_title">永久購入</string>
     <string name="upgrade_screen_owned_iap_body">一回限りのPro購入を所有しています。期限はありません。</string>
     <string name="upgrade_screen_owned_sub_title">サブスクリプション</string>
@@ -77,7 +74,6 @@
     <string name="upgrade_screen_owned_both_title">両方を所有しています</string>
     <string name="upgrade_screen_owned_both_warning">サブスクリプションと一回限りの購入の両方を所有しています。二重支払いを避けるには、Google Playでサブスクリプションをキャンセルしてください — 永久購入によってProは継続されます。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">あなたはOcti Proです 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$sをご購入いただきありがとうございます！Pro機能がロック解除され、期限はありません。</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$sにご登録いただきありがとうございます！Pro機能がロック解除されました。</string>
     <string name="upgrade_screen_manage_subscription_action">サブスクリプションを管理</string>

--- a/app/src/gplay/res/values-ka/strings.xml
+++ b/app/src/gplay/res/values-ka/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play მიუწვდომელია</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ვერ უკავშირდება Google Play-ს. Google Play არის დამყენებული და განახლებული? თქვენ შედიხართ Google ანგარიშით? სცადეთ Google Play აპის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
     <string name="upgrades_no_purchases_found_check_account">ვერ მოიძებნა შეძენილი პროდუქტები. ნამდვილად სწორ ანგარიშს იყენებთ?</string>
-    <string name="upgrades_dashcard_title">მიიღეთ Octi Pro</string>
     <string name="upgrades_dashcard_body">განაახლეთ თქვენი Octi დამატებითი შესაძლებლობების გასახსნელად და განვითარების მხარდასაჭერად!</string>
     <string name="upgrades_dashcard_upgrade_action">განახლება</string>
     <string name="upgrade_screen_preamble">Octi-ს არ აქვს რეკლამები და არ ყიდის მომხმარებლის მონაცემებს. ჩემი საქმიანობა ფინანსდება თქვენით ❤️.</string>

--- a/app/src/gplay/res/values-kk/strings.xml
+++ b/app/src/gplay/res/values-kk/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play қолжетімсіз</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi Google Play қызметіне қосыла алмайды. Google Play орнатылған және жаңартылған ба? Google есептік жазбаңызға кіргенсіз бе? Google Play қолданбасының кэшін тазалап, құрылғыны қайта іске қосып көріңіз.</string>
     <string name="upgrades_no_purchases_found_check_account">Сатып алулар табылмады. Дұрыс есептік жазбаны пайдаланудасыз ба?</string>
-    <string name="upgrades_dashcard_title">Octi Pro алыңыз</string>
     <string name="upgrades_dashcard_body">Қосымша мүмкіндіктерді ашу және дамуды қолдау үшін жаңартыңыз!</string>
     <string name="upgrades_dashcard_upgrade_action">Жаңарту</string>
     <string name="upgrade_screen_preamble">Octi жарнамаларды көрсетпейді және пайдаланушы деректерін сатпайды. Менің жұмысым сіздің қолдауыңызбен қаржыландырылады ❤️.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play에서 현재 이 업그레이드 옵션을 제공하지 않습니다. 나중에 다시 시도하거나 Google Play 스토어를 확인해주세요.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play를 열 수 없습니다. 이 기기에서 Google Play가 없거나 비활성화되었거나 제한되었을 수 있습니다.</string>
-    <string name="upgrades_dashcard_title">Octi Pro 받기</string>
     <string name="upgrades_dashcard_body">업그레이드하여 추가 기능을 잠금 해제하고 개발을 지원하세요!</string>
     <string name="upgrades_dashcard_upgrade_action">업그레이드</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -67,8 +66,6 @@
     <string name="upgrade_screen_restore_contact_hint">여전히 문제가 있나요? 지원팀에 문의하면 도와드리겠습니다.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Google Play 확인이 시간 내에 완료되지 않아 구매 상태를 알 수 없습니다. 계정에는 변화가 없습니다.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">당신은 Octi Pro입니다 🎉</string>
-    <string name="upgrade_screen_owned_body">Octi를 지원해주셔서 감사합니다! Pro 기능이 잠금 해제되었습니다.</string>
     <string name="upgrade_screen_owned_iap_title">평생 구매</string>
     <string name="upgrade_screen_owned_iap_body">일회성 Pro 구매를 소유하고 있습니다. 절대 만료되지 않습니다.</string>
     <string name="upgrade_screen_owned_sub_title">구독</string>
@@ -77,7 +74,6 @@
     <string name="upgrade_screen_owned_both_title">둘 다 소유하고 있습니다</string>
     <string name="upgrade_screen_owned_both_warning">구독과 일회성 구매를 모두 소유하고 있습니다. 중복 결제를 피하려면 Google Play에서 구독을 취소하세요 — 평생 구매를 통해 Pro를 계속 유지합니다.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">당신은 Octi Pro입니다 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s를 구매해주셔서 감사합니다! Pro 기능이 잠금 해제되었으며 절대 만료되지 않습니다.</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$s를 구독해주셔서 감사합니다! Pro 기능이 잠금 해제되었습니다.</string>
     <string name="upgrade_screen_manage_subscription_action">구독 관리</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play nepasiekiama</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nepavyksta prisijungti prie Google Play. Ar Google Play įdiegta ir atnaujinta? Ar jūsų Google paskyra yra prisijungusi? Pabandykite išvalyti Google Play programos podėlį ir paleisti įrenginį iš naujo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nerasta jokių pirkinių. Ar naudojate tinkamą paskyrą?</string>
-    <string name="upgrades_dashcard_title">Gauti Octi Pro</string>
     <string name="upgrades_dashcard_body">Atnaujinkite, kad atrakintumėte papildomas funkcijas ir palaikytumėte tobulinimą!</string>
     <string name="upgrades_dashcard_upgrade_action">Atnaujinti</string>
     <string name="upgrade_screen_preamble">Octi neturi reklamų ir neparduoda naudotojų duomenų. Mano darbą finansuojate jūs ❤️.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play nav pieejams</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai jūsu Google konts ir pieslēgts? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un restartēt ierīci.</string>
     <string name="upgrades_no_purchases_found_check_account">Netika atrasti pirkumi. Vai izmantojat pareizo kontu?</string>
-    <string name="upgrades_dashcard_title">Iegūt Octi Pro</string>
     <string name="upgrades_dashcard_body">Atjauniniet, lai atbloķētu papildu funkcijas un atbalstītu izstrādi!</string>
     <string name="upgrades_dashcard_upgrade_action">Atjaunināt</string>
     <string name="upgrade_screen_preamble">Octi nerāda reklāmas un nepārdod lietotāju datus. Manu darbu finansējat jūs ❤️.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi tidak dapat menyambung ke Google Play. Adakah Google Play telah dipasang dan dikemas kini? Adakah akaun Google anda telah log masuk? Cuba kosongkan cache aplikasi Google Play dan mulakan semula peranti anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Tiada pembelian dijumpai. Adakah anda menggunakan akaun yang betul?</string>
-    <string name="upgrades_dashcard_title">Dapatkan Octi Pro</string>
     <string name="upgrades_dashcard_body">Naik taraf untuk membuka ciri tambahan dan menyokong pembangunan!</string>
     <string name="upgrades_dashcard_upgrade_action">Naik Taraf</string>
     <string name="upgrade_screen_preamble">Octi tiada iklan dan tidak menjual data pengguna. Kerja saya dibiayai oleh anda ❤️.</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbyr ikke denne oppgraderingsalternativet nå. Vennligst prøv igjen senere eller sjekk Google Play Butikk.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunne ikke åpne Google Play. Det kan mangle, være deaktivert eller begrenset på denne enheten.</string>
-    <string name="upgrades_dashcard_title">Få Octi Pro</string>
     <string name="upgrades_dashcard_body">Oppgrader for å låse opp flere funksjoner og støtte utvikling!</string>
     <string name="upgrades_dashcard_upgrade_action">Oppgrader</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@ Samme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_restore_contact_hint">Fortsatt fast? Kontakt support og vi hjelper til med å løse det.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play ble ikke fullført i tide, så kjøpsstatusen din er fortsatt ukjent. Ingenting har endret seg på kontoen din.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Du er Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Takk for at du støtter Octi! Dine Pro-funksjoner er låst opp.</string>
     <string name="upgrade_screen_owned_iap_title">Livstidskjøp</string>
     <string name="upgrade_screen_owned_iap_body">Du eier engangs-Pro-kjøpet. Det utløper aldri.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnement</string>
@@ -79,7 +76,6 @@ Samme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_owned_both_title">Du eier begge</string>
     <string name="upgrade_screen_owned_both_warning">Du eier både abonnementet og engangs-kjøpet. For å unngå å betale dobbelt, avbryt abonnementet i Google Play – du beholder Pro gjennom livstidskjøpet.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Du er Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Takk for at du kjøpte %1$s! Dine Pro-funksjoner er låst opp og utløper aldri.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Takk for at du abonnerte på %1$s! Dine Pro-funksjoner er låst opp.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play biedt deze upgrade-optie momenteel niet aan. Probeer het later opnieuw of raadpleeg de Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kon Google Play niet openen. Het kan ontbreken, uitgeschakeld of beperkt zijn op dit apparaat.</string>
-    <string name="upgrades_dashcard_title">Krijg Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade om extra functies te ontgrendelen en de ontwikkeling te steunen!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgraden</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@ Dezelfde functies, gewoon verschillende prijsmodellen.</string>
     <string name="upgrade_screen_restore_contact_hint">Zit je nog vast? Neem contact op met support en we helpen je graag.</string>
     <string name="upgrade_screen_restore_inconclusive_message">De controle bij Google Play is niet op tijd voltooid, waardoor de status van je aankoop nog steeds onbekend is. Er is niets gewijzigd in je account.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Je bent Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Bedankt dat je Octi ondersteunt! Je Pro-functies zijn ontgrendeld.</string>
     <string name="upgrade_screen_owned_iap_title">Levenslange aankoop</string>
     <string name="upgrade_screen_owned_iap_body">Je hebt de eenmalige Pro-aankoop. Deze verloopt nooit.</string>
     <string name="upgrade_screen_owned_sub_title">Abonnement</string>
@@ -79,7 +76,6 @@ Dezelfde functies, gewoon verschillende prijsmodellen.</string>
     <string name="upgrade_screen_owned_both_title">Je hebt beide</string>
     <string name="upgrade_screen_owned_both_warning">Je hebt zowel het abonnement als de eenmalige aankoop. Om dubbel betalen te vermijden, annuleer het abonnement in Google Play — je houdt Pro door de levenslange aankoop.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Je bent Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bedankt voor het kopen van %1$s! Je Pro-functies zijn ontgrendeld en verlopen nooit.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Bedankt voor het abonneren op %1$s! Je Pro-functies zijn ontgrendeld.</string>
     <string name="upgrade_screen_manage_subscription_action">Abonnement beheren</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Sklep Google Play obecnie nie oferuje tej opcji aktualizacji. Spróbuj ponownie później lub sprawdź w Sklepie Google Play.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nie udało się otworzyć Sklepu Google Play. Aplikacja może być niedostępna, wyłączona lub ograniczona na tym urządzeniu.</string>
-    <string name="upgrades_dashcard_title">Uzyskaj Octi Pro</string>
     <string name="upgrades_dashcard_body">Uaktualnij, aby odblokować dodatkowe funkcje i wesprzeć rozwój!</string>
     <string name="upgrades_dashcard_upgrade_action">Uaktualnij</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -70,8 +69,6 @@
     <string name="upgrade_screen_restore_contact_hint">Nadal masz problem? Skontaktuj się z pomocą techniczną, a pomożemy ci go rozwiązać.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Weryfikacja w Sklepie Google Play nie zakończyła się na czas, więc status twojego zakupu jest nadal nieznany. Na twoim koncie nic się nie zmieniło.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Jesteś Octi Pro</string>
-    <string name="upgrade_screen_owned_body">Dziękuję za wsparcie Octi! Twoje funkcje Pro są odblokowane.</string>
     <string name="upgrade_screen_owned_iap_title">Zakup dożywotni</string>
     <string name="upgrade_screen_owned_iap_body">Jesteś właścicielem jednorazowego zakupu Pro. Nigdy nie wygasa.</string>
     <string name="upgrade_screen_owned_sub_title">Subskrypcja</string>
@@ -80,7 +77,6 @@
     <string name="upgrade_screen_owned_both_title">Jesteś właścicielem obu</string>
     <string name="upgrade_screen_owned_both_warning">Posiadasz zarówno subskrypcję, jak i jednorazowy zakup. Aby uniknąć podwójnego płacenia, anuluj subskrypcję w Sklepie Google Play — trzymasz Pro przez dożywotni zakup.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Jesteś Octi Pro</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dziękujemy za zakup %1$s! Twoje funkcje Pro są odblokowane i nigdy nie wygasają.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dziękuję za subskrybowanie %1$s! Twoje funkcje Pro są odblokowane.</string>
     <string name="upgrade_screen_manage_subscription_action">Zarządzaj subskrypcją</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play não está oferecendo essa opção de upgrade no momento. Tente novamente mais tarde ou verifique a Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Ele pode estar ausente, desabilitado ou restrito neste dispositivo.</string>
-    <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Atualize para desbloquear recursos adicionais e apoiar o desenvolvimento!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@ Os mesmos recursos, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_restore_contact_hint">Ainda com dúvidas? Entre em contato com o suporte e ajudaremos a resolver.</string>
     <string name="upgrade_screen_restore_inconclusive_message">A verificação com o Google Play não foi concluída a tempo, portanto seu status de compra ainda é desconhecido. Nada foi alterado em sua conta.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Você é Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Obrigado por apoiar o Octi! Seus recursos Pro estão desbloqueados.</string>
     <string name="upgrade_screen_owned_iap_title">Compra vitalícia</string>
     <string name="upgrade_screen_owned_iap_body">Você tem a compra única do Pro. Nunca expira.</string>
     <string name="upgrade_screen_owned_sub_title">Assinatura</string>
@@ -79,7 +76,6 @@ Os mesmos recursos, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_owned_both_title">Você tem ambos</string>
     <string name="upgrade_screen_owned_both_warning">Você tem tanto a assinatura quanto a compra única. Para evitar pagar duas vezes, cancele a assinatura no Google Play — você mantém o Pro através da compra vitalícia.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Você é Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Obrigado por comprar %1$s! Seus recursos Pro estão desbloqueados e nunca expiram.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Obrigado por se inscrever em %1$s! Seus recursos Pro estão desbloqueados.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerenciar assinatura</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">A Google Play não está a oferecer esta opção de atualização neste momento. Tente novamente mais tarde ou consulte a Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Não foi possível abrir a Google Play. Pode estar ausente, desativada ou bloqueada neste dispositivo.</string>
-    <string name="upgrades_dashcard_title">Obter Octi Pro</string>
     <string name="upgrades_dashcard_body">Atualize para desbloquear recursos adicionais e apoiar o desenvolvimento!</string>
     <string name="upgrades_dashcard_upgrade_action">Atualizar</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Ainda com problemas? Contacte o suporte e ajudaremos a resolver.</string>
     <string name="upgrade_screen_restore_inconclusive_message">A verificação com a Google Play não foi concluída a tempo, por isso o estado da sua compra permanece desconhecido. Nada foi alterado na sua conta.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">É Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Obrigado por apoiar o Octi! As suas funcionalidades Pro estão desbloqueadas.</string>
     <string name="upgrade_screen_owned_iap_title">Compra vitalícia</string>
     <string name="upgrade_screen_owned_iap_body">Tem a compra Pro única. Nunca expira.</string>
     <string name="upgrade_screen_owned_sub_title">Subscrição</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Tem ambas</string>
     <string name="upgrade_screen_owned_both_warning">Tem a subscrição e a compra única. Para evitar pagar duas vezes, cancele a subscrição no Google Play — mantém o Pro através da compra vitalícia.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">É Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Obrigado por comprar %1$s! As suas funcionalidades Pro estão desbloqueadas e nunca expiram.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Obrigado por subscrever %1$s! As suas funcionalidades Pro estão desbloqueadas.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerir subscrição</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play nu oferă în prezent această opțiune de upgrade. Încercați din nou mai târziu sau verificați Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nu se poate deschide Google Play. E posibil să lipsească, să fie dezactivat sau restricționat pe acest dispozitiv.</string>
-    <string name="upgrades_dashcard_title">Obține Octi Pro</string>
     <string name="upgrades_dashcard_body">Fă upgrade pentru a debloca funcții suplimentare și a sprijini dezvoltarea!</string>
     <string name="upgrades_dashcard_upgrade_action">Actualizează</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@
     <string name="upgrade_screen_restore_contact_hint">Încă blocat? Contactează asistența și te vom ajuta să rezolvi problema.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Verificarea cu Google Play nu s-a finalizat la timp, deci starea achiziției dvs. este încă necunoscută. Nimic nu s-a schimbat în contul dvs.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Ești Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Mulțumesc pentru suportul acordat Octi! Caracteristicile tale Pro sunt deblocate.</string>
     <string name="upgrade_screen_owned_iap_title">Achiziție pe viață</string>
     <string name="upgrade_screen_owned_iap_body">Deții achiziția Pro unică. Nu expiră niciodată.</string>
     <string name="upgrade_screen_owned_sub_title">Abonament</string>
@@ -79,7 +76,6 @@
     <string name="upgrade_screen_owned_both_title">Deții ambele</string>
     <string name="upgrade_screen_owned_both_warning">Deții atât abonamentul cât și achiziția unică. Pentru a evita plata de două ori, anulează abonamentul în Google Play — păstrezi Pro prin achiziția pe viață.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Ești Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Mulțumesc că ai cumpărat %1$s! Caracteristicile tale Pro sunt deblocate și nu expiră niciodată.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Mulțumesc că te-ai abonat la %1$s! Caracteristicile tale Pro sunt deblocate.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestionează abonamentul</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">В настоящее время Google Play не предлагает эту опцию обновления. Пожалуйста, повторите попытку позже или проверьте Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, он отсутствует, отключен или недоступен на этом устройстве.</string>
-    <string name="upgrades_dashcard_title">Получить Octi Pro</string>
     <string name="upgrades_dashcard_body">Обновитесь, чтобы разблокировать дополнительные функции и поддержать развитие!</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -70,8 +69,6 @@
     <string name="upgrade_screen_restore_contact_hint">Всё ещё не получается? Обратитесь в службу поддержки и мы поможем разобраться.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Проверка с Google Play не закончилась вовремя, поэтому статус покупки до сих пор неизвестен. В Вашей учетной записи ничего не изменилось.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Вы с Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Спасибо за поддержку Octi! Ваши функции Pro разблокированы.</string>
     <string name="upgrade_screen_owned_iap_title">Единовременная покупка</string>
     <string name="upgrade_screen_owned_iap_body">У Вас есть единовременная покупка Pro. Она никогда не истекает.</string>
     <string name="upgrade_screen_owned_sub_title">Подписка</string>
@@ -80,7 +77,6 @@
     <string name="upgrade_screen_owned_both_title">У Вас оба варианта</string>
     <string name="upgrade_screen_owned_both_warning">У Вас есть как подписка, так и единоразовая покупка. Чтобы избежать двойной оплаты, отмените подписку в Google Play — Вы обладатель Pro посредством покупки.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Вы с Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Спасибо за покупку %1$s! Ваши функции Pro разблокированы и никогда не заканчиваются.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Спасибо за подписку на %1$s! Ваши функции Pro разблокированы.</string>
     <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play nie je dostupný</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi sa nemôže pripojiť k službe Google Play. Je Google Play nainštalovaný a aktuálny? Je váš účet Google prihlásený? Skúste vymazať vyrovnávaciu pamäť aplikácie Google Play a reštartovať zariadenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>
-    <string name="upgrades_dashcard_title">Získať Octi Pro</string>
     <string name="upgrades_dashcard_body">Prejdite na vyššiu verziu a odomknite ďalšie funkcie a podporíte vývoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Aktualizovať</string>
     <string name="upgrade_screen_preamble">Octi nemá reklamy a nepredáva údaje používateľov. Moja práca je financovaná vami ❤️.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play ni na voljo</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi se ne more povezati z Google Play. Ali je Google Play nameščen in posodobljen? Ali ste prijavljeni v svoj Google račun? Poskusite počistiti predpomnilnik aplikacije Google Play in znova zagnati napravo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nakupi niso bili najdeni. Ali uporabljate pravi račun?</string>
-    <string name="upgrades_dashcard_title">Pridobite Octi Pro</string>
     <string name="upgrades_dashcard_body">Nadgradite za odklep dodatnih funkcij in podprite razvoj!</string>
     <string name="upgrades_dashcard_upgrade_action">Nadgradi</string>
     <string name="upgrade_screen_preamble">Octi ne prikazuje oglasov in ne prodaja podatkov uporabnikov. Moje delo financirate vi ❤️.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play тренутно не нуди ову опцију надградње. Молимо покушајте касније или проверите Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не може се отворити Google Play. Могуће је да недостаје, да је онемогућена или ограничена на овом уређају.</string>
-    <string name="upgrades_dashcard_title">Преузмите Octi Pro</string>
     <string name="upgrades_dashcard_body">Надоградите да бисте откључали додатне функције и подржали развој!</string>
     <string name="upgrades_dashcard_upgrade_action">Надогради</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@
     <string name="upgrade_screen_restore_contact_hint">Још увек заглављени? Контактирајте подршку и помоћићемо вам да то решимо.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Провера са Google Play није завршена на време, па је статус ваше куповине и даље непознат. Ништа се није променило на вашем налогу.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Ви сте Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Хвала вам што подржавате Octi! Ваше Pro функције су откључане.</string>
     <string name="upgrade_screen_owned_iap_title">Доживотна куповина</string>
     <string name="upgrade_screen_owned_iap_body">Поседујете једнократну Pro куповину. Никада не истиче.</string>
     <string name="upgrade_screen_owned_sub_title">Претплата</string>
@@ -79,7 +76,6 @@
     <string name="upgrade_screen_owned_both_title">Поседујете оба</string>
     <string name="upgrade_screen_owned_both_warning">Поседујете и претплату и једнократну куповину. Да бисте избегли двоструко плаћање, откажите претплату у Google Play — задржавате Pro кроз доживотну куповину.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Ви сте Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Хвала вам што сте купили %1$s! Ваше Pro функције су откључане и никада не истичу.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Хвала вам што сте се претплатили на %1$s! Ваше Pro функције су откључане.</string>
     <string name="upgrade_screen_manage_subscription_action">Управљајте претплатом</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play erbjuder för närvarande inte det här uppgraderingsalternativet. Försök igen senare eller kontrollera Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunde inte öppna Google Play. Det kanske saknas, är inaktiverat eller begränsat på denna enhet.</string>
-    <string name="upgrades_dashcard_title">Skaffa Octi Pro</string>
     <string name="upgrades_dashcard_body">Uppgradera för att låsa upp fler funktioner och stödja utvecklingen!</string>
     <string name="upgrades_dashcard_upgrade_action">Uppgradera</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">Fortfarande fast? Kontakta supporten så hjälper vi dig att lösa det.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Kontrollen med Google Play avslutades inte i tid, så din köpstatus är fortfarande okänd. Ingenting har ändrats på ditt konto.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Du är Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Tack för att du stödjer Octi! Dina Pro-funktioner är upplåsta.</string>
     <string name="upgrade_screen_owned_iap_title">Livstidsköp</string>
     <string name="upgrade_screen_owned_iap_body">Du äger engångsköpet av Pro. Det upphör aldrig att gälla.</string>
     <string name="upgrade_screen_owned_sub_title">Prenumeration</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">Du äger båda</string>
     <string name="upgrade_screen_owned_both_warning">Du äger både prenumerationen och engångsköpet. För att undvika att betala två gånger, avsluta prenumerationen i Google Play — du behåller Pro genom livstidsköpet.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Du är Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tack för att du köpte %1$s! Dina Pro-funktioner är upplåsta och upphör aldrig att gälla.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tack för att du prenumererar på %1$s! Dina Pro-funktioner är upplåsta.</string>
     <string name="upgrade_screen_manage_subscription_action">Hantera prenumeration</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrades_gplay_unavailable_error_title">Google Play ไม่พร้อมใช้งาน</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi ไม่สามารถเชื่อมต่อกับ Google Play ได้ ติดตั้งและอัปเดต Google Play แล้วหรือยัง? คุณเข้าสู่ระบบด้วยบัญชี Google หรือไม่? ลองล้างแคชของแอป Google Play และรีสตาร์ทอุปกรณ์ของคุณ</string>
     <string name="upgrades_no_purchases_found_check_account">ไม่พบการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>
-    <string name="upgrades_dashcard_title">รับ Octi Pro</string>
     <string name="upgrades_dashcard_body">อัปเกรดเพื่อปลดล็อกฟีเจอร์เพิ่มเติมและสนับสนุนการพัฒนา!</string>
     <string name="upgrades_dashcard_upgrade_action">อัปเกรด</string>
     <string name="upgrade_screen_preamble">Octi ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ งานของฉันได้รับเงินสนับสนุนจากคุณ ❤️</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play şu anda bu yükseltme seçeneğini sunmuyor. Lütfen daha sonra tekrar deneyin veya Google Play Store\'u kontrol edin.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play açılamadı. Cihazda eksik, devre dışı bırakılmış veya kısıtlanmış olabilir.</string>
-    <string name="upgrades_dashcard_title">Octi Pro Al</string>
     <string name="upgrades_dashcard_body">Ek özelliklerin kilidini açmak ve geliştirmeyi desteklemek için yükseltin!</string>
     <string name="upgrades_dashcard_upgrade_action">Yükselt</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -69,8 +68,6 @@ Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_restore_contact_hint">Hâlâ sorun mu yaşıyorsunuz? Destek ekibiyle iletişime geçin, sorunu birlikte çözelim.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Google Play ile yapılan kontrol zamanında tamamlanmadığından, satın alma durumunuz hala bilinmiyor. Hesabınızda hiçbir şey değişmedi.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Octi Pro\'sunuz 🎉</string>
-    <string name="upgrade_screen_owned_body">Octi\'yi desteklediğiniz için teşekkürler! Pro özellikleriniz açıldı.</string>
     <string name="upgrade_screen_owned_iap_title">Ömür Boyu Satın Alma</string>
     <string name="upgrade_screen_owned_iap_body">Tek seferlik Pro satın alımına sahipsiniz. Hiçbir zaman süresi dolmaz.</string>
     <string name="upgrade_screen_owned_sub_title">Abonelik</string>
@@ -79,7 +76,6 @@ Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_owned_both_title">Her ikisine de sahipsiniz</string>
     <string name="upgrade_screen_owned_both_warning">Hem aboneliğe hem de tek seferlik satın almaya sahipsiniz. İki kez ödeme yapmamak için Google Play\'de aboneliği iptal edin — ömür boyu satın alma yoluyla Pro\'ya sahip olmaya devam edersiniz.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Siz Octi Pro\'sunuz 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Satın aldığınız %1$s için teşekkür ederiz! Pro özellikleriniz açık ve asla süresi dolmaz.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abone olduğunuz %1$s için teşekkür ederiz! Pro özellikleriniz açık.</string>
     <string name="upgrade_screen_manage_subscription_action">Aboneliği Yönetin</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play зараз не пропонує цей варіант оновлення. Будь ласка, спробуйте пізніше або перевірте Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не вдалося відкрити Google Play. Він може бути відсутнім, вимкненим або обмеженим на цьому пристрої.</string>
-    <string name="upgrades_dashcard_title">Отримати Octi Pro</string>
     <string name="upgrades_dashcard_body">Оновіть до Pro, щоб розблокувати додаткові функції та підтримати розвиток!</string>
     <string name="upgrades_dashcard_upgrade_action">Оновити</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -70,8 +69,6 @@
     <string name="upgrade_screen_restore_contact_hint">Все ще не виходить? Зв\'яжіться з підтримкою, і ми допоможемо з цим розібратися.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Перевірка з Google Play не завершилася вчасно, тому стан вашої покупки залишається невідомим. На вашому обліковому записі нічого не змінилося.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Ви — Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Дякуємо за підтримку Octi! Ваші функції Pro розблоковано.</string>
     <string name="upgrade_screen_owned_iap_title">Довічна покупка</string>
     <string name="upgrade_screen_owned_iap_body">Ви володієте одноразовою покупкою Pro. Вона ніколи не спливає.</string>
     <string name="upgrade_screen_owned_sub_title">Підписка</string>
@@ -80,7 +77,6 @@
     <string name="upgrade_screen_owned_both_title">Ви володієте обома</string>
     <string name="upgrade_screen_owned_both_warning">Ви володієте і підпискою, і одноразовою покупкою. Щоб не платити двічі, скасуйте підписку в Google Play — ви збережете Pro завдяки довічній покупці.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Ви — Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Дякуємо за покупку %1$s! Ваші функції Pro розблоковано і ніколи не спливають.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Дякуємо за підписку %1$s! Ваші функції Pro розблоковано.</string>
     <string name="upgrade_screen_manage_subscription_action">Керувати підпискою</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play hiện tại không cung cấp tùy chọn nâng cấp này. Vui lòng thử lại sau hoặc kiểm tra Google Play Store.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Không thể mở Google Play. Ứng dụng có thể bị thiếu, vô hiệu hóa hoặc bị hạn chế trên thiết bị này.</string>
-    <string name="upgrades_dashcard_title">Nhận Octi Pro</string>
     <string name="upgrades_dashcard_body">Nâng cấp để mở khóa các tính năng bổ sung và hỗ trợ phát triển!</string>
     <string name="upgrades_dashcard_upgrade_action">Nâng cấp</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@ Các tính năng giống nhau, chỉ khác các mô hình giá.</string>
     <string name="upgrade_screen_restore_contact_hint">Vẫn gặp vấn đề? Liên hệ hỗ trợ và chúng tôi sẽ giúp bạn giải quyết.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Kiểm tra với Google Play không kết thúc kịp thời, vì vậy trạng thái mua hàng của bạn vẫn chưa được xác định. Không có thay đổi nào trên tài khoản của bạn.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">Bạn là Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Cảm ơn bạn đã hỗ trợ Octi! Các tính năng Pro của bạn đã được mở khóa.</string>
     <string name="upgrade_screen_owned_iap_title">Mua trọn đời</string>
     <string name="upgrade_screen_owned_iap_body">Bạn sở hữu gói mua Pro một lần. Nó không bao giờ hết hạn.</string>
     <string name="upgrade_screen_owned_sub_title">Đăng ký</string>
@@ -78,7 +75,6 @@ Các tính năng giống nhau, chỉ khác các mô hình giá.</string>
     <string name="upgrade_screen_owned_both_title">Bạn sở hữu cả hai</string>
     <string name="upgrade_screen_owned_both_warning">Bạn sở hữu cả gói đăng ký và gói mua một lần. Để tránh thanh toán hai lần, hãy hủy gói đăng ký trong Google Play — bạn vẫn giữ Pro thông qua gói mua trọn đời.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">Bạn là Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Cảm ơn bạn đã mua %1$s! Các tính năng Pro của bạn đã được mở khóa và không bao giờ hết hạn.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Cảm ơn bạn đã đăng ký %1$s! Các tính năng Pro của bạn đã được mở khóa.</string>
     <string name="upgrade_screen_manage_subscription_action">Quản lý đăng ký</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前不提供此升级选项。请稍后重试或检查 Google Play Store。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">无法打开 Google Play。此设备上可能缺少、禁用或限制了该应用。</string>
-    <string name="upgrades_dashcard_title">获取Octi Pro</string>
     <string name="upgrades_dashcard_body">升级以解锁附加功能并支持开发！</string>
     <string name="upgrades_dashcard_upgrade_action">升级</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -67,8 +66,6 @@
     <string name="upgrade_screen_restore_contact_hint">仍然无法解决？请联系支持团队，我们将帮您解决。</string>
     <string name="upgrade_screen_restore_inconclusive_message">与 Google Play 的检查没有及时完成，因此您的购买状态仍然未知。您的账户没有任何改变。</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">您已拥有 Octi 专业版 🎉</string>
-    <string name="upgrade_screen_owned_body">感谢您对 Octi 的支持！您的专业版功能已解锁。</string>
     <string name="upgrade_screen_owned_iap_title">一次性购买</string>
     <string name="upgrade_screen_owned_iap_body">您拥有一次性专业版购买。它永不过期。</string>
     <string name="upgrade_screen_owned_sub_title">订阅</string>
@@ -77,7 +74,6 @@
     <string name="upgrade_screen_owned_both_title">您同时拥有两者</string>
     <string name="upgrade_screen_owned_both_warning">您同时拥有订阅和一次性购买。为避免重复付费，请在 Google Play 中取消订阅——您将通过一次性购买保留专业版。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">您已拥有 Octi 专业版 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">感谢您购买 %1$s！您的专业版功能已解锁且永不过期。</string>
     <string name="upgrade_screen_owned_hero_sub_body">感谢您订阅 %1$s！您的专业版功能已解锁。</string>
     <string name="upgrade_screen_manage_subscription_action">管理订阅</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -17,7 +17,6 @@
     <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前不提供此升級選項。請稍後重試或查看 Google Play 商店。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。應用程式可能已遺失、被停用或在此裝置上受到限制。</string>
-    <string name="upgrades_dashcard_title">取得 Octi Pro</string>
     <string name="upgrades_dashcard_body">升級以解鎖額外功能並支持開發！</string>
     <string name="upgrades_dashcard_upgrade_action">升級</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -68,8 +67,6 @@
     <string name="upgrade_screen_restore_contact_hint">還是卡住？聯絡支援，我們會幫您解決。</string>
     <string name="upgrade_screen_restore_inconclusive_message">與 Google Play 的檢查未能及時完成，因此您的購買狀態仍未知。您的帳戶未有任何變更。</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">您是 Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">感謝您支持 Octi！您的 Pro 功能已解鎖。</string>
     <string name="upgrade_screen_owned_iap_title">終身購買</string>
     <string name="upgrade_screen_owned_iap_body">您擁有一次性 Pro 購買。它永不過期。</string>
     <string name="upgrade_screen_owned_sub_title">訂閱</string>
@@ -78,7 +75,6 @@
     <string name="upgrade_screen_owned_both_title">您同時擁有兩者</string>
     <string name="upgrade_screen_owned_both_warning">您同時擁有訂閱和一次性購買。為避免重複付款，請在 Google Play 中取消訂閱 — 您將透過終身購買保留 Pro。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">您是 Octi Pro 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">感謝您購買 %1$s！您的 Pro 功能已解鎖，永不過期。</string>
     <string name="upgrade_screen_owned_hero_sub_body">感謝您訂閱 %1$s！您的 Pro 功能已解鎖。</string>
     <string name="upgrade_screen_manage_subscription_action">管理訂閱</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -23,7 +23,6 @@
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Couldn\'t open Google Play. It may be missing, disabled or restricted on this device.</string>
 
-    <string name="upgrades_dashcard_title">Get Octi Pro</string>
     <string name="upgrades_dashcard_body">Upgrade to unlock additional features and support development!</string>
     <string name="upgrades_dashcard_upgrade_action">Upgrade</string>
     <plurals name="upgrades_dashcard_device_limit_hint">
@@ -75,8 +74,6 @@
     <string name="upgrade_screen_restore_contact_hint">Still stuck? Contact support and we\'ll help sort it out.</string>
     <string name="upgrade_screen_restore_inconclusive_message">The check with Google Play didn\'t finish in time, so your purchase status is still unknown. Nothing has changed on your account.</string>
     <!-- Pro status / ownership -->
-    <string name="upgrade_screen_owned_title">You are Octi Pro 🎉</string>
-    <string name="upgrade_screen_owned_body">Thanks for supporting Octi! Your Pro features are unlocked.</string>
     <string name="upgrade_screen_owned_iap_title">Lifetime purchase</string>
     <string name="upgrade_screen_owned_iap_body">You own the one-time Pro purchase. It never expires.</string>
     <string name="upgrade_screen_owned_sub_title">Subscription</string>
@@ -85,7 +82,12 @@
     <string name="upgrade_screen_owned_both_title">You own both</string>
     <string name="upgrade_screen_owned_both_warning">You own both the subscription and the one-time purchase. To avoid paying twice, cancel the subscription in Google Play — you keep Pro through the lifetime purchase.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <string name="upgrade_screen_owned_hero_title">You are Octi Pro 🎉</string>
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">You have %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Thanks for buying %1$s! Your Pro features are unlocked and never expire.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Thanks for subscribing to %1$s! Your Pro features are unlocked.</string>
     <string name="upgrade_screen_manage_subscription_action">Manage subscription</string>

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardScreen.kt
@@ -1564,7 +1564,7 @@ private fun DeviceLimitCard(
             val body = buildString {
                 append(pluralStringResource(R.plurals.pro_device_limit_current_description, current, current))
                 append(" ")
-                append(pluralStringResource(R.plurals.pro_device_limit_maximum_description, maximum, maximum))
+                append(pluralStringResource(R.plurals.pro_device_limit_maximum_hint, maximum, maximum))
             }
             Text(
                 text = body,
@@ -1606,7 +1606,7 @@ private fun UpgradeCard(
                 )
                 Spacer(modifier = Modifier.width(12.dp))
                 Text(
-                    text = stringResource(R.string.upgrades_dashcard_title),
+                    text = stringResource(R.string.upgrades_dashcard_headline),
                     style = MaterialTheme.typography.titleMedium,
                 )
             }

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Hulp</string>
     <string name="general_manage_devices_action">Bestuur toestelle</string>
     <string name="onboarding_welcome_subtitle">Jou Toestelmaat</string>
-    <string name="onboarding_welcome_body1">Octi is \'n hulpmiddel vir mense met verskeie Android-toestelle.</string>
-    <string name="onboarding_welcome_body2">Dit hou jou op hoogte met al jou toestelle. Of dit nou jou foon, tablet of enige ander toestel met Octi is, jy kry belangrike inligting op \'n oogopslag.</string>
-    <string name="onboarding_welcome_body3">Gradeer op na Octi Pro om ekstra kenmerke te kry en ontwikkeling te ondersteun.</string>
     <string name="onboarding_welcome_beta_hint">Net \'n waarskuwing, dit is \'n beta-weergawe, dankie vir jou geduld terwyl ek aanhou om die app te verbeter!</string>
     <string name="onboarding_features_page1_title">Al jou toestelle in een oogopslag</string>
     <string name="onboarding_features_page1_body">Sien battery, WiFi en konnektiwiteit oor al jou Android-toestelle.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Jy het tans %1$d gesinkroniseerde toestel.</item>
         <item quantity="other">Jy het tans %1$d gesinkroniseerde toestelle.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Om meer as %1$d toestel te sien, gradeer op na Octi Pro of verwyder toestelle.</item>
-        <item quantity="other">Om meer as %1$d toestelle te sien, gradeer op na Octi Pro of verwyder toestelle.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">As jy hierdie toestel verwyder, word sy data geskrap, maar toegang bly. Om toegang te herroep, ontkoppel Octi op die toestel.</string>
     <string name="sync_delete_device_revokeaccess_caveat">As jy hierdie toestel uitvee, word sy data verwyder en sy toegang herroep.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">المساعدة</string>
     <string name="general_manage_devices_action">التحكم في الجهاز</string>
     <string name="onboarding_welcome_subtitle">رفيق جهازك</string>
-    <string name="onboarding_welcome_body1">أوكتي هو أداة للأشخاص الذين يمتلكون أجهزة أندرويد متعددة.</string>
-    <string name="onboarding_welcome_body2">يبقيك على اطلاع دائم بجميع أجهزتك. سواء كان هاتفك أو جهازك اللوحي أو أي جهاز آخر مثبت عليه أوكتي، ستحصل على التفاصيل الأساسية بلمحة واحدة.</string>
-    <string name="onboarding_welcome_body3">قم بالترقية إلى Octi Pro للحصول على ميزات إضافية ودعم التطوير.</string>
     <string name="onboarding_welcome_beta_hint">تنبيه: هذه نسخة تجريبية، لذا شكرًا لصبركم بينما أواصل تحسين التطبيق!</string>
     <string name="onboarding_features_page1_title">جميع أجهزتك في نظرة واحدة</string>
     <string name="onboarding_features_page1_body">اطّلع على البطارية وشبكة WiFi والاتصال عبر جميع أجهزة Android الخاصة بك.</string>
@@ -208,14 +205,6 @@
         <item quantity="few">لديك حاليًا %1$d أجهزة متزامنة.</item>
         <item quantity="many">لديك حاليًا %1$d جهازًا متزامنًا.</item>
         <item quantity="other">لديك حاليًا %1$d جهازًا متزامنًا.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="zero">لعرض أكثر من %1$d أجهزة، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
-        <item quantity="one">لعرض أكثر من جهاز %1$d، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
-        <item quantity="two">لعرض أكثر من جهازين (%1$d)، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
-        <item quantity="few">لعرض أكثر من %1$d أجهزة، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
-        <item quantity="many">لعرض أكثر من %1$d جهازًا، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
-        <item quantity="other">لعرض أكثر من %1$d جهازًا، قم بالترقية إلى Octi Pro أو أزل أجهزة.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">إزالة هذا الجهاز ستحذف بياناته ولكن لن تلغي الوصول. لإلغاء الوصول، افصل أوكتي على الجهاز.</string>
     <string name="sync_delete_device_revokeaccess_caveat">حذف هذا الجهاز سيزيل بياناته ويلغي وصوله.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ajuda</string>
     <string name="general_manage_devices_action">Gestionar dispositius</string>
     <string name="onboarding_welcome_subtitle">El teu company del dispositiu</string>
-    <string name="onboarding_welcome_body1">L\'Octi és una eina per a persones amb diversos dispositius Android.</string>
-    <string name="onboarding_welcome_body2">Us manté al corrent de tots els vostres dispositius. Tant si es tracta del vostre telèfon, tauleta o qualsevol altre giny amb l\'Octi instal·lat, obtindreu els detalls clau d\'un cop d\'ull.</string>
-    <string name="onboarding_welcome_body3">Actualitzeu a Octi Pro per obtenir funcions addicionals i donar suport al desenvolupament.</string>
     <string name="onboarding_welcome_beta_hint">Només un avís: aquesta és una versió beta, així que gràcies per la vostra paciència mentre continuo millorant l\'aplicació!</string>
     <string name="onboarding_features_page1_title">Tots els vostres dispositius d\'un cop d\'ull</string>
     <string name="onboarding_features_page1_body">Vegeu la bateria, el WiFi i la connectivitat de tots els vostres dispositius Android.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Actualment teniu %1$d dispositiu sincronitzat.</item>
         <item quantity="other">Actualment teniu %1$d dispositius sincronitzats.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Per veure més de %1$d dispositiu, actualitzeu a Octi Pro o elimineu dispositius.</item>
-        <item quantity="other">Per veure més de %1$d dispositius, actualitzeu a Octi Pro o elimineu dispositius.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">En suprimir aquest dispositiu, se suprimiran les seves dades, però no se\'n revocarà l\'accés. Per revocar l\'accés, desconnecteu l\'Octi al dispositiu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">En suprimir aquest dispositiu, se n\'eliminaran les dades i se\'n revocarà l\'accés.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Nápověda</string>
     <string name="general_manage_devices_action">Spravovat zařízení</string>
     <string name="onboarding_welcome_subtitle">Váš kamarád v zařízení</string>
-    <string name="onboarding_welcome_body1">Octi je nástroj pro uživatele s více zařízeními se systémem Android.</string>
-    <string name="onboarding_welcome_body2">Díky němu budete mít přehled o všech svých zařízeních. Ať už se jedná o telefon, tablet nebo jakýkoli jiný přístroj s nainstalovanou aplikací Octi, na první pohled získáte klíčové informace.</string>
-    <string name="onboarding_welcome_body3">Upgradujte na Octi Pro, abyste získali další funkce a podpořili vývoj.</string>
     <string name="onboarding_welcome_beta_hint">Jen upozorňuji, že se jedná o beta verzi, takže děkuji za trpělivost, protože aplikaci stále vylepšuji!</string>
     <string name="onboarding_features_page1_title">Všechna vaše zařízení na jednom místě</string>
     <string name="onboarding_features_page1_body">Sledujte stav baterie, Wi-Fi a připojení na všech svých zařízeních Android.</string>
@@ -196,12 +193,6 @@
         <item quantity="few">Aktuálně máte %1$d synchronizovaná zařízení.</item>
         <item quantity="many">Aktuálně máte %1$d synchronizovaných zařízení.</item>
         <item quantity="other">Aktuálně máte %1$d synchronizovaných zařízení.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Chcete-li zobrazit více než %1$d zařízení, upgradujte na Octi Pro nebo zařízení odeberte.</item>
-        <item quantity="few">Chcete-li zobrazit více než %1$d zařízení, upgradujte na Octi Pro nebo zařízení odeberte.</item>
-        <item quantity="many">Chcete-li zobrazit více než %1$d zařízení, upgradujte na Octi Pro nebo zařízení odeberte.</item>
-        <item quantity="other">Chcete-li zobrazit více než %1$d zařízení, upgradujte na Octi Pro nebo zařízení odeberte.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Odebráním tohoto zařízení smažete jeho data, ale nebude odvolán přístup. Chcete-li odvolat přístup, odpojte aplikaci Octi na zařízení.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Smazáním tohoto zařízení se odstraní jeho data a zruší se jeho přístup.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Hjælp</string>
     <string name="general_manage_devices_action">Administrer enheder</string>
     <string name="onboarding_welcome_subtitle">Din Enhedsgenbo</string>
-    <string name="onboarding_welcome_body1">Octi er et værktøj til folk med flere Android-enheder.</string>
-    <string name="onboarding_welcome_body2">Den holder dig opdateret med alle dine enheder. Uanset om det er din telefon, tablet eller en anden Octi-enhed, får du det vigtigste samlet ét sted.</string>
-    <string name="onboarding_welcome_body3">Opgrader til Octi Pro for at få ekstra funktioner og støtte udviklingen.</string>
     <string name="onboarding_welcome_beta_hint">Bare en lille note: Dette er en betaversion, så tak for din tålmodighed, mens jeg fortsætter med at forbedre appen!</string>
     <string name="onboarding_features_page1_title">Alle dine enheder på et øjeblik</string>
     <string name="onboarding_features_page1_body">Se batteri, WiFi og forbindelse på tværs af alle dine Android-enheder.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har i øjeblikket %1$d synkroniseret enhed.</item>
         <item quantity="other">Du har i øjeblikket %1$d synkroniserede enheder.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">For at se mere end %1$d enhed, opgrader til Octi Pro eller fjern enheder.</item>
-        <item quantity="other">For at se mere end %1$d enheder, opgrader til Octi Pro eller fjern enheder.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Fjernelse af denne enhed sletter data, men fjerner ikke adgang. For at fjerne adgang, afbryd Octi på enheden.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Sletning af enheden fjerner både data og adgang.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Hilfe</string>
     <string name="general_manage_devices_action">Geräte verwalten</string>
     <string name="onboarding_welcome_subtitle">Dein Geräte Partner</string>
-    <string name="onboarding_welcome_body1">Octi ist eine App für Menschen mit mehreren Androidgeräten.</string>
-    <string name="onboarding_welcome_body2">Es hält dich über alle deine Geräte auf dem Laufenden. Ob es sich um dein Telefon, Tablet oder ein anderes Gerät mit installiertem Octi handelt, du erhältst wichtige Details auf einen Blick.</string>
-    <string name="onboarding_welcome_body3">Du kannst auf Octi Pro upgraden, um zusätzliche Funktionen zu erhalten und die Entwicklung zu unterstützen.</string>
     <string name="onboarding_welcome_beta_hint">Nur zur Information, dies ist eine Beta-Version, also danke für deine Geduld, während ich die App weiter verbessere!</string>
     <string name="onboarding_features_page1_title">Alle deine Geräte auf einen Blick</string>
     <string name="onboarding_features_page1_body">Sieh Akku, WLAN und Konnektivität aller deiner Android-Geräte.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du hast derzeit %1$d synchronisiertes Gerät.</item>
         <item quantity="other">Du hast derzeit %1$d synchronisierte Geräte.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Um mehr als %1$d Gerät anzuzeigen, upgrade auf Octi Pro oder entferne Geräte.</item>
-        <item quantity="other">Um mehr als %1$d Geräte anzuzeigen, upgrade auf Octi Pro oder entferne Geräte.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Das Entfernen dieses Geräts löscht seine Daten, widerruft aber nicht den Zugriff. Um den Zugriff zu widerrufen, trennen Sie Octi auf dem Gerät.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Das Löschen dieses Geräts entfernt seine Daten und widerruft seinen Zugriff.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Βοήθεια</string>
     <string name="general_manage_devices_action">Διαχείριση συσκευών</string>
     <string name="onboarding_welcome_subtitle">Ο Συνοδός της Συσκευής σας</string>
-    <string name="onboarding_welcome_body1">Το Octi είναι ένα εργαλείο για άτομα με πολλαπλές συσκευές Android.</string>
-    <string name="onboarding_welcome_body2">Σας κρατά ενήμερους για όλες τις συσκευές σας. Είτε είναι το τηλέφωνό σας, το tablet σας ή οποιαδήποτε άλλη συσκευή με εγκατεστημένο το Octi, βλέπετε βασικές πληροφορίες με μια ματιά.</string>
-    <string name="onboarding_welcome_body3">Αναβαθμίστε στο Octi Pro για επιπλέον λειτουργίες και υποστήριξη της ανάπτυξης.</string>
     <string name="onboarding_welcome_beta_hint">Ενημερωτικά: αυτή είναι έκδοση beta, ευχαριστώ για την υπομονή σας καθώς συνεχίζω να βελτιώνω την εφαρμογή!</string>
     <string name="onboarding_features_page1_title">Όλες οι συσκευές σας με μια ματιά</string>
     <string name="onboarding_features_page1_body">Δείτε μπαταρία, WiFi και συνδεσιμότητα σε όλες τις Android συσκευές σας.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Αυτή τη στιγμή έχετε %1$d συγχρονισμένη συσκευή.</item>
         <item quantity="other">Αυτή τη στιγμή έχετε %1$d συγχρονισμένες συσκευές.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Για να δείτε περισσότερες από %1$d συσκευή, αναβαθμίστε στο Octi Pro ή αφαιρέστε συσκευές.</item>
-        <item quantity="other">Για να δείτε περισσότερες από %1$d συσκευές, αναβαθμίστε στο Octi Pro ή αφαιρέστε συσκευές.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Η κατάργηση αυτής της συσκευής διαγράφει τα δεδομένα της αλλά δεν αφαιρεί την πρόσβαση. Για να αφαιρέσετε την πρόσβαση, αποσυνδέστε το Octi στη συσκευή.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Διαγράφοντας αυτή τη συσκευή διαγράφονται τα δεδομένα και ακυρώνεται η πρόσβαση.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ayuda</string>
     <string name="general_manage_devices_action">Gestionar dispositivos</string>
     <string name="onboarding_welcome_subtitle">Tu compañero de dispositivos</string>
-    <string name="onboarding_welcome_body1">Octi es una herramienta para personas con múltiples dispositivos Android.</string>
-    <string name="onboarding_welcome_body2">Te mantiene al día con todos tus dispositivos. Ya sea tu teléfono, tablet o cualquier otro gadget con Octi instalado, obtendrás detalles clave de un vistazo.</string>
-    <string name="onboarding_welcome_body3">Actualiza a Octi Pro para obtener funciones adicionales y apoyar el desarrollo.</string>
     <string name="onboarding_welcome_beta_hint">Solo para que sepas, esta es una versión beta, ¡así que gracias por tu paciencia mientras sigo mejorando la aplicación!</string>
     <string name="onboarding_features_page1_title">Todos tus dispositivos de un vistazo</string>
     <string name="onboarding_features_page1_body">Consulta la batería, WiFi y conectividad de todos tus dispositivos Android.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Actualmente tienes %1$d dispositivo sincronizado.</item>
         <item quantity="other">Actualmente tienes %1$d dispositivos sincronizados.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Para ver más de %1$d dispositivo, actualiza a Octi Pro o elimina dispositivos.</item>
-        <item quantity="other">Para ver más de %1$d dispositivos, actualiza a Octi Pro o elimina dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Eliminar este dispositivo borrará sus datos pero no revocará el acceso. Para revocar el acceso, desconecta Octi en el dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminar este dispositivo removerá sus datos y revocará su acceso.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ohjeet</string>
     <string name="general_manage_devices_action">Hallitse laitteita</string>
     <string name="onboarding_welcome_subtitle">Laitetoverisi</string>
-    <string name="onboarding_welcome_body1">Octi on työkalu ihmisille, joilla on useita Android-laitteita.</string>
-    <string name="onboarding_welcome_body2">Se pitää sinut ajan tasalla kaikista laitteistasi. Olipa kyse puhelimesta, tabletista tai muusta laitteesta, jossa Octi on asennettuna, näet tärkeimmät tiedot yhdellä silmäyksellä.</string>
-    <string name="onboarding_welcome_body3">Päivitä Octi Prohon saadaksesi lisäominaisuuksia ja tukeaksesi kehitystä.</string>
     <string name="onboarding_welcome_beta_hint">Huom! Tämä on beta-versio, joten kiitos kärsivällisyydestäsi kun parannan sovellusta jatkuvasti!</string>
     <string name="onboarding_features_page1_title">Kaikki laitteesi yhdellä silmäyksellä</string>
     <string name="onboarding_features_page1_body">Näe akku, WiFi ja yhteys kaikilla Android-laitteillasi.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Sinulla on tällä hetkellä %1$d synkronoitu laite.</item>
         <item quantity="other">Sinulla on tällä hetkellä %1$d synkronoitua laitetta.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Nähdäksesi enemmän kuin %1$d laitteen, päivitä Octi Prohon tai poista laitteita.</item>
-        <item quantity="other">Nähdäksesi enemmän kuin %1$d laitetta, päivitä Octi Prohon tai poista laitteita.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot, mutta ei poista käyttöoikeutta. Poistaaksesi käyttöoikeuden, irrota Octi laitteessa.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot ja käyttöoikeudet.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Aide</string>
     <string name="general_manage_devices_action">Gérer les appareils</string>
     <string name="onboarding_welcome_subtitle">Le compagnon de vos appareils</string>
-    <string name="onboarding_welcome_body1">Octi est un outil pour les personnes qui utilisent plusieurs appareils Android.</string>
-    <string name="onboarding_welcome_body2">Avec Octi installé sur votre téléphone, votre tablette ou sur tout autre gadget Android, connaissez l’état de vos appareils en un coup d’œil,.</string>
-    <string name="onboarding_welcome_body3">Passez à Octi Pro pour débloquer des fonctions supplémentaires et financer le développement.</string>
     <string name="onboarding_welcome_beta_hint">Ceci est une version bêta. Faites preuve de patience alors que je continue d\'améliorer l\'appli.</string>
     <string name="onboarding_features_page1_title">Tous vos appareils en un coup d\'œil</string>
     <string name="onboarding_features_page1_body">Consultez la batterie, le Wi-Fi et la connectivité sur tous vos appareils Android.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">%1$d appareil est synchronisé actuellement.</item>
         <item quantity="other">%1$d appareils sont synchronisés actuellement.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Pour afficher plus de %1$d appareil, passez à Octi Pro ou supprimez des périphériques.</item>
-        <item quantity="other">Pour afficher plus de %1$d appareils, passez à Octi Pro ou supprimez des périphériques.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Supprimer cet appareil supprimera ses données, mais ne révoquera pas son accès. Pour révoquer l\'accès, déconnectez Octi sur l\'appareil en question.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Supprimer cet appareil supprimera ses données et révoquera son accès.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Súgó</string>
     <string name="general_manage_devices_action">Eszközök kezelése</string>
     <string name="onboarding_welcome_subtitle">Készülék-segéded</string>
-    <string name="onboarding_welcome_body1">Az Octi több Android-eszközzel rendelkező felhasználóknak készült.</string>
-    <string name="onboarding_welcome_body2">Minden eszközödről tájékoztat. Legyen telefon, tablet vagy bármilyen Octival ellátott eszközöd, egy pillantással látod a főbb információkat.</string>
-    <string name="onboarding_welcome_body3">Frissíts Octi Próra, hogy extra funkciókat kapj és támogasd a fejlesztést.</string>
     <string name="onboarding_welcome_beta_hint">Ez egy béta verzió, köszönöm a türelmed, miközben folyamatosan fejlesztem az alkalmazást!</string>
     <string name="onboarding_features_page1_title">Minden eszköze egy helyen</string>
     <string name="onboarding_features_page1_body">Tekintse meg az összes Android-eszköze akkumulátorát, Wi-Fi-jét és kapcsolódási állapotát.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Jelenleg %1$d szinkronizált eszközöd van.</item>
         <item quantity="other">Jelenleg %1$d szinkronizált eszközöd van.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Több mint %1$d eszköz megtekintéséhez frissíts Octi Próra, vagy távolíts el eszközöket.</item>
-        <item quantity="other">Több mint %1$d eszköz megtekintéséhez frissíts Octi Próra, vagy távolíts el eszközöket.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Az eszköz eltávolításakor annak adatai törlődnek, de a hozzáférést nem vonja vissza. A hozzáférés visszavonásához válaszd le az Octit az eszközön.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ez az eszköz törlésekor az adatait és a hozzáférését is törlöd.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Aiuto</string>
     <string name="general_manage_devices_action">Gestisci dispositivi</string>
     <string name="onboarding_welcome_subtitle">Il tuo dispositivo</string>
-    <string name="onboarding_welcome_body1">Octi è uno strumento per possessori di più dispositivi Android.</string>
-    <string name="onboarding_welcome_body2">Ti mantiene aggiornato su tutti i tuoi dispositivi. Che sia un telefono, tablet o qualsiasi altro gadget con Octi installato, potrai avere sott\'occhio le info importanti.</string>
-    <string name="onboarding_welcome_body3">Passa a Octi Pro per ottenere funzionalità extra e supportare lo sviluppo.</string>
     <string name="onboarding_welcome_beta_hint">Avviso. Questa è una versione beta, grazie per la pazienza mentre continuerò a migliorare l\'app!</string>
     <string name="onboarding_features_page1_title">Tutti i tuoi dispositivi in un colpo d\'occhio</string>
     <string name="onboarding_features_page1_body">Visualizza batteria, WiFi e connettività su tutti i tuoi dispositivi Android.</string>
@@ -186,10 +183,6 @@ I dispositivi possono vedersi solo se hanno un servizio di sincronizzazione comu
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Hai attualmente %1$d dispositivo sincronizzato.</item>
         <item quantity="other">Hai attualmente %1$d dispositivi sincronizzati.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Per visualizzare più di %1$d dispositivo, passa a Octi Pro o rimuovi dispositivi.</item>
-        <item quantity="other">Per visualizzare più di %1$d dispositivi, passa a Octi Pro o rimuovi dispositivi.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Rimuovere questo dispositivo cancellerà i suoi dati, ma non revoca l\'accesso. Per revocare l\'accesso, disconnetti Octi dal dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminare questo dispositivo rimuoverà i suoi dati e revocerà il suo accesso.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">עזרה</string>
     <string name="general_manage_devices_action">נהל מכשירים</string>
     <string name="onboarding_welcome_subtitle">חבר מכשיר שלך</string>
-    <string name="onboarding_welcome_body1">Octi הוא כלי עבור אנשים עם מספר מכשירי אנדרואיד.</string>
-    <string name="onboarding_welcome_body2">זה שומר אותך בעניינים עם כל המכשירים שלך. בין אם זה הטלפון, הטאבלט או כל גאדג\'ט אחר עם Octi מותקן, תקבלו פרטי מפתח במבט חטוף.</string>
-    <string name="onboarding_welcome_body3">שדרג ל-Octi פרימיום כדי לקבל תכונות נוספות ולתמוך בפיתוח.</string>
     <string name="onboarding_welcome_beta_hint">רק הערה, זו גרסת בטא, אז תודה על הסבלנות בזמן שאני ממשיך לשפר את האפליקציה!</string>
     <string name="onboarding_features_page1_title">כל המכשירים שלך במבט אחד</string>
     <string name="onboarding_features_page1_body">ראה סוללה, WiFi וקישוריות בכל מכשירי ה-Android שלך.</string>
@@ -196,12 +193,6 @@
         <item quantity="two">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
         <item quantity="many">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
         <item quantity="other">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">כדי לצפות ביותר מ-%1$d מכשירים, שדרג ל-Octi Pro או הסר מכשירים.</item>
-        <item quantity="two">כדי לצפות ביותר מ-%1$d מכשירים, שדרג ל-Octi Pro או הסר מכשירים.</item>
-        <item quantity="many">כדי לצפות ביותר מ-%1$d מכשירים, שדרג ל-Octi Pro או הסר מכשירים.</item>
-        <item quantity="other">כדי לצפות ביותר מ-%1$d מכשירים, שדרג ל-Octi Pro או הסר מכשירים.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">הסרת מכשיר זה תמחק את הנתונים שלו אך לא תבטל את הגישה. כדי לבטל גישה, נתק את Octi במכשיר.</string>
     <string name="sync_delete_device_revokeaccess_caveat">מחיקת המכשיר הזה תסיר את הנתונים שלו ותבטל את הגישה שלו.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">ヘルプ</string>
     <string name="general_manage_devices_action">デバイスを管理</string>
     <string name="onboarding_welcome_subtitle">あなたのデバイスの相棒</string>
-    <string name="onboarding_welcome_body1">Octi は複数の Android デバイスを持っている人のためのツールです。</string>
-    <string name="onboarding_welcome_body2">Octi は、あなたのすべてのデバイスを常に最新の状態に保ちます。Octi がインストールされたスマートフォン、タブレット、その他ガジェットを問わずに主要な情報を一目で把握することができます。</string>
-    <string name="onboarding_welcome_body3">Octi Pro にアップグレードして、追加機能を利用し開発を支援しましょう。</string>
     <string name="onboarding_welcome_beta_hint">念のためのお知らせですが、これはベータ版です。アプリの改善に努めますので、ご理解のほどよろしくお願いします！</string>
     <string name="onboarding_features_page1_title">すべてのデバイスを一目で確認</string>
     <string name="onboarding_features_page1_body">すべてのAndroidデバイスのバッテリー、WiFi、接続状況を確認できます。</string>
@@ -178,9 +175,6 @@
     <string name="pro_device_limit_reached_title">デバイスの上限に達しました</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">現在 %1$d 台の同期済みデバイスがあります。</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="other">%1$d 台以上のデバイスを表示するには、Octi Pro にアップグレードするか、デバイスを削除してください。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">このデバイスを削除するとデータは削除されますが、アクセスは取り消されません。アクセスを取り消すにはデバイス上の Octi を切断してください。</string>
     <string name="sync_delete_device_revokeaccess_caveat">このデバイスを削除するとデータが削除され、アクセスが取り消されます。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">도움말</string>
     <string name="general_manage_devices_action">기기 관리</string>
     <string name="onboarding_welcome_subtitle">기기의 동반자</string>
-    <string name="onboarding_welcome_body1">Octi는 여러 Android 기기를 가진 사람들을 위한 도구입니다.</string>
-    <string name="onboarding_welcome_body2">모든 기기의 정보를 한눈에 확인할 수 있습니다. 휴대폰, 태블릿, 기타 Octi가 설치된 기기 등 주요 정보를 쉽게 볼 수 있습니다.</string>
-    <string name="onboarding_welcome_body3">Octi Pro로 업그레이드하여 추가 기능을 사용하고 개발을 지원하세요.</string>
     <string name="onboarding_welcome_beta_hint">참고: 이 앱은 베타버전입니다. 계속 개선하고 있으니 양해해 주세요!</string>
     <string name="onboarding_features_page1_title">한눈에 보는 내 모든 기기</string>
     <string name="onboarding_features_page1_body">모든 안드로이드 기기의 배터리, WiFi, 연결 상태를 확인하세요.</string>
@@ -178,9 +175,6 @@
     <string name="pro_device_limit_reached_title">기기 제한에 도달함</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">현재 %1$d개의 동기화된 기기가 있습니다.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="other">%1$d개 이상의 기기를 보려면 Octi Pro로 업그레이드하거나 기기를 제거하세요.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">이 기기를 삭제하면 데이터는 지워지나 접근 권한은 남아있습니다. 접근권한을 해제하려면 해당 기기에서 Octi 연결을 해제하세요.</string>
     <string name="sync_delete_device_revokeaccess_caveat">이 기기를 삭제하면 데이터와 접근 권한 모두 삭제됩니다.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Hjelp</string>
     <string name="general_manage_devices_action">Administrer enheter</string>
     <string name="onboarding_welcome_subtitle">Din enhetsvenn</string>
-    <string name="onboarding_welcome_body1">Octi er et verktøy for personer med flere Android-enheter.</string>
-    <string name="onboarding_welcome_body2">Holder deg oppdatert med alle enhetene dine. Enten det er telefonen din, nettbrettet eller et annet Octi-enhet får du nøkkelinformasjon på et øyeblikk.</string>
-    <string name="onboarding_welcome_body3">Oppgrader til Octi Pro for å få ekstra funksjoner og støtte utviklingen.</string>
     <string name="onboarding_welcome_beta_hint">Bare en liten notis: Dette er en betaversjon, så takk for tålmodigheten mens jeg fortsetter å forbedre appen!</string>
     <string name="onboarding_features_page1_title">Alle enhetene dine på ett sted</string>
     <string name="onboarding_features_page1_body">Se batteri, WiFi og tilkobling på tvers av alle Android-enhetene dine.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har for øyeblikket %1$d synkronisert enhet.</item>
         <item quantity="other">Du har for øyeblikket %1$d synkroniserte enheter.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">For å se mer enn %1$d enhet, oppgrader til Octi Pro eller fjern enheter.</item>
-        <item quantity="other">For å se mer enn %1$d enheter, oppgrader til Octi Pro eller fjern enheter.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Å fjerne denne enheten sletter dens data, men fjerner ikke tilgang. For å fjerne tilgang, koble Octi fra enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Å slette denne enheten fjerner både data og tilgang.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Help</string>
     <string name="general_manage_devices_action">Apparaten beheren</string>
     <string name="onboarding_welcome_subtitle">Uw apparaat-buddy</string>
-    <string name="onboarding_welcome_body1">Octi is een hulpmiddel voor mensen met meerdere Android-apparaten.</string>
-    <string name="onboarding_welcome_body2">Het houdt u op de hoogte van al uw apparaten. Of het nu uw telefoon, tablet of een ander apparaat is met Octi geïnstalleerd, u krijgt belangrijke details in één oogopslag.</string>
-    <string name="onboarding_welcome_body3">Upgrade naar Octi Pro voor extra functies en om de ontwikkeling te ondersteunen.</string>
     <string name="onboarding_welcome_beta_hint">Ter info, dit is een bètaversie, dus bedankt voor uw geduld terwijl ik de app blijf verbeteren!</string>
     <string name="onboarding_features_page1_title">Al je apparaten in één oogopslag</string>
     <string name="onboarding_features_page1_body">Bekijk batterij, WiFi en connectiviteit op al je Android-apparaten.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">U heeft momenteel %1$d gesynchroniseerd apparaat.</item>
         <item quantity="other">U heeft momenteel %1$d gesynchroniseerde apparaten.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Om meer dan %1$d apparaat te bekijken, upgrade naar Octi Pro of verwijder apparaten.</item>
-        <item quantity="other">Om meer dan %1$d apparaten te bekijken, upgrade naar Octi Pro of verwijder apparaten.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Dit apparaat verwijderen zal de gegevens wissen maar toegang niet intrekken. Om toegang in te trekken, koppel Octi los op het apparaat.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Dit apparaat verwijderen zal de gegevens verwijderen en toegang intrekken.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Pomoc</string>
     <string name="general_manage_devices_action">Zarządzaj urządzeniami</string>
     <string name="onboarding_welcome_subtitle">Twój towarzysz urządzenia</string>
-    <string name="onboarding_welcome_body1">Octi to narzędzie dla osób z wieloma urządzeniami Android.</string>
-    <string name="onboarding_welcome_body2">Utrzymuje cię w pętli ze wszystkimi twoimi urządzeniami. Czy to twój telefon, tablet czy jakikolwiek inny gadżet z zainstalowanym Octi, otrzymasz kluczowe szczegóły na pierwszy rzut oka.</string>
-    <string name="onboarding_welcome_body3">Uaktualnij do Octi Pro, aby uzyskać dodatkowe funkcje i wesprzeć rozwój.</string>
     <string name="onboarding_welcome_beta_hint">Chcę tylko zaznaczyć, że to wersja beta, więc dziękuję za cierpliwość, podczas gdy cały czas udoskonalam aplikację!</string>
     <string name="onboarding_features_page1_title">Wszystkie urządzenia w skrócie</string>
     <string name="onboarding_features_page1_body">Zobacz baterię, Wi-Fi i łączność na wszystkich urządzeniach z systemem Android.</string>
@@ -196,12 +193,6 @@
         <item quantity="few">Masz obecnie %1$d zsynchronizowane urządzenia.</item>
         <item quantity="many">Masz obecnie %1$d zsynchronizowanych urządzeń.</item>
         <item quantity="other">Masz obecnie %1$d zsynchronizowanych urządzeń.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Aby wyświetlić więcej niż %1$d urządzenie, przejdź na Octi Pro lub usuń urządzenia.</item>
-        <item quantity="few">Aby wyświetlić więcej niż %1$d urządzenia, przejdź na Octi Pro lub usuń urządzenia.</item>
-        <item quantity="many">Aby wyświetlić więcej niż %1$d urządzeń, przejdź na Octi Pro lub usuń urządzenia.</item>
-        <item quantity="other">Aby wyświetlić więcej niż %1$d urządzeń, przejdź na Octi Pro lub usuń urządzenia.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Usunięcie tego urządzenia usunie jego dane, ale nie cofnie dostępu. Aby cofnąć dostęp, rozłącz Octi na urządzeniu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Usunięcie tego urządzenia usunie jego dane i cofnie jego dostęp.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ajuda</string>
     <string name="general_manage_devices_action">Gerenciar dispositivos</string>
     <string name="onboarding_welcome_subtitle">Seu companheiro de dispositivos</string>
-    <string name="onboarding_welcome_body1">Octi é uma ferramenta para pessoas com vários dispositivos Android.</string>
-    <string name="onboarding_welcome_body2">Mantém você informado sobre todos os seus dispositivos. Seja telefone, tablet ou qualquer outro dispositivo com Octi instalado, você verá as principais informações em um piscar de olhos.</string>
-    <string name="onboarding_welcome_body3">Atualize para o Octi Pro para ter recursos extras e apoiar o desenvolvimento.</string>
     <string name="onboarding_welcome_beta_hint">Atenção: essa é uma versão beta, obrigado pela paciência enquanto continuo melhorando o app!</string>
     <string name="onboarding_features_page1_title">Todos os seus dispositivos de relance</string>
     <string name="onboarding_features_page1_body">Veja bateria, Wi-Fi e conectividade em todos os seus dispositivos Android.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Você tem atualmente %1$d dispositivo sincronizado.</item>
         <item quantity="other">Você tem atualmente %1$d dispositivos sincronizados.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Para ver mais de %1$d dispositivo, atualize para o Octi Pro ou remova dispositivos.</item>
-        <item quantity="other">Para ver mais de %1$d dispositivos, atualize para o Octi Pro ou remova dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo apagará seus dados, mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Apagar este dispositivo removerá seus dados e revogará o acesso.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ajuda</string>
     <string name="general_manage_devices_action">Gerir dispositivos</string>
     <string name="onboarding_welcome_subtitle">Seu companheiro de dispositivos</string>
-    <string name="onboarding_welcome_body1">Octi é uma ferramenta para pessoas com múltiplos dispositivos Android.</string>
-    <string name="onboarding_welcome_body2">Ele mantém você informado sobre todos os seus dispositivos. Seja seu telefone, tablet ou qualquer outro dispositivo com Octi instalado, você terá detalhes importantes rapidamente.</string>
-    <string name="onboarding_welcome_body3">Atualize para o Octi Pro para obter funcionalidades extra e apoiar o desenvolvimento.</string>
     <string name="onboarding_welcome_beta_hint">Só para avisar, esta é uma versão beta, então obrigado pela paciência enquanto continuo melhorando o app!</string>
     <string name="onboarding_features_page1_title">Todos os seus dispositivos num relance</string>
     <string name="onboarding_features_page1_body">Veja a bateria, WiFi e conectividade em todos os seus dispositivos Android.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Tem atualmente %1$d dispositivo sincronizado.</item>
         <item quantity="other">Tem atualmente %1$d dispositivos sincronizados.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Para ver mais do que %1$d dispositivo, atualize para o Octi Pro ou remova dispositivos.</item>
-        <item quantity="other">Para ver mais do que %1$d dispositivos, atualize para o Octi Pro ou remova dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo deletará seus dados mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Deletar este dispositivo removerá seus dados e revogará seu acesso.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Ajutor</string>
     <string name="general_manage_devices_action">Gestionează dispozitive</string>
     <string name="onboarding_welcome_subtitle">Partenerul tău de dispozitive</string>
-    <string name="onboarding_welcome_body1">Octi este un instrument pentru persoanele cu mai multe dispozitive Android.</string>
-    <string name="onboarding_welcome_body2">Te ține la curent cu toate dispozitivele tale. Fie că e telefonul, tableta sau orice alt gadget cu Octi instalat, ai detalii esențiale dintr-o privire.</string>
-    <string name="onboarding_welcome_body3">Fă upgrade la Octi Pro pentru funcții suplimentare și pentru a susține dezvoltarea.</string>
     <string name="onboarding_welcome_beta_hint">Doar un avertisment, aceasta este o versiune beta, deci mulțumesc pentru răbdare cât timp continui să îmbunătățesc aplicația!</string>
     <string name="onboarding_features_page1_title">Toate dispozitivele tale dintr-o privire</string>
     <string name="onboarding_features_page1_body">Vedeți bateria, WiFi şi conectivitatea pe toate dispozitivele Android.</string>
@@ -190,11 +187,6 @@
         <item quantity="one">Ai în prezent %1$d dispozitiv sincronizat.</item>
         <item quantity="few">Ai în prezent %1$d dispozitive sincronizate.</item>
         <item quantity="other">Ai în prezent %1$d dispozitive sincronizate.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Pentru a vedea mai mult de %1$d dispozitiv, fă upgrade la Octi Pro sau elimină dispozitive.</item>
-        <item quantity="few">Pentru a vedea mai mult de %1$d dispozitive, fă upgrade la Octi Pro sau elimină dispozitive.</item>
-        <item quantity="other">Pentru a vedea mai mult de %1$d dispozitive, fă upgrade la Octi Pro sau elimină dispozitive.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Eliminarea acestui dispozitiv îi va șterge datele, dar nu va revoca accesul. Pentru a revoca accesul, deconectează Octi pe acel dispozitiv.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ștergând acest dispozitiv îi elimini datele și îi revoci accesul.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Помощь</string>
     <string name="general_manage_devices_action">Управление устройствами</string>
     <string name="onboarding_welcome_subtitle">Ваш помощник</string>
-    <string name="onboarding_welcome_body1">Octi — это инструмент для людей с несколькими Android-устройствами.</string>
-    <string name="onboarding_welcome_body2">Он держит вас в курсе всех Ваших устройств. Будь то Ваш телефон, планшет или любой другой гаджет с установленным Octi, Вы сразу получите ключевую информацию.</string>
-    <string name="onboarding_welcome_body3">Обновитесь до Octi Pro, чтобы получить дополнительные функции и поддержать разработку.</string>
     <string name="onboarding_welcome_beta_hint">Просто к сведению, это бета-версия, так что спасибо за Ваше терпение, пока я продолжаю улучшать приложение!</string>
     <string name="onboarding_features_page1_title">Все Ваши устройства с первого взгляда</string>
     <string name="onboarding_features_page1_body">Смотрите уровень заряда, WiFi и подключение на всех Ваших Android-устройствах.</string>
@@ -196,12 +193,6 @@
         <item quantity="few">У вас сейчас %1$d синхронизированных устройства.</item>
         <item quantity="many">У вас сейчас %1$d синхронизированных устройств.</item>
         <item quantity="other">У вас сейчас %1$d синхронизированных устройств.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Чтобы просматривать более %1$d устройства, обновитесь до Octi Pro или удалите устройства.</item>
-        <item quantity="few">Чтобы просматривать более %1$d устройств, обновитесь до Octi Pro или удалите устройства.</item>
-        <item quantity="many">Чтобы просматривать более %1$d устройств, обновитесь до Octi Pro или удалите устройства.</item>
-        <item quantity="other">Чтобы просматривать более %1$d устройств, обновитесь до Octi Pro или удалите устройства.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Удаление этого устройства удалит его данные, но не отзовет доступ. Чтобы отозвать доступ, отключите Octi на устройстве.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Удаление этого устройства удалит его данные и отзовет его доступ.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Помоћ</string>
     <string name="general_manage_devices_action">Управљај уређајима</string>
     <string name="onboarding_welcome_subtitle">Партнер уређаја</string>
-    <string name="onboarding_welcome_body1">Octi је алат за људе са више Android уређаја.</string>
-    <string name="onboarding_welcome_body2">Држи вас у току са свим вашим уређајима. Без обзира да ли је то ваш телефон, таблет или било који други уређај са инсталираним Octi-јем, добијате кључне детаље на први поглед.</string>
-    <string name="onboarding_welcome_body3">Надогради на Octi Pro за додатне функције и подршку развоју.</string>
     <string name="onboarding_welcome_beta_hint">Ово је бета верзија, хвала на стрпљењу док настављам да унапређујем апликацију!</string>
     <string name="onboarding_features_page1_title">Сви ваши уређаји на једном месту</string>
     <string name="onboarding_features_page1_body">Прегледајте батерију, WiFi и повезаност на свим вашим Android уређајима.</string>
@@ -190,11 +187,6 @@
         <item quantity="one">Тренутно имате %1$d синхронизован уређај.</item>
         <item quantity="few">Тренутно имате %1$d синхронизована уређаја.</item>
         <item quantity="other">Тренутно имате %1$d синхронизованих уређаја.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Да видите више од %1$d уређаја, надоградите на Octi Pro или уклоните уређаје.</item>
-        <item quantity="few">Да видите више од %1$d уређаја, надоградите на Octi Pro или уклоните уређаје.</item>
-        <item quantity="other">Да видите више од %1$d уређаја, надоградите на Octi Pro или уклоните уређаје.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Уклањањем овог уређаја ће се обрисати његови подаци, али приступ ће остати. Да укинеш приступ, одјави Octi на овом уређају.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Брисањем овог уређаја ће се обрисати његови подаци и потпуно укинути приступ.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Hjälp</string>
     <string name="general_manage_devices_action">Hantera enheter</string>
     <string name="onboarding_welcome_subtitle">Din enhetskompis</string>
-    <string name="onboarding_welcome_body1">Octi är ett verktyg för personer med flera Android-enheter.</string>
-    <string name="onboarding_welcome_body2">Håller dig uppdaterad med alla dina enheter. Det gäller din telefon, surfplatta eller vilken annan Octi-enhet som helst – du får viktiga detaljer direkt.</string>
-    <string name="onboarding_welcome_body3">Uppgradera till Octi Pro för extra funktioner och stöd utvecklingen.</string>
     <string name="onboarding_welcome_beta_hint">Bara så du vet, detta är en betaversion – tack för ditt tålamod medan jag fortsätter förbättra appen!</string>
     <string name="onboarding_features_page1_title">Alla dina enheter i översikt</string>
     <string name="onboarding_features_page1_body">Se batteri, WiFi och anslutning för alla dina Android-enheter.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har för närvarande %1$d synkroniserad enhet.</item>
         <item quantity="other">Du har för närvarande %1$d synkroniserade enheter.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">För att se fler än %1$d enhet, uppgradera till Octi Pro eller ta bort enheter.</item>
-        <item quantity="other">För att se fler än %1$d enheter, uppgradera till Octi Pro eller ta bort enheter.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Att ta bort denna enhet tar bort dess data men tar inte bort åtkomst. För att ta bort åtkomst måste du koppla loss Octi på enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ta bort denna enhet raderar dess data och tar bort dess åtkomst.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Yardım</string>
     <string name="general_manage_devices_action">Cihazları yönet</string>
     <string name="onboarding_welcome_subtitle">Cihaz Arkadaşınız</string>
-    <string name="onboarding_welcome_body1">Octi, birden fazla Android cihazı olan kişiler için bir araçtır.</string>
-    <string name="onboarding_welcome_body2">Sizi tüm cihazlarınızla döngü içinde tutar. İster telefonunuz, ister tabletiniz veya Octi yüklü başka bir aygıt olsun, önemli ayrıntıları bir bakışta alırsınız.</string>
-    <string name="onboarding_welcome_body3">Ekstra özellikler ve geliştirme desteği için Octi Pro\'ya yükseltin.</string>
     <string name="onboarding_welcome_beta_hint">Sadece ufak bir uyarı, bu bir beta sürümüdür, bu yüzden uygulamayı geliştirmeye devam ederken sabrınız için teşekkürler!</string>
     <string name="onboarding_features_page1_title">Tüm cihazlarınıza bir bakışta</string>
     <string name="onboarding_features_page1_body">Tüm Android cihazlarınızdaki pil, WiFi ve bağlantı durumunu görün.</string>
@@ -184,10 +181,6 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Şu anda %1$d senkronize edilmiş cihazınız var.</item>
         <item quantity="other">Şu anda %1$d senkronize edilmiş cihazınız var.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">%1$d\'den fazla cihazı görüntülemek için Octi Pro\'ya yükseltin veya cihazları kaldırın.</item>
-        <item quantity="other">%1$d\'den fazla cihazı görüntülemek için Octi Pro\'ya yükseltin veya cihazları kaldırın.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Bu cihazın kaldırılması verilerini silecek ancak erişimi iptal etmeyecektir. Erişimi iptal etmek için cihazdaki Octi bağlantısını kesin.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Bu cihazın silinmesi, verilerini kaldıracak ve erişimini iptal edecektir.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Довідка</string>
     <string name="general_manage_devices_action">Керувати пристроями</string>
     <string name="onboarding_welcome_subtitle">Ваш напарник по пристроях</string>
-    <string name="onboarding_welcome_body1">Octi — це інструмент для людей із багатьма Android-пристроями.</string>
-    <string name="onboarding_welcome_body2">Він допомагає стежити за всіма вашими пристроями. Будь то телефон, планшет чи інший пристрій із Octi — ви бачите важливі деталі з першого погляду.</string>
-    <string name="onboarding_welcome_body3">Оновіться до Octi Pro, щоб отримати додаткові функції та підтримати розробку.</string>
     <string name="onboarding_welcome_beta_hint">До відома: це бета-версія. Дякую за терпіння, доки я покращую застосунок!</string>
     <string name="onboarding_features_page1_title">Усі ваші пристрої одним поглядом</string>
     <string name="onboarding_features_page1_body">Переглядайте заряд батареї, WiFi та з\'єднання на всіх своїх Android-пристроях.</string>
@@ -196,12 +193,6 @@
         <item quantity="few">Наразі у вас %1$d синхронізованих пристроїв.</item>
         <item quantity="many">Наразі у вас %1$d синхронізованих пристроїв.</item>
         <item quantity="other">Наразі у вас %1$d синхронізованих пристроїв.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">Щоб переглядати більше ніж %1$d пристрій, оновіться до Octi Pro або видаліть пристрої.</item>
-        <item quantity="few">Щоб переглядати більше ніж %1$d пристроїв, оновіться до Octi Pro або видаліть пристрої.</item>
-        <item quantity="many">Щоб переглядати більше ніж %1$d пристроїв, оновіться до Octi Pro або видаліть пристрої.</item>
-        <item quantity="other">Щоб переглядати більше ніж %1$d пристроїв, оновіться до Octi Pro або видаліть пристрої.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Видалення пристрою видалить його дані, але не скасує доступ. Щоб скасувати доступ, від\'єднайте Octi на пристрої.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Видалення пристрою також видалить дані та скасує доступ.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">Trợ giúp</string>
     <string name="general_manage_devices_action">Quản lý thiết bị</string>
     <string name="onboarding_welcome_subtitle">Người bạn thiết bị của bạn</string>
-    <string name="onboarding_welcome_body1">Octi là công cụ dành cho người dùng sở hữu nhiều thiết bị Android.</string>
-    <string name="onboarding_welcome_body2">Giúp bạn cập nhật thông tin với tất cả thiết bị của mình. Dù là điện thoại, máy tính bảng hay bất kỳ thiết bị nào có cài Octi, bạn sẽ xem ngay được thông tin quan trọng.</string>
-    <string name="onboarding_welcome_body3">Nâng cấp lên Octi Pro để có thêm tính năng và hỗ trợ phát triển.</string>
     <string name="onboarding_welcome_beta_hint">Thông báo: Đây là phiên bản beta, cảm ơn bạn đã kiên nhẫn khi tôi tiếp tục hoàn thiện ứng dụng!</string>
     <string name="onboarding_features_page1_title">Tất cả thiết bị của bạn trong tầm tay</string>
     <string name="onboarding_features_page1_body">Xem pin, WiFi và kết nối trên tất cả thiết bị Android của bạn.</string>
@@ -178,9 +175,6 @@
     <string name="pro_device_limit_reached_title">Đã đạt giới hạn thiết bị</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">Bạn hiện có %1$d thiết bị đã đồng bộ.</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="other">Để xem nhiều hơn %1$d thiết bị, hãy nâng cấp lên Octi Pro hoặc xóa bớt thiết bị.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu nhưng không thu hồi quyền truy cập. Để thu hồi quyền, hãy ngắt Octi trên thiết bị.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu và thu hồi cả quyền truy cập.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">帮助</string>
     <string name="general_manage_devices_action">管理设备</string>
     <string name="onboarding_welcome_subtitle">你的设备助手</string>
-    <string name="onboarding_welcome_body1">Octi 是一款为拥有多台 Android 设备的用户提供的工具。</string>
-    <string name="onboarding_welcome_body2">它让您随时掌握所有设备的最新动态。无论是手机、平板电脑还是其他安装了 Octi 的设备，您都可以一目了然地了解关键详细信息。</string>
-    <string name="onboarding_welcome_body3">升级到 Octi Pro 以获取额外功能并支持开发。</string>
     <string name="onboarding_welcome_beta_hint">请注意，这是一个测试版本，所以感谢您的耐心，我会继续改进应用程序！</string>
     <string name="onboarding_features_page1_title">一览所有设备</string>
     <string name="onboarding_features_page1_body">查看所有 Android 设备的电量、WiFi 和连接状态。</string>
@@ -178,9 +175,6 @@
     <string name="pro_device_limit_reached_title">设备达到极限</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">您当前有 %1$d 台已同步设备。</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="other">要查看超过 %1$d 台设备，请升级到 Octi Pro 或移除设备。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">删除此设备将删除其数据，但不会撤销访问权限。要撤销访问权限，请断开设备上的Octi连接。</string>
     <string name="sync_delete_device_revokeaccess_caveat">删除此设备将删除其数据并撤销其访问权限。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -4,9 +4,6 @@
     <string name="label_help">幫助</string>
     <string name="general_manage_devices_action">管理裝置</string>
     <string name="onboarding_welcome_subtitle">你的設備夥伴</string>
-    <string name="onboarding_welcome_body1">Octi 是專為擁有多台 Android 裝置的用戶設計的工具。</string>
-    <string name="onboarding_welcome_body2">它讓你能隨時掌握所有裝置的最新狀態。不論是手機、平板或其他安裝了 Octi 的裝置，關鍵細節一目了然。</string>
-    <string name="onboarding_welcome_body3">升級至 Octi Pro 以獲得額外功能並支持開發。</string>
     <string name="onboarding_welcome_beta_hint">注意：這是 beta 版本，感謝你的耐心等待，我會持續改進本應用！</string>
     <string name="onboarding_features_page1_title">一覽所有裝置</string>
     <string name="onboarding_features_page1_body">查看您所有 Android 裝置的電池、WiFi 和連線狀態。</string>
@@ -178,9 +175,6 @@
     <string name="pro_device_limit_reached_title">已達設備上限</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">你目前有 %1$d 台已同步裝置。</item>
-    </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="other">要查看超過 %1$d 台裝置，請升級至 Octi Pro 或移除裝置。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">移除本設備將刪除數據但不影響訪問權限。欲撤銷請於該設備上斷開 Octi。</string>
     <string name="sync_delete_device_revokeaccess_caveat">刪除本設備將移除其數據並撤銷訪問權限。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,9 +5,6 @@
     <string name="general_manage_devices_action">Manage devices</string>
 
     <string name="onboarding_welcome_subtitle">Your Device Buddy</string>
-    <string name="onboarding_welcome_body1">Octi is a tool for people with multiple Android devices.</string>
-    <string name="onboarding_welcome_body2">It keeps you in the loop with all your devices. Whether it\'s your phone, tablet or any other gadget with Octi installed, you\'ll get key details at a glance.</string>
-    <string name="onboarding_welcome_body3">Upgrade to Octi Pro to gain extra features and support development.</string>
     <string name="onboarding_welcome_beta_hint">Just a heads-up, this is a beta version, so thanks for your patience as I keep improving the app!</string>
 
     <string name="onboarding_features_page1_title">All your devices at a glance</string>
@@ -162,6 +159,11 @@
     <string name="updates_dashcard_title">Update available</string>
     <string name="updates_dashcard_body">An update is available. You have %1$s and the latest version is %2$s.</string>
 
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Upgrade Octi</string>
+
     <string name="sync_settings_label">Synchronization</string>
     <string name="sync_settings_desc">Device name, timing and trigger conditions.</string>
     <string name="sync_setting_devicelabel_label">Device label</string>
@@ -216,9 +218,12 @@
         <item quantity="one">You currently have %1$d synced device.</item>
         <item quantity="other">You currently have %1$d synced devices.</item>
     </plurals>
-    <plurals name="pro_device_limit_maximum_description">
-        <item quantity="one">To view more than %1$d device, upgrade to Octi Pro or remove devices.</item>
-        <item quantity="other">To view more than %1$d devices, upgrade to Octi Pro or remove devices.</item>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">To view more than %1$d device, upgrade or remove devices.</item>
+        <item quantity="other">To view more than %1$d devices, upgrade or remove devices.</item>
     </plurals>
 
     <string name="sync_delete_device_keepaccess_caveat">Removing this device will delete its data but won\'t revoke access. To revoke access, disconnect Octi on the device.</string>

--- a/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/octi/common/upgrade/ui/FossUpgradeScreenTest.kt
@@ -28,8 +28,11 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    // Composed through the translated template, never by gluing the parts with a literal space: a
+    // space is what the production code used to hardcode, so an expectation built that way would
+    // agree with the bug instead of catching it.
     private val upgradedTitle: String
-        get() = "${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}"
+        get() = composedTitle(context.getString(R.string.app_name_upgrade_postfix))
 
     @Test
     fun `renders the pitch content without duplicated app bar title`() {
@@ -37,7 +40,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
             UpgradeScreen()
         }
 
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_support_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_how_body)).assertCountEquals(1)
@@ -75,7 +78,7 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(0)
-        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_support_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(upgradedTitle).assertCountEquals(0)
         // The status views keep the standalone mascot header — the hero card belongs to the pitch.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)

--- a/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/octi/common/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -22,6 +22,8 @@ import eu.darken.octi.common.compose.PreviewWrapper
 import eu.darken.octi.common.upgrade.core.OurSku
 import eu.darken.octi.common.upgrade.core.billing.SkuDetails
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
@@ -33,8 +35,15 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
+    // Composed through the translated template, never by gluing the parts with a literal space: a
+    // space is what the production code used to hardcode, so an expectation built that way would
+    // agree with the bug instead of catching it.
     private val composedBrand: String
-        get() = "${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}"
+        get() = context.getString(
+            CommonR.string.app_name_upgraded_template,
+            context.getString(CommonR.string.app_name),
+            context.getString(R.string.app_name_upgrade_postfix),
+        )
 
     private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(
         bodyRes,
@@ -466,7 +475,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_sub_renewing_body)).assertCountEquals(1)
-        composeRule.onAllNodesWithText("${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(composedBrand).assertCountEquals(1)
         // The congrats hero names the variant.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_OWNED_HERO).assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
@@ -506,6 +515,71 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_switch_locked_note)).assertCountEquals(0)
         composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).performScrollTo().performClick()
         composeRule.runOnIdle { check(iapClicks == 1) { "expected 1 iap click, got $iapClicks" } }
+    }
+
+    /**
+     * The headline is two nested translations and both have to be honoured: the outer sentence
+     * ("You have %1$s 🎉") and the brand template it receives ("%1$s %2$s"). The expectation is built
+     * from both resources, so hardcoding either — the sentence, or a space between name and
+     * qualifier — fails here rather than shipping a title no translator wrote.
+     *
+     * Verified by sabotage: dropping %1$s from the outer string makes this fail on
+     * `"You have 🎉" should include substring "Octi Pro"`.
+     */
+    @Test
+    fun `the owned hero headline composes the outer sentence around the templated brand`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = ownedState(Ownership(hasIap = true)))
+        }
+
+        val expected = context.getString(R.string.upgrade_screen_owned_hero_brand_title, composedBrand)
+        composeRule.onAllNodesWithText(expected).assertCountEquals(1)
+
+        // Assert the property, never re-derive `expected` from the same resource: formatting it a
+        // second time is a tautology. Drop %1$s from the outer string and getString discards the
+        // surplus argument on both sides, so the screen silently loses the brand while every
+        // re-derived expectation still agrees. These two guards fail instead.
+        //
+        // First: the expectation has to actually carry the brand, and carry it inside a sentence
+        // rather than being nothing but the brand.
+        expected shouldContain composedBrand
+        expected shouldNotBe composedBrand
+
+        // Second: the unformatted pattern must never reach the screen. That is what a call site
+        // which forgot to pass the argument would render (a literal "%1$s"), and it is also what
+        // the rendered text collapses to once the placeholder is gone.
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_hero_brand_title))
+            .assertCountEquals(0)
+    }
+
+    /**
+     * Arabic reorders nothing here, but it is the one locale that translates `app_name` AND the
+     * qualifier, so it proves the headline carries localized parts rather than a baked-in "Octi Pro".
+     */
+    @Test
+    @Config(qualifiers = "ar")
+    fun `the owned hero headline carries the translated brand in arabic`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = ownedState(Ownership(hasIap = true)))
+        }
+
+        val name = context.getString(CommonR.string.app_name)
+        val qualifier = context.getString(R.string.app_name_upgrade_postfix)
+        name shouldBe "أوكتي"
+        qualifier shouldBe "احترافي"
+
+        val expected = context.getString(R.string.upgrade_screen_owned_hero_brand_title, composedBrand)
+        composeRule.onAllNodesWithText(expected).assertCountEquals(1)
+
+        // Pinning the two components in isolation only proves the resources exist. What matters is
+        // that the headline the user actually sees contains them, so read it back off the node.
+        val rendered = composeRule.onNodeWithText(expected)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.Text]
+            .single()
+            .text
+        rendered shouldContain name
+        rendered shouldContain qualifier
     }
 
     @Test
@@ -568,7 +642,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // must not undercut the calm quiet stage with its own restore CTA.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         // Grace users are still Pro: neutral status title, not the acquisition pitch title.
-        composeRule.onAllNodesWithText("${context.getString(CommonR.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(composedBrand).assertCountEquals(1)
         // A young episode is treated as a blip: calm status only — no offers, no sales pitch.
         // The offers return with the aged (diagnostics) stage.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardGlanceWidget.kt
@@ -144,7 +144,7 @@ private fun ClipboardWidgetUpgradeRequired(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = ctx.getString(CommonR.string.widget_upgrade_required_title),
+                text = ctx.getString(CommonR.string.widget_upgrade_required_headline),
                 style = TextStyle(
                     color = onContainerColor,
                     fontWeight = FontWeight.Bold,

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkGlanceWidget.kt
@@ -148,7 +148,7 @@ private fun NetworkWidgetUpgradeRequired(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = ctx.getString(CommonR.string.widget_upgrade_required_title),
+                text = ctx.getString(CommonR.string.widget_upgrade_required_headline),
                 style = TextStyle(
                     color = onContainerColor,
                     fontWeight = FontWeight.Bold,


### PR DESCRIPTION
## What changed

Several screens named the Google Play "Pro" tier where it did not apply.

Users who bought the upgrade were told "You are Octi Pro", which says the person *is* the product tier rather than that they own it. It now reads "You have Octi Pro".

FOSS users were offered "Octi Pro" on the upgrade screen, the dashboard upgrade card, the device-limit hint and four widget setup screens, none of which their build sells. Those now either name no tier at all or use wording that fits both builds. Six strings no screen could reach were removed.

## Technical Context

- New string ids instead of editing the English in place, with the old ids deleted from the base files and every locale copy in the same commit. Editing the source keeps the equally wrong translations shipping until Crowdin re-translates. Same approach as 8daa8104.
- Strings in locations shared by both builds (app-common and app/src/main) now avoid tier names entirely, matching how sdmaid-se handles the same problem. A per-flavor version, using a base value in app-common overridden by the app module's flavor source sets, was built and verified working against the merged resource tables, then dropped: it would have created a cross-module resource override contract and duplicate translation units without telling the user anything more.
- The dashboard card string was declared in both flavors with identical English but read from shared code, so it could not be renamed in one flavor alone. It is now a single shared id, which removes the divergence permanently. Crowdin sees two deletions and one new shared unit; the old translations do not migrate, which is correct here since the wording changed.
- The ownership headline previously glued app name and tier together with a hardcoded space, bypassing the translated title template. It now composes through the template, and the tests that encoded the same hardcoded space were fixed so they can no longer mask it.
- The device-limit entry is a plurals resource and locale files carry between one and six quantity items, so whole blocks were removed rather than lines. Translated locales fall back to English for the new ids until Crowdin syncs; this change adds more new ids than usual.
