### PR TITLE
Publish a sync protocol reference for third-party clients

### DIFF
--- a/.claude/rules/interop-fixtures.md
+++ b/.claude/rules/interop-fixtures.md
@@ -85,10 +85,10 @@ makes it deliberate.
 
 ## Cross-repo workflow (consumer side)
 
-See [pull-request-guidelines.md](pull-request-guidelines.md) — sister PRs must
-be linked when a wire-format change crosses repos. The web/desktop side keeps a
-`fixture-lock.json` that pins this directory by app-main commit SHA, fetches via
-sparse-checkout, and verifies against `manifest.json` before running its tests.
+Sister PRs must be linked when a wire-format change crosses repos. The
+web/desktop side keeps a `fixture-lock.json` that pins this directory by
+app-main commit SHA, fetches via sparse-checkout, and verifies against
+`manifest.json` before running its tests.
 
 ## Upstream gating (this repo's CI)
 
@@ -199,10 +199,9 @@ impossible on its own. Two ways to break wire format intentionally:
 
 Open the consumer PRs first (or simultaneously). Each includes the matching
 decoder change. The producer PR then merges because the consumers' default
-branches already have the updated decoders when the gate fetches them. The
-[pull-request-guidelines.md](pull-request-guidelines.md) sister-repo section
-covers the mechanics. Right tool for renames, additions of required fields, or
-new value-class shapes.
+branches already have the updated decoders when the gate fetches them. Link the
+sister PRs to each other so the coordination is visible from either side. Right
+tool for renames, additions of required fields, or new value-class shapes.
 
 ### 2. Staged via capability flag
 
@@ -220,8 +219,12 @@ Full sequence:
 3. **Producer advertises a new capability tag** in `Octi-Device-Capabilities`
    (see [device-capabilities.md](device-capabilities.md)). Consumers reading
    peers' capabilities now know "peer X has the new format."
-4. **Producer adds dual-write**: emit old format unconditionally, emit new
-   format only for peers whose capabilities include the new tag.
+4. **Producer writes one backward-compatible document** carrying both shapes,
+   old fields and new fields side by side. There is exactly one stored document
+   per (owner device, module) and every peer reads that same document, so a
+   producer cannot emit one format to one peer and another format to another.
+   Capability tags don't route the write; they answer "may the old shape be
+   dropped yet?" (steps 5 and 6).
 5. **Support floor moves** — once every peer that matters has advertised the
    capability, the old format becomes dead code.
 6. **Producer removes the old write path** and the old fixture vector. This

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Companion clients (early-stage, talk to the same Octi Server):
 * [Octi Desktop](https://github.com/d4rken-org/octi-desktop) — Compose Multiplatform desktop client (Linux / macOS / Windows).
 * [Octi Web](https://github.com/d4rken-org/octi-web) — Browser-based client, connects directly to your self-hosted Octi Server.
 
+Writing your own client? The [sync protocol reference](docs/protocol/README.md) documents the Octi
+Server wire protocol: linking, HTTP API, change notifications, and end-to-end encryption.
+
 Hungry for details? [Check the wiki](https://github.com/d4rken-org/octi/wiki). Still have
 questions? [Join us on discord](https://discord.gg/s7V4C6zuVy)!
 

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,24 +1,24 @@
 # Octi sync protocol
 
 Reference documentation for the wire protocol Octi clients speak to an
-[Octi Server](https://github.com/d4rken-org/octi-server). It exists so a third-party client can be
-written from this document instead of from another client's source.
+[Octi Server](https://github.com/d4rken-org/octi-server). A third-party client should be writable
+from this document alone, without reading another client's source.
 
 The protocol is end-to-end encrypted. The server stores and relays opaque ciphertext and never
 holds the encryption keyset.
 
 ## Source revisions
 
-Every statement in these pages was read out of two repositories at fixed commits. Both are
-recorded because they evolve independently.
+Every statement here was read out of two repositories at fixed commits. Both are recorded because
+they evolve separately.
 
 | Component | Repository | Commit |
 |---|---|---|
 | Android client | [`d4rken-org/octi`](https://github.com/d4rken-org/octi) | `8aeacf4c7e5641716c33a6fd77c54ba73ea45fd7` |
 | Sync server | [`d4rken-org/octi-server`](https://github.com/d4rken-org/octi-server) | [`7e813e2b7d198daae30bdb3cc17e5544ab9b3c22`](https://github.com/d4rken-org/octi-server/tree/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22) |
 
-Links into server code below are commit-pinned to that server SHA. Links into client code are
-repository-relative and therefore track this branch.
+Server code links are pinned to that server SHA. Client code links are repository-relative and
+track this branch.
 
 ## Contents
 
@@ -31,8 +31,8 @@ repository-relative and therefore track this branch.
 | [capabilities.md](capabilities.md) | Per-peer feature tags and their authority semantics |
 | [stability.md](stability.md) | What is machine-checked, how to pin fixtures, change policy |
 
-[stability.md](stability.md) is the page to read before relying on anything here. It states per
-area whether a claim is backed by a committed test fixture or by prose alone.
+Read [stability.md](stability.md) before relying on anything here. It says per area whether a claim
+is backed by a committed test fixture or by prose alone.
 
 ## Object model
 
@@ -44,28 +44,25 @@ account
 
 - An **account** is a UUID. It owns a set of devices and, through them, all stored data.
 - A **device** is a UUID chosen by the client. Registration binds it to exactly one account, and a
-  device UUID can be registered only once across the whole server.
+  device UUID can be registered only once server-wide.
 - A **module** is a namespaced identifier such as `eu.darken.octi.module.core.power`. For every
-  pair of (owner device, module id) the server stores exactly **one** document plus its metadata.
+  pair of (owner device, module id) the server stores exactly one document plus its metadata.
 - Every device on an account can read every other device's documents. The account is the unit of
   sharing; there is no per-module access control.
 
-A document is an opaque byte string as far as the server is concerned. Its plaintext contents are
-a module-specific structure that only the account's devices can decrypt.
+To the server a document is an opaque byte string. Its plaintext is a module-specific structure
+only the account's devices can decrypt.
 
 ## Single-writer invariant
 
-Every write targets a slot identified by `(target device id, module id)`. The server authorizes any
-authenticated device on the account to write any peer's slot. Clients must not use that freedom: a
-client writes only the slot belonging to its own device id and treats every other device's slots as
-read-only. The Android client enforces this locally and refuses to send a write with a foreign
-device id.
+Every write targets a slot identified by `(target device id, module id)`. The server lets any
+authenticated device on the account write any peer's slot. Do not use that freedom: write only your
+own device id's slot, and treat every other device's slots as read-only. The Android client
+enforces this and refuses to send a write with a foreign device id.
 
-Two consequences matter for implementers:
-
-- Data flows one way per slot. A peer publishes, everyone else observes. There is no merge.
-- Because a slot holds one document that all peers read, a producer cannot serve different document
-  formats to different peers. See the change policy in [stability.md](stability.md).
+Data flows one way per slot. A peer publishes, everyone else observes. There is no merge. And since
+a slot holds one document that all peers read, a producer cannot serve different document formats
+to different peers. See the change policy in [stability.md](stability.md).
 
 ## Scope of this revision
 
@@ -77,21 +74,21 @@ Specified here:
 
 Not specified here:
 
-- **Google Drive sync.** Octi also synchronizes through a user's Google Drive app-data folder. That
-  backend is out of scope; only the Octi Server backend is described.
+- **Google Drive sync.** Octi also syncs through a user's Google Drive app-data folder. Only the
+  Octi Server backend is described here.
 - **The blob / file-transfer layer.** Endpoints under `/v1/module/{moduleId}/blobs` and
   `/v1/module/{moduleId}/blob-sessions` and their streaming encryption exist and are named in
   [http-api.md](http-api.md) and [encryption.md](encryption.md), but their request and response
-  shapes are not specified in this revision. A client that never attaches blobs does not need them.
-- **Module document schemas.** The inner structure of the seven known modules' documents is not
-  described, only the envelope around them. Unknown module ids must be tolerated, not rejected.
+  shapes are not specified here. A client that never attaches blobs does not need them.
+- **Module document schemas.** Only the envelope around the seven known modules' documents is
+  described, not their inner structure. Unknown module ids must be tolerated, not rejected.
 
 ## Conventions
 
-- Every identifier, header name, field name, status code, and limit was read out of the sources at
-  the commits above. Where the Android client and the server disagree, the server's behavior is
-  documented and the divergence is called out on the spot.
-- Values marked as **deployment-configurable defaults** come from the server's command-line
+- Every identifier, header name, field name, status code and limit was read out of the sources at
+  the commits above. Where the Android client and the server disagree, this documents the server's
+  behavior and says so on the spot.
+- Values marked **deployment-configurable defaults** come from the server's command-line
   configuration. They are what a stock deployment does, not protocol constants. An operator can
-  change them, so a client must handle the corresponding error rather than assume a number.
+  change them, so handle the corresponding error rather than assume a number.
 - All credentials, codes, keys, and identifiers in examples are obviously fake placeholders.

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -1,0 +1,97 @@
+# Octi sync protocol
+
+Reference documentation for the wire protocol Octi clients speak to an
+[Octi Server](https://github.com/d4rken-org/octi-server). It exists so a third-party client can be
+written from this document instead of from another client's source.
+
+The protocol is end-to-end encrypted. The server stores and relays opaque ciphertext and never
+holds the encryption keyset.
+
+## Source revisions
+
+Every statement in these pages was read out of two repositories at fixed commits. Both are
+recorded because they evolve independently.
+
+| Component | Repository | Commit |
+|---|---|---|
+| Android client | [`d4rken-org/octi`](https://github.com/d4rken-org/octi) | `8aeacf4c7e5641716c33a6fd77c54ba73ea45fd7` |
+| Sync server | [`d4rken-org/octi-server`](https://github.com/d4rken-org/octi-server) | [`7e813e2b7d198daae30bdb3cc17e5544ab9b3c22`](https://github.com/d4rken-org/octi-server/tree/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22) |
+
+Links into server code below are commit-pinned to that server SHA. Links into client code are
+repository-relative and therefore track this branch.
+
+## Contents
+
+| Page | Covers |
+|---|---|
+| [linking.md](linking.md) | Joining an account: share codes, the link payload, registration |
+| [http-api.md](http-api.md) | Endpoints, headers, status codes, write semantics, limits |
+| [websocket.md](websocket.md) | Change notifications, frame schema, delivery guarantees |
+| [encryption.md](encryption.md) | Keysets, modes, associated data, the gzip and AEAD layering |
+| [capabilities.md](capabilities.md) | Per-peer feature tags and their authority semantics |
+| [stability.md](stability.md) | What is machine-checked, how to pin fixtures, change policy |
+
+[stability.md](stability.md) is the page to read before relying on anything here. It states per
+area whether a claim is backed by a committed test fixture or by prose alone.
+
+## Object model
+
+```
+account
+ └── device            (one registration per client)
+      └── module       (one stored document per module id)
+```
+
+- An **account** is a UUID. It owns a set of devices and, through them, all stored data.
+- A **device** is a UUID chosen by the client. Registration binds it to exactly one account, and a
+  device UUID can be registered only once across the whole server.
+- A **module** is a namespaced identifier such as `eu.darken.octi.module.core.power`. For every
+  pair of (owner device, module id) the server stores exactly **one** document plus its metadata.
+- Every device on an account can read every other device's documents. The account is the unit of
+  sharing; there is no per-module access control.
+
+A document is an opaque byte string as far as the server is concerned. Its plaintext contents are
+a module-specific structure that only the account's devices can decrypt.
+
+## Single-writer invariant
+
+Every write targets a slot identified by `(target device id, module id)`. The server authorizes any
+authenticated device on the account to write any peer's slot. Clients must not use that freedom: a
+client writes only the slot belonging to its own device id and treats every other device's slots as
+read-only. The Android client enforces this locally and refuses to send a write with a foreign
+device id.
+
+Two consequences matter for implementers:
+
+- Data flows one way per slot. A peer publishes, everyone else observes. There is no merge.
+- Because a slot holds one document that all peers read, a producer cannot serve different document
+  formats to different peers. See the change policy in [stability.md](stability.md).
+
+## Scope of this revision
+
+Specified here:
+
+- The Octi Server HTTP backend and its WebSocket notification channel.
+- The payload encryption envelope and the linking payload.
+- The device capability tag set.
+
+Not specified here:
+
+- **Google Drive sync.** Octi also synchronizes through a user's Google Drive app-data folder. That
+  backend is out of scope; only the Octi Server backend is described.
+- **The blob / file-transfer layer.** Endpoints under `/v1/module/{moduleId}/blobs` and
+  `/v1/module/{moduleId}/blob-sessions` and their streaming encryption exist and are named in
+  [http-api.md](http-api.md) and [encryption.md](encryption.md), but their request and response
+  shapes are not specified in this revision. A client that never attaches blobs does not need them.
+- **Module document schemas.** The inner structure of the seven known modules' documents is not
+  described, only the envelope around them. Unknown module ids must be tolerated, not rejected.
+
+## Conventions
+
+- Every identifier, header name, field name, status code, and limit was read out of the sources at
+  the commits above. Where the Android client and the server disagree, the server's behavior is
+  documented and the divergence is called out on the spot.
+- Values marked as **deployment-configurable defaults** come from the server's command-line
+  configuration. They are what a stock deployment does, not protocol constants. An operator can
+  change them, so a client must handle the corresponding error rather than assume a number.
+- All credentials, codes, keys, and identifiers in examples are obviously fake placeholders.

--- a/docs/protocol/capabilities.md
+++ b/docs/protocol/capabilities.md
@@ -1,8 +1,7 @@
 # Device capabilities
 
-Each device publishes a set of feature tags describing what it supports. Peers read that set instead
-of guessing from a version string, which is meaningless across clients with independent release
-trains.
+Each device publishes a set of feature tags describing what it supports. Peers read that set
+instead of guessing from a version string.
 
 ## Tag grammar
 
@@ -16,19 +15,18 @@ matching the regular expression
 [a-z][a-z0-9]*:[A-Za-z0-9._\-]+
 ```
 
-The namespace is lowercase ASCII; the value part additionally allows uppercase, digits, dot,
-underscore and hyphen.
+The namespace is lowercase ASCII. The value part also allows uppercase, digits, dot, underscore and
+hyphen.
 
 ### The `_reported` marker
 
-Every producer that participates in a namespace emits a marker tag `<namespace>:_reported` alongside
+Every producer that participates in a namespace emits a marker tag `<namespace>:_reported` next to
 its value tags.
 
-The marker exists to separate two states that are otherwise indistinguishable. Without it, a missing
-`encryption:AES256_GCM_SIV` could mean either "this peer does not support GCM-SIV" or "this peer's
-client predates the whole encryption namespace and has told us nothing". Those call for opposite
-behavior: the first is a definite incompatibility to warn about, the second is a fall back to
-whatever heuristic the consumer has.
+The marker separates two states that would otherwise look identical. Without it, a missing
+`encryption:AES256_GCM_SIV` could mean "this peer does not support GCM-SIV" or "this peer's client
+predates the encryption namespace and has told us nothing". The first is a definite incompatibility
+to warn about, the second a fall back to whatever heuristic the consumer has.
 
 ## Limits
 
@@ -38,32 +36,29 @@ whatever heuristic the consumer has.
 | Characters per tag | 128 |
 | Bytes per header value | 4096 |
 
-The first two are enforced identically on the client and on the server. The third is not. The
-Android encoder (`CapabilitiesCodec.encodeToHeader`) validates the tag count, the tag grammar and
-the per-tag length, but never measures the serialized header; only the decoder and the server's
-header parser check the 4096 limit. A set the encoder accepts can therefore be too long to be
-accepted anywhere: 32 tags at the maximum 128 characters serialize to 4193 bytes, which Android
-would send and the server would discard whole, leaving the device's previously stored capability
-set in place with no error anyone can observe.
+Android checks the first two limits when it encodes (`CapabilitiesCodec.encodeToHeader` validates
+the tag count, the tag grammar and the per-tag length), but never measures the serialized header.
+Only decoders and the server's header parser check the 4096 limit.
 
-A producer must serialize its tag set and check the length of the result before sending it. The
-per-tag limits do not keep the header under 4096 on their own.
+So Android can send a header the server then throws away. 32 tags of 128 characters come to 4193
+bytes. The server keeps the old capability set and returns no error.
+
+Measure the serialized array yourself before sending it. The per-tag limits do not keep the header
+under 4096 on their own.
 
 ## Rejection semantics
 
-Validation is **all or nothing**. One tag that is too long, malformed, not a string, or one tag too
-many, discards the entire advertised set. There is no partial acceptance, so every consumer sees a
-set that is either wholly valid or absent.
+Validation is all or nothing. One tag that is too long, malformed, not a string, or one tag too
+many, discards the entire advertised set. Every consumer sees a set that is either wholly valid or
+absent.
 
-What that does **not** mean:
+Rejection does not fail the HTTP request. A request carrying a malformed
+`Octi-Device-Capabilities` header still executes normally; only the capability update is dropped.
+It does not clear a previously stored set either, because the server applies metadata only for
+headers that parse. A device keeps whatever set it last advertised successfully.
 
-- It does not fail the HTTP request. A request carrying a malformed `Octi-Device-Capabilities`
-  header still executes normally; only the capability update is dropped.
-- It does not clear a previously stored set. The server applies metadata only for headers that parse,
-  so an existing device keeps whatever capability set it last advertised successfully.
-
-The same applies to a header that is simply absent: absent means "no update", never "clear". A
-device cannot retract its capability set by omitting the header.
+An absent header also means "no update", never "clear". A device cannot retract its capability set
+by omitting the header.
 
 ## Authority table
 
@@ -76,13 +71,13 @@ For a peer's capability set, a namespace `X`, and a value tag `<X>:V`:
 | present | present | absent | **Known unsupported.** The peer speaks `X` and does not support `V`. |
 | present | present | present | **Known supported.** |
 
-The distinction between rows one and two matters: a peer can participate in one namespace while
-knowing nothing about another. Evaluate authority per namespace, never for the set as a whole.
+A peer can participate in one namespace while knowing nothing about another. Evaluate authority per
+namespace, never for the set as a whole.
 
-The Android client applies one fallback for the unknown rows: for peers whose `platform` is `android`
+The Android client has one fallback for the unknown rows: for peers whose `platform` is `android`
 (or absent, for clients predating the field) it compares the reported version against a minimum
-version. Peers on other platforms without capabilities are skipped rather than guessed at. That
-fallback is Android-specific policy, not part of the protocol.
+version. Peers on other platforms without capabilities are skipped, not guessed at. That fallback
+is Android policy, not protocol.
 
 ## Transport
 
@@ -105,8 +100,7 @@ omitted entirely for devices that have never reported a valid set. See
 [http-api.md](http-api.md).
 
 Google Drive sync carries the same tag set in the `capabilities` field of its device manifest. That
-backend is otherwise out of scope here; the point is that the tag vocabulary and semantics are
-shared across transports.
+backend is out of scope here, but the tag vocabulary and semantics are shared across transports.
 
 ## The `encryption` namespace
 
@@ -122,27 +116,27 @@ The only namespace defined at this revision. Values are the encryption mode iden
 The Android client always advertises `encryption:_reported` and `encryption:AES256_SIV`, and adds
 `encryption:AES256_GCM_SIV` when its runtime check confirms a working AES-GCM-SIV implementation.
 
-The single consumer today is the compatibility check that warns a user when a peer on the account
-cannot read what this device writes. Because the account's encryption mode is fixed, that condition
-is a permanent incompatibility and not something to retry.
+The one consumer today is the check that warns a user when a peer on the account cannot read what
+this device writes. The account's encryption mode is fixed, so that is a permanent incompatibility,
+not something to retry.
 
 ## Trust model
 
-Capabilities live on server-visible device metadata, not inside the encrypted payload. That is
-deliberate: the compatibility check has to decide whether a peer can decrypt **before** anything is
-decrypted, so the signal must be readable without a key.
+Capabilities live on server-visible device metadata, not inside the encrypted payload. The
+compatibility check has to decide whether a peer can decrypt before anything is decrypted, so the
+signal must be readable without a key.
 
 The price is that capabilities are advisory and unauthenticated. A hostile or compromised server
 could rewrite a peer's tag set, most usefully to suppress a warning. It cannot manufacture
-compatibility: a peer that genuinely cannot decrypt still fails at decrypt time. Treat capabilities
-as a hint that improves diagnostics, never as an authorization or security decision.
+compatibility: a peer that cannot decrypt still fails at decrypt time. Treat capabilities as a
+diagnostic hint, never as an authorization or security decision.
 
 ## Adding a namespace
 
 Adding one touches every implementation, since a tag nobody else understands accomplishes nothing.
-The procedure, the file-by-file checklist, and the cross-repository coordination are documented in
+The procedure, the file-by-file checklist and the cross-repository coordination live in
 [`.claude/rules/device-capabilities.md`](../../.claude/rules/device-capabilities.md). In outline:
-define the marker and value tags plus a tri-state `supports` helper, publish the tags from the local
-capability provider, replace the consumer's version heuristic, extend the tests, then land the
-matching declarations in the desktop and web clients. The server needs no change; it stores and
+define the marker and value tags plus a tri-state `supports` helper, publish the tags from the
+local capability provider, replace the consumer's version heuristic, extend the tests, then land
+the matching declarations in the desktop and web clients. The server needs no change; it stores and
 echoes tags without interpreting them.

--- a/docs/protocol/capabilities.md
+++ b/docs/protocol/capabilities.md
@@ -1,0 +1,148 @@
+# Device capabilities
+
+Each device publishes a set of feature tags describing what it supports. Peers read that set instead
+of guessing from a version string, which is meaningless across clients with independent release
+trains.
+
+## Tag grammar
+
+```
+<namespace>:<value>
+```
+
+matching the regular expression
+
+```
+[a-z][a-z0-9]*:[A-Za-z0-9._\-]+
+```
+
+The namespace is lowercase ASCII; the value part additionally allows uppercase, digits, dot,
+underscore and hyphen.
+
+### The `_reported` marker
+
+Every producer that participates in a namespace emits a marker tag `<namespace>:_reported` alongside
+its value tags.
+
+The marker exists to separate two states that are otherwise indistinguishable. Without it, a missing
+`encryption:AES256_GCM_SIV` could mean either "this peer does not support GCM-SIV" or "this peer's
+client predates the whole encryption namespace and has told us nothing". Those call for opposite
+behavior: the first is a definite incompatibility to warn about, the second is a fall back to
+whatever heuristic the consumer has.
+
+## Limits
+
+| Limit | Value |
+|---|---|
+| Tags per device | 64 |
+| Characters per tag | 128 |
+| Bytes per header value | 4096 |
+
+The first two are enforced identically on the client and on the server. The third is not. The
+Android encoder (`CapabilitiesCodec.encodeToHeader`) validates the tag count, the tag grammar and
+the per-tag length, but never measures the serialized header; only the decoder and the server's
+header parser check the 4096 limit. A set the encoder accepts can therefore be too long to be
+accepted anywhere: 32 tags at the maximum 128 characters serialize to 4193 bytes, which Android
+would send and the server would discard whole, leaving the device's previously stored capability
+set in place with no error anyone can observe.
+
+A producer must serialize its tag set and check the length of the result before sending it. The
+per-tag limits do not keep the header under 4096 on their own.
+
+## Rejection semantics
+
+Validation is **all or nothing**. One tag that is too long, malformed, not a string, or one tag too
+many, discards the entire advertised set. There is no partial acceptance, so every consumer sees a
+set that is either wholly valid or absent.
+
+What that does **not** mean:
+
+- It does not fail the HTTP request. A request carrying a malformed `Octi-Device-Capabilities`
+  header still executes normally; only the capability update is dropped.
+- It does not clear a previously stored set. The server applies metadata only for headers that parse,
+  so an existing device keeps whatever capability set it last advertised successfully.
+
+The same applies to a header that is simply absent: absent means "no update", never "clear". A
+device cannot retract its capability set by omitting the header.
+
+## Authority table
+
+For a peer's capability set, a namespace `X`, and a value tag `<X>:V`:
+
+| Peer's `capabilities` | `<X>:_reported` | `<X>:V` | Verdict |
+|---|---|---|---|
+| absent or null | n/a | n/a | **Unknown.** The peer reports nothing. Fall back to another heuristic or skip. |
+| present | absent | n/a | **Namespace unknown.** The peer says nothing about `X`. Fall back. |
+| present | present | absent | **Known unsupported.** The peer speaks `X` and does not support `V`. |
+| present | present | present | **Known supported.** |
+
+The distinction between rows one and two matters: a peer can participate in one namespace while
+knowing nothing about another. Evaluate authority per namespace, never for the set as a whole.
+
+The Android client applies one fallback for the unknown rows: for peers whose `platform` is `android`
+(or absent, for clients predating the field) it compares the reported version against a minimum
+version. Peers on other platforms without capabilities are skipped rather than guessed at. That
+fallback is Android-specific policy, not part of the protocol.
+
+## Transport
+
+| Direction | Carrier |
+|---|---|
+| Outbound | `Octi-Device-Capabilities` request header, a JSON-stringified array of tag strings |
+| Inbound | The `capabilities` field on each device in `GET /v1/devices`, a real JSON array |
+
+The header is a JSON array serialized into a header value, for example:
+
+```http
+Octi-Device-Capabilities: ["encryption:AES256_GCM_SIV","encryption:AES256_SIV","encryption:_reported"]
+```
+
+The encoder sorts tags before serializing, so an unchanged set produces a byte-identical header.
+Consumers must not depend on that ordering.
+
+In the device list the field is a proper array element, not a string containing an array. It is
+omitted entirely for devices that have never reported a valid set. See
+[http-api.md](http-api.md).
+
+Google Drive sync carries the same tag set in the `capabilities` field of its device manifest. That
+backend is otherwise out of scope here; the point is that the tag vocabulary and semantics are
+shared across transports.
+
+## The `encryption` namespace
+
+The only namespace defined at this revision. Values are the encryption mode identifiers from
+[encryption.md](encryption.md):
+
+| Tag | Meaning |
+|---|---|
+| `encryption:_reported` | This peer participates in the namespace |
+| `encryption:AES256_GCM_SIV` | This peer can read and write AES-256-GCM-SIV |
+| `encryption:AES256_SIV` | This peer can read and write AES-256-SIV |
+
+The Android client always advertises `encryption:_reported` and `encryption:AES256_SIV`, and adds
+`encryption:AES256_GCM_SIV` when its runtime check confirms a working AES-GCM-SIV implementation.
+
+The single consumer today is the compatibility check that warns a user when a peer on the account
+cannot read what this device writes. Because the account's encryption mode is fixed, that condition
+is a permanent incompatibility and not something to retry.
+
+## Trust model
+
+Capabilities live on server-visible device metadata, not inside the encrypted payload. That is
+deliberate: the compatibility check has to decide whether a peer can decrypt **before** anything is
+decrypted, so the signal must be readable without a key.
+
+The price is that capabilities are advisory and unauthenticated. A hostile or compromised server
+could rewrite a peer's tag set, most usefully to suppress a warning. It cannot manufacture
+compatibility: a peer that genuinely cannot decrypt still fails at decrypt time. Treat capabilities
+as a hint that improves diagnostics, never as an authorization or security decision.
+
+## Adding a namespace
+
+Adding one touches every implementation, since a tag nobody else understands accomplishes nothing.
+The procedure, the file-by-file checklist, and the cross-repository coordination are documented in
+[`.claude/rules/device-capabilities.md`](../../.claude/rules/device-capabilities.md). In outline:
+define the marker and value tags plus a tri-state `supports` helper, publish the tags from the local
+capability provider, replace the consumer's version heuristic, extend the tests, then land the
+matching declarations in the desktop and web clients. The server needs no change; it stores and
+echoes tags without interpreting them.

--- a/docs/protocol/encryption.md
+++ b/docs/protocol/encryption.md
@@ -2,10 +2,10 @@
 
 Every module document is encrypted on the writing device and decrypted on the reading device. The
 server stores ciphertext, never sees a key, and cannot read or forge a document. It can still
-delete one, and it does see the metadata described in [http-api.md](http-api.md).
+delete one, and it sees the metadata in [http-api.md](http-api.md).
 
-The encryption mode is a property of the **account**, fixed when the account is created and shared
-by every device on it through the linking payload. It is not negotiated per peer and not per module.
+The encryption mode is a property of the **account**, fixed at creation and shared by every device
+through the linking payload. It is not negotiated per peer or per module.
 
 ## Keyset on the wire
 
@@ -20,11 +20,11 @@ The keyset travels inside the [link payload](linking.md) as:
 
 - `type` is the mode identifier, either `AES256_GCM_SIV` or `AES256_SIV`.
 - `key` is base64 of a serialized Tink keyset proto, not a raw symmetric key. Parse it with Tink's
-  `TinkProtoKeysetFormat` (the Android client uses `parseKeyset` with `InsecureSecretKeyAccess`,
-  because the keyset is stored unwrapped by design: there is no server-side key management).
+  `TinkProtoKeysetFormat` (the Android client uses `parseKeyset` with `InsecureSecretKeyAccess`: the
+  keyset is stored unwrapped by design, since there is no server-side key management).
 
-An implementation that does not use Tink has to reproduce both the keyset proto parsing and the Tink
-ciphertext framing described below.
+Without Tink you have to reproduce both the keyset proto parsing and the ciphertext framing
+described below.
 
 ## `AES256_GCM_SIV`, the default
 
@@ -40,13 +40,12 @@ Default for accounts created by current clients.
   <target device id>:<module id>
   ```
 
-  for example `11111111-1111-1111-1111-111111111111:eu.darken.octi.module.core.power`. The device id
-  is the owner of the slot, written in the same lowercase UUID form used in the API, and the module
-  id is the full dotted identifier, not a shortened label.
+  for example `11111111-1111-1111-1111-111111111111:eu.darken.octi.module.core.power`. The device
+  id is the slot's owner, in the lowercase UUID form used in the API. The module id is the full
+  dotted identifier, not a short label.
 
-The associated data binds a document to its slot. Moving ciphertext to a different device id or
-module id makes decryption fail, which is what stops a malicious server from shuffling documents
-between slots.
+The associated data binds a document to its slot: ciphertext moved to a different device id or
+module id fails to decrypt, so a malicious server cannot shuffle documents between slots.
 
 ## `AES256_SIV`, legacy
 
@@ -58,10 +57,9 @@ is unavailable.
 - **Associated data is not used.** The encrypt and decrypt calls pass an empty byte array
   unconditionally, and the caller-supplied associated data is discarded.
 
-This is the contrast that most often breaks a new implementation. Passing the
-`<deviceId>:<moduleId>` string as associated data to a legacy SIV keyset produces ciphertext that no
-existing Octi client can read, and fails to decrypt everything those clients wrote. The mode
-determines the associated data:
+Passing the `<deviceId>:<moduleId>` string as associated data to a legacy SIV keyset produces
+ciphertext no existing Octi client can read, and fails to decrypt everything those clients wrote.
+The mode decides:
 
 | Mode | Primitive | Associated data |
 |---|---|---|
@@ -70,8 +68,8 @@ determines the associated data:
 
 ## Layering
 
-The transport carries **bytes**. The known modules currently encode their documents as JSON, but the
-envelope does not require it and a client must not assume the plaintext is text.
+The transport carries bytes. The known modules encode their documents as JSON today, but the
+envelope does not require it; do not assume the plaintext is text.
 
 Writing:
 
@@ -92,12 +90,10 @@ response body (or base64-decoded documentBase64)
   -> module document bytes
 ```
 
-The gzip layer is inside the encryption, so the server sees only ciphertext and never a compressible
-representation. Compression happens before encryption on every write, without exception; there is no
-"uncompressed" flag on the wire.
+The gzip layer sits inside the encryption, so the server only ever sees ciphertext. Every write
+compresses first, without exception; there is no "uncompressed" flag on the wire.
 
-A zero-length response body means the slot exists but holds no document. Do not attempt to decrypt
-it.
+A zero-length response body means the slot exists but holds no document. Do not try to decrypt it.
 
 ## Tink ciphertext framing
 
@@ -109,26 +105,24 @@ Both modes start with the same 5-byte prefix: the version byte `0x01` followed b
 | `AES256_GCM_SIV` | 12-byte random nonce, then ciphertext, then a 16-byte tag | 33 bytes |
 | `AES256_SIV` | 16-byte synthetic IV, which doubles as the authentication tag, then ciphertext | 21 bytes |
 
-Legacy SIV carries no random nonce. Its synthetic IV is derived from the key and the plaintext,
-which is what makes the mode deterministic. The 12-byte difference between the two overheads is
-exactly that nonce, and the committed vectors show it: every GCM-SIV ciphertext is 33 bytes longer
-than the gzipped document it wraps, every SIV ciphertext 21 bytes longer.
+Legacy SIV carries no random nonce. Its synthetic IV comes from the key and the plaintext, which
+makes the mode deterministic. The 12-byte difference between the overheads is exactly that nonce.
+The committed vectors show it: every GCM-SIV ciphertext is 33 bytes longer than the gzipped document
+it wraps, every SIV ciphertext 21 bytes longer.
 
-Pin the leading `0x01`. It is what catches a silent Tink wire-format upgrade on the producing side,
-and it is the check the committed interop fixtures perform. See
-[stability.md](stability.md).
+Pin the leading `0x01`. It catches a silent Tink wire-format upgrade on the producing side, and it
+is the check the committed interop fixtures perform. See [stability.md](stability.md).
 
 ## Mode availability
 
-AES-GCM-SIV is not usable on every Android device: some platform providers accept the transformation
-name but return plain AES-GCM. The Android client verifies a known-answer test vector at startup and
-falls back to creating a **legacy SIV account** when the check fails. A legacy-SIV account is
+AES-GCM-SIV is not usable on every Android device: some platform providers accept the
+transformation name but return plain AES-GCM. The Android client checks a known-answer test vector
+at startup and creates a **legacy SIV account** when the check fails. A legacy-SIV account is
 therefore not necessarily an old account.
 
-Because the mode is account-wide, a device that cannot do AES-GCM-SIV cannot join a GCM-SIV account
-usefully; it will fail to decrypt what its peers write. Peers advertise which modes they can handle
-through their capability tags, which is how a client detects the mismatch before attempting to
-decrypt. See [capabilities.md](capabilities.md).
+Because the mode is account-wide, a device that cannot do AES-GCM-SIV cannot usefully join a
+GCM-SIV account; it will fail to decrypt what its peers write. Capability tags let a client spot
+that mismatch before it tries to decrypt. See [capabilities.md](capabilities.md).
 
 ## Blob encryption, out of scope
 

--- a/docs/protocol/encryption.md
+++ b/docs/protocol/encryption.md
@@ -1,0 +1,154 @@
+# Encryption
+
+Every module document is encrypted on the writing device and decrypted on the reading device. The
+server stores ciphertext, never sees a key, and cannot read or forge a document. It can still
+delete one, and it does see the metadata described in [http-api.md](http-api.md).
+
+The encryption mode is a property of the **account**, fixed when the account is created and shared
+by every device on it through the linking payload. It is not negotiated per peer and not per module.
+
+## Keyset on the wire
+
+The keyset travels inside the [link payload](linking.md) as:
+
+```json
+{
+  "type": "AES256_GCM_SIV",
+  "key": "<base64 of the Tink binary keyset proto>"
+}
+```
+
+- `type` is the mode identifier, either `AES256_GCM_SIV` or `AES256_SIV`.
+- `key` is base64 of a serialized Tink keyset proto, not a raw symmetric key. Parse it with Tink's
+  `TinkProtoKeysetFormat` (the Android client uses `parseKeyset` with `InsecureSecretKeyAccess`,
+  because the keyset is stored unwrapped by design: there is no server-side key management).
+
+An implementation that does not use Tink has to reproduce both the keyset proto parsing and the Tink
+ciphertext framing described below.
+
+## `AES256_GCM_SIV`, the default
+
+Default for accounts created by current clients.
+
+- Tink `Aead` primitive over an AES-256-GCM-SIV key.
+- Nonce-misuse resistant, but Tink still picks a **random nonce per encryption**, so encrypting the
+  same document twice produces different bytes. Never byte-compare ciphertext to detect change; use
+  the `ETag`.
+- **Associated data is used**: the UTF-8 bytes of
+
+  ```
+  <target device id>:<module id>
+  ```
+
+  for example `11111111-1111-1111-1111-111111111111:eu.darken.octi.module.core.power`. The device id
+  is the owner of the slot, written in the same lowercase UUID form used in the API, and the module
+  id is the full dotted identifier, not a shortened label.
+
+The associated data binds a document to its slot. Moving ciphertext to a different device id or
+module id makes decryption fail, which is what stops a malicious server from shuffling documents
+between slots.
+
+## `AES256_SIV`, legacy
+
+Used by accounts created before app version 1.0.0, and by new accounts on devices where AES-GCM-SIV
+is unavailable.
+
+- Tink `DeterministicAead` primitive over an AES-256-SIV key.
+- Deterministic: the same plaintext under the same key always yields the same ciphertext.
+- **Associated data is not used.** The encrypt and decrypt calls pass an empty byte array
+  unconditionally, and the caller-supplied associated data is discarded.
+
+This is the contrast that most often breaks a new implementation. Passing the
+`<deviceId>:<moduleId>` string as associated data to a legacy SIV keyset produces ciphertext that no
+existing Octi client can read, and fails to decrypt everything those clients wrote. The mode
+determines the associated data:
+
+| Mode | Primitive | Associated data |
+|---|---|---|
+| `AES256_GCM_SIV` | `Aead` | UTF-8 of `<deviceId>:<moduleId>` |
+| `AES256_SIV` | `DeterministicAead` | empty, always |
+
+## Layering
+
+The transport carries **bytes**. The known modules currently encode their documents as JSON, but the
+envelope does not require it and a client must not assume the plaintext is text.
+
+Writing:
+
+```
+module document bytes
+  -> gzip
+  -> AEAD encrypt (associated data per the table above)
+  -> base64            for PUT, as documentBase64
+     or raw bytes      for the legacy POST body
+```
+
+Reading reverses it exactly:
+
+```
+response body (or base64-decoded documentBase64)
+  -> AEAD decrypt (same associated data)
+  -> gunzip
+  -> module document bytes
+```
+
+The gzip layer is inside the encryption, so the server sees only ciphertext and never a compressible
+representation. Compression happens before encryption on every write, without exception; there is no
+"uncompressed" flag on the wire.
+
+A zero-length response body means the slot exists but holds no document. Do not attempt to decrypt
+it.
+
+## Tink ciphertext framing
+
+Both modes start with the same 5-byte prefix: the version byte `0x01` followed by the key id as
+4 bytes big-endian. What follows the prefix differs by mode.
+
+| Mode | After the prefix | Overhead over the encrypted input |
+|---|---|---|
+| `AES256_GCM_SIV` | 12-byte random nonce, then ciphertext, then a 16-byte tag | 33 bytes |
+| `AES256_SIV` | 16-byte synthetic IV, which doubles as the authentication tag, then ciphertext | 21 bytes |
+
+Legacy SIV carries no random nonce. Its synthetic IV is derived from the key and the plaintext,
+which is what makes the mode deterministic. The 12-byte difference between the two overheads is
+exactly that nonce, and the committed vectors show it: every GCM-SIV ciphertext is 33 bytes longer
+than the gzipped document it wraps, every SIV ciphertext 21 bytes longer.
+
+Pin the leading `0x01`. It is what catches a silent Tink wire-format upgrade on the producing side,
+and it is the check the committed interop fixtures perform. See
+[stability.md](stability.md).
+
+## Mode availability
+
+AES-GCM-SIV is not usable on every Android device: some platform providers accept the transformation
+name but return plain AES-GCM. The Android client verifies a known-answer test vector at startup and
+falls back to creating a **legacy SIV account** when the check fails. A legacy-SIV account is
+therefore not necessarily an old account.
+
+Because the mode is account-wide, a device that cannot do AES-GCM-SIV cannot join a GCM-SIV account
+usefully; it will fail to decrypt what its peers write. Peers advertise which modes they can handle
+through their capability tags, which is how a client detects the mismatch before attempting to
+decrypt. See [capabilities.md](capabilities.md).
+
+## Blob encryption, out of scope
+
+Blob content uses a separate scheme that this revision does not specify: Tink's streaming AEAD
+(`AesGcmHkdfStreaming`, 1 MB segments) under a key derived from the account keyset with HKDF-SHA256,
+salt `octi-blob` and info `octi-blob-stream-v1`, with associated data
+`<deviceId>:<moduleId>:<blobKey>`; legacy SIV keysets are rejected outright for blob encryption.
+Read [`StreamingPayloadCipher.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/core/blob/StreamingPayloadCipher.kt)
+and the committed vectors in
+[`streaming-vectors.json`](../../sync-core/src/test/resources/interop/streaming-vectors.json) if you
+need it.
+
+## Source
+
+- [`PayloadEncryption.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt),
+  the keyset facade and both primitives.
+- [`EncryptionMode.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/core/encryption/EncryptionMode.kt),
+  the two mode identifiers.
+- [`CryptoBootstrap.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/core/encryption/CryptoBootstrap.kt),
+  the availability check.
+- [`tink-vectors.json`](../../sync-core/src/test/resources/interop/tink-vectors.json), committed
+  ciphertext with the keysets needed to decrypt it, and
+  [the fixtures README](../../sync-core/src/test/resources/interop/README.md) explaining the format.

--- a/docs/protocol/http-api.md
+++ b/docs/protocol/http-api.md
@@ -1,7 +1,7 @@
 # HTTP API
 
-All endpoints live under `/v1/`. A server address is a protocol, a domain, and a port, so the base
-URL a client builds is:
+All endpoints live under `/v1/`. A server address is a protocol, a domain and a port, so the base
+URL is:
 
 ```
 <protocol>://<domain>:<port>/v1/
@@ -9,8 +9,8 @@ URL a client builds is:
 
 for example `https://octi.example.invalid:443/v1/`.
 
-Error responses carry a human-readable **plain text** body, not JSON. Clients must branch on the
-status code and the `X-Octi-Reason` header, never on the body text.
+Error bodies are human-readable plain text, not JSON. Branch on the status code and the
+`X-Octi-Reason` header, never on the body text.
 
 ## Authentication
 
@@ -21,10 +21,10 @@ Every request except registration carries two headers:
 | `Authorization` | `Basic ` + base64 of `<accountId>:<devicePassword>` |
 | `X-Device-ID` | The caller's device UUID |
 
-The server splits the decoded credential on the first `:`, parses the left half as the account UUID,
-and looks up the device by the pair (account id, device id). The password is compared in constant
-time. Both headers are required together: the device id identifies which device inside the account
-is calling, and the account id comes only from the credential.
+The server splits the decoded credential on the first `:`, parses the left half as the account
+UUID, and looks up the device by (account id, device id). The password is compared in constant
+time. Both headers are required: the device id identifies which device inside the account is
+calling, and the account id comes only from the credential.
 
 Authentication failures:
 
@@ -35,13 +35,12 @@ Authentication failures:
 | `404` | No device with that (account id, device id) pair |
 | `401` | Device exists but the password does not match |
 
-The Android client treats `401`, `404` and `410` on any call as "this device is no longer
-registered" and pauses the connector. The server at the pinned revision never returns `410`; the
-client accepts it defensively.
+The Android client treats `401`, `404` and `410` on any call as "no longer registered" and pauses
+the connector. The pinned server never returns `410`; the client accepts it defensively.
 
 ## Device metadata headers
 
-A client may send these on any request. They are how a device advertises itself to its peers.
+Optional on any request. This is how a device advertises itself to peers.
 
 | Header | Meaning |
 |---|---|
@@ -50,27 +49,26 @@ A client may send these on any request. They are how a device advertises itself 
 | `Octi-Device-Label` | Human-readable device name |
 | `Octi-Device-Capabilities` | JSON array of capability tags, see [capabilities.md](capabilities.md) |
 
-Server rules:
+How the server treats them:
 
 - Values are stored on the device record and echoed back to peers through `GET /v1/devices`.
-- A header that is **absent** leaves the stored value untouched. There is no way to clear a value by
-  omitting the header. Sending a header with a new value overwrites the stored one.
-- `Octi-Device-Label` is trimmed and truncated to 128 characters. A value that is blank after
-  trimming normalizes to null, and null means different things on the two paths. At
-  **registration** the device is created with no label. On an **existing** device null is
-  indistinguishable from an absent header and is treated as no update, so the previously stored
-  label survives. There is no way to clear a label over HTTP at this revision.
+- An absent header leaves the stored value untouched; a header with a new value overwrites it.
+  Omitting a header never clears a value.
+- `Octi-Device-Label` is trimmed and truncated to 128 characters. Blank after trimming normalizes
+  to null, which means different things on the two paths. At **registration** the device is
+  created with no label. On an **existing** device it looks like an absent header and is treated as
+  no update, so the stored label survives. A label cannot be cleared over HTTP at this revision.
 - `Octi-Device-Version` and `Octi-Device-Platform` are stored verbatim, with no length or charset
   constraint at this revision.
 - `Octi-Device-Capabilities` is validated as a whole set. One bad tag discards the entire header
   value; the request itself still succeeds. See [capabilities.md](capabilities.md).
-- During registration only, `Octi-Device-Version` falls back to the `User-Agent` header when absent.
-- Metadata is recorded only for requests that pass both authentication and the per-account rate
-  limit, so a rejected request does not update `lastSeen` or any metadata field.
+- During registration only, `Octi-Device-Version` falls back to the `User-Agent` header when
+  absent.
+- Metadata is recorded only for requests that pass authentication and the per-account rate limit,
+  so a rejected request updates neither `lastSeen` nor any metadata field.
 
-Producer policy is separate from the server rule. The Android client derives its label by stripping
-non-printable ASCII from the device model and truncating to 128 characters. That filter is the
-client's own choice; the server neither requires nor enforces it, and other clients are not bound to
+Producer policy is separate. The Android client strips non-printable ASCII from the device model
+and truncates to 128 characters. The server does not require that, and other clients need not copy
 it.
 
 ## Identifiers and validation
@@ -105,16 +103,16 @@ Routes served at the pinned server revision:
 | `GET /v1/myip` | Returns `{"ip":"<caller ip>"}`, unauthenticated | no |
 | `GET /v1/ws` | WebSocket upgrade, see [websocket.md](websocket.md) | yes |
 
-`DELETE /v1/module/{moduleId}` is listed so the endpoint set is not silently partial. It exists,
-takes the same `device-id` query parameter as the other module routes, deletes the document together
-with every blob it references, and emits a `deleted` notification. No shipping client calls it.
+`DELETE /v1/module/{moduleId}` is listed so the endpoint set is not silently partial. It takes the
+same `device-id` parameter as the other module routes, deletes the document and every blob it
+references, and emits a `deleted` notification. No shipping client calls it.
 
 ## Account endpoints
 
 ### `POST /v1/account`
 
-Registers the calling device. With `?share=<code>` it joins the account behind that code; without
-it, a new account is created. See [linking.md](linking.md) for the full flow.
+Registers the calling device. With `?share=<code>` it joins that code's account; without it, a new
+account is created. See [linking.md](linking.md) for the full flow.
 
 Request: `X-Device-ID` required, `Authorization` must **not** be present, device metadata headers
 optional.
@@ -135,21 +133,21 @@ Response `200`:
 
 On `403` because the account vanished, and on `409`, the share code is restored and can be retried.
 
-The credential check is narrower than "no `Authorization` header". The server rejects only a
-header it can parse as Basic credentials: the value must start with `Basic `, the remainder must
-base64-decode, the decoded text must contain a `:`, and the part before that `:` must parse as a
-UUID. Anything else is treated as if no header were present and the registration proceeds. A
-`Bearer` token, a `Basic ` value that is not valid base64, and Basic credentials whose username is
-not a UUID all fall into that gap. It matters most with `?share=`: the credential check runs
-before the share is consumed, so a header the server rejects leaves the code usable, while a
-header it ignores lets the registration complete and burn the one-use code. Send no
-`Authorization` header at all.
+The check is narrower than "no `Authorization` header". The server rejects only a header it can
+parse as Basic credentials: it starts with `Basic `, the rest base64-decodes, the decoded text
+contains a `:`, and the part before that `:` parses as a UUID. Anything else counts as no header
+and the
+registration proceeds. A `Bearer` token, a `Basic ` value that is not valid base64, and Basic
+credentials with a non-UUID username all fall into that gap.
+
+The gap matters with `?share=`: the check runs before the share is consumed, so a rejected header
+leaves the code usable while an ignored one burns it. Send no `Authorization` header at all.
 
 ### `DELETE /v1/account`
 
-Authenticated. Deletes the account: aborts upload sessions, releases quota, deletes every device,
-every share, and all stored data. Responds `200` with no body. Not reversible and not confirmable;
-the caller's own registration is destroyed too.
+Authenticated. Aborts upload sessions, releases quota, and deletes every device, every share and
+all stored data. Responds `200` with no body. Not reversible, not confirmable, and it destroys the
+caller's own registration too.
 
 ### `POST /v1/account/share`
 
@@ -184,15 +182,15 @@ discovery endpoint for everything an operator can tune.
 
 All seventeen fields are always present. `availableBytes` is
 `max(0, accountQuotaBytes - usedBytes - reservedBytes)`. `reservedBytes` covers blob upload sessions
-that have reserved space but not yet committed.
+that reserved space but have not committed.
 
-`storageApiVersion` is the feature probe for the blob layer: the Android client treats a value of
-`1` or higher as "this server supports blob-backed modules" and a `404` or `405` on this endpoint as
-"legacy server, no blob support". The value at this revision is `2`. A client that never uses blobs
-does not need to call this endpoint at all.
+`storageApiVersion` is the feature probe for the blob layer. The Android client treats `1` or
+higher as "blob-backed modules supported", and a `404` or `405` here as "legacy server, no blob
+support". The value at this revision is `2`. A client that never uses blobs need not call this
+endpoint.
 
-The Android client's DTO decodes only five of these fields. That is a client limitation, not the
-contract; the response above is what the server sends.
+The Android client's DTO decodes only five of these fields. That is a client limitation; the server
+sends the response above.
 
 ## Device endpoints
 
@@ -218,23 +216,23 @@ Authenticated. Lists every device on the caller's account, including the caller.
 
 Field notes:
 
-- `version`, `platform` and `label` are always present and are `null` when the device has never
+- `version`, `platform` and `label` are always present, and `null` when the device has never
   reported them.
 - `capabilities` is **omitted entirely** when the device has never reported a valid capability set.
   When present it is a real JSON array of strings, not a stringified one. See
   [capabilities.md](capabilities.md).
 - `addedAt` and `lastSeen` are ISO-8601 instants in UTC.
 
-This is also how a client discovers which peers exist. There is no separate peer list.
+This is also how a client discovers its peers. There is no separate peer list.
 
 ### `DELETE /v1/devices/{deviceId}`
 
-Authenticated. Removes another device (or the caller) from the account, aborting its upload sessions
-and deleting all of its stored modules. `400` if the path segment is not a UUID, `404` if no such
-device is on this account, `200` on success.
+Authenticated. Removes another device (or the caller), aborting its upload sessions and deleting
+all of its stored modules. `400` if the path segment is not a UUID, `404` if no such device is on
+this account, `200` on success.
 
-The removed device's credentials stop working immediately. Its next request gets `404`, which is how
-a client learns it was revoked.
+The removed device's credentials stop working at once. Its next request gets `404`, which is how it
+learns it was revoked.
 
 ### `POST /v1/devices/reset`
 
@@ -245,12 +243,11 @@ Authenticated. Deletes stored module data without removing the device registrati
 ```
 
 An empty `targets` array means every device on the account. `404` if any listed device is not on
-this account, and in that case nothing is reset. `200` on success.
+this account, and nothing is reset in that case. `200` on success.
 
 Client divergence: the server expects `targets` to be an array of UUID **strings**. The Android
-client's request DTO would encode each entry as an object of the form `{"id": "<uuid>"}`, which the
-server would reject with `400`. This never fires today because the Android client only ever sends an
-empty list.
+client's DTO would encode each entry as `{"id": "<uuid>"}`, which the server rejects with `400`. It
+never fires today because the Android client only ever sends an empty list.
 
 ## Module endpoints
 
@@ -260,8 +257,8 @@ All three take the same target selector:
 /v1/module/{moduleId}?device-id=<target device uuid>
 ```
 
-`moduleId` is the owner-independent module identifier; `device-id` selects whose copy is addressed.
-Reading a peer's document and writing your own use the same route with a different `device-id`.
+`moduleId` is the same for every owner; `device-id` selects whose copy is addressed. Reading a
+peer's document and writing your own use the same route with a different `device-id`.
 
 ### `GET /v1/module/{moduleId}?device-id=`
 
@@ -282,23 +279,21 @@ A `200` response carries:
 | `ETag` | Current strong entity tag, quoted, 32 lowercase hex characters |
 | `Content-Type` | `application/octet-stream` |
 
-The body is the raw stored bytes, which is the ciphertext described in
-[encryption.md](encryption.md). It may be zero length. The `ETag` header is present whenever
-metadata exists.
+The body is the raw stored bytes, the ciphertext from [encryption.md](encryption.md). It may be
+zero length. `ETag` is present whenever metadata exists.
 
-Two client-side notes. The Android client reads the standard `Date` response header to estimate its
-clock offset against the server; that is ordinary HTTP, not an Octi extension. It also treats a body
-consisting of the four bytes `null` as empty. The pinned server never emits that, so a new client
-does not need the tolerance.
+Two Android quirks. It reads the standard `Date` response header to estimate its clock offset
+against the server, ordinary HTTP rather than an Octi extension. It treats a body of the four bytes
+`null` as empty; the pinned server never emits that.
 
 ### Write semantics and concurrency
 
-There are two write verbs and they are not interchangeable. Getting this wrong is the easiest way
-for a third-party client to destroy a peer's data.
+The two write verbs are not interchangeable. Confusing them is the easiest way to destroy a peer's
+data.
 
-`POST` is the **unconditional legacy write**. The body is the raw ciphertext. It has no precondition
-and always overwrites. Once a module has external blob references it stops working entirely and
-returns `409`, because an unconditional raw write cannot express what should happen to the blobs.
+`POST` is the **unconditional legacy write**. The body is raw ciphertext, there is no precondition,
+and it always overwrites. Once a module has external blob references it returns `409`, since a raw
+overwrite cannot say what happens to the blobs.
 
 `PUT` is the **conditional commit**. It requires exactly one applicable precondition:
 
@@ -317,15 +312,14 @@ Rules the server enforces:
 - A malformed entity tag is `400`. Weak tags (`W/"..."`) are rejected outright, since `If-Match`
   requires strong comparison. Both `"quoted"` and bare unquoted forms are accepted.
 
-**On `412`, re-read before retrying.** A `412` means the slot changed since the tag you hold was
-issued. Repeating the same body with a refreshed tag silently discards whatever the other writer
-committed. Read the current document, reconcile, then write. The Android client refreshes its cached
-tag and retries once, which is safe only because the single-writer invariant means the concurrent
-writer was itself.
+**On `412`, re-read before retrying.** The slot changed since the tag you hold was issued.
+Repeating the same body with a refreshed tag silently discards what the other writer committed.
+Read, reconcile, then write. The Android client refreshes its cached tag and retries once, safe only
+because the single-writer invariant means the concurrent writer was itself.
 
 Entity tags are **random 16-byte values, hex-encoded**, regenerated on every successful write. They
-are not derived from the content, so an identical document written twice produces two different
-tags. Compare them for equality only.
+are not content-derived, so writing an identical document twice gives two different tags. Compare
+them for equality only.
 
 ### `POST /v1/module/{moduleId}?device-id=`
 
@@ -350,9 +344,8 @@ Body: JSON.
 }
 ```
 
-`blobRefs` may be omitted or empty; a client that does not use blobs always sends it empty. Each
-listed blob must have been uploaded through the blob session routes, which this revision does not
-specify.
+`blobRefs` may be omitted or empty; a client without blobs always sends it empty. Each listed blob
+must already be uploaded through the blob session routes, which this revision does not specify.
 
 | Status | Meaning |
 |---|---|
@@ -363,8 +356,8 @@ specify.
 | `413` | Decoded document exceeds `maxModuleDocumentBytes` (default 256 KiB) |
 | `507` | Account quota exceeded, with `X-Octi-Reason: account_quota_exceeded` |
 
-The route's raw body limit is twice `maxModuleDocumentBytes`, which leaves room for base64 expansion
-of a document at the maximum size.
+The route's raw body limit is twice `maxModuleDocumentBytes`, leaving room for base64 expansion of
+a document at the maximum size.
 
 The Android client falls back from `PUT` to `POST` on `404` or `405`, treating those as "this server
 predates blob support".
@@ -395,17 +388,16 @@ Only ever sent alongside `507`, with exactly two defined values:
 | `account_quota_exceeded` | module `POST`, module `PUT`, and blob session routes | The account is at its storage quota |
 | `server_disk_low` | blob routes only | The server host is below its free-disk floor |
 
-A module write therefore never produces `server_disk_low`. A client that only writes documents needs
-to handle `account_quota_exceeded`, and should treat a `507` with a missing or unrecognized reason as
-a generic storage refusal rather than an error.
+A module write therefore never produces `server_disk_low`. A client that only writes documents
+handles `account_quota_exceeded`, and should treat a `507` with a missing or unknown reason as a
+generic storage refusal.
 
 `Retry-After` is emitted only in delta-seconds form, never as an HTTP-date.
 
 ## Limits and rate limiting
 
-Every value in the table below is a **deployment-configurable default** read from the server's
-configuration, not a protocol constant. `GET /v1/account/storage` reports the live values for most
-of them.
+Every value below is a **deployment-configurable default** from the server's configuration, not a
+protocol constant. `GET /v1/account/storage` reports the live values for most of them.
 
 | Limit | Default | Notes |
 |---|---|---|
@@ -419,19 +411,17 @@ of them.
 | Per-account rate limit | 256 requests per 60 s | `429` with `Retry-After` |
 
 Rate limiting is layered. The per-IP limiter runs before authentication and counts every request
-except CORS preflight `OPTIONS`. The per-account limiter runs after credentials validate, so a
-shared NAT address does not let one account exhaust another's budget. Both can be disabled by the
-operator with a single switch.
+except CORS preflight `OPTIONS`. The per-account limiter runs after credentials validate, so one
+account on a shared NAT address cannot exhaust another's budget. An operator can disable both with
+one switch.
 
-Browser clients face one more gate: the server's CORS allowlist. It ships with the official octi-web
-origins and an operator can replace or empty it. Non-browser clients are unaffected regardless of
-that setting.
+Browser clients face one more gate: the server's CORS allowlist. It ships with the official
+octi-web origins; an operator can replace or empty it. Non-browser clients are unaffected.
 
 ### Retention and garbage collection
 
-The server deletes idle data on its own. Both sweeps are destructive, neither is announced to the
-client, and a third-party client that assumes the server keeps what it wrote indefinitely will lose
-data.
+The server deletes idle data on its own. Both sweeps are destructive and neither is announced, so a
+client that assumes the server keeps what it wrote indefinitely will lose data.
 
 | Sweep | Deletes | Clock it reads | Threshold | Interval |
 |---|---|---|---|---|
@@ -441,28 +431,28 @@ data.
 Both loops run every 10 minutes, with the first pass one minute after server start, so deletion
 happens up to one interval after the threshold is crossed.
 
-`lastSeen` is refreshed by any request **from that device** that passes both authentication and the
-per-account rate limit, including the WebSocket upgrade. It tracks the caller only. A peer reading
-or writing your slots does not refresh your `lastSeen`, so a client that goes quiet for 90 days is
-deleted together with all of its data even while its peers are still reading that data. Its next
-request gets `404`, exactly as if it had been revoked, and it has to register again. The value is
-kept in memory and written to disk at most once every 30 seconds.
+`lastSeen` is refreshed by any request **from that device** that passes authentication and the
+per-account rate limit, including the WebSocket upgrade. It tracks the caller only: a peer reading
+or writing your slots does not refresh your `lastSeen`. A device that goes quiet for 90 days is
+deleted with all
+of its data, even while its peers still read that data. Its next request gets `404`, as if it had
+been revoked, and it must register again. The value lives in memory and is written to disk at most
+once every 30 seconds.
 
-A module's last-access time is refreshed by reading the slot, by any device on the account, by
+A module's last-access time is refreshed by reading the slot, from any device on the account, by
 writing it with `POST` or `PUT`, and by the blob routes: listing blobs, downloading a blob, and
-creating, appending to or finalizing an upload session. It is held in memory and persisted at most
-once every 30 seconds; when no persisted value exists the server falls back to the modification time
-of the slot's metadata file, then of its payload file.
+creating, appending to or finalizing an upload session. It lives in memory and is persisted at most
+once every 30 seconds. With no persisted value the server falls back to the modification time of
+the slot's metadata file, then of its payload file.
 
-Module GC skips a slot that has an upload session which is active, or finalized but not yet
-committed, and has not itself expired, so an in-flight upload cannot be reaped underneath itself.
-Device GC has no equivalent exemption: it aborts the device's upload sessions and deletes it.
+Module GC skips a slot whose upload session is active, or finalized but not yet committed, and has
+not itself expired, so an in-flight upload cannot be reaped underneath itself. Device GC has no
+such exemption: it aborts the device's upload sessions and deletes it.
 
 Both thresholds are server configuration with a 90-day default. `GET /v1/account/storage` does not
-report them, and the pinned revision parses no command-line flag for either one, so a client cannot
-discover a deployment's values and must not hard-code 90 days. Treat "stored data disappears after
-long inactivity" as the contract: keep talking to the server, and be able to re-upload rather than
-assuming the server still holds what you wrote.
+report them and the pinned revision parses no command-line flag for either one, so a client cannot
+discover a deployment's values. Do not hard-code 90 days. Treat "stored data disappears after long
+inactivity" as the contract: keep talking to the server, and be able to re-upload.
 
 ## Blob layer, out of scope
 
@@ -479,7 +469,7 @@ POST   /v1/module/{moduleId}/blob-sessions/{sessionId}/finalize
 DELETE /v1/module/{moduleId}/blob-sessions/{sessionId}
 ```
 
-They implement resumable chunked upload, download, and lifecycle for file attachments. A client that
+They implement resumable chunked upload, download and lifecycle for file attachments. A client that
 never attaches files never touches them, and can always send `PUT` with an empty `blobRefs` list.
 
 For the shapes, read the client's Retrofit declarations in
@@ -501,7 +491,6 @@ and for the encryption of blob content the committed vectors in
 | `eu.darken.octi.module.core.clipboard` | Shared clipboard |
 | `eu.darken.octi.module.core.files` | Shared files |
 
-Module ids are opaque to the protocol. This table is the set the Android client currently produces
-and consumes, not a closed enumeration. A client that encounters an unknown module id must ignore
-that slot and continue, never reject the peer or the response. The document schemas behind these ids
-are out of scope for this revision.
+Module ids are opaque to the protocol. This table is what the Android client currently produces and
+consumes, not a closed set. Ignore an unknown module id and carry on; never reject the peer or the
+response. The document schemas behind these ids are out of scope for this revision.

--- a/docs/protocol/http-api.md
+++ b/docs/protocol/http-api.md
@@ -1,0 +1,507 @@
+# HTTP API
+
+All endpoints live under `/v1/`. A server address is a protocol, a domain, and a port, so the base
+URL a client builds is:
+
+```
+<protocol>://<domain>:<port>/v1/
+```
+
+for example `https://octi.example.invalid:443/v1/`.
+
+Error responses carry a human-readable **plain text** body, not JSON. Clients must branch on the
+status code and the `X-Octi-Reason` header, never on the body text.
+
+## Authentication
+
+Every request except registration carries two headers:
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Basic ` + base64 of `<accountId>:<devicePassword>` |
+| `X-Device-ID` | The caller's device UUID |
+
+The server splits the decoded credential on the first `:`, parses the left half as the account UUID,
+and looks up the device by the pair (account id, device id). The password is compared in constant
+time. Both headers are required together: the device id identifies which device inside the account
+is calling, and the account id comes only from the credential.
+
+Authentication failures:
+
+| Status | Cause |
+|---|---|
+| `400` | `X-Device-ID` missing or not a UUID |
+| `400` | `Authorization` missing, not `Basic`, not decodable, or without a `:` |
+| `404` | No device with that (account id, device id) pair |
+| `401` | Device exists but the password does not match |
+
+The Android client treats `401`, `404` and `410` on any call as "this device is no longer
+registered" and pauses the connector. The server at the pinned revision never returns `410`; the
+client accepts it defensively.
+
+## Device metadata headers
+
+A client may send these on any request. They are how a device advertises itself to its peers.
+
+| Header | Meaning |
+|---|---|
+| `Octi-Device-Version` | Client version string |
+| `Octi-Device-Platform` | Platform identifier, `android` for the Android client |
+| `Octi-Device-Label` | Human-readable device name |
+| `Octi-Device-Capabilities` | JSON array of capability tags, see [capabilities.md](capabilities.md) |
+
+Server rules:
+
+- Values are stored on the device record and echoed back to peers through `GET /v1/devices`.
+- A header that is **absent** leaves the stored value untouched. There is no way to clear a value by
+  omitting the header. Sending a header with a new value overwrites the stored one.
+- `Octi-Device-Label` is trimmed and truncated to 128 characters. A value that is blank after
+  trimming normalizes to null, and null means different things on the two paths. At
+  **registration** the device is created with no label. On an **existing** device null is
+  indistinguishable from an absent header and is treated as no update, so the previously stored
+  label survives. There is no way to clear a label over HTTP at this revision.
+- `Octi-Device-Version` and `Octi-Device-Platform` are stored verbatim, with no length or charset
+  constraint at this revision.
+- `Octi-Device-Capabilities` is validated as a whole set. One bad tag discards the entire header
+  value; the request itself still succeeds. See [capabilities.md](capabilities.md).
+- During registration only, `Octi-Device-Version` falls back to the `User-Agent` header when absent.
+- Metadata is recorded only for requests that pass both authentication and the per-account rate
+  limit, so a rejected request does not update `lastSeen` or any metadata field.
+
+Producer policy is separate from the server rule. The Android client derives its label by stripping
+non-printable ASCII from the device model and truncating to 128 characters. That filter is the
+client's own choice; the server neither requires nor enforces it, and other clients are not bound to
+it.
+
+## Identifiers and validation
+
+| Identifier | Rule |
+|---|---|
+| Account id | UUID. Issued by the server at registration. |
+| Device id | UUID. Chosen by the client. Registrable **once globally**: a second `POST /v1/account` with a device id that already exists anywhere on the server returns `400`. |
+| Module id | Semantically opaque to the server, syntactically constrained: at most **1024** characters and matching `^[a-z]+(\.[a-z0-9_]+)*$`. Anything else returns `400`. |
+| `device-id` query parameter | UUID of a device on the caller's account. Not a UUID gives `400`; not a device on this account gives `404`. |
+
+## Endpoint index
+
+Routes served at the pinned server revision:
+
+| Method and path | Purpose | Called by shipping clients |
+|---|---|---|
+| `POST /v1/account` | Register a device, creating or joining an account | yes |
+| `DELETE /v1/account` | Delete the whole account | yes |
+| `POST /v1/account/share` | Create a share code | yes |
+| `GET /v1/account/storage` | Quota and server limits | yes |
+| `GET /v1/devices` | List the account's devices | yes |
+| `DELETE /v1/devices/{deviceId}` | Remove one device | yes |
+| `POST /v1/devices/reset` | Wipe module data for devices | yes |
+| `GET /v1/module/{moduleId}` | Read a document | yes |
+| `POST /v1/module/{moduleId}` | Unconditional legacy write | yes |
+| `PUT /v1/module/{moduleId}` | Conditional write with blob references | yes |
+| `DELETE /v1/module/{moduleId}` | Delete a document and everything it references | **no** |
+| `GET /v1/module/{moduleId}/blobs` and the other blob routes | Blob transfer, see the scope note below | partially |
+| `GET /v1/status` | Liveness probe, returns `{"status":"ok"}`, unauthenticated | no |
+| `GET /v1/metrics` | Aggregate server counters, unauthenticated | no |
+| `GET /v1/myip` | Returns `{"ip":"<caller ip>"}`, unauthenticated | no |
+| `GET /v1/ws` | WebSocket upgrade, see [websocket.md](websocket.md) | yes |
+
+`DELETE /v1/module/{moduleId}` is listed so the endpoint set is not silently partial. It exists,
+takes the same `device-id` query parameter as the other module routes, deletes the document together
+with every blob it references, and emits a `deleted` notification. No shipping client calls it.
+
+## Account endpoints
+
+### `POST /v1/account`
+
+Registers the calling device. With `?share=<code>` it joins the account behind that code; without
+it, a new account is created. See [linking.md](linking.md) for the full flow.
+
+Request: `X-Device-ID` required, `Authorization` must **not** be present, device metadata headers
+optional.
+
+Response `200`:
+
+```json
+{ "account": "<account uuid>", "password": "<device password>" }
+```
+
+| Status | Cause |
+|---|---|
+| `400` | `X-Device-ID` missing or not a UUID |
+| `400` | Device id already registered anywhere on this server |
+| `400` | `Authorization` parsed as Basic credentials |
+| `403` | `?share=` did not match a stored share, or its account no longer exists |
+| `409` | Account is at its device limit (default 64, deployment-configurable) |
+
+On `403` because the account vanished, and on `409`, the share code is restored and can be retried.
+
+The credential check is narrower than "no `Authorization` header". The server rejects only a
+header it can parse as Basic credentials: the value must start with `Basic `, the remainder must
+base64-decode, the decoded text must contain a `:`, and the part before that `:` must parse as a
+UUID. Anything else is treated as if no header were present and the registration proceeds. A
+`Bearer` token, a `Basic ` value that is not valid base64, and Basic credentials whose username is
+not a UUID all fall into that gap. It matters most with `?share=`: the credential check runs
+before the share is consumed, so a header the server rejects leaves the code usable, while a
+header it ignores lets the registration complete and burn the one-use code. Send no
+`Authorization` header at all.
+
+### `DELETE /v1/account`
+
+Authenticated. Deletes the account: aborts upload sessions, releases quota, deletes every device,
+every share, and all stored data. Responds `200` with no body. Not reversible and not confirmable;
+the caller's own registration is destroyed too.
+
+### `POST /v1/account/share`
+
+Authenticated. Returns `{"code": "<share code>"}`. See [linking.md](linking.md).
+
+### `GET /v1/account/storage`
+
+Authenticated. Reports the account's usage plus the server's configured limits. This is the
+discovery endpoint for everything an operator can tune.
+
+```json
+{
+  "storageApiVersion": 2,
+  "accountQuotaBytes": 52428800,
+  "usedBytes": 0,
+  "reservedBytes": 0,
+  "availableBytes": 52428800,
+  "maxBlobBytes": 10485760,
+  "maxModuleDocumentBytes": 262144,
+  "maxActiveUploadSessionsPerDevice": 8,
+  "idleSessionTtlSeconds": 3600,
+  "absoluteSessionTtlSeconds": 86400,
+  "maxDevicesPerAccount": 64,
+  "maxModulesPerDevice": 256,
+  "maxBlobRefsPerModule": 64,
+  "maxActiveUploadSessionsPerAccount": 32,
+  "completeIdleTtlSeconds": 600,
+  "accountRateLimit": 256,
+  "accountRateLimitWindowSeconds": 60
+}
+```
+
+All seventeen fields are always present. `availableBytes` is
+`max(0, accountQuotaBytes - usedBytes - reservedBytes)`. `reservedBytes` covers blob upload sessions
+that have reserved space but not yet committed.
+
+`storageApiVersion` is the feature probe for the blob layer: the Android client treats a value of
+`1` or higher as "this server supports blob-backed modules" and a `404` or `405` on this endpoint as
+"legacy server, no blob support". The value at this revision is `2`. A client that never uses blobs
+does not need to call this endpoint at all.
+
+The Android client's DTO decodes only five of these fields. That is a client limitation, not the
+contract; the response above is what the server sends.
+
+## Device endpoints
+
+### `GET /v1/devices`
+
+Authenticated. Lists every device on the caller's account, including the caller.
+
+```json
+{
+  "devices": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "version": "1.2.3",
+      "platform": "android",
+      "label": "Example Phone",
+      "capabilities": ["encryption:AES256_GCM_SIV", "encryption:AES256_SIV", "encryption:_reported"],
+      "addedAt": "2026-01-01T12:00:00Z",
+      "lastSeen": "2026-01-02T08:30:00Z"
+    }
+  ]
+}
+```
+
+Field notes:
+
+- `version`, `platform` and `label` are always present and are `null` when the device has never
+  reported them.
+- `capabilities` is **omitted entirely** when the device has never reported a valid capability set.
+  When present it is a real JSON array of strings, not a stringified one. See
+  [capabilities.md](capabilities.md).
+- `addedAt` and `lastSeen` are ISO-8601 instants in UTC.
+
+This is also how a client discovers which peers exist. There is no separate peer list.
+
+### `DELETE /v1/devices/{deviceId}`
+
+Authenticated. Removes another device (or the caller) from the account, aborting its upload sessions
+and deleting all of its stored modules. `400` if the path segment is not a UUID, `404` if no such
+device is on this account, `200` on success.
+
+The removed device's credentials stop working immediately. Its next request gets `404`, which is how
+a client learns it was revoked.
+
+### `POST /v1/devices/reset`
+
+Authenticated. Deletes stored module data without removing the device registrations.
+
+```json
+{ "targets": ["11111111-1111-1111-1111-111111111111"] }
+```
+
+An empty `targets` array means every device on the account. `404` if any listed device is not on
+this account, and in that case nothing is reset. `200` on success.
+
+Client divergence: the server expects `targets` to be an array of UUID **strings**. The Android
+client's request DTO would encode each entry as an object of the form `{"id": "<uuid>"}`, which the
+server would reject with `400`. This never fires today because the Android client only ever sends an
+empty list.
+
+## Module endpoints
+
+All three take the same target selector:
+
+```
+/v1/module/{moduleId}?device-id=<target device uuid>
+```
+
+`moduleId` is the owner-independent module identifier; `device-id` selects whose copy is addressed.
+Reading a peer's document and writing your own use the same route with a different `device-id`.
+
+### `GET /v1/module/{moduleId}?device-id=`
+
+Authenticated read.
+
+| Status | Meaning |
+|---|---|
+| `204` | No document metadata: the slot has never been written, or it was deleted. No headers, no body. |
+| `200` | Document present. |
+| `400` | Missing or malformed `moduleId`, missing or malformed `device-id` |
+| `404` | Target device is not on this account |
+
+A `200` response carries:
+
+| Header | Value |
+|---|---|
+| `X-Modified-At` | Server-side modification time as an HTTP-date (RFC 1123) |
+| `ETag` | Current strong entity tag, quoted, 32 lowercase hex characters |
+| `Content-Type` | `application/octet-stream` |
+
+The body is the raw stored bytes, which is the ciphertext described in
+[encryption.md](encryption.md). It may be zero length. The `ETag` header is present whenever
+metadata exists.
+
+Two client-side notes. The Android client reads the standard `Date` response header to estimate its
+clock offset against the server; that is ordinary HTTP, not an Octi extension. It also treats a body
+consisting of the four bytes `null` as empty. The pinned server never emits that, so a new client
+does not need the tolerance.
+
+### Write semantics and concurrency
+
+There are two write verbs and they are not interchangeable. Getting this wrong is the easiest way
+for a third-party client to destroy a peer's data.
+
+`POST` is the **unconditional legacy write**. The body is the raw ciphertext. It has no precondition
+and always overwrites. Once a module has external blob references it stops working entirely and
+returns `409`, because an unconditional raw write cannot express what should happen to the blobs.
+
+`PUT` is the **conditional commit**. It requires exactly one applicable precondition:
+
+| Situation | Header to send |
+|---|---|
+| Updating a document you have read | `If-Match: "<the ETag from your read>"` |
+| Creating a document that must not exist yet | `If-None-Match: *` |
+
+Rules the server enforces:
+
+- Sending both headers is `400`.
+- Sending neither is `412` with the message `PUT requires If-Match or If-None-Match: *`.
+- `If-None-Match: *` when the module already exists is `412`.
+- `If-Match` when the module does not exist is `412`.
+- `If-Match` whose value is not the current tag is `412`.
+- A malformed entity tag is `400`. Weak tags (`W/"..."`) are rejected outright, since `If-Match`
+  requires strong comparison. Both `"quoted"` and bare unquoted forms are accepted.
+
+**On `412`, re-read before retrying.** A `412` means the slot changed since the tag you hold was
+issued. Repeating the same body with a refreshed tag silently discards whatever the other writer
+committed. Read the current document, reconcile, then write. The Android client refreshes its cached
+tag and retries once, which is safe only because the single-writer invariant means the concurrent
+writer was itself.
+
+Entity tags are **random 16-byte values, hex-encoded**, regenerated on every successful write. They
+are not derived from the content, so an identical document written twice produces two different
+tags. Compare them for equality only.
+
+### `POST /v1/module/{moduleId}?device-id=`
+
+Body: raw ciphertext bytes. No content type is required.
+
+| Status | Meaning |
+|---|---|
+| `200` | Written. Response carries the new `ETag` header. |
+| `409` | The module has external blob references; use `PUT` |
+| `409` | Module count limit for this device reached (default 256) |
+| `413` | Body exceeds the payload limit (default 128 KiB) |
+| `507` | Account quota exceeded, with `X-Octi-Reason: account_quota_exceeded` |
+
+### `PUT /v1/module/{moduleId}?device-id=`
+
+Body: JSON.
+
+```json
+{
+  "documentBase64": "<base64 of the ciphertext>",
+  "blobRefs": [ { "blobId": "<blob id>" } ]
+}
+```
+
+`blobRefs` may be omitted or empty; a client that does not use blobs always sends it empty. Each
+listed blob must have been uploaded through the blob session routes, which this revision does not
+specify.
+
+| Status | Meaning |
+|---|---|
+| `200` | Committed. Response carries the `ETag` header and the body `{"etag":"<hex>"}` |
+| `400` | Both preconditions sent, malformed entity tag, invalid base64, duplicate `blobId` values, too many blob refs, or a `blobId` that cannot be resolved |
+| `412` | Precondition missing, stale, or not applicable |
+| `409` | Module count limit for this device reached |
+| `413` | Decoded document exceeds `maxModuleDocumentBytes` (default 256 KiB) |
+| `507` | Account quota exceeded, with `X-Octi-Reason: account_quota_exceeded` |
+
+The route's raw body limit is twice `maxModuleDocumentBytes`, which leaves room for base64 expansion
+of a document at the maximum size.
+
+The Android client falls back from `PUT` to `POST` on `404` or `405`, treating those as "this server
+predates blob support".
+
+## Errors
+
+| Status | Emitted by | Meaning |
+|---|---|---|
+| `400` | any | Malformed header, identifier, precondition, or body |
+| `401` | any authenticated route | Wrong device password |
+| `403` | `POST /v1/account` | Invalid share code, or its account is gone |
+| `404` | any authenticated route | Caller device unknown for this account |
+| `404` | module and device routes | Target device not on this account |
+| `409` | `POST /v1/account` | Device limit reached |
+| `409` | module writes | Blob-backed module written with `POST`, or module count limit |
+| `412` | `PUT /v1/module/...` | Precondition failed |
+| `413` | any | Request body or decoded document too large |
+| `429` | any | Rate limited, with `Retry-After` in delta-seconds |
+| `500` | any | Unhandled server error |
+| `507` | module writes, blob routes | Storage refusal, qualified by `X-Octi-Reason` |
+
+### `X-Octi-Reason`
+
+Only ever sent alongside `507`, with exactly two defined values:
+
+| Value | Emitted by | Meaning |
+|---|---|---|
+| `account_quota_exceeded` | module `POST`, module `PUT`, and blob session routes | The account is at its storage quota |
+| `server_disk_low` | blob routes only | The server host is below its free-disk floor |
+
+A module write therefore never produces `server_disk_low`. A client that only writes documents needs
+to handle `account_quota_exceeded`, and should treat a `507` with a missing or unrecognized reason as
+a generic storage refusal rather than an error.
+
+`Retry-After` is emitted only in delta-seconds form, never as an HTTP-date.
+
+## Limits and rate limiting
+
+Every value in the table below is a **deployment-configurable default** read from the server's
+configuration, not a protocol constant. `GET /v1/account/storage` reports the live values for most
+of them.
+
+| Limit | Default | Notes |
+|---|---|---|
+| Request body | 128 KiB | Global; the `PUT` module route raises it to 512 KiB |
+| Module document | 256 KiB | Checked after base64 decoding |
+| Devices per account | 64 | `409` at registration |
+| Modules per device | 256 | `409` on write |
+| Blob refs per module | 64 | `400` on commit |
+| Account storage quota | 50 MB | `507` with `account_quota_exceeded` |
+| Per-IP rate limit | 512 requests per 60 s | `429` with `Retry-After` |
+| Per-account rate limit | 256 requests per 60 s | `429` with `Retry-After` |
+
+Rate limiting is layered. The per-IP limiter runs before authentication and counts every request
+except CORS preflight `OPTIONS`. The per-account limiter runs after credentials validate, so a
+shared NAT address does not let one account exhaust another's budget. Both can be disabled by the
+operator with a single switch.
+
+Browser clients face one more gate: the server's CORS allowlist. It ships with the official octi-web
+origins and an operator can replace or empty it. Non-browser clients are unaffected regardless of
+that setting.
+
+### Retention and garbage collection
+
+The server deletes idle data on its own. Both sweeps are destructive, neither is announced to the
+client, and a third-party client that assumes the server keeps what it wrote indefinitely will lose
+data.
+
+| Sweep | Deletes | Clock it reads | Threshold | Interval |
+|---|---|---|---|---|
+| Device GC | The device registration and every module that device owns | `lastSeen` on the device record | 90 days | 10 minutes |
+| Module GC | One module slot, with its document and its blobs | The module's effective last-access time | 90 days | 10 minutes |
+
+Both loops run every 10 minutes, with the first pass one minute after server start, so deletion
+happens up to one interval after the threshold is crossed.
+
+`lastSeen` is refreshed by any request **from that device** that passes both authentication and the
+per-account rate limit, including the WebSocket upgrade. It tracks the caller only. A peer reading
+or writing your slots does not refresh your `lastSeen`, so a client that goes quiet for 90 days is
+deleted together with all of its data even while its peers are still reading that data. Its next
+request gets `404`, exactly as if it had been revoked, and it has to register again. The value is
+kept in memory and written to disk at most once every 30 seconds.
+
+A module's last-access time is refreshed by reading the slot, by any device on the account, by
+writing it with `POST` or `PUT`, and by the blob routes: listing blobs, downloading a blob, and
+creating, appending to or finalizing an upload session. It is held in memory and persisted at most
+once every 30 seconds; when no persisted value exists the server falls back to the modification time
+of the slot's metadata file, then of its payload file.
+
+Module GC skips a slot that has an upload session which is active, or finalized but not yet
+committed, and has not itself expired, so an in-flight upload cannot be reaped underneath itself.
+Device GC has no equivalent exemption: it aborts the device's upload sessions and deletes it.
+
+Both thresholds are server configuration with a 90-day default. `GET /v1/account/storage` does not
+report them, and the pinned revision parses no command-line flag for either one, so a client cannot
+discover a deployment's values and must not hard-code 90 days. Treat "stored data disappears after
+long inactivity" as the contract: keep talking to the server, and be able to re-upload rather than
+assuming the server still holds what you wrote.
+
+## Blob layer, out of scope
+
+The following routes exist at the pinned revision and are **not specified** here:
+
+```
+GET    /v1/module/{moduleId}/blobs
+GET    /v1/module/{moduleId}/blobs/{blobId}
+DELETE /v1/module/{moduleId}/blobs/{blobId}
+POST   /v1/module/{moduleId}/blob-sessions
+GET    /v1/module/{moduleId}/blob-sessions/{sessionId}
+PATCH  /v1/module/{moduleId}/blob-sessions/{sessionId}
+POST   /v1/module/{moduleId}/blob-sessions/{sessionId}/finalize
+DELETE /v1/module/{moduleId}/blob-sessions/{sessionId}
+```
+
+They implement resumable chunked upload, download, and lifecycle for file attachments. A client that
+never attaches files never touches them, and can always send `PUT` with an empty `blobRefs` list.
+
+For the shapes, read the client's Retrofit declarations in
+[`OctiServerApi.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServerApi.kt),
+the server's
+[`BlobRoute.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/module/BlobRoute.kt),
+and for the encryption of blob content the committed vectors in
+[`streaming-vectors.json`](../../sync-core/src/test/resources/interop/streaming-vectors.json).
+
+## Known module ids
+
+| Module id | Content |
+|---|---|
+| `eu.darken.octi.module.core.meta` | Device metadata |
+| `eu.darken.octi.module.core.power` | Battery and charging state |
+| `eu.darken.octi.module.core.wifi` | Wi-Fi connection information |
+| `eu.darken.octi.module.core.connectivity` | Network connectivity information |
+| `eu.darken.octi.module.core.apps` | Installed applications |
+| `eu.darken.octi.module.core.clipboard` | Shared clipboard |
+| `eu.darken.octi.module.core.files` | Shared files |
+
+Module ids are opaque to the protocol. This table is the set the Android client currently produces
+and consumes, not a closed enumeration. A client that encounters an unknown module id must ignore
+that slot and continue, never reject the peer or the response. The document schemas behind these ids
+are out of scope for this revision.

--- a/docs/protocol/http-api.md
+++ b/docs/protocol/http-api.md
@@ -155,8 +155,9 @@ Authenticated. Returns `{"code": "<share code>"}`. See [linking.md](linking.md).
 
 ### `GET /v1/account/storage`
 
-Authenticated. Reports the account's usage plus the server's configured limits. This is the
-discovery endpoint for everything an operator can tune.
+Authenticated. Reports the account's usage plus the server's configured limits. Use it to discover
+a deployment's values instead of hard-coding them. It does not report every server setting: the
+per-IP rate limit, the CORS allowlist and the retention thresholds are all absent.
 
 ```json
 {

--- a/docs/protocol/linking.md
+++ b/docs/protocol/linking.md
@@ -1,0 +1,170 @@
+# Linking
+
+How a second device joins an existing account. Two things have to travel from the host device to
+the joining device: a server-issued share code, and the account's encryption keyset. The server
+only knows about the first one.
+
+## 1. The host creates a share code
+
+```http
+POST /v1/account/share
+X-Device-ID: 11111111-1111-1111-1111-111111111111
+Authorization: Basic <base64 of accountId:devicePassword>
+```
+
+Response:
+
+```json
+{ "code": "0000example000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000example" }
+```
+
+The code is generated as 64 random bytes, hex-encoded, so it is 128 lowercase hex characters. Treat
+it as an opaque string; nothing in the protocol parses it.
+
+### Lifetime is best effort, not a hard TTL
+
+A share is stored with its creation time. Two mechanisms interact:
+
+- The server's `shareExpiration` defines when a share counts as expired. It is server
+  configuration with a 60-minute default, and the pinned revision parses no command-line flag for
+  it, so a client cannot discover a deployment's value.
+- Expired shares are deleted by a periodic sweep whose interval is `shareExpiration / 2`, so
+  **30 minutes** at the default.
+
+Redemption itself does **not** check age. `consumeShare()` looks the code up and removes it, without
+comparing timestamps. A code therefore stays redeemable until a sweep happens to remove it, which at
+default settings can be up to roughly 90 minutes after creation.
+
+Clients must not treat 60 minutes as a guarantee in either direction. Do not assume a code is dead
+after an hour, and do not assume one will still work.
+
+See [`ShareRepo.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/account/share/ShareRepo.kt)
+and the `shareExpiration` default in
+[`App.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/App.kt).
+
+### Redemption is transactional
+
+The registration handler consumes the share before it creates the device, and restores it if the
+registration cannot complete. The share is put back when:
+
+- the account referenced by the share no longer exists (response `403`),
+- the account is at its device limit (response `409`),
+- device creation fails for any other reason (the error propagates as `500`).
+
+A failed join therefore does not burn the code. See
+[`AccountRoute.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt).
+
+## 2. The host renders a link payload
+
+The share code alone is not enough: without the account's keyset the joining device could talk to
+the server but could not read or write anything. The host packages both into one payload, which it
+displays as a QR code or as text.
+
+The plaintext is JSON, defined by
+[`LinkingData.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt),
+with the sub-shapes from
+[`OctiServer.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/OctiServer.kt)
+and [`PayloadEncryption.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/core/encryption/PayloadEncryption.kt):
+
+```json
+{
+  "serverAddress": {
+    "domain": "octi.example.invalid",
+    "protocol": "https",
+    "port": 443
+  },
+  "shareCode": {
+    "code": "<the 128 hex characters from step 1>"
+  },
+  "encryptionKeySet": {
+    "type": "AES256_GCM_SIV",
+    "key": "<base64 of the Tink binary keyset proto>"
+  }
+}
+```
+
+Field notes:
+
+- `serverAddress.protocol` defaults to `https` and `serverAddress.port` to `443`, but the Android
+  encoder writes defaults explicitly, so both keys are present in payloads it produces. A decoder
+  should still apply those defaults if a key is missing.
+- `encryptionKeySet.type` is an [encryption mode](encryption.md) identifier, either
+  `AES256_GCM_SIV` or `AES256_SIV`.
+- `encryptionKeySet.key` is the base64 of the serialized Tink keyset, not a raw key. See
+  [encryption.md](encryption.md).
+
+The transported form is:
+
+```
+base64( gzip( utf8( json ) ) )
+```
+
+Decoding reverses that: base64 decode, gunzip, parse JSON.
+
+### Validity hints
+
+From [`LinkCodeShape.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkCodeShape.kt),
+useful for diagnosing a bad paste without logging the payload itself:
+
+- A complete payload is roughly **496 characters**. A much shorter one was truncated.
+- It always starts with `H4sI`, which is the base64 of the gzip magic bytes `1f 8b 08`. A payload
+  that does not is missing its beginning, which whitespace-tolerant base64 decoding cannot detect on
+  its own.
+- The Android client trims the code before decoding, and okio's base64 decoder additionally skips
+  ASCII space, tab, carriage return and line feed **anywhere** in the payload, so a code that an
+  email client line-wrapped still decodes. Any other stray character fails the decode outright.
+  The `alphabet` check in `LinkCodeShape.kt` does not allow those whitespace characters, so a
+  wrapped code that decodes successfully still reports `alphabet=false`. This is what the Android
+  decoder happens to accept, not a protocol guarantee; another client may be stricter, so a
+  producer should emit the code with no embedded whitespace.
+- The Android decoder accepts both the standard and the URL-safe base64 alphabets.
+
+## 3. The joining device registers
+
+```http
+POST /v1/account?share=<the 128 hex characters>
+X-Device-ID: 22222222-2222-2222-2222-222222222222
+```
+
+Send no `Authorization` header; there is nothing to authenticate against yet. The server's own
+check is narrower than that requirement: it answers `400` only for a header it can parse as Basic
+credentials whose decoded username is a UUID. A header it cannot parse that way, a `Bearer` token
+or malformed Basic value, is ignored and the registration proceeds, consuming the share code. Do
+not rely on the `400` to protect a code from a stray header. See
+[http-api.md](http-api.md).
+
+Response:
+
+```json
+{
+  "account": "33333333-3333-3333-3333-333333333333",
+  "password": "0000example000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000example"
+}
+```
+
+`account` is the account UUID, `password` is this device's password (64 random bytes hex-encoded,
+128 characters). From here on, every request carries
+`Authorization: Basic base64("<account>:<password>")` plus the same `X-Device-ID`. See
+[http-api.md](http-api.md).
+
+Registration without `?share=` creates a **new** account instead of joining one, and the client
+generates its own encryption keyset at that point.
+
+Failure modes are listed under `POST /v1/account` in [http-api.md](http-api.md).
+
+## 4. The joining device adopts the keyset
+
+The keyset from the link payload is the account's payload encryption keyset. The joining device
+stores it and uses it for every read and write. There is no key exchange with the server and no
+key negotiation between peers; the keyset in the payload is authoritative.
+
+## Security note
+
+The link payload carries the account's encryption keyset. It is the entire secret. Anyone who
+obtains the payload before it is redeemed can join the account **and** decrypt everything stored on
+it, including documents written before and after they joined. Consuming the share code does not
+invalidate the keyset in a payload that leaked.
+
+Treat the payload like a private key: show it on screen only for as long as needed, never write it
+to logs, crash reports, or analytics, and never transmit it over a channel less trusted than the
+one it is establishing.

--- a/docs/protocol/linking.md
+++ b/docs/protocol/linking.md
@@ -1,8 +1,8 @@
 # Linking
 
-How a second device joins an existing account. Two things have to travel from the host device to
-the joining device: a server-issued share code, and the account's encryption keyset. The server
-only knows about the first one.
+How a second device joins an existing account. Two things travel from the host device to the
+joining device: a server-issued share code, and the account's encryption keyset. The server only
+knows about the first one.
 
 ## 1. The host creates a share code
 
@@ -18,25 +18,25 @@ Response:
 { "code": "0000example000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000example" }
 ```
 
-The code is generated as 64 random bytes, hex-encoded, so it is 128 lowercase hex characters. Treat
-it as an opaque string; nothing in the protocol parses it.
+The code is 64 random bytes, hex-encoded, so 128 lowercase hex characters. Treat it as an opaque
+string; nothing in the protocol parses it.
 
 ### Lifetime is best effort, not a hard TTL
 
 A share is stored with its creation time. Two mechanisms interact:
 
-- The server's `shareExpiration` defines when a share counts as expired. It is server
-  configuration with a 60-minute default, and the pinned revision parses no command-line flag for
-  it, so a client cannot discover a deployment's value.
+- The server's `shareExpiration` says when a share counts as expired. It is server configuration
+  with a 60-minute default, and the pinned revision parses no command-line flag for it, so a client
+  cannot discover a deployment's value.
 - Expired shares are deleted by a periodic sweep whose interval is `shareExpiration / 2`, so
   **30 minutes** at the default.
 
-Redemption itself does **not** check age. `consumeShare()` looks the code up and removes it, without
-comparing timestamps. A code therefore stays redeemable until a sweep happens to remove it, which at
-default settings can be up to roughly 90 minutes after creation.
+Redemption does not check age. `consumeShare()` looks the code up and removes it, without comparing
+timestamps. A code stays usable until a sweep removes it, which at the defaults can be up to
+roughly 90 minutes after creation.
 
-Clients must not treat 60 minutes as a guarantee in either direction. Do not assume a code is dead
-after an hour, and do not assume one will still work.
+60 minutes is not a guarantee in either direction: do not assume a code is dead after an hour, or
+that one will still work.
 
 See [`ShareRepo.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/account/share/ShareRepo.kt)
 and the `shareExpiration` default in
@@ -44,21 +44,20 @@ and the `shareExpiration` default in
 
 ### Redemption is transactional
 
-The registration handler consumes the share before it creates the device, and restores it if the
-registration cannot complete. The share is put back when:
+The registration handler consumes the share before creating the device, and puts it back when
+registration cannot complete:
 
 - the account referenced by the share no longer exists (response `403`),
 - the account is at its device limit (response `409`),
 - device creation fails for any other reason (the error propagates as `500`).
 
-A failed join therefore does not burn the code. See
+A failed join does not burn the code. See
 [`AccountRoute.kt`](https://github.com/d4rken-org/octi-server/blob/7e813e2b7d198daae30bdb3cc17e5544ab9b3c22/src/main/kotlin/eu/darken/octi/server/account/AccountRoute.kt).
 
 ## 2. The host renders a link payload
 
-The share code alone is not enough: without the account's keyset the joining device could talk to
-the server but could not read or write anything. The host packages both into one payload, which it
-displays as a QR code or as text.
+Without the keyset the joining device could talk to the server but not read or write anything. The
+host packages code and keyset into one payload, shown as a QR code or as text.
 
 The plaintext is JSON, defined by
 [`LinkingData.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/syncs/octiserver/core/LinkingData.kt),
@@ -85,9 +84,9 @@ and [`PayloadEncryption.kt`](../../sync-core/src/main/java/eu/darken/octi/sync/c
 
 Field notes:
 
-- `serverAddress.protocol` defaults to `https` and `serverAddress.port` to `443`, but the Android
-  encoder writes defaults explicitly, so both keys are present in payloads it produces. A decoder
-  should still apply those defaults if a key is missing.
+- `serverAddress.protocol` defaults to `https` and `serverAddress.port` to `443`. The Android
+  encoder writes both explicitly, so both keys are present in payloads it produces. A decoder
+  should still apply the defaults if a key is missing.
 - `encryptionKeySet.type` is an [encryption mode](encryption.md) identifier, either
   `AES256_GCM_SIV` or `AES256_SIV`.
 - `encryptionKeySet.key` is the base64 of the serialized Tink keyset, not a raw key. See
@@ -107,16 +106,14 @@ From [`LinkCodeShape.kt`](../../syncs-octiserver/src/main/java/eu/darken/octi/sy
 useful for diagnosing a bad paste without logging the payload itself:
 
 - A complete payload is roughly **496 characters**. A much shorter one was truncated.
-- It always starts with `H4sI`, which is the base64 of the gzip magic bytes `1f 8b 08`. A payload
-  that does not is missing its beginning, which whitespace-tolerant base64 decoding cannot detect on
-  its own.
-- The Android client trims the code before decoding, and okio's base64 decoder additionally skips
-  ASCII space, tab, carriage return and line feed **anywhere** in the payload, so a code that an
-  email client line-wrapped still decodes. Any other stray character fails the decode outright.
-  The `alphabet` check in `LinkCodeShape.kt` does not allow those whitespace characters, so a
-  wrapped code that decodes successfully still reports `alphabet=false`. This is what the Android
-  decoder happens to accept, not a protocol guarantee; another client may be stricter, so a
-  producer should emit the code with no embedded whitespace.
+- It always starts with `H4sI`, the base64 of the gzip magic bytes `1f 8b 08`. A payload that does
+  not is missing its beginning, which whitespace-tolerant base64 decoding cannot detect on its own.
+- The Android client trims the code before decoding, and okio's base64 decoder also skips ASCII
+  space, tab, carriage return and line feed **anywhere** in the payload, so a line-wrapped code
+  still decodes. Any other stray character fails the decode. The `alphabet` check in
+  `LinkCodeShape.kt` does not allow those whitespace characters, so a wrapped code that decodes
+  still reports `alphabet=false`. That is Android decoder tolerance, not a protocol guarantee.
+  Another client may be stricter, so emit the code with no embedded whitespace.
 - The Android decoder accepts both the standard and the URL-safe base64 alphabets.
 
 ## 3. The joining device registers
@@ -127,11 +124,10 @@ X-Device-ID: 22222222-2222-2222-2222-222222222222
 ```
 
 Send no `Authorization` header; there is nothing to authenticate against yet. The server's own
-check is narrower than that requirement: it answers `400` only for a header it can parse as Basic
-credentials whose decoded username is a UUID. A header it cannot parse that way, a `Bearer` token
-or malformed Basic value, is ignored and the registration proceeds, consuming the share code. Do
-not rely on the `400` to protect a code from a stray header. See
-[http-api.md](http-api.md).
+check is narrower: it answers `400` only for a header it can parse as Basic credentials whose
+decoded username is a UUID. Anything else, a `Bearer` token or a malformed Basic value, is ignored
+and the registration proceeds, consuming the share code. The `400` will not protect a code from a
+stray header. See [http-api.md](http-api.md) for the full rule.
 
 Response:
 
@@ -154,17 +150,17 @@ Failure modes are listed under `POST /v1/account` in [http-api.md](http-api.md).
 
 ## 4. The joining device adopts the keyset
 
-The keyset from the link payload is the account's payload encryption keyset. The joining device
+The keyset in the link payload is the account's payload encryption keyset. The joining device
 stores it and uses it for every read and write. There is no key exchange with the server and no
-key negotiation between peers; the keyset in the payload is authoritative.
+negotiation between peers.
 
 ## Security note
 
-The link payload carries the account's encryption keyset. It is the entire secret. Anyone who
-obtains the payload before it is redeemed can join the account **and** decrypt everything stored on
-it, including documents written before and after they joined. Consuming the share code does not
-invalidate the keyset in a payload that leaked.
+The link payload carries the account's encryption keyset, so it is the entire secret. Anyone who
+gets it before it is redeemed can join the account **and** decrypt everything stored on it,
+including documents written before and after they joined. Consuming the share code does not
+invalidate a keyset that leaked.
 
-Treat the payload like a private key: show it on screen only for as long as needed, never write it
-to logs, crash reports, or analytics, and never transmit it over a channel less trusted than the
-one it is establishing.
+Treat the payload like a private key: show it on screen only as long as needed, never write it to
+logs, crash reports or analytics, and never send it over a channel less trusted than the one it is
+establishing.

--- a/docs/protocol/stability.md
+++ b/docs/protocol/stability.md
@@ -1,0 +1,143 @@
+# Stability and change policy
+
+What a third-party client can rely on, how much of it is verified by machine rather than by prose,
+and how changes to each layer are rolled out.
+
+## Coverage matrix
+
+The repository publishes cross-repository wire fixtures under
+[`sync-core/src/test/resources/interop/`](../../sync-core/src/test/resources/interop/README.md).
+They pin exact bytes that consumers must decode. They do not cover everything this documentation
+describes.
+
+| Area | Machine-checked by the published fixtures | Where |
+|---|---|---|
+| Payload AEAD: keyset parsing, both modes, associated data, Tink prefix | **yes** | `tink-vectors.json` |
+| Blob streaming AEAD: keys, segments, associated data, truncation rejection | **yes** | `streaming-vectors.json` |
+| Linking payload encoding | no | prose in [linking.md](linking.md) |
+| HTTP endpoints, status codes, headers, precondition semantics | no | prose in [http-api.md](http-api.md) |
+| WebSocket frame schema and delivery behavior | no | prose in [websocket.md](websocket.md) |
+| Capability tag grammar, limits, authority | no | prose in [capabilities.md](capabilities.md) |
+| Module document schemas | no | not documented at this revision |
+
+The published fixtures are crypto vectors only. Module-level fixtures published from this repository
+are a planned later phase.
+
+In the other direction, this repository already **consumes** module fixtures published by
+[`octi-web`](https://github.com/d4rken-org/octi-web) and
+[`octi-desktop`](https://github.com/d4rken-org/octi-desktop): per-module tests decode their committed
+document vectors through the production decoders, pinned by
+[`fixture-lock.json`](../../fixture-lock.json). That protects this client against those producers'
+drift. It does not give a third-party client a fixture to verify against, which is what the matrix
+above measures.
+
+Anywhere the matrix says "no", the contract is prose plus the reference implementations. Prose can be
+wrong. Report a mismatch instead of assuming the code is right and this document is authoritative, or
+the reverse.
+
+## Consuming the published fixtures
+
+The verification chain has to start from something you pinned yourself. Fetching a manifest and
+hashing it proves nothing: whatever commit you fetched, its manifest hashes to whatever it hashes to.
+The anchor is a digest you recorded out of band.
+
+1. Pin a **full 40-character commit SHA** of this repository **and** the expected SHA-256 of that
+   commit's `manifest.json`, together, in your own lockfile. This is what
+   [`fixture-lock.json`](../../fixture-lock.json) does for the sources this repository consumes:
+
+   ```json
+   {
+     "schemaVersion": 2,
+     "sources": {
+       "d4rken-org/octi": {
+         "ref": "<40 hex characters>",
+         "manifest_sha256": "<64 hex characters>"
+       }
+     }
+   }
+   ```
+
+2. Fetch `sync-core/src/test/resources/interop/` at that SHA.
+3. Verify the fetched `manifest.json` against your pinned digest. Abort on mismatch.
+4. Verify every file listed in `manifest.files` against the SHA-256 recorded there.
+5. Decode and decrypt each vector under its committed keyset, comparing the resulting **plaintext**
+   to the recorded plaintext.
+6. Reject any `schemaVersion` you do not recognize, in the manifest and in each fixture file. A newer
+   schema may add fields whose absence you would silently misread. Failing is correct; guessing is
+   not.
+
+Step 1 is the one that is easy to skip and worthless to skip.
+
+## Ciphertext bytes change on every regeneration
+
+Both AES-GCM-SIV and the streaming AEAD use a random nonce per encryption. Regenerating the fixtures
+under the very same keyset produces different bytes every time.
+
+Verification therefore **decrypts** and compares plaintext. Never byte-compare a fixture's ciphertext
+against your own encryption of the same plaintext; that comparison fails even when both sides are
+completely correct.
+
+The practical consequence for producers is that a regeneration always shows up as a diff, so
+regenerating without a wire-format reason is pure noise. The keyset itself is preserved across
+regenerations by design, and rotating it is a deliberate delete-then-regenerate act, because rotation
+breaks every consumer that already pinned the old keyset.
+
+## Change policy by layer
+
+Each layer has a different escape hatch, because each has a different way of reaching a peer.
+
+### HTTP and server API
+
+Changes are **additive**, or they ship under a new endpoint or a new API version.
+
+Device capability tags cannot help here. They describe peers, not the server, and a client learns
+about a peer's tags by calling the very API in question. The server's own feature level is discovered
+through the API itself, for example the `storageApiVersion` field in
+[`GET /v1/account/storage`](http-api.md#get-v1accountstorage), and through the status codes a client
+must handle anyway.
+
+Servers are also deployed independently of clients. A client cannot assume that the server it talks
+to today is the one it talked to yesterday, and must degrade rather than fail when an endpoint or
+field is missing.
+
+### Module document format
+
+There is exactly **one** stored document per (owner device, module id), and every peer on the account
+reads that same document. A producer physically cannot emit one format to one peer and a different
+format to another. Per-peer dual-write does not exist as an option.
+
+Migrations therefore ship as **one shared backward-compatible representation**: the document carries
+the old and the new shape together, so old readers keep reading the fields they know while new readers
+prefer the new ones.
+
+Peer capability tags still matter, but for a different question. They do not decide who receives which
+shape. They decide **when it is safe to stop writing the old shape**: once every peer that matters
+advertises support for the new one, the compatibility fields become dead weight and the old shape can
+be dropped. Until then, both are written for everyone.
+
+### Encryption mode
+
+Account-wide and fixed at account creation. It cannot vary per peer and cannot be renegotiated after
+the fact. A peer that cannot handle the account's mode is permanently incompatible with that account.
+Capability tags exist to surface that condition, not to work around it. See
+[encryption.md](encryption.md) and [capabilities.md](capabilities.md).
+
+## What is not promised
+
+No compatibility promise attaches to behavior this documentation does not describe. Observed
+behavior that is not written down here, including undocumented fields, undocumented endpoints,
+incidental orderings, timing, and the exact wording of error bodies, may change without notice and
+without a fixture failing.
+
+If your client depends on something not documented here, that dependency is your risk to carry. The
+better move is to ask for it to be specified.
+
+## Further reading
+
+- [Interop fixtures README](../../sync-core/src/test/resources/interop/README.md): the fixture file
+  formats, field by field.
+- [`.claude/rules/interop-fixtures.md`](../../.claude/rules/interop-fixtures.md): the producer-side
+  workflow, regeneration rules, the cross-repository CI gate, and the staged rollout sequence for a
+  deliberate wire-format break.
+- [`.claude/rules/device-capabilities.md`](../../.claude/rules/device-capabilities.md): the capability
+  contract across all four implementations.

--- a/docs/protocol/stability.md
+++ b/docs/protocol/stability.md
@@ -7,8 +7,8 @@ and how changes to each layer are rolled out.
 
 The repository publishes cross-repository wire fixtures under
 [`sync-core/src/test/resources/interop/`](../../sync-core/src/test/resources/interop/README.md).
-They pin exact bytes that consumers must decode. They do not cover everything this documentation
-describes.
+They pin exact bytes that consumers must decode, but they do not cover everything this
+documentation describes.
 
 | Area | Machine-checked by the published fixtures | Where |
 |---|---|---|
@@ -20,26 +20,24 @@ describes.
 | Capability tag grammar, limits, authority | no | prose in [capabilities.md](capabilities.md) |
 | Module document schemas | no | not documented at this revision |
 
-The published fixtures are crypto vectors only. Module-level fixtures published from this repository
-are a planned later phase.
+The published fixtures are crypto vectors only. Module-level fixtures published from this
+repository are a planned later phase.
 
-In the other direction, this repository already **consumes** module fixtures published by
+This repository already **consumes** module fixtures published by
 [`octi-web`](https://github.com/d4rken-org/octi-web) and
-[`octi-desktop`](https://github.com/d4rken-org/octi-desktop): per-module tests decode their committed
-document vectors through the production decoders, pinned by
+[`octi-desktop`](https://github.com/d4rken-org/octi-desktop): per-module tests decode their
+committed document vectors through the production decoders, pinned by
 [`fixture-lock.json`](../../fixture-lock.json). That protects this client against those producers'
-drift. It does not give a third-party client a fixture to verify against, which is what the matrix
-above measures.
+drift, but it gives a third-party client nothing to verify against.
 
-Anywhere the matrix says "no", the contract is prose plus the reference implementations. Prose can be
-wrong. Report a mismatch instead of assuming the code is right and this document is authoritative, or
-the reverse.
+Anywhere the matrix says "no", the contract is prose plus the reference implementations. Report a
+mismatch instead of assuming either side is authoritative.
 
 ## Consuming the published fixtures
 
-The verification chain has to start from something you pinned yourself. Fetching a manifest and
-hashing it proves nothing: whatever commit you fetched, its manifest hashes to whatever it hashes to.
-The anchor is a digest you recorded out of band.
+The chain has to start from something you pinned yourself. Fetching a manifest and hashing it
+proves nothing: whatever commit you fetched, its manifest hashes to whatever it hashes to. The
+anchor is a digest you recorded out of band.
 
 1. Pin a **full 40-character commit SHA** of this repository **and** the expected SHA-256 of that
    commit's `manifest.json`, together, in your own lockfile. This is what
@@ -62,75 +60,70 @@ The anchor is a digest you recorded out of band.
 4. Verify every file listed in `manifest.files` against the SHA-256 recorded there.
 5. Decode and decrypt each vector under its committed keyset, comparing the resulting **plaintext**
    to the recorded plaintext.
-6. Reject any `schemaVersion` you do not recognize, in the manifest and in each fixture file. A newer
-   schema may add fields whose absence you would silently misread. Failing is correct; guessing is
-   not.
+6. Reject any `schemaVersion` you do not recognize, in the manifest and in each fixture file. A
+   newer schema may add fields whose absence you would silently misread.
 
-Step 1 is the one that is easy to skip and worthless to skip.
+Skipping step 1 removes the only anchor the rest of the chain rests on.
 
 ## Ciphertext bytes change on every regeneration
 
-Both AES-GCM-SIV and the streaming AEAD use a random nonce per encryption. Regenerating the fixtures
-under the very same keyset produces different bytes every time.
+Both AES-GCM-SIV and the streaming AEAD use a random nonce per encryption. Regenerating the
+fixtures under the very same keyset produces different bytes every time.
 
-Verification therefore **decrypts** and compares plaintext. Never byte-compare a fixture's ciphertext
-against your own encryption of the same plaintext; that comparison fails even when both sides are
-completely correct.
+Verification therefore **decrypts** and compares plaintext. Never byte-compare a fixture's
+ciphertext against your own encryption of the same plaintext; that comparison fails even when both
+sides are completely correct.
 
-The practical consequence for producers is that a regeneration always shows up as a diff, so
-regenerating without a wire-format reason is pure noise. The keyset itself is preserved across
-regenerations by design, and rotating it is a deliberate delete-then-regenerate act, because rotation
-breaks every consumer that already pinned the old keyset.
+For producers, a regeneration always shows up as a diff, so regenerating without a wire-format
+reason is pure noise. The keyset is preserved across regenerations by design; rotating it takes a
+deliberate delete-then-regenerate, because rotation breaks every consumer that pinned the old
+keyset.
 
 ## Change policy by layer
-
-Each layer has a different escape hatch, because each has a different way of reaching a peer.
 
 ### HTTP and server API
 
 Changes are **additive**, or they ship under a new endpoint or a new API version.
 
 Device capability tags cannot help here. They describe peers, not the server, and a client learns
-about a peer's tags by calling the very API in question. The server's own feature level is discovered
-through the API itself, for example the `storageApiVersion` field in
-[`GET /v1/account/storage`](http-api.md#get-v1accountstorage), and through the status codes a client
+a peer's tags by calling the very API in question. The server's own feature level comes from the
+API itself, for example the `storageApiVersion` field in
+[`GET /v1/account/storage`](http-api.md#get-v1accountstorage), and from the status codes a client
 must handle anyway.
 
-Servers are also deployed independently of clients. A client cannot assume that the server it talks
-to today is the one it talked to yesterday, and must degrade rather than fail when an endpoint or
-field is missing.
+Servers are deployed independently of clients. The server you talk to today may not be the one you
+talked to yesterday, so degrade rather than fail when an endpoint or field is missing.
 
 ### Module document format
 
-There is exactly **one** stored document per (owner device, module id), and every peer on the account
-reads that same document. A producer physically cannot emit one format to one peer and a different
-format to another. Per-peer dual-write does not exist as an option.
+There is exactly **one** stored document per (owner device, module id), and every peer on the
+account reads that same document. A producer physically cannot emit one format to one peer and a
+different format to another. Per-peer dual-write does not exist as an option.
 
-Migrations therefore ship as **one shared backward-compatible representation**: the document carries
-the old and the new shape together, so old readers keep reading the fields they know while new readers
-prefer the new ones.
+Migrations therefore ship as **one shared backward-compatible representation**: the document
+carries the old and the new shape together, so old readers keep reading the fields they know while
+new readers prefer the new ones.
 
-Peer capability tags still matter, but for a different question. They do not decide who receives which
-shape. They decide **when it is safe to stop writing the old shape**: once every peer that matters
-advertises support for the new one, the compatibility fields become dead weight and the old shape can
-be dropped. Until then, both are written for everyone.
+Peer capability tags do not decide who receives which shape. They decide **when it is safe to stop
+writing the old shape**: once every peer that matters advertises support for the new one, the
+compatibility fields are dead weight and the old shape can go. Until then, both are written for
+everyone.
 
 ### Encryption mode
 
-Account-wide and fixed at account creation. It cannot vary per peer and cannot be renegotiated after
-the fact. A peer that cannot handle the account's mode is permanently incompatible with that account.
+Account-wide and fixed at account creation. It cannot vary per peer and cannot be renegotiated
+later. A peer that cannot handle the account's mode is permanently incompatible with that account.
 Capability tags exist to surface that condition, not to work around it. See
 [encryption.md](encryption.md) and [capabilities.md](capabilities.md).
 
 ## What is not promised
 
-No compatibility promise attaches to behavior this documentation does not describe. Observed
-behavior that is not written down here, including undocumented fields, undocumented endpoints,
-incidental orderings, timing, and the exact wording of error bodies, may change without notice and
-without a fixture failing.
+No compatibility promise attaches to behavior this documentation does not describe. Undocumented
+fields, undocumented endpoints, incidental orderings, timing and the exact wording of error bodies
+may change without notice and without a fixture failing.
 
-If your client depends on something not documented here, that dependency is your risk to carry. The
-better move is to ask for it to be specified.
+If your client depends on something not documented here, that dependency is your risk to carry. Ask
+for it to be specified instead.
 
 ## Further reading
 
@@ -139,5 +132,5 @@ better move is to ask for it to be specified.
 - [`.claude/rules/interop-fixtures.md`](../../.claude/rules/interop-fixtures.md): the producer-side
   workflow, regeneration rules, the cross-repository CI gate, and the staged rollout sequence for a
   deliberate wire-format break.
-- [`.claude/rules/device-capabilities.md`](../../.claude/rules/device-capabilities.md): the capability
-  contract across all four implementations.
+- [`.claude/rules/device-capabilities.md`](../../.claude/rules/device-capabilities.md): the
+  capability contract across all four implementations.

--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -1,7 +1,7 @@
 # WebSocket notifications
 
-A change notification channel. It tells a client that something changed so the client can fetch it
-over HTTP sooner than its next poll. It never carries payload data, and it is not a reliable stream.
+A change notification channel. It tells a client that something changed so it can fetch it over
+HTTP sooner than its next poll. It carries no payload data and is not a reliable stream.
 
 A client that ignores this channel entirely still works. It just reacts more slowly.
 
@@ -21,25 +21,24 @@ X-Device-ID: 11111111-1111-1111-1111-111111111111
 Authorization: Basic <base64 of accountId:devicePassword>
 ```
 
-The device metadata headers described in [http-api.md](http-api.md) are also read on the upgrade and
-update the stored device record exactly as they do on an HTTP call.
+The device metadata headers from [http-api.md](http-api.md) are read on the upgrade too, and
+update the stored device record exactly as on an HTTP call.
 
-Authentication runs the same code path as the HTTP routes, and the per-account rate limit applies to
-connection establishment.
+Authentication runs the same code path as the HTTP routes, and the per-account rate limit applies
+to connection establishment.
 
 ### Close codes
 
 A refused connection fails differently depending on whether the upgrade already completed.
 
-**Before the upgrade** the request is still an ordinary HTTP call, so the HTTP plugins can reject
-it and the client sees an HTTP error response instead of a handshake. The global per-IP request
-limiter runs ahead of routing and treats the upgrade request like any other call; over the limit it
-answers `429` with `Retry-After` in delta-seconds. When CORS is enabled, an `Origin` that is not on
-the allowlist is answered with `403` before any upgrade happens; the CORS note in
-[http-api.md](http-api.md#limits-and-rate-limiting) describes the allowlist and who it applies to.
+**Before the upgrade** the request is still an ordinary HTTP call, so the client can get an HTTP
+error response instead of a handshake. The global per-IP limiter runs ahead of routing and counts
+the upgrade like any other request; over the limit it answers `429` with `Retry-After` in
+delta-seconds. With CORS enabled, an `Origin` that is not on the allowlist gets `403` before any
+upgrade happens. See the CORS note in [http-api.md](http-api.md#limits-and-rate-limiting).
 
-**After the upgrade** the route-level failures below, authentication, the per-account rate limit and
-the connection caps, arrive as a WebSocket close:
+**After the upgrade** the route-level failures below, authentication, the per-account rate limit
+and the connection caps, arrive as a WebSocket close:
 
 | Code | Reason text | Cause |
 |---|---|---|
@@ -55,11 +54,11 @@ it. `1013` is explicitly retryable after a delay.
 
 ### Session model
 
-Sessions are keyed by (account id, device id). Opening a second connection for the same key
-**replaces** the first: the old session's outbox is closed and its socket is closed with `1001`.
-A client must not hold two sockets for one device id.
+Sessions are keyed by (account id, device id). A second connection for the same key **replaces**
+the first: the old session's outbox is closed and its socket closed with `1001`. Never hold two
+sockets for one device id.
 
-Connection caps at the pinned revision, all server-side constants rather than configurable options:
+Connection caps at the pinned revision are server-side constants, not configurable:
 
 | Cap | Value |
 |---|---|
@@ -75,26 +74,25 @@ Server-side WebSocket configuration: **ping period 30 seconds**, **pong timeout 
 **maximum frame size 4096 bytes**.
 
 The 60 seconds is the pong deadline, not an inactivity timeout on application traffic. The server
-pings every 30 seconds and terminates the session if no pong comes back within 60 seconds; a
-connection that carries no notifications for hours stays open as long as pongs keep arriving. Any
-conforming WebSocket client answers pings automatically.
+pings every 30 seconds and drops the session if no pong arrives within 60 seconds. A connection
+with no notifications for hours stays open as long as pongs keep coming. Any conforming WebSocket
+client answers pings automatically.
 
-The 4096-byte frame limit is Ktor's `maxFrameSize`, and it applies to frames the server **reads**,
-counting the accumulated size of a fragmented message rather than each fragment on its own. It
-does not cap the frames the server sends. Do not refuse inbound frames larger than 4096 bytes: as
-the batching section below explains, one notification frame can describe every module of every
-peer, which is well past 4096 bytes on any account of a realistic size.
+The 4096-byte frame limit is Ktor's `maxFrameSize`. It applies to frames the server **reads**, and
+counts the accumulated size of a fragmented message rather than each fragment alone. It does not
+cap the frames the server sends. Do not refuse inbound frames larger than 4096 bytes: one
+notification frame can describe every module of every peer, well past 4096 bytes on a realistic
+account.
 
-The Android client independently sets its own OkHttp ping interval to 30 seconds and reconnects with
-exponential backoff from 1 second up to a 30 second ceiling. Those are client policy, not protocol.
-Reconnect strategy is entirely up to the implementer, within the retry semantics of the close codes
-above.
+The Android client sets its own OkHttp ping interval to 30 seconds and reconnects with exponential
+backoff from 1 second up to a 30 second ceiling. That is client policy, not protocol; reconnect
+strategy is yours to choose, within the retry semantics of the close codes above.
 
 ### Client-to-server frames
 
 There are none. The server reads incoming frames only to enforce a rate limit of **120 frames per
-60 second window**, and closes the connection with `1008` when a client exceeds it. Nothing a client
-sends is interpreted. Do not send application frames.
+60 second window**, closing with `1008` when a client exceeds it. Nothing you send is interpreted,
+so do not send application frames.
 
 ## Server frames
 
@@ -133,20 +131,19 @@ commit, and for a blob delete; `deleted` for a module delete. Treat an unrecogni
 ### Two device ids, one event
 
 `deviceId` and `sourceDeviceId` differ whenever a device writes into another device's slot. The
-server broadcasts to every connected session on the account and filters per recipient on
-`sourceDeviceId`: a peer never receives events it caused itself. A peer that received an event
-therefore knows it did not originate it, and should fetch `(deviceId, moduleId)`.
+server broadcasts to every session on the account and filters per recipient on `sourceDeviceId`, so
+a peer never receives events it caused itself. Anything you do receive came from someone else:
+fetch `(deviceId, moduleId)`.
 
 Do not self-filter on `deviceId`. Under the [single-writer invariant](README.md#single-writer-invariant)
-the two are usually equal, but filtering on the target rather than the actor would suppress
+the two are usually equal, but filtering on the target instead of the actor would suppress
 legitimate events.
 
 ### Batching
 
-Events are batched per account with a 500 millisecond debounce, and further writes inside the window
-extend it. One frame can therefore carry several events, and a burst of writes collapses into one
-delivery. Clients must handle an `events` array of any length, including one long enough to describe
-every module of every peer.
+Events are batched per account with a 500 millisecond debounce, and further writes inside the
+window extend it. A burst of writes collapses into one delivery. Handle an `events` array of any
+length, including one long enough to describe every module of every peer.
 
 ### What the Android decoder tolerates, and why you must not rely on it
 
@@ -156,35 +153,32 @@ The Android client's decoder is deliberately lenient. It is not the contract:
   it.
 - It defaults `action` to `updated` when absent. The server always sends it.
 - It accepts a `blobKey` field. The server does not emit one.
-- It has no field for `sourceDeviceId` and ignores it. The server always sends it, and it is what
-  self-suppression is based on.
+- It has no field for `sourceDeviceId` and ignores it. The server always sends it, and
+  self-suppression is based on it.
 - It logs and skips events whose `type` it does not recognize.
 
-A third-party client should encode the server contract, tolerate unknown fields for
-forward-compatibility, and not assume other implementations are as forgiving as this one.
+Encode the server contract, tolerate unknown fields, and do not assume other implementations are
+this forgiving.
 
 ## Delivery is best effort
 
-This is the single most important property of the channel. Notifications are a latency optimization
-layered on top of HTTP polling, never a source of truth.
+Notifications are a latency optimization layered on top of HTTP polling, never a source of truth.
 
-What the server does **not** do:
-
-- **No persistence.** Events go only to sessions that are connected at broadcast time. If no session
-  for the account is connected, the batch is discarded.
+- **No persistence.** Events go only to sessions that are connected at broadcast time. If no
+  session for the account is connected, the batch is discarded.
 - **No replay.** Reconnecting does not deliver anything missed while disconnected. There is no
   cursor, sequence number, or resume token in the protocol.
 - **No acknowledgement.** The server never learns whether a frame was processed, and never retries.
-- **No backpressure.** Each session has a bounded outbox buffer. When it is full, the broadcast drops
-  the notification for that peer and moves on. The socket stays open and the client sees no gap.
+- **No backpressure.** Each session has a bounded outbox buffer. When it is full, the broadcast
+  drops the notification for that peer and moves on. The socket stays open and the client sees no
+  gap.
 
 Consequences for an implementation:
 
-1. Perform a **full HTTP reconciliation** on first connect and again after **every** reconnect. Read
-   the device list, then read every module slot you care about. Do not assume the socket picked up
-   where it left off.
-2. Keep a **periodic reconciliation** running regardless of socket state if the client needs eventual
+1. Do a **full HTTP reconciliation** on first connect and after **every** reconnect: read the
+   device list, then every module slot you care about. The socket does not pick up where it left
+   off.
+2. Keep a **periodic reconciliation** running regardless of socket state if you need eventual
    consistency. A dropped notification is otherwise invisible until the next unrelated event.
 3. Treat every event as a hint to re-read, not as data. Frames carry no payload and no ciphertext.
-4. Never gate correctness on receiving an event. A feature that only works when a notification
-   arrives is a feature that intermittently does not work.
+4. Never gate correctness on receiving an event.

--- a/docs/protocol/websocket.md
+++ b/docs/protocol/websocket.md
@@ -1,0 +1,190 @@
+# WebSocket notifications
+
+A change notification channel. It tells a client that something changed so the client can fetch it
+over HTTP sooner than its next poll. It never carries payload data, and it is not a reliable stream.
+
+A client that ignores this channel entirely still works. It just reacts more slowly.
+
+## Connecting
+
+```
+wss://<domain>:<port>/v1/ws
+```
+
+Use `ws://` when the configured server protocol is plain `http`, `wss://` otherwise.
+
+The upgrade request carries the same authentication headers as any HTTP call:
+
+```http
+GET /v1/ws HTTP/1.1
+X-Device-ID: 11111111-1111-1111-1111-111111111111
+Authorization: Basic <base64 of accountId:devicePassword>
+```
+
+The device metadata headers described in [http-api.md](http-api.md) are also read on the upgrade and
+update the stored device record exactly as they do on an HTTP call.
+
+Authentication runs the same code path as the HTTP routes, and the per-account rate limit applies to
+connection establishment.
+
+### Close codes
+
+A refused connection fails differently depending on whether the upgrade already completed.
+
+**Before the upgrade** the request is still an ordinary HTTP call, so the HTTP plugins can reject
+it and the client sees an HTTP error response instead of a handshake. The global per-IP request
+limiter runs ahead of routing and treats the upgrade request like any other call; over the limit it
+answers `429` with `Retry-After` in delta-seconds. When CORS is enabled, an `Origin` that is not on
+the allowlist is answered with `403` before any upgrade happens; the CORS note in
+[http-api.md](http-api.md#limits-and-rate-limiting) describes the allowlist and who it applies to.
+
+**After the upgrade** the route-level failures below, authentication, the per-account rate limit and
+the connection caps, arrive as a WebSocket close:
+
+| Code | Reason text | Cause |
+|---|---|---|
+| `1008` | `Authentication failed` | Credentials missing, malformed, or wrong |
+| `1013` | `Account rate limit exceeded` | Per-account rate limit hit on the upgrade |
+| `1013` | `Server connection limit reached` | Global session cap reached |
+| `1013` | `Too many connections from this IP` | Per-IP session cap reached |
+| `1008` | `Frame rate limit exceeded` | The client sent too many frames |
+| `1001` | `Session replaced` | A newer session for the same device took over, or this session was evicted by the per-account session cap |
+
+`1008` on authentication is permanent until credentials change; reconnecting in a loop will not fix
+it. `1013` is explicitly retryable after a delay.
+
+### Session model
+
+Sessions are keyed by (account id, device id). Opening a second connection for the same key
+**replaces** the first: the old session's outbox is closed and its socket is closed with `1001`.
+A client must not hold two sockets for one device id.
+
+Connection caps at the pinned revision, all server-side constants rather than configurable options:
+
+| Cap | Value |
+|---|---|
+| Sessions per account | 64, oldest evicted when exceeded |
+| Sessions per client IP | 32, connection rejected |
+| Sessions server-wide | 10000, connection rejected |
+
+The server sweeps sessions whose outbox is already closed every 2 minutes.
+
+### Timing
+
+Server-side WebSocket configuration: **ping period 30 seconds**, **pong timeout 60 seconds**,
+**maximum frame size 4096 bytes**.
+
+The 60 seconds is the pong deadline, not an inactivity timeout on application traffic. The server
+pings every 30 seconds and terminates the session if no pong comes back within 60 seconds; a
+connection that carries no notifications for hours stays open as long as pongs keep arriving. Any
+conforming WebSocket client answers pings automatically.
+
+The 4096-byte frame limit is Ktor's `maxFrameSize`, and it applies to frames the server **reads**,
+counting the accumulated size of a fragmented message rather than each fragment on its own. It
+does not cap the frames the server sends. Do not refuse inbound frames larger than 4096 bytes: as
+the batching section below explains, one notification frame can describe every module of every
+peer, which is well past 4096 bytes on any account of a realistic size.
+
+The Android client independently sets its own OkHttp ping interval to 30 seconds and reconnects with
+exponential backoff from 1 second up to a 30 second ceiling. Those are client policy, not protocol.
+Reconnect strategy is entirely up to the implementer, within the retry semantics of the close codes
+above.
+
+### Client-to-server frames
+
+There are none. The server reads incoming frames only to enforce a rate limit of **120 frames per
+60 second window**, and closes the connection with `1008` when a client exceeds it. Nothing a client
+sends is interpreted. Do not send application frames.
+
+## Server frames
+
+Every server frame is a text frame containing one JSON object:
+
+```json
+{
+  "events": [
+    {
+      "type": "module_changed",
+      "deviceId": "11111111-1111-1111-1111-111111111111",
+      "moduleId": "eu.darken.octi.module.core.power",
+      "modifiedAt": "2026-01-02T08:30:00.123456789Z",
+      "action": "updated",
+      "sourceDeviceId": "22222222-2222-2222-2222-222222222222"
+    }
+  ]
+}
+```
+
+Server contract, taken from the server's notifier rather than from any client decoder:
+
+| Field | Contract |
+|---|---|
+| `type` | Always `module_changed` at this revision. It is a discriminator; more types may appear. |
+| `deviceId` | The **target**: the device whose module changed, that is the owner of the slot. |
+| `moduleId` | The module id of the changed slot. |
+| `modifiedAt` | ISO-8601 instant, always present. Generated when the event is queued, so it is a notification timestamp and not necessarily byte-identical to the `X-Modified-At` of the document. |
+| `action` | `updated` or `deleted`. |
+| `sourceDeviceId` | The **actor**: the device that performed the write. Always present. |
+
+`action` values observed at the pinned revision: `updated` for a legacy `POST` write, for a `PUT`
+commit, and for a blob delete; `deleted` for a module delete. Treat an unrecognized action as
+`updated`, meaning "re-read this slot", rather than dropping the event.
+
+### Two device ids, one event
+
+`deviceId` and `sourceDeviceId` differ whenever a device writes into another device's slot. The
+server broadcasts to every connected session on the account and filters per recipient on
+`sourceDeviceId`: a peer never receives events it caused itself. A peer that received an event
+therefore knows it did not originate it, and should fetch `(deviceId, moduleId)`.
+
+Do not self-filter on `deviceId`. Under the [single-writer invariant](README.md#single-writer-invariant)
+the two are usually equal, but filtering on the target rather than the actor would suppress
+legitimate events.
+
+### Batching
+
+Events are batched per account with a 500 millisecond debounce, and further writes inside the window
+extend it. One frame can therefore carry several events, and a burst of writes collapses into one
+delivery. Clients must handle an `events` array of any length, including one long enough to describe
+every module of every peer.
+
+### What the Android decoder tolerates, and why you must not rely on it
+
+The Android client's decoder is deliberately lenient. It is not the contract:
+
+- It accepts `modifiedAt` as absent or null, substituting the current time. The server always sends
+  it.
+- It defaults `action` to `updated` when absent. The server always sends it.
+- It accepts a `blobKey` field. The server does not emit one.
+- It has no field for `sourceDeviceId` and ignores it. The server always sends it, and it is what
+  self-suppression is based on.
+- It logs and skips events whose `type` it does not recognize.
+
+A third-party client should encode the server contract, tolerate unknown fields for
+forward-compatibility, and not assume other implementations are as forgiving as this one.
+
+## Delivery is best effort
+
+This is the single most important property of the channel. Notifications are a latency optimization
+layered on top of HTTP polling, never a source of truth.
+
+What the server does **not** do:
+
+- **No persistence.** Events go only to sessions that are connected at broadcast time. If no session
+  for the account is connected, the batch is discarded.
+- **No replay.** Reconnecting does not deliver anything missed while disconnected. There is no
+  cursor, sequence number, or resume token in the protocol.
+- **No acknowledgement.** The server never learns whether a frame was processed, and never retries.
+- **No backpressure.** Each session has a bounded outbox buffer. When it is full, the broadcast drops
+  the notification for that peer and moves on. The socket stays open and the client sees no gap.
+
+Consequences for an implementation:
+
+1. Perform a **full HTTP reconciliation** on first connect and again after **every** reconnect. Read
+   the device list, then read every module slot you care about. Do not assume the socket picked up
+   where it left off.
+2. Keep a **periodic reconciliation** running regardless of socket state if the client needs eventual
+   consistency. A dropped notification is otherwise invisible until the next unrelated event.
+3. Treat every event as a hint to re-read, not as data. Frames carry no payload and no ciphertext.
+4. Never gate correctness on receiving an event. A feature that only works when a notification
+   arrives is a feature that intermittently does not work.


### PR DESCRIPTION
## What changed

Adds `docs/protocol/`, a reference for the Octi Server wire protocol, so someone writing a third-party client can work from documentation instead of reading another client's source.

Seven pages: an index covering the object model and scope, then linking (share codes and the link payload), the HTTP API (endpoints, auth and device metadata headers, write semantics, limits, retention), the WebSocket notification channel, payload encryption (both keyset types and the associated-data scheme), the device capability contract, and the stability policy.

Three areas are named as explicitly out of scope rather than left unmentioned: the blob and file-transfer layer, Google Drive sync, and the inner document schemas of the seven modules.

Closes #371

## Technical Context

- Every claim is sourced from the Android client at this commit and from octi-server at `7e813e2b7d198daae30bdb3cc17e5544ab9b3c22`. Both SHAs are recorded on the index page, because the two repositories evolve independently and unpinned prose rots without any signal.
- The WebSocket page documents the server's `SyncNotifier` frame contract rather than the Android decoder's tolerances, which differ in both directions: the server always sends `sourceDeviceId` (the field self-suppression actually filters on) and never sends `blobKey`, while the client decoder ignores the former and accepts the latter. Both are stated, with the lenient shape marked as non-contract.
- Tink framing is documented per mode. GCM-SIV carries a 12-byte random nonce; legacy SIV carries a 16-byte synthetic IV and no nonce. The committed interop vectors corroborate this as a 33-versus-21-byte overhead. An implementation that assumes the GCM-SIV layout for legacy accounts writes undecryptable documents, which the server accepts as opaque bytes.
- Retention is included because it is destructive and was previously undocumented anywhere: device and module GC each delete after 90 days of inactivity. Values that are genuinely operator-tunable are marked as such, and the ones with no command-line flag say so explicitly, so a client cannot mistake a default for a discoverable value.
- Also corrects step 4 of the staged rollout in `.claude/rules/interop-fixtures.md`. There is exactly one stored document per (owner device, module) and every peer reads it, so the per-peer dual-write it described is not implementable; capability tags govern when the old shape may be dropped, not who receives which shape. Two links to a `pull-request-guidelines.md` that has never existed in this repository are replaced with the requirement they carried.
