### PR TITLE
Update app translations from Crowdin

### DIFF
--- a/app-common/src/main/res/values-af-rZA/strings.xml
+++ b/app-common/src/main/res/values-af-rZA/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Pas legstuk aan</string>
     <string name="widget_config_apply_action">Pas toe</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Hierdie widget benodig \'n opgradering.</string>
+    <string name="widget_config_upgrade_checking_label">Jou opgraderingstatus word nagegaan…</string>
+    <string name="widget_config_upgrade_error_label">Kon nie jou opgraderingstatus verifieer nie.</string>
     <string name="widget_config_retry_action">Probeer weer</string>
     <string name="widget_config_presets_label">Voorkeure</string>
     <string name="widget_config_background_label">Agtergrondkleur</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Geen ooreenstemmende toestelle nie</string>
     <string name="widget_no_sync_devices_label">Nog geen sinchronisasie-toestelle nie</string>
     <string name="widget_more_items">+ %1$d meer</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Opgradering benodig</string>
     <string name="widget_upgrade_required_action">Tik om op te gradeer</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Geen %1$s-data vir hierdie toestel nie</string>

--- a/app-common/src/main/res/values-ar/strings.xml
+++ b/app-common/src/main/res/values-ar/strings.xml
@@ -72,6 +72,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">تخصيص الأداة</string>
     <string name="widget_config_apply_action">تطبيق</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">تتطلب هذه الودجة ترقية.</string>
+    <string name="widget_config_upgrade_checking_label">جارٍ التحقق من حالة الترقية…</string>
+    <string name="widget_config_upgrade_error_label">تعذّر التحقق من حالة الترقية.</string>
     <string name="widget_config_retry_action">أعد المحاولة</string>
     <string name="widget_config_presets_label">الإعدادات المسبقة</string>
     <string name="widget_config_background_label">لون الخلفية</string>
@@ -87,6 +96,9 @@
     <string name="widget_empty_label">لا توجد أجهزة مطابقة</string>
     <string name="widget_no_sync_devices_label">لا توجد أجهزة مزامنة بعد</string>
     <string name="widget_more_items">+ %1$d آخر</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">الترقية مطلوبة</string>
     <string name="widget_upgrade_required_action">اضغط للترقية</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">لا توجد بيانات %1$s لهذا الجهاز</string>

--- a/app-common/src/main/res/values-ca/strings.xml
+++ b/app-common/src/main/res/values-ca/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalitza el widget</string>
     <string name="widget_config_apply_action">Aplica</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Aquest widget requereix una millora.</string>
+    <string name="widget_config_upgrade_checking_label">Comprovant l\'estat de la teva millora…</string>
+    <string name="widget_config_upgrade_error_label">No s\'ha pogut verificar l\'estat de la teva millora.</string>
     <string name="widget_config_retry_action">Reintenta</string>
     <string name="widget_config_presets_label">Predefinits</string>
     <string name="widget_config_background_label">Color de fons</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Cap dispositiu coincident</string>
     <string name="widget_no_sync_devices_label">Encara no hi ha dispositius de sincronització</string>
     <string name="widget_more_items">+ %1$d més</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Millora requerida</string>
     <string name="widget_upgrade_required_action">Toqueu per actualitzar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">No hi ha dades de %1$s per a aquest dispositiu</string>

--- a/app-common/src/main/res/values-cs/strings.xml
+++ b/app-common/src/main/res/values-cs/strings.xml
@@ -70,6 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Přizpůsobit widget</string>
     <string name="widget_config_apply_action">Použít</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Tento widget vyžaduje aktualizaci.</string>
+    <string name="widget_config_upgrade_checking_label">Ověřuji stav aktualizace…</string>
+    <string name="widget_config_upgrade_error_label">Nepodařilo se ověřit stav aktualizace.</string>
     <string name="widget_config_retry_action">Opakovat</string>
     <string name="widget_config_presets_label">Předvolby</string>
     <string name="widget_config_background_label">Barva pozadí</string>
@@ -85,6 +94,9 @@
     <string name="widget_empty_label">Žádná odpovídající zařízení</string>
     <string name="widget_no_sync_devices_label">Zatím žádná zařízení k synchronizaci</string>
     <string name="widget_more_items">+ %1$d další</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Vyžadován upgrade</string>
     <string name="widget_upgrade_required_action">Klepněte pro upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Pro toto zařízení nejsou k dispozici žádná data %1$s</string>

--- a/app-common/src/main/res/values-da/strings.xml
+++ b/app-common/src/main/res/values-da/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tilpas widget</string>
     <string name="widget_config_apply_action">Anvend</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Dette widget kræver en opgradering.</string>
+    <string name="widget_config_upgrade_checking_label">Tjekker din opgraderingsstatus…</string>
+    <string name="widget_config_upgrade_error_label">Kunne ikke bekræfte din opgraderingsstatus.</string>
     <string name="widget_config_retry_action">Prøv igen</string>
     <string name="widget_config_presets_label">Forudindstillinger</string>
     <string name="widget_config_background_label">Baggrundsfarve</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Ingen matchende enheder</string>
     <string name="widget_no_sync_devices_label">Ingen synkroniseringsenheder endnu</string>
     <string name="widget_more_items">+ %1$d mere</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Opgradering påkrævet</string>
     <string name="widget_upgrade_required_action">Tryk for at opgradere</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ingen %1$s-data for denne enhed</string>

--- a/app-common/src/main/res/values-de/strings.xml
+++ b/app-common/src/main/res/values-de/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget anpassen</string>
     <string name="widget_config_apply_action">Anwenden</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Dieses Widget erfordert ein Upgrade.</string>
+    <string name="widget_config_upgrade_checking_label">Überprüfung deines Upgrade-Status…</string>
+    <string name="widget_config_upgrade_error_label">Konnte deinen Upgrade-Status nicht überprüfen.</string>
     <string name="widget_config_retry_action">Erneut versuchen</string>
     <string name="widget_config_presets_label">Voreinstellungen</string>
     <string name="widget_config_background_label">Hintergrundfarbe</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Keine passenden Geräte</string>
     <string name="widget_no_sync_devices_label">Noch keine Synchronisierungsgeräte</string>
     <string name="widget_more_items">+ %1$d mehr</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Upgrade erforderlich</string>
     <string name="widget_upgrade_required_action">Tippen zum Upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Keine %1$s-Daten für dieses Gerät</string>

--- a/app-common/src/main/res/values-el/strings.xml
+++ b/app-common/src/main/res/values-el/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Προσαρμογή Widget</string>
     <string name="widget_config_apply_action">Εφαρμογή</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Αυτό το widget απαιτεί αναβάθμιση.</string>
+    <string name="widget_config_upgrade_checking_label">Ελέγχεται η κατάσταση αναβάθμισής σας…</string>
+    <string name="widget_config_upgrade_error_label">Δεν ήταν δυνατό να επαληθεύσουμε την κατάσταση αναβάθμισής σας.</string>
     <string name="widget_config_retry_action">Δοκιμάστε ξανά</string>
     <string name="widget_config_presets_label">Προεπιλογές</string>
     <string name="widget_config_background_label">Χρώμα φόντου</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Δεν υπάρχουν αντίστοιχες συσκευές</string>
     <string name="widget_no_sync_devices_label">Δεν υπάρχουν ακόμη συσκευές συγχρονισμού</string>
     <string name="widget_more_items">+ %1$d ακόμη</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Απαιτείται αναβάθμιση</string>
     <string name="widget_upgrade_required_action">Αγγίξτε για αναβάθμιση</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Δεν υπάρχουν δεδομένα %1$s για αυτή τη συσκευή</string>

--- a/app-common/src/main/res/values-es/strings.xml
+++ b/app-common/src/main/res/values-es/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Este widget requiere una actualización.</string>
+    <string name="widget_config_upgrade_checking_label">Comprobando el estado de tu actualización…</string>
+    <string name="widget_config_upgrade_error_label">No se pudo verificar el estado de tu actualización.</string>
     <string name="widget_config_retry_action">Reintentar</string>
     <string name="widget_config_presets_label">Predeterminados</string>
     <string name="widget_config_background_label">Color de fondo</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">No hay dispositivos coincidentes</string>
     <string name="widget_no_sync_devices_label">Aún no hay dispositivos de sincronización</string>
     <string name="widget_more_items">+ %1$d más</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Actualización necesaria</string>
     <string name="widget_upgrade_required_action">Toca para actualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sin datos de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-fi/strings.xml
+++ b/app-common/src/main/res/values-fi/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Mukauta widgettiä</string>
     <string name="widget_config_apply_action">Käytä</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Tämä widget vaatii päivityksen.</string>
+    <string name="widget_config_upgrade_checking_label">Tarkistetaan päivityksen tilaa…</string>
+    <string name="widget_config_upgrade_error_label">Päivityksen tilaa ei voitu varmistaa.</string>
     <string name="widget_config_retry_action">Yritä uudelleen</string>
     <string name="widget_config_presets_label">Esiasetukset</string>
     <string name="widget_config_background_label">Taustaväri</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Ei vastaavia laitteita</string>
     <string name="widget_no_sync_devices_label">Ei synkronoitavia laitteita vielä</string>
     <string name="widget_more_items">+ %1$d lisää</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Päivitys vaaditaan</string>
     <string name="widget_upgrade_required_action">Napauta päivittyäksesi</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ei %1$s-tietoja tältä laitteelta</string>

--- a/app-common/src/main/res/values-fr/strings.xml
+++ b/app-common/src/main/res/values-fr/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personnaliser le widget</string>
     <string name="widget_config_apply_action">Appliquer</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Ce widget nécessite une mise à niveau.</string>
+    <string name="widget_config_upgrade_checking_label">Vérification de ton statut de mise à niveau…</string>
+    <string name="widget_config_upgrade_error_label">Impossible de vérifier ton statut de mise à niveau.</string>
     <string name="widget_config_retry_action">Réessayer</string>
     <string name="widget_config_presets_label">Préréglages</string>
     <string name="widget_config_background_label">Couleur d\'arrière-plan</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Aucun appareil correspondant</string>
     <string name="widget_no_sync_devices_label">Aucun appareil de synchronisation pour l\'instant</string>
     <string name="widget_more_items">+ %1$d autres</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Mise à niveau requise</string>
     <string name="widget_upgrade_required_action">Appuyer pour mettre à niveau</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Aucune donnée %1$s pour cet appareil</string>

--- a/app-common/src/main/res/values-hu/strings.xml
+++ b/app-common/src/main/res/values-hu/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget testreszabása</string>
     <string name="widget_config_apply_action">Alkalmaz</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Ez a widget frissítést igényel.</string>
+    <string name="widget_config_upgrade_checking_label">Frissítési állapot ellenőrzése…</string>
+    <string name="widget_config_upgrade_error_label">Nem sikerült ellenőrizni a frissítési állapotot.</string>
     <string name="widget_config_retry_action">Újra</string>
     <string name="widget_config_presets_label">Előbeállítások</string>
     <string name="widget_config_background_label">Háttérszín</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Nincs egyező eszköz</string>
     <string name="widget_no_sync_devices_label">Még nincs szinkronizációs eszköz</string>
     <string name="widget_more_items">+ még %1$d</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Frissítés szükséges</string>
     <string name="widget_upgrade_required_action">Koppints a frissítéshez</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nincs %1$s adat ennél az eszköznél</string>

--- a/app-common/src/main/res/values-it/strings.xml
+++ b/app-common/src/main/res/values-it/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizza Widget</string>
     <string name="widget_config_apply_action">Applica</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Questo widget richiede un aggiornamento.</string>
+    <string name="widget_config_upgrade_checking_label">Verifica dello stato dell\'aggiornamento…</string>
+    <string name="widget_config_upgrade_error_label">Impossibile verificare lo stato dell\'aggiornamento.</string>
     <string name="widget_config_retry_action">Ritenta</string>
     <string name="widget_config_presets_label">Predefiniti</string>
     <string name="widget_config_background_label">Colore di sfondo</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Nessun dispositivo corrispondente</string>
     <string name="widget_no_sync_devices_label">Nessun dispositivo di sincronizzazione ancora</string>
     <string name="widget_more_items">+ altri %1$d</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Aggiornamento richiesto</string>
     <string name="widget_upgrade_required_action">Tocca per eseguire l’upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nessun dato %1$s per questo dispositivo</string>

--- a/app-common/src/main/res/values-iw/strings.xml
+++ b/app-common/src/main/res/values-iw/strings.xml
@@ -70,6 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">התאם אישית את הווידג\'ט</string>
     <string name="widget_config_apply_action">החל</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">ווידג\'ט זה דורש שדרוג.</string>
+    <string name="widget_config_upgrade_checking_label">בדיקת סטטוס השדרוג…</string>
+    <string name="widget_config_upgrade_error_label">לא ניתן היה לאמת את סטטוס השדרוג.</string>
     <string name="widget_config_retry_action">נסה שוב</string>
     <string name="widget_config_presets_label">הגדרות קבועות מראש</string>
     <string name="widget_config_background_label">צבע רקע</string>
@@ -85,6 +94,9 @@
     <string name="widget_empty_label">אין מכשירים מתאימים</string>
     <string name="widget_no_sync_devices_label">עדיין אין מכשירי סנכרון</string>
     <string name="widget_more_items">+ עוד %1$d</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">נדרש שדרוג</string>
     <string name="widget_upgrade_required_action">הקש לשדרג</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">אין נתוני %1$s עבור מכשיר זה</string>

--- a/app-common/src/main/res/values-ja/strings.xml
+++ b/app-common/src/main/res/values-ja/strings.xml
@@ -67,6 +67,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">ウィジェットをカスタマイズ</string>
     <string name="widget_config_apply_action">適用</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">このウィジェットにはアップグレードが必要です。</string>
+    <string name="widget_config_upgrade_checking_label">アップグレード状況を確認しています…</string>
+    <string name="widget_config_upgrade_error_label">アップグレード状況を確認できませんでした。</string>
     <string name="widget_config_retry_action">再試行</string>
     <string name="widget_config_presets_label">プリセット</string>
     <string name="widget_config_background_label">背景色</string>
@@ -82,6 +91,9 @@
     <string name="widget_empty_label">一致するデバイスがありません</string>
     <string name="widget_no_sync_devices_label">同期デバイスがまだありません</string>
     <string name="widget_more_items">+ %1$d 件</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">アップグレードが必要</string>
     <string name="widget_upgrade_required_action">タップしてアップグレード</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">このデバイスの%1$sデータがありません</string>

--- a/app-common/src/main/res/values-ko/strings.xml
+++ b/app-common/src/main/res/values-ko/strings.xml
@@ -67,6 +67,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">위젯 맞춤 설정</string>
     <string name="widget_config_apply_action">적용</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">이 위젯을 사용하려면 업그레이드가 필요합니다.</string>
+    <string name="widget_config_upgrade_checking_label">업그레이드 상태를 확인하는 중…</string>
+    <string name="widget_config_upgrade_error_label">업그레이드 상태를 확인할 수 없습니다.</string>
     <string name="widget_config_retry_action">다시 시도</string>
     <string name="widget_config_presets_label">프리셋</string>
     <string name="widget_config_background_label">배경 색상</string>
@@ -82,6 +91,9 @@
     <string name="widget_empty_label">일치하는 기기 없음</string>
     <string name="widget_no_sync_devices_label">아직 동기화 기기 없음</string>
     <string name="widget_more_items">+ %1$d개 더</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">업그레이드 필요</string>
     <string name="widget_upgrade_required_action">탭하여 업그레이드</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">이 기기의 %1$s 데이터 없음</string>

--- a/app-common/src/main/res/values-nb/strings.xml
+++ b/app-common/src/main/res/values-nb/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tilpass widget</string>
     <string name="widget_config_apply_action">Bruk</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Denne widgeten krever en oppgradering.</string>
+    <string name="widget_config_upgrade_checking_label">Sjekker oppgraderingsstatus din…</string>
+    <string name="widget_config_upgrade_error_label">Kunne ikke bekrefte oppgraderingsstatus din.</string>
     <string name="widget_config_retry_action">Prøv igjen</string>
     <string name="widget_config_presets_label">Forhåndsinnstillinger</string>
     <string name="widget_config_background_label">Bakgrunnsfarge</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Ingen samsvarende enheter</string>
     <string name="widget_no_sync_devices_label">Ingen synkroniseringsenheter ennå</string>
     <string name="widget_more_items">+ %1$d flere</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Oppgradering kreves</string>
     <string name="widget_upgrade_required_action">Trykk for å oppgradere</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Ingen %1$s-data for denne enheten</string>

--- a/app-common/src/main/res/values-nl/strings.xml
+++ b/app-common/src/main/res/values-nl/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget aanpassen</string>
     <string name="widget_config_apply_action">Toepassen</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Voor deze widget is een upgrade vereist.</string>
+    <string name="widget_config_upgrade_checking_label">Je upgradestatus wordt gecontroleerd…</string>
+    <string name="widget_config_upgrade_error_label">Je upgradestatus kon niet worden geverifieerd.</string>
     <string name="widget_config_retry_action">Opnieuw proberen</string>
     <string name="widget_config_presets_label">Voorinstellingen</string>
     <string name="widget_config_background_label">Achtergrondkleur</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Geen overeenkomende apparaten</string>
     <string name="widget_no_sync_devices_label">Nog geen synchronisatieapparaten</string>
     <string name="widget_more_items">+ %1$d meer</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Upgrade vereist</string>
     <string name="widget_upgrade_required_action">Tik om te upgraden</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Geen %1$s-gegevens voor dit apparaat</string>

--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -70,6 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Dostosuj widżet</string>
     <string name="widget_config_apply_action">Zastosuj</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Ten widżet wymaga uaktualnienia.</string>
+    <string name="widget_config_upgrade_checking_label">Sprawdzanie statusu uaktualnienia…</string>
+    <string name="widget_config_upgrade_error_label">Nie można zweryfikować statusu uaktualnienia.</string>
     <string name="widget_config_retry_action">Ponów</string>
     <string name="widget_config_presets_label">Ustawienia wstępne</string>
     <string name="widget_config_background_label">Kolor tła</string>
@@ -85,6 +94,9 @@
     <string name="widget_empty_label">Brak pasujących urządzeń</string>
     <string name="widget_no_sync_devices_label">Brak urządzeń do synchronizacji</string>
     <string name="widget_more_items">+ %1$d więcej</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Wymagana aktualizacja</string>
     <string name="widget_upgrade_required_action">Naciśnij, aby zaktualizować</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Brak danych %1$s dla tego urządzenia</string>

--- a/app-common/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common/src/main/res/values-pt-rBR/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar Widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Este widget precisa de uma atualização.</string>
+    <string name="widget_config_upgrade_checking_label">Verificando seu status de atualização…</string>
+    <string name="widget_config_upgrade_error_label">Não foi possível verificar seu status de atualização.</string>
     <string name="widget_config_retry_action">Tentar novamente</string>
     <string name="widget_config_presets_label">Predefinições</string>
     <string name="widget_config_background_label">Cor de fundo</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Nenhum dispositivo correspondente</string>
     <string name="widget_no_sync_devices_label">Nenhum dispositivo de sincronização ainda</string>
     <string name="widget_more_items">+ %1$d mais</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Atualização necessária</string>
     <string name="widget_upgrade_required_action">Toque para atualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sem dados de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-pt/strings.xml
+++ b/app-common/src/main/res/values-pt/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizar Widget</string>
     <string name="widget_config_apply_action">Aplicar</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Este widget requer uma atualização.</string>
+    <string name="widget_config_upgrade_checking_label">A verificar o estado da tua atualização…</string>
+    <string name="widget_config_upgrade_error_label">Não foi possível verificar o estado da tua atualização.</string>
     <string name="widget_config_retry_action">Tentar novamente</string>
     <string name="widget_config_presets_label">Predefinições</string>
     <string name="widget_config_background_label">Cor de fundo</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Nenhum dispositivo correspondente</string>
     <string name="widget_no_sync_devices_label">Ainda sem dispositivos de sincronização</string>
     <string name="widget_more_items">+ %1$d mais</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Atualização necessária</string>
     <string name="widget_upgrade_required_action">Toque para atualizar</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Sem dados de %1$s para este dispositivo</string>

--- a/app-common/src/main/res/values-ro/strings.xml
+++ b/app-common/src/main/res/values-ro/strings.xml
@@ -69,6 +69,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Personalizare widget</string>
     <string name="widget_config_apply_action">Aplică</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Acest widget necesită un upgrade.</string>
+    <string name="widget_config_upgrade_checking_label">Se verifică starea upgrade-ului…</string>
+    <string name="widget_config_upgrade_error_label">Nu s-a putut verifica starea upgrade-ului.</string>
     <string name="widget_config_retry_action">Reîncercați</string>
     <string name="widget_config_presets_label">Presetări</string>
     <string name="widget_config_background_label">Culoare de fundal</string>
@@ -84,6 +93,9 @@
     <string name="widget_empty_label">Niciun dispozitiv corespunzător</string>
     <string name="widget_no_sync_devices_label">Niciun dispozitiv de sincronizare încă</string>
     <string name="widget_more_items">+ %1$d mai mult</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Upgrade necesar</string>
     <string name="widget_upgrade_required_action">Atingeți pentru a face upgrade</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Nu există date %1$s pentru acest dispozitiv</string>

--- a/app-common/src/main/res/values-ru/strings.xml
+++ b/app-common/src/main/res/values-ru/strings.xml
@@ -70,6 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Настроить виджет</string>
     <string name="widget_config_apply_action">Применить</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Этот виджет требует обновления.</string>
+    <string name="widget_config_upgrade_checking_label">Проверка статуса обновления…</string>
+    <string name="widget_config_upgrade_error_label">Не удалось проверить статус обновления.</string>
     <string name="widget_config_retry_action">Повторить</string>
     <string name="widget_config_presets_label">Предустановки</string>
     <string name="widget_config_background_label">Цвет фона</string>
@@ -85,6 +94,9 @@
     <string name="widget_empty_label">Нет подходящих устройств</string>
     <string name="widget_no_sync_devices_label">Нет синхронизированных устройств</string>
     <string name="widget_more_items">+ ещё %1$d</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Требуется обновление</string>
     <string name="widget_upgrade_required_action">Нажмите для обновления</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Нет данных %1$s для этого устройства</string>

--- a/app-common/src/main/res/values-sr/strings.xml
+++ b/app-common/src/main/res/values-sr/strings.xml
@@ -69,6 +69,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Прилагоди виџет</string>
     <string name="widget_config_apply_action">Примени</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Овај виџет захтева надградњу.</string>
+    <string name="widget_config_upgrade_checking_label">Проверавам статус ваше надградње…</string>
+    <string name="widget_config_upgrade_error_label">Не могу да потврдим статус ваше надградње.</string>
     <string name="widget_config_retry_action">Поновити</string>
     <string name="widget_config_presets_label">Предефинисани изгледи</string>
     <string name="widget_config_background_label">Боја позадине</string>
@@ -84,6 +93,9 @@
     <string name="widget_empty_label">Нема уређаја који одговарају</string>
     <string name="widget_no_sync_devices_label">Још нема уређаја за синхронизацију</string>
     <string name="widget_more_items">+ %1$d више</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Потребна је надградња</string>
     <string name="widget_upgrade_required_action">Додирни да надоградиш</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Нема %1$s података за овај уређај</string>

--- a/app-common/src/main/res/values-sv/strings.xml
+++ b/app-common/src/main/res/values-sv/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Anpassa widget</string>
     <string name="widget_config_apply_action">Tillämpa</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Denna widget kräver en uppgradering.</string>
+    <string name="widget_config_upgrade_checking_label">Kontrollerar din uppgraderingsstatus…</string>
+    <string name="widget_config_upgrade_error_label">Kunde inte verifiera din uppgraderingsstatus.</string>
     <string name="widget_config_retry_action">Försök igen</string>
     <string name="widget_config_presets_label">Förinställningar</string>
     <string name="widget_config_background_label">Bakgrundsfärg</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Inga matchande enheter</string>
     <string name="widget_no_sync_devices_label">Inga synkenheter ännu</string>
     <string name="widget_more_items">+ %1$d fler</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Uppgradering krävs</string>
     <string name="widget_upgrade_required_action">Tryck för att uppgradera</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Inga %1$s-data för den här enheten</string>

--- a/app-common/src/main/res/values-tr/strings.xml
+++ b/app-common/src/main/res/values-tr/strings.xml
@@ -68,6 +68,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Widget\'ı Özelleştir</string>
     <string name="widget_config_apply_action">Uygula</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Bu widget bir yükseltme gerektiriyor.</string>
+    <string name="widget_config_upgrade_checking_label">Yükseltme durumun kontrol ediliyor…</string>
+    <string name="widget_config_upgrade_error_label">Yükseltme durumun doğrulanamadı.</string>
     <string name="widget_config_retry_action">Yeniden dene</string>
     <string name="widget_config_presets_label">Ön Ayarlar</string>
     <string name="widget_config_background_label">Arka plan rengi</string>
@@ -83,6 +92,9 @@
     <string name="widget_empty_label">Eşleşen cihaz yok</string>
     <string name="widget_no_sync_devices_label">Henüz eşzamanlama cihazı yok</string>
     <string name="widget_more_items">+ %1$d daha</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Yükseltme gerekli</string>
     <string name="widget_upgrade_required_action">Yükseltmek için dokunun</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Bu cihaz için %1$s verisi yok</string>

--- a/app-common/src/main/res/values-uk/strings.xml
+++ b/app-common/src/main/res/values-uk/strings.xml
@@ -70,6 +70,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Налаштувати віджет</string>
     <string name="widget_config_apply_action">Застосувати</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Цей віджет потребує оновлення.</string>
+    <string name="widget_config_upgrade_checking_label">Перевірка статусу оновлення…</string>
+    <string name="widget_config_upgrade_error_label">Не вдалося перевірити статус оновлення.</string>
     <string name="widget_config_retry_action">Повторити спробу</string>
     <string name="widget_config_presets_label">Попередні налаштування</string>
     <string name="widget_config_background_label">Колір фону</string>
@@ -85,6 +94,9 @@
     <string name="widget_empty_label">Немає відповідних пристроїв</string>
     <string name="widget_no_sync_devices_label">Ще немає пристроїв синхронізації</string>
     <string name="widget_more_items">+ %1$d ще</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Потрібне оновлення</string>
     <string name="widget_upgrade_required_action">Тисніть, щоб оновити</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Немає даних %1$s для цього пристрою</string>

--- a/app-common/src/main/res/values-vi/strings.xml
+++ b/app-common/src/main/res/values-vi/strings.xml
@@ -67,6 +67,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">Tùy chỉnh Widget</string>
     <string name="widget_config_apply_action">Áp dụng</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">Tiện ích này yêu cầu nâng cấp.</string>
+    <string name="widget_config_upgrade_checking_label">Đang kiểm tra trạng thái nâng cấp của bạn…</string>
+    <string name="widget_config_upgrade_error_label">Không thể xác minh trạng thái nâng cấp của bạn.</string>
     <string name="widget_config_retry_action">Thử lại</string>
     <string name="widget_config_presets_label">Cài sẵn</string>
     <string name="widget_config_background_label">Màu nền</string>
@@ -82,6 +91,9 @@
     <string name="widget_empty_label">Không có thiết bị phù hợp</string>
     <string name="widget_no_sync_devices_label">Chưa có thiết bị đồng bộ</string>
     <string name="widget_more_items">+ %1$d thêm</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">Cần nâng cấp</string>
     <string name="widget_upgrade_required_action">Nhấn để nâng cấp</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">Không có dữ liệu %1$s cho thiết bị này</string>

--- a/app-common/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common/src/main/res/values-zh-rCN/strings.xml
@@ -67,6 +67,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">自定义小部件</string>
     <string name="widget_config_apply_action">应用</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">此小组件需要升级。</string>
+    <string name="widget_config_upgrade_checking_label">正在检查你的升级状态…</string>
+    <string name="widget_config_upgrade_error_label">无法验证你的升级状态。</string>
     <string name="widget_config_retry_action">重试</string>
     <string name="widget_config_presets_label">预设</string>
     <string name="widget_config_background_label">背景颜色</string>
@@ -82,6 +91,9 @@
     <string name="widget_empty_label">无匹配设备</string>
     <string name="widget_no_sync_devices_label">尚无同步设备</string>
     <string name="widget_more_items">+ %1$d 更多</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">需要升级</string>
     <string name="widget_upgrade_required_action">点击升级</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">此设备没有 %1$s 数据</string>

--- a/app-common/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common/src/main/res/values-zh-rTW/strings.xml
@@ -67,6 +67,15 @@
     <!-- Widget config -->
     <string name="widget_config_title">自訂小工具</string>
     <string name="widget_config_apply_action">套用</string>
+    <!-- Replaces widget_config_pro_required_label / widget_config_pro_checking_label /
+         widget_config_pro_error_label, which named the Google Play tier ("Octi Pro") even in the FOSS
+         build, where the tier is called "Octi FOSS". This module is shared by both flavors and cannot
+         know which tier is meant, so the copy names none: keep it tier-free when translating, and do
+         not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
+         is gone too; its button now uses the existing general_upgrade_action. -->
+    <string name="widget_config_upgrade_required_label">此小工具需要升級。</string>
+    <string name="widget_config_upgrade_checking_label">正在檢查您的升級狀態…</string>
+    <string name="widget_config_upgrade_error_label">無法驗證您的升級狀態。</string>
     <string name="widget_config_retry_action">重試</string>
     <string name="widget_config_presets_label">預設</string>
     <string name="widget_config_background_label">背景顏色</string>
@@ -82,6 +91,9 @@
     <string name="widget_empty_label">沒有符合的裝置</string>
     <string name="widget_no_sync_devices_label">尚無同步裝置</string>
     <string name="widget_more_items">+ 還有 %1$d 個</string>
+    <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
+         Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
+    <string name="widget_upgrade_required_headline">需要升級</string>
     <string name="widget_upgrade_required_action">點擊升級</string>
     <!-- Widget deeplink -->
     <string name="widget_deeplink_no_data_msg">此裝置沒有 %1$s 資料</string>

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Die gratis weergawe is beperk tot %1$d toestel.</item>
         <item quantity="other">Die gratis weergawe is beperk tot %1$d toestelle.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Ondersteun Octi</string>
     <string name="upgrade_screen_preamble">Octi het geen advertensies en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️</string>
     <string name="upgrade_screen_how_title">Wat om te doen</string>
     <string name="upgrade_screen_how_body">Word \'n ondersteuner en borg ontwikkeling! Tik die knoppie hieronder om al die ekstra kenmerke te aktiveer en my GitHub Sponsors-profiel oop te maak.</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -10,6 +10,10 @@
         <item quantity="many">النسخة المجانية مقتصرة على %1$d جهازًا.</item>
         <item quantity="other">النسخة المجانية مقتصرة على %1$d جهاز.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">ادعم Octi</string>
     <string name="upgrade_screen_preamble">أوكتي خالٍ من الإعلانات ولا يبيع بيانات المستخدمين. عملي يُموَّل بكم ❤️</string>
     <string name="upgrade_screen_how_title">الخطوات</string>
     <string name="upgrade_screen_how_body">كن راعيًا وادعم التطوير! انقر على الزر أدناه لتفعيل كل الميزات الإضافية وفتح صفحة رعاة جيثب الخاصة بي.</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">La versió gratuïta està limitada a %1$d dispositiu.</item>
         <item quantity="other">La versió gratuïta està limitada a %1$d dispositius.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Suporta Octi</string>
     <string name="upgrade_screen_preamble">L\'Octi no té anuncis i no ven dades d\'usuari. El meu treball està finançat per usuaris com vós ❤️</string>
     <string name="upgrade_screen_how_title">Que fer?</string>
     <string name="upgrade_screen_how_body">Convertiu-vos en mecenes i patrocinadors del desenvolupament! Toqueu el botó següent per activar totes les funcions addicionals i obrir el meu perfil de patrocinadors del GitHub.</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -8,6 +8,10 @@
         <item quantity="many">Bezplatná verze je omezena na %1$d zařízení.</item>
         <item quantity="other">Bezplatná verze je omezena na %1$d zařízení.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Podpořit Octi</string>
     <string name="upgrade_screen_preamble">Octi neobsahuje žádné reklamy a neprodává data uživatelů. Moji práci financujete vy ❤️</string>
     <string name="upgrade_screen_how_title">Co dělat</string>
     <string name="upgrade_screen_how_body">Staňte se patronem a sponzorem vývoje! Klepnutím na tlačítko níže aktivujete všechny další funkce a otevřete můj profil sponzora na GitHubu.</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Gratisversionen er begrænset til %1$d enhed.</item>
         <item quantity="other">Gratisversionen er begrænset til %1$d enheder.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Støt Octi</string>
     <string name="upgrade_screen_preamble">Octi har ingen reklamer og sælger ikke brugerdata. Mit arbejde finansieres af dig ❤️</string>
     <string name="upgrade_screen_how_title">Hvad skal man gøre</string>
     <string name="upgrade_screen_how_body">Bliv sponsor og støt udviklingen! Tryk på knappen nedenfor for at aktivere alle ekstra funktioner og åbne min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Die kostenlose Version ist auf %1$d Gerät beschränkt.</item>
         <item quantity="other">Die kostenlose Version ist auf %1$d Geräte beschränkt.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Unterstütze Octi</string>
     <string name="upgrade_screen_preamble">Octi hat keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️</string>
     <string name="upgrade_screen_how_title">Was ist zu tun</string>
     <string name="upgrade_screen_how_body">Werde ein Förderer und sponsere die Entwicklung! Tippe auf die Schaltfläche unten, um alle zusätzlichen Funktionen zu aktivieren und mein GitHub-Sponsorenprofil zu öffnen.</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Η δωρεάν έκδοση περιορίζεται σε %1$d συσκευή.</item>
         <item quantity="other">Η δωρεάν έκδοση περιορίζεται σε %1$d συσκευές.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Υποστήρξτε το Octi</string>
     <string name="upgrade_screen_preamble">Το Octi δεν έχει διαφημίσεις και δεν πουλάει δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️</string>
     <string name="upgrade_screen_how_title">Τι να κάνετε</string>
     <string name="upgrade_screen_how_body">Γίνετε υποστηρικτής και σπόνσορας της ανάπτυξης! Πατήστε το παρακάτω κουμπί για να ενεργοποιήσετε όλες τις επιπλέον λειτουργίες και να ανοίξετε το προφίλ των χορηγιών μου στο GitHub.</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">%1$d dispositivo en la versión gratuita.</item>
         <item quantity="other">La versión gratuita está limitada a %1$d dispositivos.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Apoya a Octi</string>
     <string name="upgrade_screen_preamble">Octi no tiene anuncios y no vende datos de usuario. Mi trabajo está financiado por ti ❤️</string>
     <string name="upgrade_screen_how_title">Qué hacer</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y apoya el desarrollo! Toca el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de GitHub Sponsors.</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Ilmaisversio on rajoitettu %1$d laitteeseen.</item>
         <item quantity="other">Ilmaisversio on rajoitettu %1$d laitteeseen.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Tue Octia</string>
     <string name="upgrade_screen_preamble">Octi ei sisällä mainoksia eikä myy käyttäjätietoja. Työni rahoitetaan sinun avullasi ❤️</string>
     <string name="upgrade_screen_how_title">Mitä tehdä</string>
     <string name="upgrade_screen_how_body">Ryhdy tukijaksi ja sponsoroi kehitystä! Napauta alapuolella olevaa painiketta aktivoidaksesi kaikki lisäominaisuudet ja avataksesi GitHub Sponsorini profiilin.</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">La version gratuite est limitée à %1$d appareil.</item>
         <item quantity="other">La version gratuite est limitée à %1$d appareils.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Soutenir Octi</string>
     <string name="upgrade_screen_preamble">Octi n’affiche pas de publicités et ne vend pas les données des utilisateurs. Vous financez mon travail ❤️.</string>
     <string name="upgrade_screen_how_title">Ce qu’il faut faire</string>
     <string name="upgrade_screen_how_body">Devenez mécène et commanditez le développement d’Octi. Touchez le bouton ci-dessous pour activer les fonctions supplémentaires et ouvrir mon profil « GitHub Sponsors ».</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">%1$d eszközre korlátozódik az ingyenes verzió.</item>
         <item quantity="other">%1$d eszközre korlátozódik az ingyenes verzió.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Octi támogatása</string>
     <string name="upgrade_screen_preamble">Az Octi nem tartalmaz hirdetéseket és nem árulja felhasználói adatokat. A munkámat te finanszírozod ❤️</string>
     <string name="upgrade_screen_how_title">Mit kell tenni</string>
     <string name="upgrade_screen_how_body">Légy támogató és szponzoráld a fejlesztést! Érintsd meg az alábbi gombot minden extra funkció aktiválásához és a GitHub Sponsors profilom megnyitásához.</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">La versione gratuita è limitata a %1$d dispositivo.</item>
         <item quantity="other">La versione gratuita è limitata a %1$d dispositivi.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Sostieni Octi</string>
     <string name="upgrade_screen_preamble">Octi non ha pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️</string>
     <string name="upgrade_screen_how_title">Cosa fare</string>
     <string name="upgrade_screen_how_body">Diventa sostenitore dello sviluppo! Clicca il bottone qui sotto per attivare funzionalità extra e vsualizza il mio profilo github sponsors.</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -8,6 +8,10 @@
         <item quantity="many">הגרסה החינמית מוגבלת ל-%1$d מכשירים</item>
         <item quantity="other">הגרסה החינמית מוגבלת ל-%1$d מכשירים</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">תמיכה ב-Octi</string>
     <string name="upgrade_screen_preamble">Octi לא מכילה מודעות ואיננו מוכרים נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️</string>
     <string name="upgrade_screen_how_title">מה לעשות</string>
     <string name="upgrade_screen_how_body">הפוך לפטרון ונותן חסות לפיתוח! הקש על הלחצן למטה כדי להפעיל את כל התכונות הנוספות ולפתוח את פרופיל התומכים ב- GitHub שלי.</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -5,6 +5,10 @@
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">無料版は%1$dデバイスまでに制限されています。</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Octiをサポート</string>
     <string name="upgrade_screen_preamble">Octi は無広告、ユーザーデータの販売もしません。あなたの支援で成り立っています ❤️</string>
     <string name="upgrade_screen_how_title">何をしますか</string>
     <string name="upgrade_screen_how_body">支援者になって開発者のスポンサーになりましょう！下のボタンをタップしてすべての追加機能を有効化し、私の GitHub スポンサープロフィールを開いてください。</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -5,6 +5,10 @@
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">무료 버전은 %1$d개의 기기로 제한됩니다.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Octi 후원하기</string>
     <string name="upgrade_screen_preamble">Octi는 광고가 없고 사용자 데이터를 판매하지 않습니다. 제 작업은 여러분의 도움으로 이루어집니다 ❤️</string>
     <string name="upgrade_screen_how_title">해야 할 일</string>
     <string name="upgrade_screen_how_body">후원자가 되어 개발을 지원하세요! 아래 버튼을 터치하여 모든 추가 기능을 활성화하고 제 GitHub Sponsors 프로필을 여세요.</string>

--- a/app/src/foss/res/values-nb/strings.xml
+++ b/app/src/foss/res/values-nb/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Gratisversjonen er begrenset til %1$d enhet.</item>
         <item quantity="other">Gratisversjonen er begrenset til %1$d enheter.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Støtt Octi</string>
     <string name="upgrade_screen_preamble">Octi har ingen annonser og selger ikke brukerdata. Arbeidet mitt finansieres av deg ❤️</string>
     <string name="upgrade_screen_how_title">Hva du skal gjøre</string>
     <string name="upgrade_screen_how_body">Bli en beskytter og spons utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">De gratis versie is beperkt tot %1$d apparaat.</item>
         <item quantity="other">De gratis versie is beperkt tot %1$d apparaten.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Steun Octi</string>
     <string name="upgrade_screen_preamble">Octi heeft geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️</string>
     <string name="upgrade_screen_how_title">Wat te doen</string>
     <string name="upgrade_screen_how_body">Word een sponsor en steun de ontwikkeling! Tik op de knop hieronder om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -8,6 +8,10 @@
         <item quantity="many">Darmowa wersja jest ograniczona do %1$d urządzeń.</item>
         <item quantity="other">Darmowa wersja jest ograniczona do %1$d urządzeń.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Wspieraj Octi</string>
     <string name="upgrade_screen_preamble">Octi nie wyświetla reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️</string>
     <string name="upgrade_screen_how_title">Co zrobić</string>
     <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">A versão gratuita é limitada a %1$d dispositivo.</item>
         <item quantity="other">A versão gratuita é limitada a %1$d dispositivos.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Apoiar Octi</string>
     <string name="upgrade_screen_preamble">Octi não possui anúncios e não vende dados de usuário. Meu trabalho é financiado por você ❤️</string>
     <string name="upgrade_screen_how_title">O que fazer</string>
     <string name="upgrade_screen_how_body">Torne-se um patrono e patrocine o desenvolvimento! Toque no botão abaixo para ativar todos os recursos extras e abrir meu perfil no GitHub Sponsors.</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">A versão gratuita está limitada a %1$d dispositivo.</item>
         <item quantity="other">A versão gratuita está limitada a %1$d dispositivos.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Apoiar o Octi</string>
     <string name="upgrade_screen_preamble">O Octi não tem anúncios e não vende dados de usuários. Meu trabalho é financiado por você ❤️</string>
     <string name="upgrade_screen_how_title">O que fazer</string>
     <string name="upgrade_screen_how_body">Torne-se um patrocinador e apoie o desenvolvimento! Toque no botão abaixo para ativar todos os recursos extras e abrir meu perfil do GitHub Sponsors.</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -7,6 +7,10 @@
         <item quantity="few">Versiunea gratuită este limitată la %1$d dispozitive.</item>
         <item quantity="other">Versiunea gratuită este limitată la %1$d de dispozitive.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Susține Octi</string>
     <string name="upgrade_screen_preamble">Octi nu are reclame și nu vinde datele utilizatorului. Munca mea este finanțată de tine ❤️</string>
     <string name="upgrade_screen_how_title">Ce să faci</string>
     <string name="upgrade_screen_how_body">Devino patron și sponsorizează dezvoltarea! Atinge butonul de mai jos pentru a activa toate funcțiile suplimentare și a deschide profilul meu GitHub Sponsors.</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -8,6 +8,10 @@
         <item quantity="many">Бесплатная версия ограничена %1$d устройствами.</item>
         <item quantity="other">Бесплатная версия ограничена %1$d устройствами.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Поддержка Octi</string>
     <string name="upgrade_screen_preamble">В Octi нет рекламы, и он не продаёт данные пользователей. Моя работа финансируется вами ❤️</string>
     <string name="upgrade_screen_how_title">Что нужно сделать</string>
     <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -7,6 +7,10 @@
         <item quantity="few">Бесплатна верзија је ограничена на %1$d уређаја.</item>
         <item quantity="other">Бесплатна верзија је ограничена на %1$d уређаја.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Подржите Octi</string>
     <string name="upgrade_screen_preamble">Octi nema reklame i ne prodaje korisničke podatke. Moj rad finansirate vi ❤️</string>
     <string name="upgrade_screen_how_title">Šta uraditi</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj i sponzorišite razvoj! Dodirnite dugme ispod da aktivirate sve dodatne funkcije i otvorite moj GitHub Sponsors profil.</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">Gratisversionen är begränsad till %1$d enhet.</item>
         <item quantity="other">Gratisversionen är begränsad till %1$d enheter.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Stöd Octi</string>
     <string name="upgrade_screen_preamble">Octi har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️</string>
     <string name="upgrade_screen_how_title">Vad du ska göra</string>
     <string name="upgrade_screen_how_body">Bli beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -6,6 +6,10 @@
         <item quantity="one">%1$d cihaz</item>
         <item quantity="other">Ücretsiz sürüm %1$d cihazla sınırlıdır.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Octi\'yi destekle</string>
     <string name="upgrade_screen_preamble">Octi\'de reklam yoktur ve kullanıcı verilerini satmaz. Çalışmalarım sizin tarafınızdan finanse edilmektedir ❤️</string>
     <string name="upgrade_screen_how_title">Ne yapmalı</string>
     <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -8,6 +8,10 @@
         <item quantity="many">Безкоштовна версія обмежена %1$d пристроями.</item>
         <item quantity="other">Безкоштовна версія обмежена %1$d пристроями.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Підтримати Octi</string>
     <string name="upgrade_screen_preamble">В Octi немає реклами і він не продає дані користувачів. Моя робота фінансується вами ❤️</string>
     <string name="upgrade_screen_how_title">Що робити</string>
     <string name="upgrade_screen_how_body">Станьте патроном та підтримуйте розробку! Натисніть на кнопку нижче, щоб активувати всі додаткові функції та відкрити мій профіль GitHub Sponsors.</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -5,6 +5,10 @@
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">Phiên bản miễn phí bị giới hạn ở %1$d thiết bị.</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">Hỗ trợ Octi</string>
     <string name="upgrade_screen_preamble">Octi không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️</string>
     <string name="upgrade_screen_how_title">Nên làm gì</string>
     <string name="upgrade_screen_how_body">Trở thành nhà bảo trợ và tài trợ cho phát triển! Nhấn nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở trang hồ sơ GitHub Sponsors của tôi.</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -5,6 +5,10 @@
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">免费版最多支持 %1$d 台设备。</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">支持 Octi</string>
     <string name="upgrade_screen_preamble">Octi 没有广告，也不会出售用户数据。我的工作由你资助 ❤️</string>
     <string name="upgrade_screen_how_title">该怎么办</string>
     <string name="upgrade_screen_how_body">成为赞助人并赞助开发！点击下面的按钮以激活所有额外功能并打开我的 GitHub 赞助商资料。</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -5,6 +5,10 @@
     <plurals name="upgrades_dashcard_device_limit_hint">
         <item quantity="other">免費版限制最多 %1$d 台裝置。</item>
     </plurals>
+    <!-- Replaces upgrade_screen_title ("Upgrade to Octi Pro"), which sold the Google Play tier by name
+         inside the FOSS build, where the tier is called "Octi FOSS" and the ask is sponsorship rather
+         than a purchase. Keep it tier-free: name no product edition when translating. -->
+    <string name="upgrade_screen_support_title">支持 Octi</string>
     <string name="upgrade_screen_preamble">Octi 沒有廣告，也不會販售使用者資料。我的工作由你贊助 ❤️</string>
     <string name="upgrade_screen_how_title">該怎麼做</string>
     <string name="upgrade_screen_how_body">成為支持者並贊助開發！點擊下方按鈕以啟用所有額外功能並打開我的 GitHub Sponsors 個人頁面。</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Jy eie albei</string>
     <string name="upgrade_screen_owned_both_warning">Jy eie beide die inskrywing en die eenmalige aankoop. Om dubbele betaling te vermy, kanselleer die inskrywing in Google Play — jy behou Pro deur die leeftydse aankoop.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Jy het %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dankie vir die aankoop van %1$s! Jou Pro-funksies is ontsluit en verval nooit.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dankie vir inskrywing op %1$s! Jou Pro-funksies is ontsluit.</string>
     <string name="upgrade_screen_manage_subscription_action">Bestuur inskrywing</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -79,6 +79,12 @@
     <string name="upgrade_screen_owned_both_title">تملك كليهما</string>
     <string name="upgrade_screen_owned_both_warning">تملك كلاً من الاشتراك والشراء لمرة واحدة. لتجنب الدفع مرتين، ألغِ الاشتراك عبر Google Play — ستحتفظ بـ Pro من خلال الشراء مدى الحياة.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">لديك %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">شكرًا لشرائك %1$s! ميزات Pro مفتوحة الآن ولن تنتهي أبدًا.</string>
     <string name="upgrade_screen_owned_hero_sub_body">شكرًا لاشتراكك في %1$s! ميزات Pro مفتوحة الآن.</string>
     <string name="upgrade_screen_manage_subscription_action">إدارة الاشتراك</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Posseïu ambdues</string>
     <string name="upgrade_screen_owned_both_warning">Posseïu tant la subscripció com la compra única. Per evitar pagar dues vegades, cancel·leu la subscripció a Google Play — manteniu l’accés Pro a través de la compra de per vida.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tens %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Gràcies per comprar %1$s! Les vostres funcionalitats Pro estan desbloquejades i no caducaran mai.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Gràcies per subscriure-us a %1$s! Les vostres funcionalitats Pro estan desbloquejades.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestiona la subscripció</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -77,6 +77,12 @@
     <string name="upgrade_screen_owned_both_title">Vlastníte obojí</string>
     <string name="upgrade_screen_owned_both_warning">Vlastníte jak předplatné, tak jednorázový nákup. Abyste se vyhnuli zaplacení dvakrát, zrušte předplatné v Google Play — Pro si ponecháte díky nákupu na doživotí.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Máš %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Děkujeme za nákup %1$s! Vaše funkce Pro jsou odemčeny a nikdy nevyprší.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Děkujeme za přihlášení k odběru %1$s! Vaše funkce Pro jsou odemčeny.</string>
     <string name="upgrade_screen_manage_subscription_action">Spravovat předplatné</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Du ejer begge</string>
     <string name="upgrade_screen_owned_both_warning">Du ejer både abonnementet og engangskøbet. For at undgå at betale to gange, annuller abonnementet i Google Play – du beholder Pro gennem det livsvarige køb.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tak for købet af %1$s! Dine Pro-funktioner er låst op og udløber aldrig.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tak for abonnementet på %1$s! Dine Pro-funktioner er låst op.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -54,10 +54,10 @@
     <string name="upgrade_screen_restore_purchase_action">Zahlungen wiederherstellen</string>
     <string name="upgrade_screen_restore_banner_title">Bereits Pro gekauft?</string>
     <string name="upgrade_screen_restore_banner_body">Es sieht so aus, als hättest du auf diesem Gerät schon einmal ein Upgrade auf Pro durchgeführt. Falls du das Upgrade noch besitzt, wird die Wiederherstellung es erneut freischalten.</string>
-    <string name="upgrade_screen_restore_purchase_message">Ihr Upgrade ist für alle Geräte auf demselben Google-Konto gültig.</string>
+    <string name="upgrade_screen_restore_purchase_message">Dein Upgrade ist für alle Geräte auf demselben Google-Konto gültig.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tipps zur Fehlerbehebung für unbekannte Upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Die Synchronisierung des Play Store kann etwas dauern. Versuche das Gerät neu zu starten, den Google Play-Cache zu leeren oder warte einfach ab.</string>
-    <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play verwirren. Melden Sie sich aus anderen Konten ab, oder installieren Sie über die Google Play-Website, was Verbindungen mit einem bestimmten Konto erzwingt.</string>
+    <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play verwirren. Melde dich aus anderen Konten ab, oder installiere über die Google Play-Website, was Verbindungen mit einem bestimmten Konto erzwingt.</string>
     <string name="upgrade_screen_restore_success_message">Kauf wiederhergestellt — danke!</string>
     <!-- Restore section copy (plain acquisition + ownership recheck) and failed-restore dialog -->
     <string name="upgrade_screen_restore_body">Hast du Pro bereits auf diesem Konto gekauft? Frag Google Play, die Käufe dieser App erneut zu überprüfen.</string>
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Du besitzt beides</string>
     <string name="upgrade_screen_owned_both_warning">Du besitzt sowohl das Abonnement als auch den Einmalkauf. Um doppelte Zahlungen zu vermeiden, kündige das Abonnement in Google Play – du behältst Pro durch den Einmalkauf.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du hast %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Danke, dass du %1$s gekauft hast! Deine Pro-Funktionen sind freigeschaltet und verfallen nie.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Danke, dass du %1$s abonniert hast! Deine Pro-Funktionen sind freigeschaltet.</string>
     <string name="upgrade_screen_manage_subscription_action">Abo verwalten</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Κατέχετε και τα δύο</string>
     <string name="upgrade_screen_owned_both_warning">Κατέχετε τόσο τη συνδρομή όσο και την εφάπαξ αγορά. Για να αποφύγετε τη διπλή χρέωση, ακυρώστε τη συνδρομή στο Google Play — διατηρείτε το Pro μέσω της ισόβιας αγοράς.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Έχετε %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ευχαριστούμε που αγοράσατε %1$s! Οι δυνατότητες Pro είναι ξεκλειδωμένες και δεν λήγουν ποτέ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ευχαριστούμε που κάνατε εγγραφή στο %1$s! Οι δυνατότητες Pro είναι ξεκλειδωμένες.</string>
     <string name="upgrade_screen_manage_subscription_action">Διαχείριση συνδρομής</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Tienes ambas</string>
     <string name="upgrade_screen_owned_both_warning">Tienes tanto la suscripción como la compra única. Para evitar pagar dos veces, cancela la suscripción en Google Play — mantienes Pro a través de la compra de por vida.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tienes %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">¡Gracias por comprar %1$s! Tus funciones Pro están desbloqueadas y nunca caducan.</string>
     <string name="upgrade_screen_owned_hero_sub_body">¡Gracias por suscribirte a %1$s! Tus funciones Pro están desbloqueadas.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrar suscripción</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Omistat molemmat</string>
     <string name="upgrade_screen_owned_both_warning">Omistat sekä tilauksen että kertaluonteisen osion. Kaksinkertaisen maksun välttämiseksi peruuta tilaus Google Playssa — säilytät Pro-tilan elinikäisen osion kautta.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sinulla on %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Kiitos %1$s:n ostamisesta! Pro-ominaisuutesi on avattu eivätkä ne koskaan vanhene.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Kiitos %1$s:n tilaamisesta! Pro-ominaisuutesi on avattu.</string>
     <string name="upgrade_screen_manage_subscription_action">Hallitse tilausta</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -76,6 +76,12 @@ Mêmes fonctions, juste des modèles tarifaires différents.</string>
     <string name="upgrade_screen_owned_both_title">Vous possédez les deux</string>
     <string name="upgrade_screen_owned_both_warning">Vous possédez à la fois l’abonnement et l’achat unique. Pour éviter de payer deux fois, annulez l’abonnement dans Google Play — vous conservez Pro grâce à l’achat unique.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tu as %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Merci d’avoir acheté %1$s ! Vos fonctionnalités Pro sont déverrouillées et n’expirent jamais.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Merci de votre abonnement à %1$s ! Vos fonctionnalités Pro sont déverrouillées.</string>
     <string name="upgrade_screen_manage_subscription_action">Gérer l’abonnement</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Mindkettőt birtoklod</string>
     <string name="upgrade_screen_owned_both_warning">Mindkettőt birtoklod: az előfizetést és az egyszeri vásárlást. Hogy ne fizess kétszer, mondj le az előfizetésről a Google Play-ben — az élettartam vásárlás révén megtartod a Pro-t.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Megvan az %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Köszönjük a %1$s vásárlást! A Pro funkciók feloldottak és soha nem járnak le.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Köszönjük a %1$s-ra való feliratkozást! A Pro funkciók feloldottak.</string>
     <string name="upgrade_screen_manage_subscription_action">Előfizetés kezelése</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -76,6 +76,12 @@
     <string name="upgrade_screen_owned_both_title">Possiedi entrambi</string>
     <string name="upgrade_screen_owned_both_warning">Possiedi sia l’abbonamento che l’acquisto una tantum. Per evitare di pagare due volte, annulla l’abbonamento in Google Play — manterrai Pro tramite l’acquisto a vita.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Hai %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Grazie per aver acquistato %1$s! Le tue funzioni Pro sono sbloccate e non scadono mai.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Grazie per aver sottoscritto %1$s! Le tue funzioni Pro sono sbloccate.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestisci l’abbonamento</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -77,6 +77,12 @@
     <string name="upgrade_screen_owned_both_title">יש לך שניהם</string>
     <string name="upgrade_screen_owned_both_warning">יש לך גם המנוי וגם את הרכישה החד-פעמית. כדי להימנע מתשלום כפול, בטל את המנוי ב-Google Play — אתה תשמור על Pro דרך הרכישה לכל החיים.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">יש לך %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">תודה על קנייתך של %1$s! תכונות Pro שלך פתוחות ולא יפוגו לעולם.</string>
     <string name="upgrade_screen_owned_hero_sub_body">תודה על הרשמתך ל-%1$s! תכונות Pro שלך פתוחות.</string>
     <string name="upgrade_screen_manage_subscription_action">ניהול המנוי</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -74,6 +74,12 @@
     <string name="upgrade_screen_owned_both_title">両方を所有しています</string>
     <string name="upgrade_screen_owned_both_warning">サブスクリプションと一回限りの購入の両方を所有しています。二重支払いを避けるには、Google Playでサブスクリプションをキャンセルしてください — 永久購入によってProは継続されます。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$sをお持ちです 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$sをご購入いただきありがとうございます！Pro機能がロック解除され、期限はありません。</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$sにご登録いただきありがとうございます！Pro機能がロック解除されました。</string>
     <string name="upgrade_screen_manage_subscription_action">サブスクリプションを管理</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -74,6 +74,12 @@
     <string name="upgrade_screen_owned_both_title">둘 다 소유하고 있습니다</string>
     <string name="upgrade_screen_owned_both_warning">구독과 일회성 구매를 모두 소유하고 있습니다. 중복 결제를 피하려면 Google Play에서 구독을 취소하세요 — 평생 구매를 통해 Pro를 계속 유지합니다.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s을(를) 보유하고 있습니다 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s를 구매해주셔서 감사합니다! Pro 기능이 잠금 해제되었으며 절대 만료되지 않습니다.</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$s를 구독해주셔서 감사합니다! Pro 기능이 잠금 해제되었습니다.</string>
     <string name="upgrade_screen_manage_subscription_action">구독 관리</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -76,6 +76,12 @@ Samme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_owned_both_title">Du eier begge</string>
     <string name="upgrade_screen_owned_both_warning">Du eier både abonnementet og engangs-kjøpet. For å unngå å betale dobbelt, avbryt abonnementet i Google Play – du beholder Pro gjennom livstidskjøpet.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Takk for at du kjøpte %1$s! Dine Pro-funksjoner er låst opp og utløper aldri.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Takk for at du abonnerte på %1$s! Dine Pro-funksjoner er låst opp.</string>
     <string name="upgrade_screen_manage_subscription_action">Administrer abonnement</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -76,6 +76,12 @@ Dezelfde functies, gewoon verschillende prijsmodellen.</string>
     <string name="upgrade_screen_owned_both_title">Je hebt beide</string>
     <string name="upgrade_screen_owned_both_warning">Je hebt zowel het abonnement als de eenmalige aankoop. Om dubbel betalen te vermijden, annuleer het abonnement in Google Play — je houdt Pro door de levenslange aankoop.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Je hebt %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bedankt voor het kopen van %1$s! Je Pro-functies zijn ontgrendeld en verlopen nooit.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Bedankt voor het abonneren op %1$s! Je Pro-functies zijn ontgrendeld.</string>
     <string name="upgrade_screen_manage_subscription_action">Abonnement beheren</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -77,6 +77,12 @@
     <string name="upgrade_screen_owned_both_title">Jesteś właścicielem obu</string>
     <string name="upgrade_screen_owned_both_warning">Posiadasz zarówno subskrypcję, jak i jednorazowy zakup. Aby uniknąć podwójnego płacenia, anuluj subskrypcję w Sklepie Google Play — trzymasz Pro przez dożywotni zakup.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Masz %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Dziękujemy za zakup %1$s! Twoje funkcje Pro są odblokowane i nigdy nie wygasają.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dziękuję za subskrybowanie %1$s! Twoje funkcje Pro są odblokowane.</string>
     <string name="upgrade_screen_manage_subscription_action">Zarządzaj subskrypcją</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -76,6 +76,12 @@ Os mesmos recursos, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_owned_both_title">Você tem ambos</string>
     <string name="upgrade_screen_owned_both_warning">Você tem tanto a assinatura quanto a compra única. Para evitar pagar duas vezes, cancele a assinatura no Google Play — você mantém o Pro através da compra vitalícia.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Você tem %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Obrigado por comprar %1$s! Seus recursos Pro estão desbloqueados e nunca expiram.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Obrigado por se inscrever em %1$s! Seus recursos Pro estão desbloqueados.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerenciar assinatura</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Tem ambas</string>
     <string name="upgrade_screen_owned_both_warning">Tem a subscrição e a compra única. Para evitar pagar duas vezes, cancele a subscrição no Google Play — mantém o Pro através da compra vitalícia.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tens %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Obrigado por comprar %1$s! As suas funcionalidades Pro estão desbloqueadas e nunca expiram.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Obrigado por subscrever %1$s! As suas funcionalidades Pro estão desbloqueadas.</string>
     <string name="upgrade_screen_manage_subscription_action">Gerir subscrição</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -76,6 +76,12 @@
     <string name="upgrade_screen_owned_both_title">Deții ambele</string>
     <string name="upgrade_screen_owned_both_warning">Deții atât abonamentul cât și achiziția unică. Pentru a evita plata de două ori, anulează abonamentul în Google Play — păstrezi Pro prin achiziția pe viață.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Ai %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Mulțumesc că ai cumpărat %1$s! Caracteristicile tale Pro sunt deblocate și nu expiră niciodată.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Mulțumesc că te-ai abonat la %1$s! Caracteristicile tale Pro sunt deblocate.</string>
     <string name="upgrade_screen_manage_subscription_action">Gestionează abonamentul</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -77,6 +77,12 @@
     <string name="upgrade_screen_owned_both_title">У Вас оба варианта</string>
     <string name="upgrade_screen_owned_both_warning">У Вас есть как подписка, так и единоразовая покупка. Чтобы избежать двойной оплаты, отмените подписку в Google Play — Вы обладатель Pro посредством покупки.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">У вас есть %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Спасибо за покупку %1$s! Ваши функции Pro разблокированы и никогда не заканчиваются.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Спасибо за подписку на %1$s! Ваши функции Pro разблокированы.</string>
     <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -76,6 +76,12 @@
     <string name="upgrade_screen_owned_both_title">Поседујете оба</string>
     <string name="upgrade_screen_owned_both_warning">Поседујете и претплату и једнократну куповину. Да бисте избегли двоструко плаћање, откажите претплату у Google Play — задржавате Pro кроз доживотну куповину.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Имате %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Хвала вам што сте купили %1$s! Ваше Pro функције су откључане и никада не истичу.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Хвала вам што сте се претплатили на %1$s! Ваше Pro функције су откључане.</string>
     <string name="upgrade_screen_manage_subscription_action">Управљајте претплатом</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">Du äger båda</string>
     <string name="upgrade_screen_owned_both_warning">Du äger både prenumerationen och engångsköpet. För att undvika att betala två gånger, avsluta prenumerationen i Google Play — du behåller Pro genom livstidsköpet.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tack för att du köpte %1$s! Dina Pro-funktioner är upplåsta och upphör aldrig att gälla.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tack för att du prenumererar på %1$s! Dina Pro-funktioner är upplåsta.</string>
     <string name="upgrade_screen_manage_subscription_action">Hantera prenumeration</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -76,6 +76,12 @@ Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_owned_both_title">Her ikisine de sahipsiniz</string>
     <string name="upgrade_screen_owned_both_warning">Hem aboneliğe hem de tek seferlik satın almaya sahipsiniz. İki kez ödeme yapmamak için Google Play\'de aboneliği iptal edin — ömür boyu satın alma yoluyla Pro\'ya sahip olmaya devam edersiniz.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sende %1$s var 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Satın aldığınız %1$s için teşekkür ederiz! Pro özellikleriniz açık ve asla süresi dolmaz.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abone olduğunuz %1$s için teşekkür ederiz! Pro özellikleriniz açık.</string>
     <string name="upgrade_screen_manage_subscription_action">Aboneliği Yönetin</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -77,6 +77,12 @@
     <string name="upgrade_screen_owned_both_title">Ви володієте обома</string>
     <string name="upgrade_screen_owned_both_warning">Ви володієте і підпискою, і одноразовою покупкою. Щоб не платити двічі, скасуйте підписку в Google Play — ви збережете Pro завдяки довічній покупці.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">У тебе %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Дякуємо за покупку %1$s! Ваші функції Pro розблоковано і ніколи не спливають.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Дякуємо за підписку %1$s! Ваші функції Pro розблоковано.</string>
     <string name="upgrade_screen_manage_subscription_action">Керувати підпискою</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -75,6 +75,12 @@ Các tính năng giống nhau, chỉ khác các mô hình giá.</string>
     <string name="upgrade_screen_owned_both_title">Bạn sở hữu cả hai</string>
     <string name="upgrade_screen_owned_both_warning">Bạn sở hữu cả gói đăng ký và gói mua một lần. Để tránh thanh toán hai lần, hãy hủy gói đăng ký trong Google Play — bạn vẫn giữ Pro thông qua gói mua trọn đời.</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Bạn có %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Cảm ơn bạn đã mua %1$s! Các tính năng Pro của bạn đã được mở khóa và không bao giờ hết hạn.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Cảm ơn bạn đã đăng ký %1$s! Các tính năng Pro của bạn đã được mở khóa.</string>
     <string name="upgrade_screen_manage_subscription_action">Quản lý đăng ký</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -74,6 +74,12 @@
     <string name="upgrade_screen_owned_both_title">您同时拥有两者</string>
     <string name="upgrade_screen_owned_both_warning">您同时拥有订阅和一次性购买。为避免重复付费，请在 Google Play 中取消订阅——您将通过一次性购买保留专业版。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">你已拥有 %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">感谢您购买 %1$s！您的专业版功能已解锁且永不过期。</string>
     <string name="upgrade_screen_owned_hero_sub_body">感谢您订阅 %1$s！您的专业版功能已解锁。</string>
     <string name="upgrade_screen_manage_subscription_action">管理订阅</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -75,6 +75,12 @@
     <string name="upgrade_screen_owned_both_title">您同時擁有兩者</string>
     <string name="upgrade_screen_owned_both_warning">您同時擁有訂閱和一次性購買。為避免重複付款，請在 Google Play 中取消訂閱 — 您將透過終身購買保留 Pro。</string>
     <!-- Owned hero card (%1$s = "Octi Pro") -->
+    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
+         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
+         already composed from the app name and the tier qualifier - never translate it here. Render
+         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
+         %1$s access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">您擁有 %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">感謝您購買 %1$s！您的 Pro 功能已解鎖，永不過期。</string>
     <string name="upgrade_screen_owned_hero_sub_body">感謝您訂閱 %1$s！您的 Pro 功能已解鎖。</string>
     <string name="upgrade_screen_manage_subscription_action">管理訂閱</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Opdatering beskikbaar</string>
     <string name="updates_dashcard_body">\'n Opdatering is beskikbaar. Jy het %1$s en die nuutste weergawe is %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Opgradeer Octi</string>
     <string name="sync_settings_label">Sinkronisasie</string>
     <string name="sync_settings_desc">Toestelnaam, tydsberekening en snellerinstellings.</string>
     <string name="sync_setting_devicelabel_label">Toestelnaam</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Jy het tans %1$d gesinkroniseerde toestel.</item>
         <item quantity="other">Jy het tans %1$d gesinkroniseerde toestelle.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Om meer as %1$d toestel te sien, gradeer op of verwyder toestelle.</item>
+        <item quantity="other">Om meer as %1$d toestelle te sien, gradeer op of verwyder toestelle.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">As jy hierdie toestel verwyder, word sy data geskrap, maar toegang bly. Om toegang te herroep, ontkoppel Octi op die toestel.</string>
     <string name="sync_delete_device_revokeaccess_caveat">As jy hierdie toestel uitvee, word sy data verwyder en sy toegang herroep.</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -156,6 +156,10 @@
     </plurals>
     <string name="updates_dashcard_title">تحديث متوفر</string>
     <string name="updates_dashcard_body">يتوفر تحديث. لديك الإصدار %1$s وأحدث إصدار هو %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">ترقية Octi</string>
     <string name="sync_settings_label">المزامنة</string>
     <string name="sync_settings_desc">اسم الجهاز والتوقيت وشروط التشغيل.</string>
     <string name="sync_setting_devicelabel_label">تسمية الجهاز</string>
@@ -205,6 +209,17 @@
         <item quantity="few">لديك حاليًا %1$d أجهزة متزامنة.</item>
         <item quantity="many">لديك حاليًا %1$d جهازًا متزامنًا.</item>
         <item quantity="other">لديك حاليًا %1$d جهازًا متزامنًا.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="zero">لعرض أكثر من %1$d جهاز، قم بالترقية أو احذف بعض الأجهزة.</item>
+        <item quantity="one">لعرض أكثر من جهاز واحد، قم بالترقية أو احذف بعض الأجهزة.</item>
+        <item quantity="two">لعرض أكثر من جهازين، قم بالترقية أو احذف بعض الأجهزة.</item>
+        <item quantity="few">لعرض أكثر من %1$d أجهزة، قم بالترقية أو احذف بعض الأجهزة.</item>
+        <item quantity="many">لعرض أكثر من %1$d جهازًا، قم بالترقية أو احذف بعض الأجهزة.</item>
+        <item quantity="other">لعرض أكثر من %1$d جهاز، قم بالترقية أو احذف بعض الأجهزة.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">إزالة هذا الجهاز ستحذف بياناته ولكن لن تلغي الوصول. لإلغاء الوصول، افصل أوكتي على الجهاز.</string>
     <string name="sync_delete_device_revokeaccess_caveat">حذف هذا الجهاز سيزيل بياناته ويلغي وصوله.</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Actualització disponible</string>
     <string name="updates_dashcard_body">Hi ha una actualització disponible. Teniu la versió %1$s i la darrera és %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Millora Octi</string>
     <string name="sync_settings_label">Sincronització</string>
     <string name="sync_settings_desc">Nom del dispositiu, temps i condicions d\'activació.</string>
     <string name="sync_setting_devicelabel_label">Etiqueta del dispositiu</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Actualment teniu %1$d dispositiu sincronitzat.</item>
         <item quantity="other">Actualment teniu %1$d dispositius sincronitzats.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Per veure més de %1$d dispositiu, millorar o eliminar els dispositius.</item>
+        <item quantity="other">Per veure més de %1$d dispositius, millorar o eliminar els dispositius.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">En suprimir aquest dispositiu, se suprimiran les seves dades, però no se\'n revocarà l\'accés. Per revocar l\'accés, desconnecteu l\'Octi al dispositiu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">En suprimir aquest dispositiu, se n\'eliminaran les dades i se\'n revocarà l\'accés.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -146,6 +146,10 @@
     </plurals>
     <string name="updates_dashcard_title">Aktualizace k dispozici</string>
     <string name="updates_dashcard_body">K dispozici je aktualizace. Máte %1$s a nejnovější verze je %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Upgraduj Octi</string>
     <string name="sync_settings_label">Synchronizace</string>
     <string name="sync_settings_desc">Název zařízení, časování a podmínky spouštění.</string>
     <string name="sync_setting_devicelabel_label">Název zařízení</string>
@@ -193,6 +197,15 @@
         <item quantity="few">Aktuálně máte %1$d synchronizovaná zařízení.</item>
         <item quantity="many">Aktuálně máte %1$d synchronizovaných zařízení.</item>
         <item quantity="other">Aktuálně máte %1$d synchronizovaných zařízení.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Chceš-li zobrazit více než %1$d zařízení, upgraduj nebo odeber zařízení.</item>
+        <item quantity="few">Chceš-li zobrazit více než %1$d zařízení, upgraduj nebo odeber zařízení.</item>
+        <item quantity="many">Chceš-li zobrazit více než %1$d zařízení, upgraduj nebo odeber zařízení.</item>
+        <item quantity="other">Chceš-li zobrazit více než %1$d zařízení, upgraduj nebo odeber zařízení.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Odebráním tohoto zařízení smažete jeho data, ale nebude odvolán přístup. Chcete-li odvolat přístup, odpojte aplikaci Octi na zařízení.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Smazáním tohoto zařízení se odstraní jeho data a zruší se jeho přístup.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Opdatering tilgængelig</string>
     <string name="updates_dashcard_body">En opdatering er tilgængelig. Du har %1$s og den seneste version er %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Opgrader Octi</string>
     <string name="sync_settings_label">Synkronisering</string>
     <string name="sync_settings_desc">Enhedsnavn, timing og betingelser for udløsning.</string>
     <string name="sync_setting_devicelabel_label">Enhedsetiket</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har i øjeblikket %1$d synkroniseret enhed.</item>
         <item quantity="other">Du har i øjeblikket %1$d synkroniserede enheder.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">For at se mere end %1$d enhed skal du opgradere eller fjerne enheder.</item>
+        <item quantity="other">For at se mere end %1$d enheder skal du opgradere eller fjerne enheder.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Fjernelse af denne enhed sletter data, men fjerner ikke adgang. For at fjerne adgang, afbryd Octi på enheden.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Sletning af enheden fjerner både data og adgang.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Update verfügbar</string>
     <string name="updates_dashcard_body">Ein Update ist verfügbar. Du hast %1$s und die aktuellste Version ist %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octi upgraden</string>
     <string name="sync_settings_label">Synchronisation</string>
     <string name="sync_settings_desc">Gerätename, Timing und Auslösebedingungen.</string>
     <string name="sync_setting_devicelabel_label">Gerätebezeichnung</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du hast derzeit %1$d synchronisiertes Gerät.</item>
         <item quantity="other">Du hast derzeit %1$d synchronisierte Geräte.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Um mehr als %1$d Gerät anzuzeigen, upgrade oder entferne Geräte.</item>
+        <item quantity="other">Um mehr als %1$d Geräte anzuzeigen, upgrade oder entferne Geräte.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Das Entfernen dieses Geräts löscht seine Daten, widerruft aber nicht den Zugriff. Um den Zugriff zu widerrufen, trennen Sie Octi auf dem Gerät.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Das Löschen dieses Geräts entfernt seine Daten und widerruft seinen Zugriff.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Ενημέρωση διαθέσιμη</string>
     <string name="updates_dashcard_body">Υπάρχει διαθέσιμη ενημέρωση. Έχετε την έκδοση %1$s και η τελευταία έκδοση είναι %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Αναβαθμίστε το Octi</string>
     <string name="sync_settings_label">Συγχρονισμός</string>
     <string name="sync_settings_desc">Όνομα συσκευής, χρονισμός και προϋποθέσεις ενεργοποίησης.</string>
     <string name="sync_setting_devicelabel_label">Όνομα συσκευής</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Αυτή τη στιγμή έχετε %1$d συγχρονισμένη συσκευή.</item>
         <item quantity="other">Αυτή τη στιγμή έχετε %1$d συγχρονισμένες συσκευές.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Για να δείτε περισσότερες από %1$d συσκευή, αναβαθμίστε ή αφαιρέστε συσκευές.</item>
+        <item quantity="other">Για να δείτε περισσότερες από %1$d συσκευές, αναβαθμίστε ή αφαιρέστε συσκευές.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Η κατάργηση αυτής της συσκευής διαγράφει τα δεδομένα της αλλά δεν αφαιρεί την πρόσβαση. Για να αφαιρέσετε την πρόσβαση, αποσυνδέστε το Octi στη συσκευή.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Διαγράφοντας αυτή τη συσκευή διαγράφονται τα δεδομένα και ακυρώνεται η πρόσβαση.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Actualización disponible</string>
     <string name="updates_dashcard_body">Una actualización está disponible. Tienes %1$s y la última versión es %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Actualiza Octi</string>
     <string name="sync_settings_label">Sincronización</string>
     <string name="sync_settings_desc">Nombre del dispositivo, tiempo y condiciones de activación.</string>
     <string name="sync_setting_devicelabel_label">Etiqueta del dispositivo</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Actualmente tienes %1$d dispositivo sincronizado.</item>
         <item quantity="other">Actualmente tienes %1$d dispositivos sincronizados.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Para ver más de %1$d dispositivo, actualiza o elimina dispositivos.</item>
+        <item quantity="other">Para ver más de %1$d dispositivos, actualiza o elimina dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Eliminar este dispositivo borrará sus datos pero no revocará el acceso. Para revocar el acceso, desconecta Octi en el dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminar este dispositivo removerá sus datos y revocará su acceso.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Päivitys saatavilla</string>
     <string name="updates_dashcard_body">Päivitys saatavilla. Sinulla on %1$s, uusin versio on %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Päivitä Octi</string>
     <string name="sync_settings_label">Synkronointi</string>
     <string name="sync_settings_desc">Laitteen nimi, ajoitus ja ehdot.</string>
     <string name="sync_setting_devicelabel_label">Laiteotsikko</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Sinulla on tällä hetkellä %1$d synkronoitu laite.</item>
         <item quantity="other">Sinulla on tällä hetkellä %1$d synkronoitua laitetta.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Nähdäksesi enemmän kuin %1$d laitetta, päivitä tai poista laitteita.</item>
+        <item quantity="other">Nähdäksesi enemmän kuin %1$d laitetta, päivitä tai poista laitteita.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot, mutta ei poista käyttöoikeutta. Poistaaksesi käyttöoikeuden, irrota Octi laitteessa.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Tämän laitteen poistaminen poistaa sen tiedot ja käyttöoikeudet.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Une mise à jour est proposée</string>
     <string name="updates_dashcard_body">Une mise à jour est proposée. Vous utilisez %1$s, la version la plus récente est %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Mettre à niveau Octi</string>
     <string name="sync_settings_label">Synchronisation</string>
     <string name="sync_settings_desc">Nom de l’appareil, synchronisation et conditions de déclenchement.</string>
     <string name="sync_setting_devicelabel_label">Étiquette de l’appareil</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">%1$d appareil est synchronisé actuellement.</item>
         <item quantity="other">%1$d appareils sont synchronisés actuellement.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Pour afficher plus de %1$d appareil, mettre à niveau ou supprimer des appareils.</item>
+        <item quantity="other">Pour afficher plus de %1$d appareils, mettre à niveau ou supprimer des appareils.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Supprimer cet appareil supprimera ses données, mais ne révoquera pas son accès. Pour révoquer l\'accès, déconnectez Octi sur l\'appareil en question.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Supprimer cet appareil supprimera ses données et révoquera son accès.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Frissítés elérhető</string>
     <string name="updates_dashcard_body">Új frissítés érhető el. A te verziód: %1$s, legújabb: %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octi frissítése</string>
     <string name="sync_settings_label">Szinkronizáció</string>
     <string name="sync_settings_desc">Eszköz neve, időzítés, és feltételek.</string>
     <string name="sync_setting_devicelabel_label">Eszközcímke</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Jelenleg %1$d szinkronizált eszközöd van.</item>
         <item quantity="other">Jelenleg %1$d szinkronizált eszközöd van.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Több mint %1$d eszköz megtekintéséhez frissítsd vagy távolíts el eszközöket.</item>
+        <item quantity="other">Több mint %1$d eszköz megtekintéséhez frissítsd vagy távolíts el eszközöket.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Az eszköz eltávolításakor annak adatai törlődnek, de a hozzáférést nem vonja vissza. A hozzáférés visszavonásához válaszd le az Octit az eszközön.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ez az eszköz törlésekor az adatait és a hozzáférését is törlöd.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -138,6 +138,10 @@ I dispositivi possono vedersi solo se hanno un servizio di sincronizzazione comu
     </plurals>
     <string name="updates_dashcard_title">Aggiornamento disponibile</string>
     <string name="updates_dashcard_body">È disponibile un aggiornamento. Hai la versione %1$s e l\'ultima versione è la %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Aggiorna Octi</string>
     <string name="sync_settings_label">Sincronizzazione</string>
     <string name="sync_settings_desc">Nome del dispositivo, tempistica e condizioni di attivazione.</string>
     <string name="sync_setting_devicelabel_label">Etichetta dispositivo</string>
@@ -183,6 +187,13 @@ I dispositivi possono vedersi solo se hanno un servizio di sincronizzazione comu
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Hai attualmente %1$d dispositivo sincronizzato.</item>
         <item quantity="other">Hai attualmente %1$d dispositivi sincronizzati.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Per visualizzare più di %1$d dispositivo, aggiorna o rimuovi dispositivi.</item>
+        <item quantity="other">Per visualizzare più di %1$d dispositivi, aggiorna o rimuovi dispositivi.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Rimuovere questo dispositivo cancellerà i suoi dati, ma non revoca l\'accesso. Per revocare l\'accesso, disconnetti Octi dal dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Eliminare questo dispositivo rimuoverà i suoi dati e revocerà il suo accesso.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -146,6 +146,10 @@
     </plurals>
     <string name="updates_dashcard_title">יש עדכון זמין</string>
     <string name="updates_dashcard_body">עדכון זמין. מותקן לך %1$s והגרסה האחרונה היא %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">שדרוג Octi</string>
     <string name="sync_settings_label">סנכרון</string>
     <string name="sync_settings_desc">שם מכשיר, תזמון ותנאי הפעלה.</string>
     <string name="sync_setting_devicelabel_label">תווית מכשיר</string>
@@ -193,6 +197,15 @@
         <item quantity="two">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
         <item quantity="many">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
         <item quantity="other">יש לך כרגע %1$d מכשירים מסונכרנים.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">כדי לצפות ביותר מ-%1$d מכשיר, יש לשדרג או להסיר מכשירים.</item>
+        <item quantity="two">כדי לצפות ביותר מ-%1$d מכשירים, יש לשדרג או להסיר מכשירים.</item>
+        <item quantity="many">כדי לצפות ביותר מ-%1$d מכשירים, יש לשדרג או להסיר מכשירים.</item>
+        <item quantity="other">כדי לצפות ביותר מ-%1$d מכשירים, יש לשדרג או להסיר מכשירים.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">הסרת מכשיר זה תמחק את הנתונים שלו אך לא תבטל את הגישה. כדי לבטל גישה, נתק את Octi במכשיר.</string>
     <string name="sync_delete_device_revokeaccess_caveat">מחיקת המכשיר הזה תסיר את הנתונים שלו ותבטל את הגישה שלו.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -131,6 +131,10 @@
     </plurals>
     <string name="updates_dashcard_title">最新のバージョンが利用可能です</string>
     <string name="updates_dashcard_body">更新を利用可能です。現在は %1$s を使用中、%2$s が最新のバージョンです。</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octiをアップグレード</string>
     <string name="sync_settings_label">同期</string>
     <string name="sync_settings_desc">デバイス名、タイミングとトリガーの条件を設定します。</string>
     <string name="sync_setting_devicelabel_label">デバイスラベル</string>
@@ -175,6 +179,12 @@
     <string name="pro_device_limit_reached_title">デバイスの上限に達しました</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">現在 %1$d 台の同期済みデバイスがあります。</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="other">%1$d台を超えるデバイスを表示するには、アップグレードするかデバイスを削除してください。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">このデバイスを削除するとデータは削除されますが、アクセスは取り消されません。アクセスを取り消すにはデバイス上の Octi を切断してください。</string>
     <string name="sync_delete_device_revokeaccess_caveat">このデバイスを削除するとデータが削除され、アクセスが取り消されます。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -131,6 +131,10 @@
     </plurals>
     <string name="updates_dashcard_title">업데이트 가능</string>
     <string name="updates_dashcard_body">업데이트가 있습니다. 현재 %1$s 버전, 최신 버전은 %2$s입니다.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octi 업그레이드</string>
     <string name="sync_settings_label">동기화</string>
     <string name="sync_settings_desc">기기명, 동기화 간격 및 트리거 조건.</string>
     <string name="sync_setting_devicelabel_label">기기 라벨</string>
@@ -175,6 +179,12 @@
     <string name="pro_device_limit_reached_title">기기 제한에 도달함</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">현재 %1$d개의 동기화된 기기가 있습니다.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="other">%1$d대 이상의 기기를 보려면 업그레이드하거나 기기를 제거하세요.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">이 기기를 삭제하면 데이터는 지워지나 접근 권한은 남아있습니다. 접근권한을 해제하려면 해당 기기에서 Octi 연결을 해제하세요.</string>
     <string name="sync_delete_device_revokeaccess_caveat">이 기기를 삭제하면 데이터와 접근 권한 모두 삭제됩니다.</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Oppdatering tilgjengelig</string>
     <string name="updates_dashcard_body">En oppdatering er tilgjengelig. Du har %1$s og den siste versjonen er %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Oppgrader Octi</string>
     <string name="sync_settings_label">Synkronisering</string>
     <string name="sync_settings_desc">Enhetsnavn, tidspunkter og betingelser for utløsing.</string>
     <string name="sync_setting_devicelabel_label">Enhetsnavn</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har for øyeblikket %1$d synkronisert enhet.</item>
         <item quantity="other">Du har for øyeblikket %1$d synkroniserte enheter.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">For å vise mer enn %1$d enhet, oppgrader eller fjern enheter.</item>
+        <item quantity="other">For å vise mer enn %1$d enheter, oppgrader eller fjern enheter.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Å fjerne denne enheten sletter dens data, men fjerner ikke tilgang. For å fjerne tilgang, koble Octi fra enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Å slette denne enheten fjerner både data og tilgang.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Update beschikbaar</string>
     <string name="updates_dashcard_body">Een update is beschikbaar. U heeft %1$s en de nieuwste versie is %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octi upgraden</string>
     <string name="sync_settings_label">Synchronisatie</string>
     <string name="sync_settings_desc">Apparaatnaam, timing en triggervoorwaarden.</string>
     <string name="sync_setting_devicelabel_label">Apparaatlabel</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">U heeft momenteel %1$d gesynchroniseerd apparaat.</item>
         <item quantity="other">U heeft momenteel %1$d gesynchroniseerde apparaten.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Om meer dan %1$d apparaat te bekijken, upgrade je of verwijder je apparaten.</item>
+        <item quantity="other">Om meer dan %1$d apparaten te bekijken, upgrade je of verwijder je apparaten.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Dit apparaat verwijderen zal de gegevens wissen maar toegang niet intrekken. Om toegang in te trekken, koppel Octi los op het apparaat.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Dit apparaat verwijderen zal de gegevens verwijderen en toegang intrekken.</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -146,6 +146,10 @@
     </plurals>
     <string name="updates_dashcard_title">Dostępna aktualizacja</string>
     <string name="updates_dashcard_body">Aktualizacja jest dostępna. Masz %1$s, a najnowsza wersja to %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Ulepsz Octi</string>
     <string name="sync_settings_label">Synchronizacja</string>
     <string name="sync_settings_desc">Nazwa urządzenia, harmonogram i warunki wyzwalania.</string>
     <string name="sync_setting_devicelabel_label">Etykieta urządzenia</string>
@@ -193,6 +197,15 @@
         <item quantity="few">Masz obecnie %1$d zsynchronizowane urządzenia.</item>
         <item quantity="many">Masz obecnie %1$d zsynchronizowanych urządzeń.</item>
         <item quantity="other">Masz obecnie %1$d zsynchronizowanych urządzeń.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Aby wyświetlić więcej niż %1$d urządzenie, uaktualnij lub usuń urządzenia.</item>
+        <item quantity="few">Aby wyświetlić więcej niż %1$d urządzenia, uaktualnij lub usuń urządzenia.</item>
+        <item quantity="many">Aby wyświetlić więcej niż %1$d urządzeń, uaktualnij lub usuń urządzenia.</item>
+        <item quantity="other">Aby wyświetlić więcej niż %1$d urządzenia, uaktualnij lub usuń urządzenia.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Usunięcie tego urządzenia usunie jego dane, ale nie cofnie dostępu. Aby cofnąć dostęp, rozłącz Octi na urządzeniu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Usunięcie tego urządzenia usunie jego dane i cofnie jego dostęp.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Atualização disponível</string>
     <string name="updates_dashcard_body">Uma atualização está disponível. Você tem a versão %1$s e a mais recente é %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Atualizar Octi</string>
     <string name="sync_settings_label">Sincronização</string>
     <string name="sync_settings_desc">Nome do dispositivo, intervalo e condições de sincronização.</string>
     <string name="sync_setting_devicelabel_label">Rótulo do dispositivo</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Você tem atualmente %1$d dispositivo sincronizado.</item>
         <item quantity="other">Você tem atualmente %1$d dispositivos sincronizados.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Para visualizar mais de %1$d dispositivo, atualize ou remova dispositivos.</item>
+        <item quantity="other">Para visualizar mais de %1$d dispositivos, atualize ou remova dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo apagará seus dados, mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Apagar este dispositivo removerá seus dados e revogará o acesso.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Atualização disponível</string>
     <string name="updates_dashcard_body">Uma atualização está disponível. Você tem %1$s e a versão mais recente é %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Atualizar o Octi</string>
     <string name="sync_settings_label">Sincronização</string>
     <string name="sync_settings_desc">Nome do dispositivo, tempo e condições de ativação.</string>
     <string name="sync_setting_devicelabel_label">Rótulo do dispositivo</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Tem atualmente %1$d dispositivo sincronizado.</item>
         <item quantity="other">Tem atualmente %1$d dispositivos sincronizados.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Para veres mais do que %1$d dispositivo, atualiza ou remove dispositivos.</item>
+        <item quantity="other">Para veres mais do que %1$d dispositivos, atualiza ou remove dispositivos.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Remover este dispositivo deletará seus dados mas não revogará o acesso. Para revogar o acesso, desconecte Octi no dispositivo.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Deletar este dispositivo removerá seus dados e revogará seu acesso.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -141,6 +141,10 @@
     </plurals>
     <string name="updates_dashcard_title">Actualizare disponibilă</string>
     <string name="updates_dashcard_body">Există o actualizare disponibilă. Ai %1$s și ultima versiune este %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Fă upgrade la Octi</string>
     <string name="sync_settings_label">Sincronizare</string>
     <string name="sync_settings_desc">Numele dispozitivului, orarul și condițiile de declanșare.</string>
     <string name="sync_setting_devicelabel_label">Etichetă dispozitiv</string>
@@ -187,6 +191,14 @@
         <item quantity="one">Ai în prezent %1$d dispozitiv sincronizat.</item>
         <item quantity="few">Ai în prezent %1$d dispozitive sincronizate.</item>
         <item quantity="other">Ai în prezent %1$d dispozitive sincronizate.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Pentru a vedea mai mult de %1$d dispozitiv, fă upgrade sau elimină dispozitive.</item>
+        <item quantity="few">Pentru a vedea mai mult de %1$d dispozitive, fă upgrade sau elimină dispozitive.</item>
+        <item quantity="other">Pentru a vedea mai mult de %1$d de dispozitive, fă upgrade sau elimină dispozitive.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Eliminarea acestui dispozitiv îi va șterge datele, dar nu va revoca accesul. Pentru a revoca accesul, deconectează Octi pe acel dispozitiv.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ștergând acest dispozitiv îi elimini datele și îi revoci accesul.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -146,6 +146,10 @@
     </plurals>
     <string name="updates_dashcard_title">Доступно обновление</string>
     <string name="updates_dashcard_body">Доступно обновление. У Вас версия %1$s, а последняя версия %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Обновление Octi</string>
     <string name="sync_settings_label">Синхронизация</string>
     <string name="sync_settings_desc">Имя устройства, время и условия запуска.</string>
     <string name="sync_setting_devicelabel_label">Метка устройства</string>
@@ -193,6 +197,15 @@
         <item quantity="few">У вас сейчас %1$d синхронизированных устройства.</item>
         <item quantity="many">У вас сейчас %1$d синхронизированных устройств.</item>
         <item quantity="other">У вас сейчас %1$d синхронизированных устройств.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Чтобы просматривать более %1$d устройства, обновитесь или удалите устройства.</item>
+        <item quantity="few">Чтобы просматривать более %1$d устройства, обновитесь или удалите устройства.</item>
+        <item quantity="many">Чтобы просматривать более %1$d устройств, обновитесь или удалите устройства.</item>
+        <item quantity="other">Чтобы просматривать более %1$d устройств, обновитесь или удалите устройства.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Удаление этого устройства удалит его данные, но не отзовет доступ. Чтобы отозвать доступ, отключите Octi на устройстве.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Удаление этого устройства удалит его данные и отзовет его доступ.</string>
@@ -264,7 +277,7 @@
     <string name="dashboard_device_remove_picker_title">Выберите службу синхронизации</string>
     <string name="dashboard_device_remove_picker_message">Это устройство синхронизируется через несколько сервисов. Выберите один из них, чтобы удалить его — подтвердите на следующем экране.</string>
     <string name="review_app_review_action">Отзыв</string>
-    <string name="review_app_body">Хочешь оставить отзыв для Octi? ❤️</string>
+    <string name="review_app_body">Хотите оставить отзыв на Octi? ❤️</string>
     <!-- Shared upgrade screen chrome (used by both flavors' upgrade screens). -->
     <string name="upgrade_screen_navigate_up">Перейти вверх</string>
     <string name="upgrade_screen_progress_loading">Загрузка…</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -141,6 +141,10 @@
     </plurals>
     <string name="updates_dashcard_title">Доступно ажурирање</string>
     <string name="updates_dashcard_body">Доступно је ажурирање. Имате %1$s, најновија верзија је %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Надградите Octi</string>
     <string name="sync_settings_label">Синхронизација</string>
     <string name="sync_settings_desc">Назив уређаја, време и услови покретања.</string>
     <string name="sync_setting_devicelabel_label">Ознака уређаја</string>
@@ -187,6 +191,14 @@
         <item quantity="one">Тренутно имате %1$d синхронизован уређај.</item>
         <item quantity="few">Тренутно имате %1$d синхронизована уређаја.</item>
         <item quantity="other">Тренутно имате %1$d синхронизованих уређаја.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Да видите више од %1$d уређаја, надградите или уклоните уређаје.</item>
+        <item quantity="few">Да видите више од %1$d уређаја, надградите или уклоните уређаје.</item>
+        <item quantity="other">Да видите више од %1$d уређаја, надградите или уклоните уређаје.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Уклањањем овог уређаја ће се обрисати његови подаци, али приступ ће остати. Да укинеш приступ, одјави Octi на овом уређају.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Брисањем овог уређаја ће се обрисати његови подаци и потпуно укинути приступ.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Uppdatering tillgänglig</string>
     <string name="updates_dashcard_body">En uppdatering finns tillgänglig. Du har %1$s och den senaste versionen är %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Uppgradera Octi</string>
     <string name="sync_settings_label">Synkronisering</string>
     <string name="sync_settings_desc">Enhetsnamn, timing och utlösande villkor.</string>
     <string name="sync_setting_devicelabel_label">Enhetsetikett</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Du har för närvarande %1$d synkroniserad enhet.</item>
         <item quantity="other">Du har för närvarande %1$d synkroniserade enheter.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">För att se fler än %1$d enhet, uppgradera eller ta bort enheter.</item>
+        <item quantity="other">För att se fler än %1$d enheter, uppgradera eller ta bort enheter.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Att ta bort denna enhet tar bort dess data men tar inte bort åtkomst. För att ta bort åtkomst måste du koppla loss Octi på enheten.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Ta bort denna enhet raderar dess data och tar bort dess åtkomst.</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -136,6 +136,10 @@
     </plurals>
     <string name="updates_dashcard_title">Güncelleme mevcut</string>
     <string name="updates_dashcard_body">Bir güncelleme mevcut. Cihazınızda %1$s yüklü fakat en son sürüm %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Octi\'yi yükselt</string>
     <string name="sync_settings_label">Senkronizasyon</string>
     <string name="sync_settings_desc">Cihaz adı, zamanlama ve tetikleme koşulları.</string>
     <string name="sync_setting_devicelabel_label">Cihaz etiketi</string>
@@ -181,6 +185,13 @@
     <plurals name="pro_device_limit_current_description">
         <item quantity="one">Şu anda %1$d senkronize edilmiş cihazınız var.</item>
         <item quantity="other">Şu anda %1$d senkronize edilmiş cihazınız var.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">%1$d\'den fazla cihazı görüntülemek için yükselt veya cihazları kaldır.</item>
+        <item quantity="other">%1$d\'den fazla cihazı görüntülemek için yükselt veya cihazları kaldır.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Bu cihazın kaldırılması verilerini silecek ancak erişimi iptal etmeyecektir. Erişimi iptal etmek için cihazdaki Octi bağlantısını kesin.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Bu cihazın silinmesi, verilerini kaldıracak ve erişimini iptal edecektir.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -146,6 +146,10 @@
     </plurals>
     <string name="updates_dashcard_title">Доступно оновлення</string>
     <string name="updates_dashcard_body">Доступне оновлення. У вас %1$s, а остання версія — %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Оновити Octi</string>
     <string name="sync_settings_label">Синхронізація</string>
     <string name="sync_settings_desc">Назва пристрою, розклад і умови запуску.</string>
     <string name="sync_setting_devicelabel_label">Мітка пристрою</string>
@@ -193,6 +197,15 @@
         <item quantity="few">Наразі у вас %1$d синхронізованих пристроїв.</item>
         <item quantity="many">Наразі у вас %1$d синхронізованих пристроїв.</item>
         <item quantity="other">Наразі у вас %1$d синхронізованих пристроїв.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="one">Щоб переглянути більше ніж %1$d пристрій, оновляй або видаляй пристрої.</item>
+        <item quantity="few">Щоб переглянути більше ніж %1$d пристрої, оновляй або видаляй пристрої.</item>
+        <item quantity="many">Щоб переглянути більше ніж %1$d пристроїв, оновляй або видаляй пристрої.</item>
+        <item quantity="other">Щоб переглянути більше ніж %1$d пристроїв, оновляй або видаляй пристрої.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Видалення пристрою видалить його дані, але не скасує доступ. Щоб скасувати доступ, від\'єднайте Octi на пристрої.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Видалення пристрою також видалить дані та скасує доступ.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -131,6 +131,10 @@
     </plurals>
     <string name="updates_dashcard_title">Đã có bản cập nhật</string>
     <string name="updates_dashcard_body">Một bản cập nhật có sẵn. Bạn có %1$s, bản mới nhất là %2$s.</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">Nâng cấp Octi</string>
     <string name="sync_settings_label">Đồng bộ</string>
     <string name="sync_settings_desc">Tên thiết bị, lịch trình và điều kiện kích hoạt.</string>
     <string name="sync_setting_devicelabel_label">Nhãn thiết bị</string>
@@ -175,6 +179,12 @@
     <string name="pro_device_limit_reached_title">Đã đạt giới hạn thiết bị</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">Bạn hiện có %1$d thiết bị đã đồng bộ.</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="other">Để xem hơn %1$d thiết bị, hãy nâng cấp hoặc xóa thiết bị.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu nhưng không thu hồi quyền truy cập. Để thu hồi quyền, hãy ngắt Octi trên thiết bị.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Xóa thiết bị này sẽ xóa dữ liệu và thu hồi cả quyền truy cập.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -131,6 +131,10 @@
     </plurals>
     <string name="updates_dashcard_title">有可用更新</string>
     <string name="updates_dashcard_body">可用更新。您为%1$s，最新版本是%2$s。</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">升级 Octi</string>
     <string name="sync_settings_label">同步</string>
     <string name="sync_settings_desc">设备名称、定时和触发条件。</string>
     <string name="sync_setting_devicelabel_label">设备标签</string>
@@ -175,6 +179,12 @@
     <string name="pro_device_limit_reached_title">设备达到极限</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">您当前有 %1$d 台已同步设备。</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="other">如需查看超过 %1$d 台设备，请升级或移除设备。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">删除此设备将删除其数据，但不会撤销访问权限。要撤销访问权限，请断开设备上的Octi连接。</string>
     <string name="sync_delete_device_revokeaccess_caveat">删除此设备将删除其数据并撤销其访问权限。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -131,6 +131,10 @@
     </plurals>
     <string name="updates_dashcard_title">可用更新</string>
     <string name="updates_dashcard_body">有可用更新。你是 %1$s，最新版為 %2$s。</string>
+    <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
+         tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
+         so it lives here instead of being declared twice. Keep it tier-free when translating. -->
+    <string name="upgrades_dashcard_headline">升級 Octi</string>
     <string name="sync_settings_label">同步</string>
     <string name="sync_settings_desc">設備名稱、排程與觸發條件。</string>
     <string name="sync_setting_devicelabel_label">設備標籤</string>
@@ -175,6 +179,12 @@
     <string name="pro_device_limit_reached_title">已達設備上限</string>
     <plurals name="pro_device_limit_current_description">
         <item quantity="other">你目前有 %1$d 台已同步裝置。</item>
+    </plurals>
+    <!-- Replaces pro_device_limit_maximum_description, which named the Google Play tier ("upgrade to
+         Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
+         Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
+    <plurals name="pro_device_limit_maximum_hint">
+        <item quantity="other">要查看超過 %1$d 個裝置，請升級或移除裝置。</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">移除本設備將刪除數據但不影響訪問權限。欲撤銷請於該設備上斷開 Octi。</string>
     <string name="sync_delete_device_revokeaccess_caveat">刪除本設備將移除其數據並撤銷訪問權限。</string>

--- a/modules-meta/src/main/res/values-pl/strings.xml
+++ b/modules-meta/src/main/res/values-pl/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="module_meta_label">Moduł meta</string>
     <string name="module_meta_android_name_x_label">Android %1$s</string>
-    <string name="module_meta_uptime_label">Działanie %1$s</string>
+    <string name="module_meta_uptime_label">Czas działania %1$s</string>
     <string name="module_meta_detail_label_label">Etykieta</string>
     <string name="module_meta_detail_manufacturer_label">Producent</string>
     <string name="module_meta_detail_model_label">Model</string>

--- a/sync-core/src/main/res/values-pl/strings.xml
+++ b/sync-core/src/main/res/values-pl/strings.xml
@@ -33,11 +33,11 @@
     <string name="sync_connector_progress_syncing">Synchronizowanie...</string>
     <string name="sync_connector_progress_sync_queued">Synchronizacja w kolejce...</string>
     <string name="sync_connector_progress_pausing">Wstrzymywanie synchronizacji...</string>
-    <string name="sync_connector_progress_pause_queued">Wstrzymaj w kolejce...</string>
+    <string name="sync_connector_progress_pause_queued">Wstrzymywanie w kolejce...</string>
     <string name="sync_connector_progress_resuming">Wznawianie synchronizacji...</string>
     <string name="sync_connector_progress_resume_queued">Wznowienie w kolejce...</string>
     <string name="sync_connector_progress_resetting">Resetowanie danych...</string>
-    <string name="sync_connector_progress_reset_queued">Reset w kolejce...</string>
+    <string name="sync_connector_progress_reset_queued">Resetowanie w kolejce...</string>
     <string name="sync_connector_progress_device_updating">Aktualizowanie urządzeń...</string>
     <string name="sync_connector_progress_device_update_queued">Aktualizacja urządzenia w kolejce...</string>
     <string name="sync_synced_devices_label">Zsynchronizowane urządzenia</string>


### PR DESCRIPTION
## What changed
Updated translations for 29 languages, pulled from Crowdin. No source (English) strings were touched.

## Technical Context
- Pulled and validated `strings.xml` changes for 29 locales (118 files across `app-common`, `app/foss`, `app/gplay`, `app/main`, `modules-meta`, `sync-core`). Each locale was checked for vandalism, placeholder integrity (`%1$s`/`%1$d`), and escaping — all clean.
- A few non-blocking style/terminology nuances were flagged (not fixed, since they're wording judgment calls rather than defects): French mixes formal "vous" and informal "tu" in 3 new strings; Czech translates "upgrade" (paid-tier concept) as "aktualizace" (software update) in 3 strings, diverging from the locale's existing "upgrade" terminology; Greek has a minor imperative-verb misspelling in 1 string; Russian uses the wrong plural grammar case in 1 plural category. These are logged locally for optional Crowdin-side cleanup but not included in this PR.
- Verified with a full `assembleDebug` build (all flavors/source-sets, not a single variant) to catch resource-merge and AAPT-level errors — passes clean.