### PR TITLE
Update app translations from Crowdin

### DIFF
--- a/app-common/src/main/res/values-pl/strings.xml
+++ b/app-common/src/main/res/values-pl/strings.xml
@@ -77,8 +77,8 @@
          not reintroduce a product name. The old widget_config_upgrade_action ("Upgrade to Octi Pro")
          is gone too; its button now uses the existing general_upgrade_action. -->
     <string name="widget_config_upgrade_required_label">Ten widżet wymaga uaktualnienia.</string>
-    <string name="widget_config_upgrade_checking_label">Sprawdzanie statusu uaktualnienia…</string>
-    <string name="widget_config_upgrade_error_label">Nie można zweryfikować statusu uaktualnienia.</string>
+    <string name="widget_config_upgrade_checking_label">Sprawdzanie statusu aktualizacji…</string>
+    <string name="widget_config_upgrade_error_label">Nie można zweryfikować statusu aktualizacji.</string>
     <string name="widget_config_retry_action">Ponów</string>
     <string name="widget_config_presets_label">Ustawienia wstępne</string>
     <string name="widget_config_background_label">Kolor tła</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Koop eenmalige aankoop (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Inskrywing nog aktief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Jou inskrywing is nog steeds ingestel om te verleng. Kanselleer dit eers in Google Play sodat jy nie twee keer gehef word nie, koop dan die eenmalige aankoop. Dit terugbetaal nie die inskrywing nie.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play het nie betyds gereageer nie, dus kan ons jou aankoopstatus nie veilig bevestig nie. Probeer asseblief oor \'n oomblik weer.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Betaling in afwagting</string>
+    <string name="upgrade_screen_pending_card_body">Google Play verwerk steeds jou betaling. Pro ontsluit outomaties sodra die betaling deurloop. Sommige betalingsmetodes kan \'n tyd duur. Daar is niks anders wat jy moet doen nie.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play het \'n aankoop met \'n betaling in afwagting gevind en verwerk dit steeds. Pro ontsluit outomaties sodra die betaling deurloop.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro is nog aktief</string>
     <string name="upgrade_screen_grace_body">Ons bevestig jou aankoop met Google Play. Jou Pro-funksies bly ondertussen ontgrendel.</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -95,6 +95,11 @@
     <string name="upgrade_screen_switch_action">شراء لمرة واحدة (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">الاشتراك لا يزال نشطًا</string>
     <string name="upgrade_screen_sub_still_renewing_message">لا يزال اشتراكك مضبوطًا على التجديد. ألغِه عبر Google Play أولاً حتى لا تُحاسب مرتين، ثم اشترِ الشراء لمرة واحدة. هذا لا يسترد الاشتراك.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play لم تستجب في الوقت المناسب، لذا لا يمكننا التأكد من حالة عملية الشراء. حاول مجدداً بعد قليل.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">الدفع قيد الانتظار</string>
+    <string name="upgrade_screen_pending_card_body">Google Play تعالج الدفع الآن. سيتم فتح Pro تلقائياً عند اكتمال الدفع. قد تستغرق بعض طرق الدفع وقتاً أطول. لا تحتاج إلى فعل أي شيء.</string>
+    <string name="upgrade_screen_pending_dialog_message">وجدت Google Play عملية شراء برصيد معلق وتعالجها الآن. سيتم فتح Pro تلقائياً عند اكتمال الدفع.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro لا يزال نشطًا</string>
     <string name="upgrade_screen_grace_body">نحن نؤكد عملية شرائك مع Google Play. تبقى ميزات Pro مفتوحة في هذه الأثناء.</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Compra única (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">La subscripció encara està activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">La subscripció segueix configurada per renovar-se. Cancel·leu-la primer a Google Play perquè no us cobrin dues vegades, després compreu la compra única. Això no reemborsa la subscripció.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play no ha respost a temps, per la qual cosa no podem confirmar de manera segura l\'estat de la teva compra. Torna-ho a provar d\'aquí a un moment.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Pagament pendent</string>
+    <string name="upgrade_screen_pending_card_body">Google Play encara està processant el teu pagament. La versió Pro es desbloqueja automàticament quan el pagament es completa. Alguns mètodes de pagament poden trigar una mica. No cal que facis res més.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play ha trobat una compra amb un pagament pendent i encara l\'està processant. La versió Pro es desbloqueja automàticament quan el pagament es completa.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro segueix actiu</string>
     <string name="upgrade_screen_grace_body">Estem confirmant la vostra compra amb Google Play. Les vostres funcions de Pro es mantenen desbloquejades mentrestant.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -93,6 +93,11 @@
     <string name="upgrade_screen_switch_action">Koupit jednorázový nákup (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále nastaveno na obnovení. Nejdříve jej zrušte v Obchodě Play, abyste nebyli účtováni dvakrát, poté si koupte jednorázový nákup. To nevrátí peníze za předplatné.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play včas neodpověděl, takže nemůžeme bezpečně potvrdit stav tvého nákupu. Zkus to prosím za chvíli znovu.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Platba čeká na zpracování</string>
+    <string name="upgrade_screen_pending_card_body">Google Play stále zpracovává tvou platbu. Jakmile bude platba dokončena, Pro se odemkne automaticky. U některých platebních metod to může chvíli trvat. Nic dalšího nemusíš dělat.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play našel nákup s čekající platbou a stále ho zpracovává. Jakmile bude platba dokončena, Pro se odemkne automaticky.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro je stále aktivní</string>
     <string name="upgrade_screen_grace_body">Potvrzujeme váš nákup pomocí Obchodu Play. Vaše funkce Pro zatím zůstávají odemčené.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Køb engangskøb (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement stadig aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig indstillet til at fornyes. Annuller det først i Google Play, så du ikke bliver debiteret to gange, derefter køb engangskøbet. Dette refunderer ikke abonnementet.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play svarede ikke i tide, så vi kan ikke bekræfte din købsstatus. Prøv igen om et øjeblik.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Betaling afventer</string>
+    <string name="upgrade_screen_pending_card_body">Google Play behandler stadig din betaling. Pro låses automatisk op, når betalingen er gennemført. Nogle betalingsmetoder kan tage lidt tid. Du behøver ikke gøre andet.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play fandt et køb med en afventende betaling og behandler den stadig. Pro låses automatisk op, når betalingen er gennemført.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro er stadig aktivt</string>
     <string name="upgrade_screen_grace_body">Vi bekræfter dit køb med Google Play. Dine Pro-funktioner forbliver låst op i mellemtiden.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Einmalig kaufen (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dein Abonnement ist weiterhin zum Verlängern eingestellt. Kündige es zuerst in Google Play, damit du nicht doppelt berechnet wirst, dann kaufe den einmaligen Kauf. Dies erstattet das Abonnement nicht.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play hat nicht rechtzeitig geantwortet, daher können wir deinen Kaufstatus nicht sicher bestätigen. Bitte versuche es gleich noch einmal.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Zahlung ausstehend</string>
+    <string name="upgrade_screen_pending_card_body">Google Play verarbeitet deine Zahlung noch. Pro wird automatisch freigeschaltet, sobald die Zahlung abgeschlossen ist. Manche Zahlungsmethoden können eine Weile dauern. Du musst nichts weiter tun.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play hat einen Kauf mit ausstehender Zahlung gefunden und verarbeitet ihn noch. Pro wird automatisch freigeschaltet, sobald die Zahlung abgeschlossen ist.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro ist immer noch aktiv</string>
     <string name="upgrade_screen_grace_body">Wir bestätigen deinen Kauf mit Google Play. Deine Pro-Funktionen bleiben unterdessen freigeschaltet.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Αγορά εφάπαξ αγοράς (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή είναι ακόμα ενεργή</string>
     <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σας είναι ακόμα ορισμένη να ανανεωθεί. Ακυρώστε την πρώτα στο Google Play ώστε να μην χρεωθείτε δύο φορές, και στη συνέχεια αγοράστε την εφάπαξ αγορά. Αυτό δεν επιστρέφει χρήματα για τη συνδρομή.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Το Google Play δεν ανταποκρίθηκε έγκαιρα, γι\' αυτό δεν μπορούμε να επιβεβαιώσουμε με ασφάλεια την κατάστασή σου. Προσπάθησε ξανά σε λίγο.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Εκκρεμή πληρωμή</string>
+    <string name="upgrade_screen_pending_card_body">Το Google Play επεξεργάζεται ακόμη την πληρωμή σου. Το Pro θα ξεκλειδωθεί αυτόματα μόλις η πληρωμή ολοκληρωθεί. Ορισμένες μέθοδοι πληρωμής μπορεί να χρειάσουν χρόνο. Δεν χρειάζεται να κάνεις κάτι άλλο.</string>
+    <string name="upgrade_screen_pending_dialog_message">Το Google Play βρήκε μια αγορά με εκκρεμή πληρωμή και εξακολουθεί να την επεξεργάζεται. Το Pro θα ξεκλειδωθεί αυτόματα μόλις η πληρωμή ολοκληρωθεί.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Το Pro είναι ακόμα ενεργό</string>
     <string name="upgrade_screen_grace_body">Επιβεβαιώνουμε την αγορά σας με το Google Play. Οι δυνατότητες Pro σας παραμένουν ξεκλείδωτες στο μεταξύ.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Compra Pro única (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción aún activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción aún está configurada para renovarse. Cancélala primero en Google Play para que no se te cobre dos veces, luego compra Pro de forma única. Esto no reembolsa la suscripción.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play no respondió a tiempo, así que no podemos confirmar tu estado de compra de forma segura. Inténtalo de nuevo en un momento.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Pago pendiente</string>
+    <string name="upgrade_screen_pending_card_body">Google Play todavía está procesando tu pago. Pro se desbloquea automáticamente en cuanto se complete el pago. Algunos métodos de pago pueden tardar un poco. No tienes que hacer nada más.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play encontró una compra con un pago pendiente y todavía la está procesando. Pro se desbloquea automáticamente en cuanto se complete el pago.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro aún está activo</string>
     <string name="upgrade_screen_grace_body">Estamos confirmando tu compra con Google Play. Tus funciones Pro permanecen desbloqueadas mientras tanto.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Osta kertamaksu (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Tilaus on edelleen aktiivinen</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tilauksesi on edelleen asetettu uusimiselle. Peruuta se ensin Google Play -sovelluksesta, jotta sinua ei veloiteta kahdesti, sitten osta kertamaksu. Tämä ei palauta tilausta.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play ei vastannut ajoissa, joten emme voi varmistaa ostotilannettasi turvallisesti. Yritä hetken kuluttua uudelleen.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Maksu vireillä</string>
+    <string name="upgrade_screen_pending_card_body">Google Play käsittelee maksuasi. Pro avataan automaattisesti, kun maksu on suoritettu. Jotkut maksutavat voivat kestää kauan. Sinun ei tarvitse tehdä mitään muuta.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play löysi oston, jolla on odottava maksu, ja käsittelee sitä vielä. Pro avataan automaattisesti, kun maksu on suoritettu.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro on edelleen aktiivinen</string>
     <string name="upgrade_screen_grace_body">Vahvistamme ostoksesi Google Play:n kanssa. Pro-ominaisuudet pysyvät avattuna sillä välin.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -92,6 +92,11 @@ Mêmes fonctions, juste des modèles tarifaires différents.</string>
     <string name="upgrade_screen_switch_action">Acheter l’accès unique (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours configuré pour se renouveler. Annulez-le d’abord dans Google Play pour ne pas être facturé deux fois, puis achetez l’accès unique. Cela ne rembourse pas l’abonnement.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play n\'a pas répondu à temps, donc on ne peut pas confirmer en toute sécurité l\'état de ton achat. Réessaie dans un instant.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Paiement en attente</string>
+    <string name="upgrade_screen_pending_card_body">Google Play est toujours en train de traiter ton paiement. Pro se déverrouille automatiquement une fois le paiement accepté. Certains modes de paiement peuvent prendre du temps. Tu n\'as rien d\'autre à faire.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play a trouvé un achat avec un paiement en attente et le traite toujours. Pro se déverrouille automatiquement une fois le paiement accepté.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro est toujours actif</string>
     <string name="upgrade_screen_grace_body">Nous confirmons votre achat auprès de Google Play. Vos fonctions Pro restent déverrouillées en attendant.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Vásárold meg az egyszeri verziót (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Az előfizetés még aktív</string>
     <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed továbbra is megújulásra van beállítva. Először töröld le a Google Play-ben, hogy ne legyél kétszer felszámítva, majd vásárold meg az egyszeri verziót. Ez nem téríti vissza az előfizetést.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">A Google Play nem válaszolt időben, így nem tudjuk biztonságosan megerősíteni a vásárlásod állapotát. Kérjük, próbáld újra egy kicsit később.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Fizetés folyamatban</string>
+    <string name="upgrade_screen_pending_card_body">A Google Play még feldolgozza a fizetésedet. A Pro automatikusan feloldódik, amint a fizetés megtörténik. Egyes fizetési módoknál ez eltarthat egy ideig. Nincs más teendőd.</string>
+    <string name="upgrade_screen_pending_dialog_message">A Google Play talált egy vásárlást függőben lévő fizetéssel, és még feldolgozza azt. A Pro automatikusan feloldódik, amint a fizetés megtörténik.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">A Pro továbbra is aktív</string>
     <string name="upgrade_screen_grace_body">Megerősítjük a vásárlásodat a Google Play-ben. A Pro funkciók addig is feloldva maradnak.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -92,6 +92,11 @@
     <string name="upgrade_screen_switch_action">Acquista l’acquisto una tantum (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora impostato per il rinnovo. Annullalo prima su Google Play in modo da non essere addebitato due volte, quindi acquista l’acquisto una tantum. Questo non rimborsa l’abbonamento.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play non ha risposto in tempo, quindi non possiamo confermare in modo sicuro lo stato del tuo acquisto. Riprova tra un momento.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Pagamento in sospeso</string>
+    <string name="upgrade_screen_pending_card_body">Google Play sta ancora elaborando il tuo pagamento. Pro si sblocca automaticamente non appena il pagamento va a buon fine. Alcuni metodi di pagamento possono richiedere del tempo. Non devi fare nient\'altro.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play ha trovato un acquisto con un pagamento in sospeso e lo sta ancora elaborando. Pro si sblocca automaticamente non appena il pagamento va a buon fine.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro è ancora attivo</string>
     <string name="upgrade_screen_grace_body">Stiamo confermando il tuo acquisto con Google Play. Le tue funzioni Pro rimangono sbloccate nel frattempo.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -93,6 +93,11 @@
     <string name="upgrade_screen_switch_action">קנה רכישה חד-פעמית (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">המנוי עדיין פעיל</string>
     <string name="upgrade_screen_sub_still_renewing_message">המנוי שלך עדיין מוגדר להתחדש. בטל אותו ב-Google Play תחילה כדי שלא תחויב פעמיים, ואז קנה את הרכישה החד-פעמית. זה לא מחזיר כסף עבור המנוי.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">‏Google Play לא הגיב בזמן, ולכן לא ניתן לאשר בבטחה את מצב הרכישה שלך. כדאי לנסות שוב בעוד רגע.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">תשלום בהמתנה</string>
+    <string name="upgrade_screen_pending_card_body">‏Google Play עדיין מעבד את התשלום שלך. גרסת Pro תיפתח באופן אוטומטי לאחר אישור התשלום. חלק מאמצעי התשלום עשויים לקחת זמן. אין צורך לעשות שום דבר נוסף.</string>
+    <string name="upgrade_screen_pending_dialog_message">‏Google Play מצא רכישה עם תשלום הממתין לאישור והוא עדיין מעבד אותה. גרסת Pro תיפתח באופן אוטומטי לאחר אישור התשלום.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro עדיין פעיל</string>
     <string name="upgrade_screen_grace_body">אנחנו מאשרים את הרכישה שלך עם Google Play. תכונות Pro שלך נשארות פתוחות בינתיים.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -90,6 +90,11 @@
     <string name="upgrade_screen_switch_action">一回限りの購入（%1$s）を購入</string>
     <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
     <string name="upgrade_screen_sub_still_renewing_message">あなたのサブスクリプションはまだ更新されるように設定されています。二重課金を避けるためにまずGoogle Playでキャンセルしてから、一回限りの購入を行ってください。これによりサブスクリプションの返金はされません。</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play からの応答がなかったため、購入状況を安全に確認できませんでした。しばらくしてからもう一度お試しください。</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">支払い処理中</string>
+    <string name="upgrade_screen_pending_card_body">Google Play が支払いを処理しています。支払いが完了すると、Pro は自動的にアンロックされます。決済方法によっては時間がかかることがあります。ほかに操作は必要ありません。</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play で保留中の支払いのある購入が見つかり、現在処理中です。支払いが完了すると、Pro は自動的にアンロックされます。</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Proはまだ有効です</string>
     <string name="upgrade_screen_grace_body">Google Playであなたの購入を確認しています。その間もPro機能はロック解除されたままです。</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -90,6 +90,11 @@
     <string name="upgrade_screen_switch_action">일회성 구매 (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">구독이 여전히 활성입니다</string>
     <string name="upgrade_screen_sub_still_renewing_message">구독이 여전히 갱신되도록 설정되어 있습니다. 중복 청구를 피하기 위해 먼저 Google Play에서 취소한 후 일회성 구매를 하세요. 이는 구독을 환불하지 않습니다.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">구글 플레이가 제때 응답하지 않아 구매 상태를 안전하게 확인할 수 없습니다. 잠시 후 다시 시도해 주세요.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">결제 대기 중</string>
+    <string name="upgrade_screen_pending_card_body">구글 플레이가 아직 결제를 처리하고 있습니다. 결제가 완료되면 Pro가 자동으로 잠금 해제됩니다. 일부 결제 수단은 시간이 걸릴 수 있습니다. 따로 하실 일은 없습니다.</string>
+    <string name="upgrade_screen_pending_dialog_message">구글 플레이에서 결제 대기 중인 구매를 발견하여 아직 처리하고 있습니다. 결제가 완료되면 Pro가 자동으로 잠금 해제됩니다.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro가 여전히 활성입니다</string>
     <string name="upgrade_screen_grace_body">Google Play에서 구매를 확인하는 중입니다. Pro 기능은 계속 사용 가능합니다.</string>

--- a/app/src/gplay/res/values-nb/strings.xml
+++ b/app/src/gplay/res/values-nb/strings.xml
@@ -92,6 +92,11 @@ Samme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_switch_action">Kjøp engangsbetaling (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement fortsatt aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt satt til å fornyes. Avbryt det i Google Play først slik at du ikke blir belastet to ganger, deretter kjøper du engangsbetalingen. Dette refunderer ikke abonnementet.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play svarte ikke i tide, så vi kan ikke bekrefte kjøpsstatusen din på en sikker måte. Prøv igjen om litt.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Betaling venter</string>
+    <string name="upgrade_screen_pending_card_body">Google Play behandler fortsatt betalingen din. Pro låses opp automatisk når betalingen er gjennomført. Enkelte betalingsmetoder kan ta litt tid. Du trenger ikke å gjøre noe mer.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play fant et kjøp med en betaling som venter, og behandler den fortsatt. Pro låses opp automatisk når betalingen er gjennomført.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro er fortsatt aktivt</string>
     <string name="upgrade_screen_grace_body">Vi bekrefter kjøpet ditt med Google Play. Pro-funksjonene dine forblir låst opp i mellomtiden.</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -92,6 +92,11 @@ Dezelfde functies, gewoon verschillende prijsmodellen.</string>
     <string name="upgrade_screen_switch_action">Eenmalige aankoop kopen (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog actief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds ingesteld om te vernieuwen. Annuleer het eerst in Google Play zodat je niet dubbel wordt belast, koop dan de eenmalige aankoop. Dit vergoedt het abonnement niet.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play reageerde niet op tijd, dus we kunnen je aankoopstatus niet veilig bevestigen. Probeer het straks nog eens.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Betaling in behandeling</string>
+    <string name="upgrade_screen_pending_card_body">Google Play verwerkt je betaling nog. Pro wordt automatisch ontgrendeld zodra de betaling is voltooid. Sommige betaalmethoden kunnen even duren. Je hoeft verder niets te doen.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play heeft een aankoop met een betaling in behandeling gevonden en verwerkt deze nog. Pro wordt automatisch ontgrendeld zodra de betaling is voltooid.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro is nog actief</string>
     <string name="upgrade_screen_grace_body">We bevestigen je aankoop met Google Play. Je Pro-functies blijven in de tussentijd ontgrendeld.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -93,6 +93,11 @@
     <string name="upgrade_screen_switch_action">Kup - jednorazowy zakup (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja nadal jest ustawiona na odnowienie. Anuluj ją najpierw w Sklepie Google Play, aby uniknąć podwójnej opłaty, a następnie dokonaj jednorazowego zakupu. Nie spowoduje to zwrotu kosztów subskrypcji.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Sklep Google Play nie odpowiedział na czas, więc nie możemy bezpiecznie potwierdzić stanu twojego zakupu. Spróbuj ponownie za chwilę.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Płatność oczekuje</string>
+    <string name="upgrade_screen_pending_card_body">Sklep Google Play nadal przetwarza twoją płatność. Wersja Pro zostanie odblokowana automatycznie po przejściu płatności. Niektóre sposoby płatności mogą trwać dłużej. Nie musisz nic więcej robić.</string>
+    <string name="upgrade_screen_pending_dialog_message">Sklep Google Play znalazł zakup z oczekującą płatnością i nadal go przetwarza. Wersja Pro zostanie odblokowana automatycznie po przejściu płatności.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro jest nadal aktywne</string>
     <string name="upgrade_screen_grace_body">Potwierdzamy twój zakup w Google Play. Twoje funkcje Pro są w międzyczasie odblokowane.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -92,6 +92,11 @@ Os mesmos recursos, apenas modelos de preços diferentes.</string>
     <string name="upgrade_screen_switch_action">Comprar compra única (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está definida para se renovar. Cancele-a no Google Play primeiro para não ser cobrado duas vezes e depois compre a compra única. Isso não reembolsa a assinatura.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play não respondeu a tempo, então não conseguimos confirmar sua compra com segurança. Tente novamente em um instante.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Pagamento pendente</string>
+    <string name="upgrade_screen_pending_card_body">Google Play ainda está processando seu pagamento. Pro será desbloqueado automaticamente quando o pagamento for processado. Alguns métodos de pagamento podem demorar mais. Não precisa fazer mais nada.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play encontrou uma compra com pagamento pendente e ainda está processando. Pro será desbloqueado automaticamente quando o pagamento for processado.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro ainda está ativo</string>
     <string name="upgrade_screen_grace_body">Estamos confirmando sua compra com o Google Play. Seus recursos Pro permanecem desbloqueados enquanto isso.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Comprar compra única (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">A sua subscrição ainda está definida para renovar. Cancele-a primeiro no Google Play para não ser cobrado duas vezes e depois compre a compra única. Isto não reembolsa a subscrição.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">O Google Play não respondeu a tempo, por isso não conseguimos confirmar com segurança o estado da tua compra. Tenta novamente dentro de momentos.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Pagamento pendente</string>
+    <string name="upgrade_screen_pending_card_body">O Google Play ainda está a processar o teu pagamento. O Pro é desbloqueado automaticamente assim que o pagamento for concluído. Alguns métodos de pagamento podem demorar algum tempo. Não precisas de fazer mais nada.</string>
+    <string name="upgrade_screen_pending_dialog_message">O Google Play encontrou uma compra com um pagamento pendente e ainda está a processá-la. O Pro é desbloqueado automaticamente assim que o pagamento for concluído.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro continua ativo</string>
     <string name="upgrade_screen_grace_body">Estamos a confirmar a sua compra com o Google Play. As funcionalidades Pro mantêm-se desbloqueadas entretanto.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -92,6 +92,11 @@
     <string name="upgrade_screen_switch_action">Cumpără achiziția unică (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonament încă activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă setat să se reînnoiască. Anulează-l mai întâi în Google Play pentru a nu fi taxat de două ori, apoi cumpără achiziția unică. Aceasta nu returnează abonamentul.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play nu a răspuns la timp, deci nu putem confirma în siguranță starea achiziției tale. Te rog, încearcă din nou peste puțin.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Plată în așteptare</string>
+    <string name="upgrade_screen_pending_card_body">Google Play procesează plata ta. Pro se deblochează automat odată ce plata se efectuează. Unele metode de plată pot dura mai mult. Nu mai ai nimic de făcut.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play a găsit o achiziție cu plată în așteptare și o procesează. Pro se deblochează automat odată ce plata se efectuează.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro este încă activ</string>
     <string name="upgrade_screen_grace_body">Confirmăm achiziția ta cu Google Play. Funcțiile tale Pro rămân deblocate deocamdată.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -93,6 +93,11 @@
     <string name="upgrade_screen_switch_action">Оформить единоразовую покупку (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка все ещё продлевается. Отмените её в Google Play, чтобы оплата не производилась дважды, а затем оформите единоразовую покупку. Это не возмещает оплату подписки.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play не ответил вовремя, поэтому мы не можем безопасно подтвердить твой статус покупки. Попробуй ещё раз через некоторое время.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Платёж обрабатывается</string>
+    <string name="upgrade_screen_pending_card_body">Google Play всё ещё обрабатывает твой платёж. Pro активируется автоматически, как только платёж пройдёт. Некоторые способы оплаты могут занять какое-то время. Больше ничего делать не нужно.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play обнаружил покупку с ожидающим платежом и всё ещё обрабатывает её. Pro активируется автоматически, как только платёж пройдёт.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro все ещё активен</string>
     <string name="upgrade_screen_grace_body">Мы подтверждаем Вашу покупку с помощью Google Play. Ваши Pro-функции будут разблокированы через некоторое время.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -92,6 +92,11 @@
     <string name="upgrade_screen_switch_action">Купите једнократну куповину (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Претплата је и даље активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је и даље подешена да се обнови. Прво је откажите у Google Play како не бисте били наплаћени два пута, затим купите једнократну куповину. Ово не враћа претплату.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play се није одазвао на време, па не можемо поуздано да потврдимо стање твоје куповине. Покушај поново за тренутак.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Плаћање на чекању</string>
+    <string name="upgrade_screen_pending_card_body">Google Play још увек обрађује твоју уплату. Pro се аутоматски откључава чим уплата прође. Неки начини плаћања могу потрајати. Не треба ништа друго да урадиш.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play је пронашао куповину са уплатом на чекању и још увек је обрађује. Pro се аутоматски откључава чим уплата прође.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro је и даље активан</string>
     <string name="upgrade_screen_grace_body">Потврђујемо вашу куповину са Google Play. Ваше Pro функције остају откључане у међувремену.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">Köp engångsköp (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Prenumeration fortfarande aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande inställd på att förnyas. Avsluta den i Google Play först så att du inte debiteras två gånger, köp sedan engångsköpet. Detta återbetalar inte prenumerationen.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play svarade inte i tid, så vi kan inte säkert bekräfta din köpstatus. Försök igen om en liten stund.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Betalning väntar</string>
+    <string name="upgrade_screen_pending_card_body">Google Play bearbetar fortfarande din betalning. Pro låses upp automatiskt när betalningen har gått igenom. Vissa betalningsmetoder kan ta ett tag. Du behöver inte göra något mer.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play hittade ett köp med en väntande betalning och bearbetar det fortfarande. Pro låses upp automatiskt när betalningen har gått igenom.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro är fortfarande aktivt</string>
     <string name="upgrade_screen_grace_body">Vi bekräftar ditt köp med Google Play. Dina Pro-funktioner förblir upplåsta under tiden.</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -92,6 +92,11 @@ Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_switch_action">Tek Seferlik Satın Al (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Abonelik Hâlâ Etkin</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hâlâ yenilenecek şekilde ayarlanmıştır. Önce Google Play\'de iptal edin, böylece iki kez ücretlendirilmezsiniz, ardından tek seferlik satın alma yapın. Bu işlem aboneliğin para iadesini içermez.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play zamanında yanıt vermedi, bu yüzden satın alma durumunu güvenli bir şekilde onaylayamıyoruz. Lütfen bir süre sonra tekrar dene.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Ödeme bekliyor</string>
+    <string name="upgrade_screen_pending_card_body">Google Play ödemeni hâlâ işliyor. Ödeme tamamlandığında Pro otomatik olarak açılır. Bazı ödeme yöntemleri biraz zaman alabilir. Yapman gereken başka bir şey yok.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play, ödemesi bekleyen bir satın alma buldu ve hâlâ işliyor. Ödeme tamamlandığında Pro otomatik olarak açılır.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro hâlâ etkin</string>
     <string name="upgrade_screen_grace_body">Satın alımınızı Google Play ile doğruluyoruz. Pro özellikleriniz bu arada açık kalır.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -93,6 +93,11 @@
     <string name="upgrade_screen_switch_action">Купити одноразову покупку (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Підписка все ще активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще налаштована на продовження. Спочатку скасуйте її в Google Play, щоб з вас не стягнули двічі, а потім купіть одноразову покупку. Це не повертає кошти за підписку.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play не відповів вчасно, тому ми не можемо надійно підтвердити стан твоєї покупки. Спробуй ще раз за хвилину.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Очікується оплата</string>
+    <string name="upgrade_screen_pending_card_body">Google Play ще обробляє твій платіж. Pro розблокується автоматично, щойно платіж пройде. Деякі способи оплати можуть тривати довше. Тобі більше нічого не потрібно робити.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play знайшов покупку з платежем, що очікує обробки, і ще обробляє її. Pro розблокується автоматично, щойно платіж пройде.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro все ще активний</string>
     <string name="upgrade_screen_grace_body">Ми підтверджуємо вашу покупку через Google Play. Тим часом ваші функції Pro залишаються розблокованими.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -91,6 +91,11 @@ Các tính năng giống nhau, chỉ khác các mô hình giá.</string>
     <string name="upgrade_screen_switch_action">Mua một lần (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">Đăng ký vẫn hoạt động</string>
     <string name="upgrade_screen_sub_still_renewing_message">Đăng ký của bạn vẫn được đặt để gia hạn. Vui lòng hủy nó trên Google Play trước để bạn không bị tính phí hai lần, sau đó mua một lần. Điều này không hoàn tiền cho đăng ký.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play không phản hồi kịp thời, vì vậy chúng tôi không thể xác nhận trạng thái mua hàng của bạn một cách an toàn. Vui lòng thử lại sau.</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">Thanh toán đang chờ xử lý</string>
+    <string name="upgrade_screen_pending_card_body">Google Play vẫn đang xử lý khoản thanh toán của bạn. Pro sẽ tự động mở khóa ngay khi thanh toán hoàn tất. Một số phương thức thanh toán có thể mất một thời gian. Bạn không cần làm gì thêm.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play đã tìm thấy một giao dịch mua với khoản thanh toán đang chờ xử lý và vẫn đang xử lý. Pro sẽ tự động mở khóa ngay khi thanh toán hoàn tất.</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro vẫn hoạt động</string>
     <string name="upgrade_screen_grace_body">Chúng tôi đang xác nhận lệnh mua của bạn với Google Play. Các tính năng Pro của bạn vẫn được mở khóa trong lúc đó.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -90,6 +90,11 @@
     <string name="upgrade_screen_switch_action">购买一次性购买（%1$s）</string>
     <string name="upgrade_screen_sub_still_renewing_title">订阅仍在活跃</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍设置为自动续订。请先在 Google Play 中取消，以免重复收费，然后再购买一次性购买。此操作不会退还订阅费用。</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play 没有及时响应，因此我们无法安全地确认你的购买状态。请稍后再试。</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">付款处理中</string>
+    <string name="upgrade_screen_pending_card_body">Google Play 仍在处理你的付款。付款完成后，Pro 会自动解锁。某些付款方式可能需要一些时间。你无需再做任何操作。</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play 发现一笔付款仍在处理中的购买，正在继续处理。付款完成后，Pro 会自动解锁。</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">专业版仍在激活中</string>
     <string name="upgrade_screen_grace_body">我们正在与 Google Play 确认您的购买。在此期间，您的专业版功能保持解锁。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -91,6 +91,11 @@
     <string name="upgrade_screen_switch_action">購買一次性版本 (%1$s)</string>
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍處於活躍狀態</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為續訂。請先在 Google Play 中取消以免被重複扣費，然後購買一次性版本。這不會退款訂閱。</string>
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play 沒有及時回應，因此我們無法安全地確認你的購買狀態。請稍後再試一次。</string>
+    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_pending_card_title">付款處理中</string>
+    <string name="upgrade_screen_pending_card_body">Google Play 仍在處理你的付款。付款完成後，專業版會自動解鎖。某些付款方式可能需要一些時間。你不需要進行其他操作。</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play 發現一筆待處理付款的購買，仍在處理中。付款完成後，專業版會自動解鎖。</string>
     <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro 仍處於活躍狀態</string>
     <string name="upgrade_screen_grace_body">我們正在與 Google Play 確認您的購買。您的 Pro 功能在此期間保持解鎖。</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -149,7 +149,7 @@
     <!-- Replaces the per-flavor upgrades_dashcard_title ("Get Octi Pro"), which named the Google Play
          tier in the FOSS build too. Now that the wording names no tier it is the same in both flavors,
          so it lives here instead of being declared twice. Keep it tier-free when translating. -->
-    <string name="upgrades_dashcard_headline">Ulepsz Octi</string>
+    <string name="upgrades_dashcard_headline">Zaktualizuj Octi</string>
     <string name="sync_settings_label">Synchronizacja</string>
     <string name="sync_settings_desc">Nazwa urządzenia, harmonogram i warunki wyzwalania.</string>
     <string name="sync_setting_devicelabel_label">Etykieta urządzenia</string>
@@ -202,10 +202,10 @@
          Octi Pro") on a screen shared by both flavors, where the FOSS tier is called "Octi FOSS".
          Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
     <plurals name="pro_device_limit_maximum_hint">
-        <item quantity="one">Aby wyświetlić więcej niż %1$d urządzenie, uaktualnij lub usuń urządzenia.</item>
-        <item quantity="few">Aby wyświetlić więcej niż %1$d urządzenia, uaktualnij lub usuń urządzenia.</item>
-        <item quantity="many">Aby wyświetlić więcej niż %1$d urządzeń, uaktualnij lub usuń urządzenia.</item>
-        <item quantity="other">Aby wyświetlić więcej niż %1$d urządzenia, uaktualnij lub usuń urządzenia.</item>
+        <item quantity="one">Aby wyświetlić więcej niż %1$d urządzenie, zaktualizuj lub usuń urządzenia.</item>
+        <item quantity="few">Aby wyświetlić więcej niż %1$d urządzenia, zaktualizuj lub usuń urządzenia.</item>
+        <item quantity="many">Aby wyświetlić więcej niż %1$d urządzeń, zaktualizuj lub usuń urządzenia.</item>
+        <item quantity="other">Aby wyświetlić więcej niż %1$d urządzenia, zaktualizuj lub usuń urządzenia.</item>
     </plurals>
     <string name="sync_delete_device_keepaccess_caveat">Usunięcie tego urządzenia usunie jego dane, ale nie cofnie dostępu. Aby cofnąć dostęp, rozłącz Octi na urządzeniu.</string>
     <string name="sync_delete_device_revokeaccess_caveat">Usunięcie tego urządzenia usunie jego dane i cofnie jego dostęp.</string>

--- a/syncs-octiserver/src/main/res/values-af-rZA/strings.xml
+++ b/syncs-octiserver/src/main/res/values-af-rZA/strings.xml
@@ -37,4 +37,12 @@ Aangesien beide die app en die bediener nog verbeter word, kan dit minder stabie
     <string name="sync_octiserver_add_link_existing_action">Koppel aan bestaande rekening</string>
     <string name="sync_octiserver_add_select_server_label">Kies bediener</string>
     <string name="sync_octiserver_add_custom_server_label">Persoonlike bediener</string>
+    <string name="sync_octiserver_link_code_invalid_label">Skakelkode onvolledig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Hierdie skakelkode is onvolledig of is onderweg verander. Kopieer die hele kode van die ander toestel en plak dit sonder om dit oortik nie, of skandeer eerder die QR-kode.</string>
+    <string name="sync_octiserver_link_code_copied_message">Skakelkode gekopieer</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d karakter</item>
+        <item quantity="other">%d karakters</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Beide toestelle moet dieselfde aantal wys.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ar/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ar/strings.xml
@@ -37,4 +37,16 @@
     <string name="sync_octiserver_add_link_existing_action">الربط بحساب موجود</string>
     <string name="sync_octiserver_add_select_server_label">اختر الخادم</string>
     <string name="sync_octiserver_add_custom_server_label">خادم مخصص</string>
+    <string name="sync_octiserver_link_code_invalid_label">كود الربط غير مكتمل</string>
+    <string name="sync_octiserver_link_code_invalid_description">كود الربط هذا غير مكتمل أو أنه تغيّر في الطريق. انسخ الكود بالكامل من الجهاز الآخر والصقه كما هو دون إعادة كتابته، أو امسح رمز QR بدلاً من ذلك.</string>
+    <string name="sync_octiserver_link_code_copied_message">تم نسخ كود الربط</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="zero">%d حرف</item>
+        <item quantity="one">حرف واحد</item>
+        <item quantity="two">حرفان</item>
+        <item quantity="few">%d أحرف</item>
+        <item quantity="many">%d حرفًا</item>
+        <item quantity="other">%d حرف</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">يجب أن يعرض كلا الجهازين نفس العدد.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ca/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ca/strings.xml
@@ -37,4 +37,12 @@ Com que tant l’aplicació com el servidor encara s’estan millorant, pot ser 
     <string name="sync_octiserver_add_link_existing_action">Enllaça a un compte ja existent</string>
     <string name="sync_octiserver_add_select_server_label">Seleccioneu un servidor</string>
     <string name="sync_octiserver_add_custom_server_label">Servidor personalitzat</string>
+    <string name="sync_octiserver_link_code_invalid_label">Codi d\'enllaç incomplet</string>
+    <string name="sync_octiserver_link_code_invalid_description">Aquest codi d\'enllaç és incomplet o s\'ha alterat pel camí. Copia tot el codi de l\'altre dispositiu i enganxa\'l sense tornar-lo a escriure, o bé escaneja el codi QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Codi d\'enllaç copiat</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d caràcter</item>
+        <item quantity="other">%d caràcters</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Els dos dispositius han de mostrar el mateix nombre.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-cs/strings.xml
+++ b/syncs-octiserver/src/main/res/values-cs/strings.xml
@@ -35,4 +35,14 @@
     <string name="sync_octiserver_add_link_existing_action">Připojit existující účet</string>
     <string name="sync_octiserver_add_select_server_label">Vybrat server</string>
     <string name="sync_octiserver_add_custom_server_label">Vlastní server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Nekompletní propojovací kód</string>
+    <string name="sync_octiserver_link_code_invalid_description">Tento propojovací kód je nekompletní nebo byl při přenosu pozměněn. Zkopíruj celý kód z druhého zařízení a vlož ho bez přepisování, nebo místo toho naskenuj QR kód.</string>
+    <string name="sync_octiserver_link_code_copied_message">Propojovací kód zkopírován</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d znak</item>
+        <item quantity="few">%d znaky</item>
+        <item quantity="many">%d znaku</item>
+        <item quantity="other">%d znaků</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Obě zařízení musí zobrazovat stejný počet.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-da/strings.xml
+++ b/syncs-octiserver/src/main/res/values-da/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Link til eksisterende konto</string>
     <string name="sync_octiserver_add_select_server_label">Vælg server</string>
     <string name="sync_octiserver_add_custom_server_label">Brugerdefineret server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Linkkoden er ufuldstændig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Denne linkkode er ufuldstændig eller blev ændret undervejs. Kopiér hele koden fra den anden enhed, og indsæt den uden at skrive den om, eller scan QR-koden i stedet.</string>
+    <string name="sync_octiserver_link_code_copied_message">Linkkode kopieret</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d tegn</item>
+        <item quantity="other">%d tegn</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Begge enheder skal vise det samme antal.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-de/strings.xml
+++ b/syncs-octiserver/src/main/res/values-de/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Verbinde zu vorhandenem Konto</string>
     <string name="sync_octiserver_add_select_server_label">Server auswählen</string>
     <string name="sync_octiserver_add_custom_server_label">Benutzerdefinierter Server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Link-Code unvollständig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Dieser Link-Code ist unvollständig oder wurde bei der Übertragung verändert. Kopiere den vollständigen Code vom anderen Gerät und füge ihn ein, ohne ihn erneut einzutippen, oder scanne stattdessen den QR-Code.</string>
+    <string name="sync_octiserver_link_code_copied_message">Link-Code kopiert</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d Zeichen</item>
+        <item quantity="other">%d Zeichen</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Beide Geräte müssen dieselbe Anzahl anzeigen.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-el/strings.xml
+++ b/syncs-octiserver/src/main/res/values-el/strings.xml
@@ -37,4 +37,12 @@
     <string name="sync_octiserver_add_link_existing_action">Σύνδεση με υπάρχοντα λογαριασμό</string>
     <string name="sync_octiserver_add_select_server_label">Επιλογή διακομιστή</string>
     <string name="sync_octiserver_add_custom_server_label">Προσαρμοσμένος διακομιστής</string>
+    <string name="sync_octiserver_link_code_invalid_label">Κώδικας σύνδεσης ατελής</string>
+    <string name="sync_octiserver_link_code_invalid_description">Αυτός ο κώδικας σύνδεσης είναι ατελής ή έχει αλλοιωθεί. Αντιγράφε ολόκληρο τον κώδικα από την άλλη συσκευή και επικόλλησέ τον χωρίς να τον ξαναγράψεις, ή σάρωσε το κωδικό QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Ο κώδικας σύνδεσης αντιγράφηκε</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d χαρακτήρας</item>
+        <item quantity="other">%d χαρακτήρες</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Και οι δύο συσκευές πρέπει να εμφανίζουν τον ίδιο αριθμό.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-es/strings.xml
+++ b/syncs-octiserver/src/main/res/values-es/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Enlace a cuenta ya existente</string>
     <string name="sync_octiserver_add_select_server_label">Seleccionar un servidor</string>
     <string name="sync_octiserver_add_custom_server_label">Servidor personalizado</string>
+    <string name="sync_octiserver_link_code_invalid_label">Código de vinculación incompleto</string>
+    <string name="sync_octiserver_link_code_invalid_description">Este código de vinculación está incompleto o se alteró durante la transmisión. Copia el código completo del otro dispositivo y pégalo sin volver a escribirlo, o escanea el código QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Código de vinculación copiado</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d carácter</item>
+        <item quantity="other">%d caracteres</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Ambos dispositivos deben mostrar el mismo número.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-fi/strings.xml
+++ b/syncs-octiserver/src/main/res/values-fi/strings.xml
@@ -37,4 +37,12 @@ Koska sekä sovellusta että palvelinta parannetaan edelleen, se voi olla epäva
     <string name="sync_octiserver_add_link_existing_action">Linkitä olemassa olevaan tiliin</string>
     <string name="sync_octiserver_add_select_server_label">Valitse palvelin</string>
     <string name="sync_octiserver_add_custom_server_label">Mukautettu palvelin</string>
+    <string name="sync_octiserver_link_code_invalid_label">Linkkikoodi epätäydellinen</string>
+    <string name="sync_octiserver_link_code_invalid_description">Tämä linkkikoodi on epätäydellinen tai sitä muutettiin matkalla. Kopioi koodi kokonaisuudessaan toisesta laitteesta ja liitä se, älä kirjoita sitä uudelleen, tai skannaa QR-koodi sen sijaan.</string>
+    <string name="sync_octiserver_link_code_copied_message">Linkkikoodi kopioitu</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d merkki</item>
+        <item quantity="other">%d merkkiä</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Molempien laitteiden on näytettävä sama merkkilukumäärä.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-fr/strings.xml
+++ b/syncs-octiserver/src/main/res/values-fr/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Relier à un compte existant</string>
     <string name="sync_octiserver_add_select_server_label">Choisir le serveur</string>
     <string name="sync_octiserver_add_custom_server_label">Serveur personnalisé</string>
+    <string name="sync_octiserver_link_code_invalid_label">Code de lien incomplet</string>
+    <string name="sync_octiserver_link_code_invalid_description">Ce code de lien est incomplet ou a été modifié en chemin. Copie le code complet depuis l\'autre appareil et colle-le sans le retaper, ou scanne plutôt le code QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Code de lien copié</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d caractère</item>
+        <item quantity="other">%d caractères</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Les deux appareils doivent afficher le même nombre.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-hu/strings.xml
+++ b/syncs-octiserver/src/main/res/values-hu/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Kapcsolódás meglévő fiókhoz</string>
     <string name="sync_octiserver_add_select_server_label">Szerver kiválasztása</string>
     <string name="sync_octiserver_add_custom_server_label">Egyéni szerver</string>
+    <string name="sync_octiserver_link_code_invalid_label">Hiányos összekapcsolási kód</string>
+    <string name="sync_octiserver_link_code_invalid_description">Ez az összekapcsolási kód hiányos, vagy megváltozott útközben. Másold ki a teljes kódot a másik eszközről, és illeszd be újragépelés nélkül, vagy inkább olvasd be a QR-kódot.</string>
+    <string name="sync_octiserver_link_code_copied_message">Összekapcsolási kód másolva</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d karakter</item>
+        <item quantity="other">%d karakter</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Mindkét eszközön ugyanannak a számnak kell megjelennie.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-it/strings.xml
+++ b/syncs-octiserver/src/main/res/values-it/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Collega un account esistente</string>
     <string name="sync_octiserver_add_select_server_label">Seleziona server</string>
     <string name="sync_octiserver_add_custom_server_label">Server personalizzato</string>
+    <string name="sync_octiserver_link_code_invalid_label">Codice di collegamento incompleto</string>
+    <string name="sync_octiserver_link_code_invalid_description">Questo codice di collegamento è incompleto o è stato alterato durante il trasferimento. Copia l\'intero codice dall\'altro dispositivo e incollalo senza digitarlo di nuovo, oppure scansiona il codice QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Codice di collegamento copiato</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d carattere</item>
+        <item quantity="other">%d caratteri</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Entrambi i dispositivi devono mostrare lo stesso numero.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-iw/strings.xml
+++ b/syncs-octiserver/src/main/res/values-iw/strings.xml
@@ -35,4 +35,8 @@
     <string name="sync_octiserver_add_link_existing_action">קישור לחשבון קיים</string>
     <string name="sync_octiserver_add_select_server_label">בחר שרת</string>
     <string name="sync_octiserver_add_custom_server_label">שרת מותאם אישית</string>
+    <string name="sync_octiserver_link_code_invalid_label">קוד הקישור לא שלם</string>
+    <string name="sync_octiserver_link_code_invalid_description">קוד הקישור הזה אינו שלם או שהשתנה בדרך. יש להעתיק את הקוד המלא מהמכשיר האחר ולהדביק אותו בלי להקליד אותו מחדש, או לסרוק את קוד ה-QR במקום זאת.</string>
+    <string name="sync_octiserver_link_code_copied_message">קוד הקישור הועתק</string>
+    <string name="sync_octiserver_link_code_character_count_hint">שני המכשירים צריכים להציג את אותו המספר.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ja/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ja/strings.xml
@@ -37,4 +37,11 @@
     <string name="sync_octiserver_add_link_existing_action">既存のアカウントへリンク</string>
     <string name="sync_octiserver_add_select_server_label">サーバーを選択</string>
     <string name="sync_octiserver_add_custom_server_label">カスタムサーバー</string>
+    <string name="sync_octiserver_link_code_invalid_label">リンクコードが不完全です</string>
+    <string name="sync_octiserver_link_code_invalid_description">このリンクコードは不完全か、送信中に変更された可能性があります。もう一方の端末でコード全体をコピーし、手入力せずに貼り付けるか、代わりにQRコードをスキャンしてください。</string>
+    <string name="sync_octiserver_link_code_copied_message">リンクコードをコピーしました</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="other">%d 文字</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">両方の端末で同じ文字数が表示されている必要があります。</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ko/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ko/strings.xml
@@ -37,4 +37,11 @@
     <string name="sync_octiserver_add_link_existing_action">기존 계정에 연결</string>
     <string name="sync_octiserver_add_select_server_label">서버 선택</string>
     <string name="sync_octiserver_add_custom_server_label">사용자 서버</string>
+    <string name="sync_octiserver_link_code_invalid_label">연결 코드 불완전</string>
+    <string name="sync_octiserver_link_code_invalid_description">이 연결 코드가 불완전하거나 전송 중 변경되었습니다. 다른 기기에서 코드 전체를 복사해 다시 입력하지 말고 그대로 붙여넣거나, 대신 QR 코드를 스캔해 주세요.</string>
+    <string name="sync_octiserver_link_code_copied_message">연결 코드가 복사되었습니다</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="other">%d자</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">두 기기에 표시되는 개수가 같아야 합니다.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-nb/strings.xml
+++ b/syncs-octiserver/src/main/res/values-nb/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Koble til eksisterende konto</string>
     <string name="sync_octiserver_add_select_server_label">Velg server</string>
     <string name="sync_octiserver_add_custom_server_label">Egendefinert server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Koblingskode ufullstendig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Denne koblingskoden er ufullstendig eller ble endret underveis. Kopier hele koden fra den andre enheten og lim den inn uten å skrive den på nytt, eller skann QR-koden i stedet.</string>
+    <string name="sync_octiserver_link_code_copied_message">Koblingskode kopiert</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d tegn</item>
+        <item quantity="other">%d tegn</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Begge enhetene må vise samme antall.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-nl/strings.xml
+++ b/syncs-octiserver/src/main/res/values-nl/strings.xml
@@ -37,4 +37,12 @@ Da zowel de app als de server nog worden verbeterd, kan deze minder stabiel zijn
     <string name="sync_octiserver_add_link_existing_action">Koppelen aan bestaand account</string>
     <string name="sync_octiserver_add_select_server_label">Server selecteren</string>
     <string name="sync_octiserver_add_custom_server_label">Aangepaste server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Linkcode onvolledig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Deze linkcode is onvolledig of is onderweg gewijzigd. Kopieer de volledige code van het andere apparaat en plak deze zonder opnieuw te typen, of scan in plaats daarvan de QR-code.</string>
+    <string name="sync_octiserver_link_code_copied_message">Linkcode gekopieerd</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d teken</item>
+        <item quantity="other">%d tekens</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Beide apparaten moeten hetzelfde aantal tonen.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-pl/strings.xml
+++ b/syncs-octiserver/src/main/res/values-pl/strings.xml
@@ -35,4 +35,14 @@
     <string name="sync_octiserver_add_link_existing_action">Połącz z istniejącym kontem</string>
     <string name="sync_octiserver_add_select_server_label">Wybierz serwer</string>
     <string name="sync_octiserver_add_custom_server_label">Niestandardowy serwer</string>
+    <string name="sync_octiserver_link_code_invalid_label">Kod linku niekompletny</string>
+    <string name="sync_octiserver_link_code_invalid_description">Ten kod linku jest niekompletny lub został zmieniony w drodze. Skopiuj cały kod z drugiego urządzenia i wklej go bez ponownego wpisywania, albo zamiast tego zeskanuj kod QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Kod linku skopiowany</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d znak</item>
+        <item quantity="few">%d znaki</item>
+        <item quantity="many">%d znaków</item>
+        <item quantity="other">%d znaków</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Oba urządzenia muszą wyświetlać tę samą liczbę.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-pt-rBR/strings.xml
+++ b/syncs-octiserver/src/main/res/values-pt-rBR/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Vincular a conta existente</string>
     <string name="sync_octiserver_add_select_server_label">Selecionar servidor</string>
     <string name="sync_octiserver_add_custom_server_label">Servidor personalizado</string>
+    <string name="sync_octiserver_link_code_invalid_label">Código de link incompleto</string>
+    <string name="sync_octiserver_link_code_invalid_description">Este código de link está incompleto ou foi alterado durante a transmissão. Copie o código completo do outro dispositivo e cole-o sem redigitar, ou escaneie o código QR em vez disso.</string>
+    <string name="sync_octiserver_link_code_copied_message">Código de link copiado</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d caractere</item>
+        <item quantity="other">%d caracteres</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Os dois dispositivos devem mostrar a mesma contagem.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-pt/strings.xml
+++ b/syncs-octiserver/src/main/res/values-pt/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Vincular à conta existente</string>
     <string name="sync_octiserver_add_select_server_label">Selecionar servidor</string>
     <string name="sync_octiserver_add_custom_server_label">Servidor personalizado</string>
+    <string name="sync_octiserver_link_code_invalid_label">Código de ligação incompleto</string>
+    <string name="sync_octiserver_link_code_invalid_description">Este código de ligação está incompleto ou foi alterado durante a transferência. Copia o código completo do outro dispositivo e cola-o sem o voltar a escrever, ou lê antes o código QR.</string>
+    <string name="sync_octiserver_link_code_copied_message">Código de ligação copiado</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d carácter</item>
+        <item quantity="other">%d caracteres</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Ambos os dispositivos devem mostrar a mesma contagem.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ro/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ro/strings.xml
@@ -37,4 +37,13 @@ Deoarece atat aplicatia cat si serverul sunt inca in dezvoltare, poate fi mai pu
     <string name="sync_octiserver_add_link_existing_action">Conectează la cont existent</string>
     <string name="sync_octiserver_add_select_server_label">Selectează server</string>
     <string name="sync_octiserver_add_custom_server_label">Server personalizat</string>
+    <string name="sync_octiserver_link_code_invalid_label">Cod de legare incomplet</string>
+    <string name="sync_octiserver_link_code_invalid_description">Acest cod de legare este incomplet sau a fost modificat în tranzit. Copiază codul complet de pe celălalt dispozitiv și lipește-l fără să-l retipezi, sau scanează codul QR în schimb.</string>
+    <string name="sync_octiserver_link_code_copied_message">Cod de legare copiat</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d caracter</item>
+        <item quantity="few">%d caractere</item>
+        <item quantity="other">%d caractere</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Ambele dispozitive trebuie să arate același număr.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-ru/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ru/strings.xml
@@ -37,4 +37,14 @@
     <string name="sync_octiserver_add_link_existing_action">Привязать к существующему аккаунту</string>
     <string name="sync_octiserver_add_select_server_label">Выбрать сервер</string>
     <string name="sync_octiserver_add_custom_server_label">Пользовательский сервер</string>
+    <string name="sync_octiserver_link_code_invalid_label">Код связи неполный</string>
+    <string name="sync_octiserver_link_code_invalid_description">Этот код связи неполный или был изменён при передаче. Скопируй код целиком с другого устройства и вставь его, не набирая вручную, либо отсканируй QR-код.</string>
+    <string name="sync_octiserver_link_code_copied_message">Код связи скопирован</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d символ</item>
+        <item quantity="few">%d символа</item>
+        <item quantity="many">%d символов</item>
+        <item quantity="other">%d символа</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">На обоих устройствах должно отображаться одинаковое количество.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-sr/strings.xml
+++ b/syncs-octiserver/src/main/res/values-sr/strings.xml
@@ -35,4 +35,13 @@
     <string name="sync_octiserver_add_link_existing_action">Повежи са постојећим налогом</string>
     <string name="sync_octiserver_add_select_server_label">Изабери сервер</string>
     <string name="sync_octiserver_add_custom_server_label">Прилагођени сервер</string>
+    <string name="sync_octiserver_link_code_invalid_label">Код за повезивање непотпун</string>
+    <string name="sync_octiserver_link_code_invalid_description">Овај код за повезивање је непотпун или је измењен током преноса. Копирај цео код са другог уређаја и налепи га без поновног куцања, или уместо тога скенирај QR код.</string>
+    <string name="sync_octiserver_link_code_copied_message">Код за повезивање копиран</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d карактер</item>
+        <item quantity="few">%d карактера</item>
+        <item quantity="other">%d карактера</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Оба уређаја морају приказивати исти број.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-sv/strings.xml
+++ b/syncs-octiserver/src/main/res/values-sv/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Länka till befintligt konto</string>
     <string name="sync_octiserver_add_select_server_label">Välj server</string>
     <string name="sync_octiserver_add_custom_server_label">Anpassad server</string>
+    <string name="sync_octiserver_link_code_invalid_label">Länkkoden är ofullständig</string>
+    <string name="sync_octiserver_link_code_invalid_description">Den här länkkoden är ofullständig eller har ändrats på vägen. Kopiera hela koden från den andra enheten och klistra in den utan att skriva om den, eller skanna QR-koden istället.</string>
+    <string name="sync_octiserver_link_code_copied_message">Länkkoden kopierad</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d tecken</item>
+        <item quantity="other">%d tecken</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Båda enheterna måste visa samma antal.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-tr/strings.xml
+++ b/syncs-octiserver/src/main/res/values-tr/strings.xml
@@ -35,4 +35,12 @@
     <string name="sync_octiserver_add_link_existing_action">Mevcut hesaba bağlantı</string>
     <string name="sync_octiserver_add_select_server_label">Sunucu seç</string>
     <string name="sync_octiserver_add_custom_server_label">Özel sunucu</string>
+    <string name="sync_octiserver_link_code_invalid_label">Bağlantı kodu eksik</string>
+    <string name="sync_octiserver_link_code_invalid_description">Bu bağlantı kodu eksik veya aktarım sırasında değişmiş. Kodun tamamını diğer cihazdan kopyalayıp yeniden yazmadan yapıştır ya da bunun yerine QR kodunu tara.</string>
+    <string name="sync_octiserver_link_code_copied_message">Bağlantı kodu kopyalandı</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d karakter</item>
+        <item quantity="other">%d karakter</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Her iki cihaz da aynı sayıyı göstermeli.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-uk/strings.xml
+++ b/syncs-octiserver/src/main/res/values-uk/strings.xml
@@ -37,4 +37,14 @@
     <string name="sync_octiserver_add_link_existing_action">Додати існуючий акаунт</string>
     <string name="sync_octiserver_add_select_server_label">Вибрати сервер</string>
     <string name="sync_octiserver_add_custom_server_label">Індивідуальний сервер</string>
+    <string name="sync_octiserver_link_code_invalid_label">Код зв\'язування неповний</string>
+    <string name="sync_octiserver_link_code_invalid_description">Цей код зв\'язування неповний або був змінений під час передавання. Скопіюй увесь код з іншого пристрою і встав його, не передруковуючи, або натомість відскануй QR-код.</string>
+    <string name="sync_octiserver_link_code_copied_message">Код зв\'язування скопійовано</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="one">%d символ</item>
+        <item quantity="few">%d символи</item>
+        <item quantity="many">%d символів</item>
+        <item quantity="other">%d символа</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">На обох пристроях має відображатися однакова кількість.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-vi/strings.xml
+++ b/syncs-octiserver/src/main/res/values-vi/strings.xml
@@ -35,4 +35,11 @@
     <string name="sync_octiserver_add_link_existing_action">Liên kết tài khoản hiện có</string>
     <string name="sync_octiserver_add_select_server_label">Chọn máy chủ</string>
     <string name="sync_octiserver_add_custom_server_label">Máy chủ tùy chỉnh</string>
+    <string name="sync_octiserver_link_code_invalid_label">Mã liên kết chưa đầy đủ</string>
+    <string name="sync_octiserver_link_code_invalid_description">Mã liên kết này chưa đầy đủ hoặc đã bị thay đổi trong quá trình truyền. Hãy sao chép toàn bộ mã từ thiết bị kia và dán vào mà không gõ lại, hoặc quét mã QR thay thế.</string>
+    <string name="sync_octiserver_link_code_copied_message">Đã sao chép mã liên kết</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="other">%d ký tự</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">Cả hai thiết bị phải hiển thị cùng một số lượng.</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-zh-rCN/strings.xml
+++ b/syncs-octiserver/src/main/res/values-zh-rCN/strings.xml
@@ -37,4 +37,11 @@
     <string name="sync_octiserver_add_link_existing_action">链接到现有帐户</string>
     <string name="sync_octiserver_add_select_server_label">选择服务器</string>
     <string name="sync_octiserver_add_custom_server_label">自定义服务器</string>
+    <string name="sync_octiserver_link_code_invalid_label">链接代码不完整</string>
+    <string name="sync_octiserver_link_code_invalid_description">此链接代码不完整，或在传输过程中被更改。请从另一台设备复制完整代码并直接粘贴，不要手动输入，或者改用扫描二维码的方式。</string>
+    <string name="sync_octiserver_link_code_copied_message">链接代码已复制</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="other">%d 个字符</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">两台设备显示的数量必须一致。</string>
 </resources>

--- a/syncs-octiserver/src/main/res/values-zh-rTW/strings.xml
+++ b/syncs-octiserver/src/main/res/values-zh-rTW/strings.xml
@@ -37,4 +37,11 @@
     <string name="sync_octiserver_add_link_existing_action">連接現有帳號</string>
     <string name="sync_octiserver_add_select_server_label">選擇伺服器</string>
     <string name="sync_octiserver_add_custom_server_label">自訂伺服器</string>
+    <string name="sync_octiserver_link_code_invalid_label">連結代碼不完整</string>
+    <string name="sync_octiserver_link_code_invalid_description">此連結代碼不完整，或在傳輸過程中被更改。請從另一台裝置複製完整代碼並貼上，不要重新輸入，或改用掃描 QR 碼。</string>
+    <string name="sync_octiserver_link_code_copied_message">連結代碼已複製</string>
+    <plurals name="sync_octiserver_link_code_character_count">
+        <item quantity="other">%d 個字元</item>
+    </plurals>
+    <string name="sync_octiserver_link_code_character_count_hint">兩台裝置必須顯示相同的數字。</string>
 </resources>


### PR DESCRIPTION
## What changed

Pulled the latest Crowdin translations across 29 languages. Two areas of the app get new localized text:

- The device-link screen (link code entry, invalid-code messages, character-count hints) in the Octi Server sync flow.
- The upgrade screen's payment-status messages (pending payment, purchase check failed).

A handful of existing Polish strings were also reworded for clarity.

## Technical Context

- Routine Crowdin pull (`./crowdin.sh download --skip-untranslated-strings`), validated per locale for placeholder correctness, escaping, and plural-category structure before merging.
- Hebrew is still missing a translation for the new link-code character-count plural entry — Crowdin hasn't translated it yet, so it currently falls back to the default plural resolution.
- Three Russian strings use informal address form ("ty") inconsistent with the formal form ("Vy") used elsewhere in the same files — a register inconsistency worth a follow-up correction on Crowdin, not blocking here.
- No store-listing (fastlane) content changed in this pull.
