### PR TITLE
Fix device linking on Android TV and unclear link code errors

### DIFF
--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/InvalidLinkCodeException.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/InvalidLinkCodeException.kt
@@ -1,0 +1,41 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import eu.darken.octi.common.ca.toCaString
+import eu.darken.octi.common.error.HasLocalizedError
+import eu.darken.octi.common.error.LocalizedError
+import eu.darken.octi.syncs.octiserver.R
+
+/**
+ * A link code that could not be turned back into [LinkingData].
+ *
+ * The three decode stages fail with wildly different exceptions for what is, to the user, always the
+ * same situation: the code that arrived is not the code that was generated. Without this, a partial
+ * paste surfaces okio's internal gzip wording ("ID1ID2: actual 0x... != expected 0x...") in the
+ * error dialog, which tells the user nothing they can act on.
+ *
+ * Note that base64 alone catches almost nothing: okio's decoder does no length or alignment
+ * validation and skips whitespace, so any string built purely from alphabet characters decodes
+ * "successfully" no matter how much of it is missing. Truncation therefore surfaces at [Stage.GZIP],
+ * not [Stage.BASE64].
+ *
+ * The triggering exception is deliberately **not** chained. [eu.darken.octi.common.uix.ViewModel4]
+ * logs the whole cause chain with `asLog()`, and a decoder message can carry payload bytes:
+ * kotlinx.serialization embeds a "JSON input:" excerpt around the failure offset, and the plaintext
+ * being parsed at [Stage.JSON] contains `encryptionKeySet.key` in full. [stage] plus the exception
+ * type is the entire diagnostic value those messages had, without the leak.
+ */
+class InvalidLinkCodeException private constructor(
+    val stage: Stage,
+    private val causeType: String,
+) : IllegalArgumentException("Link code could not be decoded at $stage ($causeType)"), HasLocalizedError {
+
+    internal constructor(stage: Stage, cause: Throwable) : this(stage, cause::class.simpleName ?: "Unknown")
+
+    enum class Stage { BASE64, GZIP, JSON }
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.sync_octiserver_link_code_invalid_label.toCaString(),
+        description = R.string.sync_octiserver_link_code_invalid_description.toCaString(),
+    )
+}

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkCodeShape.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkCodeShape.kt
@@ -1,0 +1,23 @@
+package eu.darken.octi.syncs.octiserver.core
+
+/** Base64 alphabet accepted by okio's decoder, both the standard and the URL-safe variant. */
+private val BASE64_ALPHABET = Regex("^[A-Za-z0-9+/\\-_=]*$")
+
+/** Base64 of the gzip magic `1f 8b 08`, so every complete link code starts with it. */
+private const val GZIP_BASE64_PREFIX = "H4sI"
+
+/**
+ * A loggable description of a link code that contains none of its characters.
+ *
+ * A link code carries the account's payload encryption keyset and the server link credential, so it
+ * must never reach a debug recording. These three facts are what actually diagnose a failed link and
+ * none of them reveal any of the code:
+ *  - `len`: a complete code is ~496 chars, so a short one was truncated.
+ *  - `gzipPrefix`: false means the start of the code was lost, which whitespace-tolerant base64
+ *    decoding cannot detect on its own. Deliberately a boolean rather than the leading characters:
+ *    when it is false those characters are arbitrary payload bytes, not the known constant.
+ *  - `alphabet`: false means a stray character got in (autocorrect, a smart quote, a space inside
+ *    the code), true narrows it to a length or ordering problem.
+ */
+fun String.linkCodeShape(): String =
+    "len=$length, gzipPrefix=${startsWith(GZIP_BASE64_PREFIX)}, alphabet=${BASE64_ALPHABET.matches(this)}"

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt
@@ -26,9 +26,30 @@ data class LinkingData(
         .base64()
 
     companion object {
-        fun fromEncodedString(json: Json, encoded: String): LinkingData = (encoded
-            .decodeBase64() ?: throw IllegalArgumentException("Invalid link code: not valid base64"))
-            .fromGzip()
-            .let { json.decodeFromString<LinkingData>(it.utf8()) }
+        /**
+         * @throws InvalidLinkCodeException if [encoded] is not a complete, unaltered link code.
+         * Surrounding whitespace is tolerated: share targets and clipboards routinely add it.
+         */
+        fun fromEncodedString(json: Json, encoded: String): LinkingData {
+            // Staged rather than one try/catch: which stage failed is the whole diagnostic, and it
+            // is the only part of the failure that is safe to log.
+            val compressed = try {
+                encoded.trim().decodeBase64() ?: throw IllegalArgumentException("Not valid base64")
+            } catch (e: Exception) {
+                throw InvalidLinkCodeException(InvalidLinkCodeException.Stage.BASE64, e)
+            }
+
+            val plaintext = try {
+                compressed.fromGzip()
+            } catch (e: Exception) {
+                throw InvalidLinkCodeException(InvalidLinkCodeException.Stage.GZIP, e)
+            }
+
+            return try {
+                json.decodeFromString<LinkingData>(plaintext.utf8())
+            } catch (e: Exception) {
+                throw InvalidLinkCodeException(InvalidLinkCodeException.Stage.JSON, e)
+            }
+        }
     }
 }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientScreen.kt
@@ -37,9 +37,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.journeyapps.barcodescanner.ScanContract
@@ -204,8 +206,32 @@ fun OctiServerLinkClientScreen(
                                 onValueChange = { linkCodeText = it },
                                 label = { Text(text = stringResource(OctiServerR.string.sync_octiserver_link_code_label)) },
                                 singleLine = true,
-                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
+                                // A link code is a case-sensitive base64 blob, not prose. Left to
+                                // the platform defaults the IME applies autocorrect, word
+                                // suggestions and sentence capitalization to it, which silently
+                                // rewrites the code for anyone typing it by hand.
+                                keyboardOptions = KeyboardOptions(
+                                    capitalization = KeyboardCapitalization.None,
+                                    autoCorrectEnabled = false,
+                                    imeAction = ImeAction.Go,
+                                ),
                                 keyboardActions = KeyboardActions(onGo = { onCodeEntered(linkCodeText) }),
+                                // Counted trimmed, matching what the decoder sees and what the
+                                // sending device displays, so the two numbers are comparable.
+                                supportingText = {
+                                    val trimmed = linkCodeText.trim()
+                                    Text(
+                                        text = if (trimmed.isEmpty()) {
+                                            stringResource(OctiServerR.string.sync_octiserver_link_code_character_count_hint)
+                                        } else {
+                                            pluralStringResource(
+                                                OctiServerR.plurals.sync_octiserver_link_code_character_count,
+                                                trimmed.length,
+                                                trimmed.length,
+                                            )
+                                        },
+                                    )
+                                },
                                 modifier = Modifier.fillMaxWidth(),
                             )
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientScreen.kt
@@ -46,6 +46,7 @@ import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import eu.darken.octi.common.debug.logging.log
 import eu.darken.octi.common.debug.logging.logTag
+import eu.darken.octi.syncs.octiserver.core.linkCodeShape
 import eu.darken.octi.syncs.octiserver.R as OctiServerR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
@@ -61,7 +62,8 @@ fun OctiServerLinkClientScreenHost(vm: OctiServerLinkClientVM = hiltViewModel())
 
     val barcodeLauncher = rememberLauncherForActivityResult(ScanContract()) { result ->
         if (result.contents != null) {
-            log(TAG) { "QRCode scanned: ${result.contents}" }
+            // Shape only, never the code: it carries the account's encryption keyset.
+            log(TAG) { "QRCode scanned: ${result.contents.linkCodeShape()}" }
             vm.onCodeEntered(result.contents)
         } else {
             log(TAG) { "QRCode scan was cancelled." }

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientVM.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/client/OctiServerLinkClientVM.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.common.navigation.Nav
 import eu.darken.octi.common.uix.ViewModel4
 import eu.darken.octi.syncs.octiserver.core.OctiServerHub
 import eu.darken.octi.syncs.octiserver.core.LinkingData
+import eu.darken.octi.syncs.octiserver.core.linkCodeShape
 import eu.darken.octi.syncs.octiserver.ui.link.OctiServerLinkOption
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
@@ -43,11 +44,16 @@ class OctiServerLinkClientVM @Inject constructor(
     }
 
     fun onCodeEntered(rawCode: String) = launch {
-        log(TAG) { "onCodeEntered(rawCode=$rawCode)" }
+        // Never log the code itself: it carries the account's payload encryption keyset and the
+        // server link credential, and debug recordings are shared with support. This fingerprint is
+        // enough to tell truncation from a typo from a wrong-format paste.
+        log(TAG) { "onCodeEntered(${rawCode.trim().linkCodeShape()})" }
         _state.value = _state.value.copy(isBusy = true)
         try {
+            // Server address only. Logging the whole container pulled in the redacted-but-still
+            // key-derived prefixes that LinkCode and KeySet put in their toString().
             val linkContainer = LinkingData.fromEncodedString(json, rawCode).also {
-                log(TAG) { "Got container: $it" }
+                log(TAG) { "Decoded link code for ${it.serverAdress.address}" }
             }
 
             kServerHub.linkAcount(linkContainer)

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -29,6 +30,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -44,9 +46,10 @@ import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
@@ -86,6 +89,16 @@ fun OctiServerLinkHostScreenHost(
         }
     }
 
+    LaunchedEffect(vm) {
+        vm.linkCodeCopiedEvents.collect {
+            Toast.makeText(
+                context,
+                OctiServerR.string.sync_octiserver_link_code_copied_message,
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+    }
+
     val state by vm.state.collectAsState(initial = null)
     state?.let {
         OctiServerLinkHostScreen(
@@ -93,6 +106,7 @@ fun OctiServerLinkHostScreenHost(
             onNavigateUp = { vm.navUp() },
             onLinkOptionSelected = { option -> vm.onLinkOptionSelected(option) },
             onShareLinkCode = { activity?.let { act -> vm.shareLinkCode(act) } },
+            onCopyLinkCode = { vm.copyLinkCode(context) },
         )
     }
 }
@@ -103,6 +117,7 @@ fun OctiServerLinkHostScreen(
     onNavigateUp: () -> Unit,
     onLinkOptionSelected: (OctiServerLinkOption) -> Unit,
     onShareLinkCode: () -> Unit,
+    onCopyLinkCode: () -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -164,6 +179,7 @@ fun OctiServerLinkHostScreen(
                     LinkContent(
                         state = state,
                         onShareLinkCode = onShareLinkCode,
+                        onCopyLinkCode = onCopyLinkCode,
                         // No cap needed and no scroll around it: this pane is bounded, so QrCode
                         // measures the real height itself. A scroll here would hand it Infinity
                         // again and let its own padding push it back off the bottom.
@@ -191,6 +207,7 @@ fun OctiServerLinkHostScreen(
                     LinkContent(
                         state = state,
                         onShareLinkCode = onShareLinkCode,
+                        onCopyLinkCode = onCopyLinkCode,
                         qrMaxSide = viewportHeight * STACKED_QR_VIEWPORT_FRACTION,
                         // The Column above already scrolls; a second one here would nest.
                         contentScrolls = false,
@@ -268,6 +285,7 @@ private fun LinkOptionRow(
 private fun LinkContent(
     state: OctiServerLinkHostVM.State,
     onShareLinkCode: () -> Unit,
+    onCopyLinkCode: () -> Unit,
     contentScrolls: Boolean,
     modifier: Modifier = Modifier,
     qrMaxSide: Dp = Dp.Infinity,
@@ -281,6 +299,7 @@ private fun LinkContent(
     OctiServerLinkOption.DIRECT -> TextCode(
         encodedLinkCode = state.encodedLinkCode,
         onShareLinkCode = onShareLinkCode,
+        onCopyLinkCode = onCopyLinkCode,
         // Only the text code can outgrow its pane, and only where nothing else scrolls already.
         modifier = if (contentScrolls) modifier.verticalScroll(rememberScrollState()) else modifier,
     )
@@ -332,6 +351,7 @@ private fun QrCode(
 private fun TextCode(
     encodedLinkCode: String?,
     onShareLinkCode: () -> Unit,
+    onCopyLinkCode: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     // No scroll of its own: each layout branch owns exactly one scroll container, otherwise the
@@ -348,19 +368,50 @@ private fun TextCode(
                 .padding(bottom = 8.dp),
         )
 
-        Text(
-            text = encodedLinkCode ?: "",
-            style = MaterialTheme.typography.bodyLarge,
-            fontStyle = FontStyle.Italic,
-        )
+        // Selectable and monospaced: the code is ~500 characters of case-sensitive base64 wrapped
+        // over several lines. Unselectable italic prose is the worst case for both copying it and
+        // reading it back, and losing one wrapped line while transcribing silently corrupts it.
+        SelectionContainer {
+            Text(
+                text = encodedLinkCode ?: "",
+                style = MaterialTheme.typography.bodyMedium,
+                fontFamily = FontFamily.Monospace,
+            )
+        }
+
+        // The count is the one property of the code a person can compare across two screens without
+        // reading 500 characters, and a mismatch is exactly the failure this screen feeds into.
+        encodedLinkCode?.let { code ->
+            Text(
+                text = pluralStringResource(
+                    OctiServerR.plurals.sync_octiserver_link_code_character_count,
+                    code.length,
+                    code.length,
+                ),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .padding(top = 8.dp),
+            )
+        }
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Button(
-            onClick = onShareLinkCode,
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(text = stringResource(CommonR.string.general_share_action))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Button(
+                onClick = onCopyLinkCode,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(text = stringResource(CommonR.string.general_copy_action))
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            OutlinedButton(
+                onClick = onShareLinkCode,
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(text = stringResource(CommonR.string.general_share_action))
+            }
         }
     }
 }
@@ -396,6 +447,7 @@ private fun OctiServerLinkHostScreenQRPreview() = PreviewWrapper {
         onNavigateUp = {},
         onLinkOptionSelected = {},
         onShareLinkCode = {},
+        onCopyLinkCode = {},
     )
 }
 
@@ -410,6 +462,7 @@ private fun OctiServerLinkHostScreenDirectPreview() = PreviewWrapper {
         onNavigateUp = {},
         onLinkOptionSelected = {},
         onShareLinkCode = {},
+        onCopyLinkCode = {},
     )
 }
 

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostScreen.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostScreen.kt
@@ -1,16 +1,21 @@
 package eu.darken.octi.syncs.octiserver.ui.link.host
 
 import android.app.Activity
-import android.graphics.Bitmap
 import android.widget.Toast
+import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
@@ -25,37 +30,36 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.FilterQuality
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontStyle
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.zxing.BarcodeFormat
 import com.journeyapps.barcodescanner.BarcodeEncoder
-import eu.darken.octi.common.R as CommonR
-import eu.darken.octi.syncs.octiserver.R as OctiServerR
 import eu.darken.octi.common.compose.Preview2
 import eu.darken.octi.common.compose.PreviewWrapper
-import androidx.compose.runtime.collectAsState
 import eu.darken.octi.common.error.ErrorEventHandler
 import eu.darken.octi.common.navigation.NavigationEventHandler
 import eu.darken.octi.syncs.octiserver.ui.link.OctiServerLinkOption
+import eu.darken.octi.common.R as CommonR
+import eu.darken.octi.syncs.octiserver.R as OctiServerR
 
 @Composable
 fun OctiServerLinkHostScreenHost(
@@ -120,143 +124,264 @@ fun OctiServerLinkHostScreen(
             )
         },
     ) { innerPadding ->
-        Column(
+        // BoxWithConstraints sits OUTSIDE any scroll on purpose: it is the only place that sees the
+        // real viewport height. Inside a verticalScroll the height constraint is Infinity, which is
+        // what let the QR grow to a full-screen-width square and run off the bottom of the display.
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .verticalScroll(rememberScrollState())
-                .padding(bottom = 16.dp),
+                .padding(innerPadding),
         ) {
-            Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                elevation = CardDefaults.elevatedCardElevation(),
-            ) {
+            // Captured here: inside the Row/Column below these are no longer reachable as implicit
+            // receivers, and they are the only reading of the true viewport in the whole screen.
+            val viewportHeight = maxHeight
+            val isWide = maxWidth > viewportHeight
+
+            if (isWide) {
+                // Landscape and TV: stacking the QR under the option card leaves it far less height
+                // than the display has width. Side by side, the QR pane carries no other content,
+                // so it gets the full viewport height and needs no allowance for chrome.
+                Row(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight(),
+                    ) {
+                        // Only the card scrolls, so a large font scale or a long translation cannot
+                        // clip the options out of reach while the indicator stays pinned below.
+                        Column(
+                            modifier = Modifier
+                                .weight(1f)
+                                .verticalScroll(rememberScrollState()),
+                        ) {
+                            LinkOptions(
+                                selected = state.linkOption,
+                                onLinkOptionSelected = onLinkOptionSelected,
+                            )
+                        }
+                        WaitingIndicator(modifier = Modifier.padding(bottom = 16.dp))
+                    }
+                    LinkContent(
+                        state = state,
+                        onShareLinkCode = onShareLinkCode,
+                        // No cap needed and no scroll around it: this pane is bounded, so QrCode
+                        // measures the real height itself. A scroll here would hand it Infinity
+                        // again and let its own padding push it back off the bottom.
+                        contentScrolls = true,
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .padding(16.dp),
+                    )
+                }
+            } else {
+                // Stacked: the whole column scrolls, so the QR cannot be sized by weight. Capping it
+                // against the viewport is what keeps it on screen; the cap is generous enough that
+                // width is the binding constraint on a normal phone, and the scroll absorbs the rest
+                // when a large font scale grows the card beyond the space left over.
                 Column(
                     modifier = Modifier
-                        .padding(16.dp)
-                        .selectableGroup(),
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState()),
                 ) {
-                    Row(
+                    LinkOptions(
+                        selected = state.linkOption,
+                        onLinkOptionSelected = onLinkOptionSelected,
+                    )
+                    LinkContent(
+                        state = state,
+                        onShareLinkCode = onShareLinkCode,
+                        qrMaxSide = viewportHeight * STACKED_QR_VIEWPORT_FRACTION,
+                        // The Column above already scrolls; a second one here would nest.
+                        contentScrolls = false,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .selectable(
-                                selected = state.linkOption == OctiServerLinkOption.QRCODE,
-                                role = Role.RadioButton,
-                                onClick = { onLinkOptionSelected(OctiServerLinkOption.QRCODE) },
-                            )
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = state.linkOption == OctiServerLinkOption.QRCODE,
-                            onClick = null,
-                        )
-                        Text(
-                            text = stringResource(OctiServerR.string.sync_octiserver_link_host_option_qrcode),
-                            modifier = Modifier.padding(start = 8.dp),
-                        )
-                    }
-
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .selectable(
-                                selected = state.linkOption == OctiServerLinkOption.DIRECT,
-                                role = Role.RadioButton,
-                                onClick = { onLinkOptionSelected(OctiServerLinkOption.DIRECT) },
-                            )
-                            .padding(vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        RadioButton(
-                            selected = state.linkOption == OctiServerLinkOption.DIRECT,
-                            onClick = null,
-                        )
-                        Text(
-                            text = stringResource(OctiServerR.string.sync_octiserver_link_host_option_direct),
-                            modifier = Modifier.padding(start = 8.dp),
-                        )
-                    }
+                            .padding(16.dp),
+                    )
+                    WaitingIndicator(modifier = Modifier.padding(bottom = 16.dp))
                 }
-            }
-
-            when (state.linkOption) {
-                OctiServerLinkOption.QRCODE -> {
-                    val qrBitmap = remember(state.encodedLinkCode) {
-                        state.encodedLinkCode?.let { code ->
-                            try {
-                                BarcodeEncoder().encodeBitmap(code, BarcodeFormat.QR_CODE, 512, 512)
-                            } catch (_: Exception) {
-                                null
-                            }
-                        }
-                    }
-                    qrBitmap?.let { bitmap ->
-                        Image(
-                            bitmap = bitmap.asImageBitmap(),
-                            contentDescription = null,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .aspectRatio(1f)
-                                .padding(8.dp),
-                        )
-                    }
-                }
-
-                OctiServerLinkOption.DIRECT -> {
-                    Column(
-                        modifier = Modifier.padding(horizontal = 32.dp),
-                    ) {
-                        Spacer(modifier = Modifier.height(32.dp))
-
-                        Text(
-                            text = stringResource(OctiServerR.string.sync_octiserver_link_code_label),
-                            style = MaterialTheme.typography.labelLarge,
-                        )
-
-                        Spacer(modifier = Modifier.height(8.dp))
-
-                        Text(
-                            text = state.encodedLinkCode ?: "",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontStyle = FontStyle.Italic,
-                        )
-
-                        Spacer(modifier = Modifier.height(16.dp))
-
-                        Button(
-                            onClick = onShareLinkCode,
-                            modifier = Modifier.fillMaxWidth(),
-                        ) {
-                            Text(text = stringResource(CommonR.string.general_share_action))
-                        }
-
-                        Spacer(modifier = Modifier.height(32.dp))
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(16.dp))
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(24.dp),
-                    strokeWidth = 2.dp,
-                )
-                Spacer(modifier = Modifier.width(12.dp))
-                Text(
-                    text = stringResource(OctiServerR.string.sync_octiserver_link_host_waiting_label),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
             }
         }
+    }
+}
+
+@Composable
+private fun LinkOptions(
+    selected: OctiServerLinkOption,
+    onLinkOptionSelected: (OctiServerLinkOption) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        elevation = CardDefaults.elevatedCardElevation(),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .selectableGroup(),
+        ) {
+            LinkOptionRow(
+                option = OctiServerLinkOption.QRCODE,
+                selected = selected,
+                labelRes = OctiServerR.string.sync_octiserver_link_host_option_qrcode,
+                onLinkOptionSelected = onLinkOptionSelected,
+            )
+            LinkOptionRow(
+                option = OctiServerLinkOption.DIRECT,
+                selected = selected,
+                labelRes = OctiServerR.string.sync_octiserver_link_host_option_direct,
+                onLinkOptionSelected = onLinkOptionSelected,
+            )
+        }
+    }
+}
+
+@Composable
+private fun LinkOptionRow(
+    option: OctiServerLinkOption,
+    selected: OctiServerLinkOption,
+    @StringRes labelRes: Int,
+    onLinkOptionSelected: (OctiServerLinkOption) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(
+                selected = selected == option,
+                role = Role.RadioButton,
+                onClick = { onLinkOptionSelected(option) },
+            )
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = selected == option, onClick = null)
+        Text(
+            text = stringResource(labelRes),
+            modifier = Modifier.padding(start = 8.dp),
+        )
+    }
+}
+
+@Composable
+private fun LinkContent(
+    state: OctiServerLinkHostVM.State,
+    onShareLinkCode: () -> Unit,
+    contentScrolls: Boolean,
+    modifier: Modifier = Modifier,
+    qrMaxSide: Dp = Dp.Infinity,
+) = when (state.linkOption) {
+    OctiServerLinkOption.QRCODE -> QrCode(
+        encodedLinkCode = state.encodedLinkCode,
+        maxSide = qrMaxSide,
+        modifier = modifier,
+    )
+
+    OctiServerLinkOption.DIRECT -> TextCode(
+        encodedLinkCode = state.encodedLinkCode,
+        onShareLinkCode = onShareLinkCode,
+        // Only the text code can outgrow its pane, and only where nothing else scrolls already.
+        modifier = if (contentScrolls) modifier.verticalScroll(rememberScrollState()) else modifier,
+    )
+}
+
+@Composable
+private fun QrCode(
+    encodedLinkCode: String?,
+    maxSide: Dp,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        // The largest square that fits, so the QR can never exceed the space it was given. maxHeight
+        // is unbounded when an ancestor scrolls, which is why the caller also supplies [maxSide].
+        val side = min(min(maxWidth, maxHeight), maxSide)
+        val sidePx = with(LocalDensity.current) { side.roundToPx() }
+
+        val qrBitmap = remember(encodedLinkCode, sidePx) {
+            if (encodedLinkCode == null || sidePx <= 0) {
+                null
+            } else {
+                try {
+                    // Encoded at the size it is actually drawn at. A fixed 512px bitmap stretched
+                    // across a 1080p TV blurs the module edges, and a blurry QR photographed off a
+                    // TV panel is markedly harder for a phone camera to decode.
+                    BarcodeEncoder().encodeBitmap(encodedLinkCode, BarcodeFormat.QR_CODE, sidePx, sidePx)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        }
+
+        qrBitmap?.let { bitmap ->
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                // Nearest-neighbour: bilinear filtering softens module edges and costs scan range.
+                filterQuality = FilterQuality.None,
+                modifier = Modifier.size(side),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TextCode(
+    encodedLinkCode: String?,
+    onShareLinkCode: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // No scroll of its own: each layout branch owns exactly one scroll container, otherwise the
+    // stacked branch would nest two vertical scrolls and measure this one against Infinity.
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(OctiServerR.string.sync_octiserver_link_code_label),
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier
+                .align(Alignment.Start)
+                .padding(bottom = 8.dp),
+        )
+
+        Text(
+            text = encodedLinkCode ?: "",
+            style = MaterialTheme.typography.bodyLarge,
+            fontStyle = FontStyle.Italic,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Button(
+            onClick = onShareLinkCode,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(text = stringResource(CommonR.string.general_share_action))
+        }
+    }
+}
+
+@Composable
+private fun WaitingIndicator(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(24.dp),
+            strokeWidth = 2.dp,
+        )
+        Spacer(modifier = Modifier.width(12.dp))
+        Text(
+            text = stringResource(OctiServerR.string.sync_octiserver_link_host_waiting_label),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -266,7 +391,7 @@ private fun OctiServerLinkHostScreenQRPreview() = PreviewWrapper {
     OctiServerLinkHostScreen(
         state = OctiServerLinkHostVM.State(
             linkOption = OctiServerLinkOption.QRCODE,
-            encodedLinkCode = "octi://link/abc123def456",
+            encodedLinkCode = PREVIEW_CODE,
         ),
         onNavigateUp = {},
         onLinkOptionSelected = {},
@@ -280,10 +405,21 @@ private fun OctiServerLinkHostScreenDirectPreview() = PreviewWrapper {
     OctiServerLinkHostScreen(
         state = OctiServerLinkHostVM.State(
             linkOption = OctiServerLinkOption.DIRECT,
-            encodedLinkCode = "octi://link/abc123def456",
+            encodedLinkCode = PREVIEW_CODE,
         ),
         onNavigateUp = {},
         onLinkOptionSelected = {},
         onShareLinkCode = {},
     )
 }
+
+/**
+ * How much of the viewport the QR may claim in the stacked layout. The option card and the waiting
+ * row take the rest, and because that column scrolls their height cannot be measured up front. On a
+ * normal phone the screen width binds first and this cap never applies; it exists so an unusually
+ * short viewport degrades into scrolling rather than an off-screen QR.
+ */
+private const val STACKED_QR_VIEWPORT_FRACTION = 0.55f
+
+/** Same length as a real link code, so previews show the layout at the size it actually renders. */
+private val PREVIEW_CODE = "H4sIAAAAAAAAA" + "Wm9jdGlwcmV2aWV3".repeat(30) + "AAA=="

--- a/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
+++ b/syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/ui/link/host/OctiServerLinkHostVM.kt
@@ -1,7 +1,11 @@
 package eu.darken.octi.syncs.octiserver.ui.link.host
 
 import android.app.Activity
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
+import android.os.Build
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.octi.common.coroutine.DispatcherProvider
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
@@ -31,13 +35,14 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 
 @HiltViewModel
 class OctiServerLinkHostVM @Inject constructor(
-    dispatcherProvider: DispatcherProvider,
+    private val dispatcherProvider: DispatcherProvider,
     private val syncManager: SyncManager,
     private val syncSettings: SyncSettings,
     private val json: Json,
@@ -64,6 +69,8 @@ class OctiServerLinkHostVM @Inject constructor(
 
     var deviceLinkedEvents = SingleEventFlow<Unit>()
         private set
+
+    val linkCodeCopiedEvents = SingleEventFlow<Unit>()
 
     private var deviceMonitorJob: Job? = null
 
@@ -140,6 +147,24 @@ class OctiServerLinkHostVM @Inject constructor(
         }
     }
 
+    /**
+     * A TV rarely has a share target that can accept text, and the code is ~500 characters, so
+     * "read it off the screen and retype it" is not a viable fallback. Copy is the escape hatch.
+     */
+    fun copyLinkCode(context: Context) = launch {
+        log(TAG) { "copyLinkCode()" }
+        val encodedCode = _state.value.encodedLinkCode ?: return@launch
+        // On Main deliberately: launch{} runs on Dispatchers.Default, and resolving CLIPBOARD_SERVICE
+        // off the main thread throws "Can't create handler inside thread that has not called
+        // Looper.prepare()" on some versions. ClipboardHelper carries a workaround for the same trap.
+        withContext(dispatcherProvider.Main) {
+            val clipboard = context.getSystemService(ClipboardManager::class.java) ?: return@withContext
+            clipboard.setPrimaryClip(ClipData.newPlainText(CLIP_LABEL, encodedCode))
+        }
+        // Android 13+ shows its own clipboard confirmation, a toast on top of it would double up.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) linkCodeCopiedEvents.tryEmit(Unit)
+    }
+
     fun shareLinkCode(activity: Activity) = launch {
         log(TAG) { "shareLinkCode()" }
         val encodedCode = _state.value.encodedLinkCode ?: return@launch
@@ -155,5 +180,6 @@ class OctiServerLinkHostVM @Inject constructor(
 
     companion object {
         private val TAG = logTag("Sync", "OctiServer", "Link", "Host", "VM")
+        private const val CLIP_LABEL = "Octi link code"
     }
 }

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -36,4 +36,10 @@
     <string name="sync_octiserver_add_custom_server_label">Custom server</string>
     <string name="sync_octiserver_link_code_invalid_label">Link code incomplete</string>
     <string name="sync_octiserver_link_code_invalid_description">This link code is incomplete or was altered on the way over. Copy the whole code from the other device and paste it without retyping it, or scan the QR code instead.</string>
+    <string name="sync_octiserver_link_code_copied_message">Link code copied</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d character</item>
+        <item quantity="other">%d characters</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Both devices must show the same count.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values/strings.xml
+++ b/syncs-octiserver/src/main/res/values/strings.xml
@@ -34,4 +34,6 @@
     <string name="sync_octiserver_add_link_existing_action">Link to existing account</string>
     <string name="sync_octiserver_add_select_server_label">Select server</string>
     <string name="sync_octiserver_add_custom_server_label">Custom server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Link code incomplete</string>
+    <string name="sync_octiserver_link_code_invalid_description">This link code is incomplete or was altered on the way over. Copy the whole code from the other device and paste it without retyping it, or scan the QR code instead.</string>
 </resources>

--- a/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/InvalidLinkCodeExceptionTest.kt
+++ b/syncs-octiserver/src/test/java/eu/darken/octi/syncs/octiserver/core/InvalidLinkCodeExceptionTest.kt
@@ -1,0 +1,149 @@
+package eu.darken.octi.syncs.octiserver.core
+
+import eu.darken.octi.common.collections.toGzip
+import eu.darken.octi.sync.core.encryption.PayloadEncryption
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import kotlinx.serialization.json.Json
+import okio.ByteString.Companion.encodeUtf8
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import testhelpers.BaseTest
+
+/**
+ * Regression cover for the failure the user hits when a link code arrives incomplete.
+ *
+ * Reported as: `Error - IOException / ID1ID2: actual 0xffffab6d != expected 0x00001f8b`, which is
+ * okio's internal gzip header wording leaking into the error dialog.
+ */
+class InvalidLinkCodeExceptionTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        encodeDefaults = true
+    }
+
+    private val testData = LinkingData(
+        serverAdress = OctiServer.Address(domain = "prod.kserver.octi.darken.eu"),
+        linkCode = OctiServer.Credentials.LinkCode(code = "ABCD1234"),
+        encryptionKeyset = PayloadEncryption.KeySet(
+            type = "AES256_GCM_SIV",
+            key = "testkey".encodeUtf8(),
+        ),
+    )
+
+    private val validCode = testData.toEncodedString(json)
+
+    @Nested
+    inner class `decode failures all surface as InvalidLinkCodeException` {
+
+        @Test
+        fun `truncated at the start`() {
+            // The reported case. Every character is still base64-alphabet, so okio's decoder
+            // accepts it and the failure only shows up at the gzip magic check.
+            val error = assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, validCode.drop(8))
+            }
+            error.stage shouldBe InvalidLinkCodeException.Stage.GZIP
+        }
+
+        @Test
+        fun `truncated at the end`() {
+            assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, validCode.dropLast(20))
+            }
+        }
+
+        @Test
+        fun `not base64 at all`() {
+            val error = assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, "not a link code!")
+            }
+            error.stage shouldBe InvalidLinkCodeException.Stage.BASE64
+        }
+
+        @Test
+        fun `empty`() {
+            assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, "")
+            }
+        }
+
+        @Test
+        fun `valid gzip but not LinkingData json`() {
+            val notOurJson = """{"hello":"world"}""".encodeUtf8().toGzip().base64()
+            val error = assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, notOurJson)
+            }
+            error.stage shouldBe InvalidLinkCodeException.Stage.JSON
+        }
+
+        @Test
+        fun `the decoder cause is never chained`() {
+            // ViewModel4 logs the whole cause chain with asLog(), and a kotlinx-serialization
+            // message embeds a "JSON input:" excerpt of the plaintext, which holds the keyset.
+            val plaintextWithSecret = """{"serverAddress":{"domain":"x"},"key":"SUPERSECRETKEY"""
+                .encodeUtf8()
+                .toGzip()
+                .base64()
+            val error = assertThrows<InvalidLinkCodeException> {
+                LinkingData.fromEncodedString(json, plaintextWithSecret)
+            }
+            error.cause shouldBe null
+            error.stackTraceToString() shouldNotContain "SUPERSECRETKEY"
+        }
+    }
+
+    @Nested
+    inner class `valid codes still decode` {
+
+        @Test
+        fun `round trip`() {
+            LinkingData.fromEncodedString(json, validCode) shouldBe testData
+        }
+
+        @Test
+        fun `surrounding whitespace is tolerated`() {
+            // Share targets and clipboards routinely add a trailing newline.
+            LinkingData.fromEncodedString(json, "\n  $validCode \n") shouldBe testData
+        }
+    }
+
+    @Nested
+    inner class `link code shape is safe to log` {
+
+        @Test
+        fun `reports length prefix and alphabet cleanliness`() {
+            val shape = validCode.linkCodeShape()
+            shape shouldContain "len=${validCode.length}"
+            shape shouldContain "gzipPrefix=true"
+            shape shouldContain "alphabet=true"
+        }
+
+        @Test
+        fun `a stray character is called out`() {
+            "H4sIabc!".linkCodeShape() shouldContain "alphabet=false"
+        }
+
+        @Test
+        fun `a lost head is visible as a missing gzip prefix`() {
+            val shape = validCode.drop(8).linkCodeShape()
+            shape shouldContain "gzipPrefix=false"
+            shape shouldContain "alphabet=true"
+        }
+
+        @Test
+        fun `no run of code characters ever reaches the log line`() {
+            // The previous version echoed the first four characters. That is the harmless constant
+            // "H4sI" only while the code is intact; on a truncated code those are payload bytes.
+            val truncated = validCode.drop(8)
+            val shape = truncated.linkCodeShape()
+            (4..12).forEach { window ->
+                truncated.windowed(window).any { shape.contains(it) } shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

On Android TV, and on any device held in landscape, the QR code for linking a new device was drawn larger than the screen and got cut off at the bottom. A QR code with a corner missing cannot be scanned, so that route was simply unusable. It now fits the screen, sitting next to the options in landscape instead of underneath them, and it is rendered sharply enough to be read off a TV panel by a phone camera.

Pasting a link code that did not arrive intact produced `Error - IOException` followed by a pair of hex numbers. It now says the code is incomplete and tells you what to do about it: copy the whole code across, or scan the QR code instead.

Getting the code off the sending device was also harder than it needed to be. The code could not be selected or copied at all, and sharing it was the only way out, which is a dead end on a TV that has no app able to receive shared text. There is now a Copy button, the text can be selected, and it is shown in a monospaced font so it is readable when it does have to be checked by eye.

Both screens now show how many characters the code has, so a partial copy is visible before you submit it rather than after it fails.

Typing a code by hand no longer fights the keyboard: autocorrect, word suggestions and automatic capitalisation are switched off for that field.

Link codes are no longer written into debug logs.

## Technical Context

- The QR used `fillMaxWidth()` with `aspectRatio(1f)` inside a `verticalScroll`, so it was always exactly as tall as the screen is wide, and the scroll made the height constraint `Infinity` with nothing left to clamp it. On a 960x540dp TV that is a 944dp square in a 476dp viewport, about a third of it visible. Portrait never showed the bug because width is the smaller dimension there. `BoxWithConstraints` now sits outside the scroll and is the only place the real viewport is read.

- The unhelpful error came from okio's base64 decoder doing no length or alignment validation and silently skipping whitespace. A truncated code is still made entirely of alphabet characters, so it decodes without complaint and only fails later at the gzip magic check, which is why the user saw gzip internals rather than "this is not a valid code".

- `InvalidLinkCodeException` deliberately does not chain the exception that triggered it. `ViewModel4` logs the whole cause chain with `asLog()`, and kotlinx.serialization embeds a `JSON input:` excerpt around the failure offset, so a JSON-stage failure would have written keyset plaintext into a log that users attach to support mail. The stage plus the exception type carries the same diagnostic value without that risk.

- Clipboard writes run on `Main` on purpose: `launch{}` dispatches to `Default`, and resolving `CLIPBOARD_SERVICE` off the main thread throws `Can't create handler inside thread that has not called Looper.prepare()` on some versions. `ClipboardHelper` already carries a workaround for the same trap.

- Worth a close read: the two layout branches on the host screen. Landscape hands the QR pane the full viewport height and scrolls only the option card, so a large font scale cannot clip the options out of reach. Portrait keeps a single scroll around the whole column and instead caps the QR against a fraction of the viewport, because `weight()` cannot size a child inside a scroll. The QR bitmap is also encoded at the size it is drawn at rather than a fixed 512px upscaled to fill a 1080p panel.

Checked on an Android TV emulator (1920x1080 at 320dpi) and a phone emulator in portrait, since the layout only misbehaves at aspect ratios CI does not exercise.
