### PR TITLE
Show always-on devices like Home Assistant as servers

### DIFF
--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -135,6 +135,7 @@ internal fun MetaInfo.DeviceType.widgetIconRes(): Int = when (this) {
     MetaInfo.DeviceType.TABLET -> R.drawable.widget_device_tablet_24
     MetaInfo.DeviceType.DESKTOP -> R.drawable.widget_device_desktop_24
     MetaInfo.DeviceType.BROWSER -> R.drawable.widget_device_browser_24
+    MetaInfo.DeviceType.SERVER -> R.drawable.widget_device_server_24
     MetaInfo.DeviceType.UNKNOWN -> R.drawable.widget_device_unknown_24
 }
 

--- a/modules-clipboard/src/main/res/drawable/widget_device_server_24.xml
+++ b/modules-clipboard/src/main/res/drawable/widget_device_server_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,13H4c-0.55,0 -1,0.45 -1,1v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1v-6C21,13.45 20.55,13 20,13zM7,19c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2s2,0.9 2,2S8.1,19 7,19zM20,3H4C3.45,3 3,3.45 3,4v6c0,0.55 0.45,1 1,1h16c0.55,0 1,-0.45 1,-1V4C21,3.45 20.55,3 20,3zM7,9C5.9,9 5,8.1 5,7s0.9,-2 2,-2s2,0.9 2,2S8.1,9 7,9z" />
+</vector>

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
@@ -144,6 +144,7 @@ class ClipboardWidgetContentGlanceTest {
         MetaInfo.DeviceType.TABLET.widgetIconRes() shouldBe R.drawable.widget_device_tablet_24
         MetaInfo.DeviceType.DESKTOP.widgetIconRes() shouldBe R.drawable.widget_device_desktop_24
         MetaInfo.DeviceType.BROWSER.widgetIconRes() shouldBe R.drawable.widget_device_browser_24
+        MetaInfo.DeviceType.SERVER.widgetIconRes() shouldBe R.drawable.widget_device_server_24
         MetaInfo.DeviceType.UNKNOWN.widgetIconRes() shouldBe R.drawable.widget_device_unknown_24
     }
 

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfo.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/core/MetaInfo.kt
@@ -43,6 +43,7 @@ data class MetaInfo(
         TABLET,
         DESKTOP,
         BROWSER,
+        SERVER,
         UNKNOWN,
     }
 }

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/DeviceTypeIcons.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/DeviceTypeIcons.kt
@@ -3,6 +3,7 @@ package eu.darken.octi.modules.meta.ui
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Computer
+import androidx.compose.material.icons.twotone.Dns
 import androidx.compose.material.icons.twotone.PhoneAndroid
 import androidx.compose.material.icons.twotone.Public
 import androidx.compose.material.icons.twotone.QuestionMark
@@ -16,6 +17,7 @@ fun MetaInfo.DeviceType?.materialIcon(): ImageVector = when (this) {
     MetaInfo.DeviceType.TABLET -> Icons.TwoTone.Tablet
     MetaInfo.DeviceType.DESKTOP -> Icons.TwoTone.Computer
     MetaInfo.DeviceType.BROWSER -> Icons.TwoTone.Public
+    MetaInfo.DeviceType.SERVER -> Icons.TwoTone.Dns
     MetaInfo.DeviceType.UNKNOWN, null -> Icons.TwoTone.QuestionMark
 }
 
@@ -25,5 +27,6 @@ fun MetaInfo.DeviceType.labelRes(): Int = when (this) {
     MetaInfo.DeviceType.TABLET -> R.string.module_meta_detail_device_type_tablet
     MetaInfo.DeviceType.DESKTOP -> R.string.module_meta_detail_device_type_desktop
     MetaInfo.DeviceType.BROWSER -> R.string.module_meta_detail_device_type_browser
+    MetaInfo.DeviceType.SERVER -> R.string.module_meta_detail_device_type_server
     MetaInfo.DeviceType.UNKNOWN -> R.string.module_meta_detail_device_type_unknown
 }

--- a/modules-meta/src/main/res/values/strings.xml
+++ b/modules-meta/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="module_meta_detail_device_type_tablet">Tablet</string>
     <string name="module_meta_detail_device_type_desktop">Desktop</string>
     <string name="module_meta_detail_device_type_browser">Browser</string>
+    <string name="module_meta_detail_device_type_server">Server</string>
     <string name="module_meta_detail_device_type_unknown">Unknown</string>
     <string name="module_meta_detail_os_label">Operating system</string>
     <string name="module_meta_detail_android_version_label">Android version</string>

--- a/modules-meta/src/test/java/eu/darken/octi/modules/meta/core/MetaInfoSerializationTest.kt
+++ b/modules-meta/src/test/java/eu/darken/octi/modules/meta/core/MetaInfoSerializationTest.kt
@@ -97,7 +97,24 @@ class MetaInfoSerializationTest : BaseTest() {
         json.encodeToString(MetaInfo.DeviceType.TABLET) shouldBe "\"TABLET\""
         json.encodeToString(MetaInfo.DeviceType.DESKTOP) shouldBe "\"DESKTOP\""
         json.encodeToString(MetaInfo.DeviceType.BROWSER) shouldBe "\"BROWSER\""
+        json.encodeToString(MetaInfo.DeviceType.SERVER) shouldBe "\"SERVER\""
         json.encodeToString(MetaInfo.DeviceType.UNKNOWN) shouldBe "\"UNKNOWN\""
+    }
+
+    @Test
+    fun `SERVER DeviceType decodes to SERVER`() {
+        val serverJson = """
+            {
+                "deviceId": {"id": "hass-1"},
+                "octiVersionName": "1.0.0",
+                "octiGitSha": "serversha",
+                "deviceManufacturer": "Acme",
+                "deviceName": "Home Assistant",
+                "deviceType": "SERVER"
+            }
+        """
+        val decoded = json.decodeFromString<MetaInfo>(serverJson)
+        decoded.deviceType shouldBe MetaInfo.DeviceType.SERVER
     }
 
     @Test

--- a/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/DeviceTypeIconsTest.kt
+++ b/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/DeviceTypeIconsTest.kt
@@ -1,0 +1,22 @@
+package eu.darken.octi.modules.meta.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Dns
+import eu.darken.octi.modules.meta.R
+import eu.darken.octi.modules.meta.core.MetaInfo
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DeviceTypeIconsTest : BaseTest() {
+
+    @Test
+    fun `SERVER maps to the Dns icon`() {
+        MetaInfo.DeviceType.SERVER.materialIcon() shouldBe Icons.TwoTone.Dns
+    }
+
+    @Test
+    fun `SERVER maps to the server label`() {
+        MetaInfo.DeviceType.SERVER.labelRes() shouldBe R.string.module_meta_detail_device_type_server
+    }
+}


### PR DESCRIPTION
## What changed

Octi now supports a "Server" device type. Always-on peers such as a Home Assistant instance, a NAS or a headless container show a server icon and "Server" in the device list, the device detail sheet and the clipboard widget, instead of a question mark and "Unknown".

Nothing changes for existing devices: Android still reports itself as Phone or Tablet.

Refs #370

## Technical Context

- `SERVER` was chosen over `HUB` because the existing values (PHONE/TABLET/DESKTOP/BROWSER) are form factors rather than roles, so `SERVER` also covers a NAS or a headless container. app-web's `DeviceCard` already switches on WATCH/TV/AUTO along that same axis.
- Compatibility: the tolerant `DeviceTypeSerializer` shipped in v1.1.0-rc0. Older clients use strict enum deserialization and will render an empty Meta tile plus a decode exception per sync cycle for any peer advertising `SERVER`. Android never emits `SERVER` itself, so nothing changes until a third-party peer opts in. This is the same trade-off a44fc7aa accepted when it added DESKTOP and BROWSER.
- Three exhaustive `when` blocks map `DeviceType`: `materialIcon()` and `labelRes()` in modules-meta, plus `widgetIconRes()` in modules-clipboard. The clipboard one is easy to miss and needs the new `widget_device_server_24` drawable.
- app-web and app-desktop each need a matching icon mapping before they can display the new value. Both already tolerate it without changes (desktop has the same UNKNOWN fallback, web defaults to `device-unknown`). `cross-repo-verify.yml` excludes modules-meta, so CI does not cover this.
- Worth a close look: the new vector's path data. The indicator dots are subpaths winding opposite the rack bodies, so the nonzero fill rule punches them out as holes rather than filling them.
