### PR TITLE
Fix operating system names shown for non-Android devices

### DIFF
--- a/app-common/src/main/java/eu/darken/octi/common/TextExtensions.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/TextExtensions.kt
@@ -9,3 +9,24 @@ fun colorString(@ColorInt color: Int, string: String): SpannableString {
     colored.setSpan(ForegroundColorSpan(color), 0, string.length, 0)
     return colored
 }
+
+private val IDENTIFIER_SEPARATORS = Regex("[_\\-\\s]+")
+
+/**
+ * Turns a machine identifier into a human readable label.
+ *
+ * The input is trimmed and split on `_`, `-` and whitespace runs, empty tokens are dropped, the
+ * first character of each remaining token is uppercased and the token tail is kept **exactly as-is**,
+ * then the tokens are joined with single spaces. If no token survives, the trimmed input is returned.
+ *
+ * Token tails are preserved on purpose, lowercasing them would turn "FreeBSD" into "Freebsd".
+ *
+ * `home_assistant` -> "Home Assistant", `desktop-linux` -> "Desktop Linux", `FreeBSD` -> "FreeBSD",
+ * `HOME_ASSISTANT` -> "HOME ASSISTANT", `"  home__assistant  "` -> "Home Assistant".
+ */
+fun humanizeIdentifier(raw: String): String {
+    val trimmed = raw.trim()
+    val tokens = trimmed.split(IDENTIFIER_SEPARATORS).filter { it.isNotEmpty() }
+    if (tokens.isEmpty()) return trimmed
+    return tokens.joinToString(" ") { token -> token.replaceFirstChar { it.uppercase() } }
+}

--- a/app-common/src/test/java/eu/darken/octi/common/TextExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/TextExtensionsTest.kt
@@ -1,0 +1,98 @@
+package eu.darken.octi.common
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class TextExtensionsTest : BaseTest() {
+
+    @Nested
+    inner class `humanizeIdentifier separators` {
+        @Test
+        fun `underscores become spaces`() {
+            humanizeIdentifier("home_assistant") shouldBe "Home Assistant"
+        }
+
+        @Test
+        fun `dashes become spaces`() {
+            humanizeIdentifier("desktop-linux") shouldBe "Desktop Linux"
+        }
+
+        @Test
+        fun `mixed separators`() {
+            humanizeIdentifier("home_assistant-core") shouldBe "Home Assistant Core"
+        }
+
+        @Test
+        fun `repeated separators collapse`() {
+            humanizeIdentifier("home__assistant") shouldBe "Home Assistant"
+        }
+
+        @Test
+        fun `leading and trailing separators are dropped`() {
+            humanizeIdentifier("_home_assistant_") shouldBe "Home Assistant"
+        }
+
+        @Test
+        fun `surrounding whitespace is trimmed`() {
+            humanizeIdentifier("  home__assistant  ") shouldBe "Home Assistant"
+        }
+
+        @Test
+        fun `internal whitespace runs collapse`() {
+            humanizeIdentifier("chrome  os   flex") shouldBe "Chrome Os Flex"
+        }
+
+        @Test
+        fun `tabs and newlines count as separators`() {
+            humanizeIdentifier("home\tassistant\ncore") shouldBe "Home Assistant Core"
+        }
+    }
+
+    @Nested
+    inner class `humanizeIdentifier casing` {
+        @Test
+        fun `token tails are preserved`() {
+            humanizeIdentifier("FreeBSD") shouldBe "FreeBSD"
+        }
+
+        @Test
+        fun `all uppercase input stays uppercase`() {
+            humanizeIdentifier("HOME_ASSISTANT") shouldBe "HOME ASSISTANT"
+        }
+
+        @Test
+        fun `single lowercase token is capitalized`() {
+            humanizeIdentifier("other") shouldBe "Other"
+        }
+
+        @Test
+        fun `already capitalized token is unchanged`() {
+            humanizeIdentifier("Linux") shouldBe "Linux"
+        }
+
+        @Test
+        fun `non letter first character is left alone`() {
+            humanizeIdentifier("3dprinter") shouldBe "3dprinter"
+        }
+    }
+
+    @Nested
+    inner class `humanizeIdentifier degenerate input` {
+        @Test
+        fun `blank input returns empty string`() {
+            humanizeIdentifier("") shouldBe ""
+        }
+
+        @Test
+        fun `whitespace only input returns empty string`() {
+            humanizeIdentifier("   ") shouldBe ""
+        }
+
+        @Test
+        fun `separator only input returns the trimmed input`() {
+            humanizeIdentifier(" __ ") shouldBe "__"
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceHeader.kt
+++ b/app/src/main/java/eu/darken/octi/sync/ui/devices/DeviceHeader.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import eu.darken.octi.common.humanizeIdentifier
 import eu.darken.octi.modules.meta.ui.materialIcon
 import eu.darken.octi.modules.meta.ui.osDisplayName
 
@@ -73,7 +74,7 @@ internal fun DeviceHeader(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            item.serverPlatform?.let { platform ->
+            item.serverPlatform?.takeIf { it.isNotBlank() }?.let { platform ->
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = when (platform.lowercase()) {
@@ -86,7 +87,7 @@ internal fun DeviceHeader(
                     )
                     Spacer(modifier = Modifier.width(2.dp))
                     Text(
-                        text = platform.replaceFirstChar { it.uppercase() },
+                        text = humanizeIdentifier(platform),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/MetaInfoFormatting.kt
+++ b/modules-meta/src/main/java/eu/darken/octi/modules/meta/ui/MetaInfoFormatting.kt
@@ -1,5 +1,6 @@
 package eu.darken.octi.modules.meta.ui
 
+import eu.darken.octi.common.humanizeIdentifier
 import eu.darken.octi.modules.meta.core.MetaInfo
 
 /**
@@ -10,29 +11,63 @@ import eu.darken.octi.modules.meta.core.MetaInfo
  * for payloads from older Android clients that don't populate the generic fields.
  */
 fun MetaInfo.osDisplayName(): String? {
-    val osLabel = osType?.takeIf { it.isNotBlank() }?.let { osDisplayLabel(it) }
-        ?: androidVersionName?.takeIf { it.isNotBlank() }?.let { "Android" }
-    val version = osVersionName?.takeIf { it.isNotBlank() }
-        ?: androidVersionName?.takeIf { it.isNotBlank() }
+    val parsed = osType?.let { parseOsFamily(it) }
+    val label = parsed?.name ?: androidVersionName?.takeIf { it.isNotBlank() }?.let { "Android" }
+    val isAndroidFamily = parsed?.name == "Android" || (parsed == null && !androidVersionName.isNullOrBlank())
+    val version = parsed?.inlineVersion
+        ?: osVersionName?.takeIf { it.isNotBlank() }
+        ?: androidVersionName?.takeIf { it.isNotBlank() && isAndroidFamily }
     return when {
-        osLabel == null && version == null -> null
-        osLabel == null -> version
-        version == null -> osLabel
+        label == null && version == null -> null
+        label == null -> version
+        version == null -> label
         else -> {
-            val base = "$osLabel $version"
-            if (osLabel == "Android" && androidApiLevel != null) "$base (API $androidApiLevel)" else base
+            val base = "$label $version"
+            if (isAndroidFamily && androidApiLevel != null) "$base (API $androidApiLevel)" else base
         }
     }
 }
 
-private fun osDisplayLabel(osType: String): String? = when (osType.lowercase()) {
-    "android" -> "Android"
-    "windows" -> "Windows"
-    "macos" -> "macOS"
-    "linux" -> "Linux"
-    "ios" -> "iOS"
-    "chromeos", "chrome_os", "chrome-os" -> "ChromeOS"
-    "browser", "web" -> "Browser"
-    "" -> null
-    else -> osType.replaceFirstChar { it.titlecase() }
+private data class OsFamily(
+    val name: String,
+    val inlineVersion: String?,
+)
+
+private val WHITESPACE_RUN = Regex("\\s+")
+
+/**
+ * Desktop clients fold the marketing version into the type string ("Windows 11"), while their
+ * `osVersionName` carries the kernel version ("10.0"). This is the only place a version is taken
+ * out of `osType`.
+ */
+private val WINDOWS_WITH_VERSION = Regex("^windows +([0-9][0-9a-z.]*)$")
+
+/**
+ * Peers report `osType` in whatever spelling their platform uses. Known spellings map to a curated
+ * family name, everything else is prettified as-is instead of being force-fitted into a family.
+ *
+ * Matching is exact (after normalizing case and whitespace), so unrelated values like "chromeosx"
+ * can't be swallowed by a prefix match.
+ */
+private fun parseOsFamily(osType: String): OsFamily? {
+    val normalized = osType.trim().lowercase().replace(WHITESPACE_RUN, " ")
+    if (normalized.isEmpty()) return null
+
+    val alias = when (normalized) {
+        "android" -> "Android"
+        "windows" -> "Windows"
+        "macos", "mac os", "mac os x" -> "macOS"
+        "ios" -> "iOS"
+        "chromeos", "chrome os", "chrome_os", "chrome-os" -> "ChromeOS"
+        "linux" -> "Linux"
+        "browser", "web" -> "Browser"
+        else -> null
+    }
+    if (alias != null) return OsFamily(alias, null)
+
+    WINDOWS_WITH_VERSION.matchEntire(normalized)?.let { match ->
+        return OsFamily("Windows", match.groupValues[1])
+    }
+
+    return OsFamily(humanizeIdentifier(osType.trim()), null)
 }

--- a/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/MetaInfoFormattingTest.kt
+++ b/modules-meta/src/test/java/eu/darken/octi/modules/meta/ui/MetaInfoFormattingTest.kt
@@ -1,0 +1,178 @@
+package eu.darken.octi.modules.meta.ui
+
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class MetaInfoFormattingTest : BaseTest() {
+
+    private fun metaInfo(
+        osType: String? = null,
+        osVersionName: String? = null,
+        androidVersionName: String? = null,
+        androidApiLevel: Int? = null,
+    ) = MetaInfo(
+        deviceLabel = null,
+        deviceId = DeviceId(id = "device-123"),
+        octiVersionName = "1.2.3",
+        octiGitSha = "abcdef",
+        deviceManufacturer = "TestCorp",
+        deviceName = "TestDevice",
+        deviceType = MetaInfo.DeviceType.PHONE,
+        androidVersionName = androidVersionName,
+        androidApiLevel = androidApiLevel,
+        osType = osType,
+        osVersionName = osVersionName,
+    )
+
+    @Nested
+    inner class `android peers` {
+        @Test
+        fun `generic and legacy fields both populated`() {
+            metaInfo(
+                osType = "android",
+                osVersionName = "14",
+                androidVersionName = "14",
+                androidApiLevel = 34,
+            ).osDisplayName() shouldBe "Android 14 (API 34)"
+        }
+
+        @Test
+        fun `legacy only payload still renders the api level`() {
+            metaInfo(
+                androidVersionName = "14",
+                androidApiLevel = 34,
+            ).osDisplayName() shouldBe "Android 14 (API 34)"
+        }
+
+        @Test
+        fun `osType android with legacy version renders the api level`() {
+            metaInfo(
+                osType = "android",
+                androidVersionName = "14",
+                androidApiLevel = 34,
+            ).osDisplayName() shouldBe "Android 14 (API 34)"
+        }
+
+        @Test
+        fun `no version at all renders the bare family`() {
+            metaInfo(
+                osType = "android",
+                androidApiLevel = 34,
+            ).osDisplayName() shouldBe "Android"
+        }
+    }
+
+    @Nested
+    inner class `windows peers` {
+        @Test
+        fun `plain family with marketing version`() {
+            metaInfo(osType = "windows", osVersionName = "11").osDisplayName() shouldBe "Windows 11"
+        }
+
+        @Test
+        fun `inline version wins over the kernel version`() {
+            metaInfo(osType = "Windows 11", osVersionName = "10.0").osDisplayName() shouldBe "Windows 11"
+        }
+
+        @Test
+        fun `inline version survives sloppy whitespace`() {
+            metaInfo(osType = "Windows  11", osVersionName = "10.0").osDisplayName() shouldBe "Windows 11"
+        }
+
+        @Test
+        fun `kernel version is neither appended nor substituted`() {
+            val rendered = metaInfo(osType = "Windows 11", osVersionName = "10.0").osDisplayName()
+            rendered shouldNotBe "Windows 11 10.0"
+            rendered shouldNotBe "Windows 10.0"
+        }
+    }
+
+    @Nested
+    inner class `desktop peers` {
+        @Test
+        fun `mac os x spelling maps to macOS`() {
+            metaInfo(osType = "Mac OS X", osVersionName = "15.3").osDisplayName() shouldBe "macOS 15.3"
+        }
+
+        @Test
+        fun `mac os spelling maps to macOS`() {
+            metaInfo(osType = "mac os", osVersionName = "15.3").osDisplayName() shouldBe "macOS 15.3"
+        }
+
+        @Test
+        fun `linux keeps its full kernel version`() {
+            metaInfo(
+                osType = "Linux",
+                osVersionName = "6.8.0-137-generic",
+            ).osDisplayName() shouldBe "Linux 6.8.0-137-generic"
+        }
+    }
+
+    @Nested
+    inner class `unknown os types` {
+        @Test
+        fun `descriptor is not treated as a version and does not suppress osVersionName`() {
+            metaInfo(
+                osType = "Chrome OS Flex",
+                osVersionName = "15699.66.0",
+            ).osDisplayName() shouldBe "Chrome OS Flex 15699.66.0"
+        }
+
+        @Test
+        fun `distro name keeps its own version`() {
+            metaInfo(osType = "Linux Mint", osVersionName = "6.8.0").osDisplayName() shouldBe "Linux Mint 6.8.0"
+        }
+
+        @Test
+        fun `snake case identifier is humanized in full`() {
+            metaInfo(osType = "home_assistant").osDisplayName() shouldBe "Home Assistant"
+        }
+
+        @Test
+        fun `single token is capitalized`() {
+            metaInfo(osType = "other").osDisplayName() shouldBe "Other"
+        }
+
+        @Test
+        fun `chromeosx is not matched as chromeos`() {
+            metaInfo(osType = "chromeosx").osDisplayName() shouldBe "Chromeosx"
+        }
+
+        @Test
+        fun `windowsphone is not matched as windows`() {
+            metaInfo(osType = "windowsphone").osDisplayName() shouldBe "Windowsphone"
+        }
+    }
+
+    @Nested
+    inner class `degenerate payloads` {
+        @Test
+        fun `legacy android version does not leak into a non android label`() {
+            metaInfo(
+                osType = "linux",
+                androidVersionName = "14",
+                androidApiLevel = 34,
+            ).osDisplayName() shouldBe "Linux"
+        }
+
+        @Test
+        fun `missing osType renders the bare version`() {
+            metaInfo(osVersionName = "15.3").osDisplayName() shouldBe "15.3"
+        }
+
+        @Test
+        fun `blank osType renders the bare version`() {
+            metaInfo(osType = "   ", osVersionName = "15.3").osDisplayName() shouldBe "15.3"
+        }
+
+        @Test
+        fun `no os metadata at all returns null`() {
+            metaInfo().osDisplayName() shouldBe null
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Other devices' operating systems are now named correctly in the device list, the device details sheet and the dashboard.

- Windows desktop peers showed a doubled version like "Windows 11 10.0" and now show "Windows 11".
- Macs showed "Mac OS X" and now show "macOS".
- Devices whose platform name Octi doesn't recognise, such as a Home Assistant instance, showed a raw identifier like "Home_assistant" and now show "Home Assistant".
- A device reporting no platform at all no longer shows a stray question-mark icon beside an empty label.

Nothing changes for Android devices.

Refs #370

## Technical Context

- `osType` is a free-form string and every client fills it differently: Android sends a constant, octi-web sends a normalized set falling back to `other`, octi-desktop sends raw `System.getProperty("os.name")`, and the Home Assistant integration sends `home_assistant`. The old lookup matched only exact lowercase keys, so desktop's real values missed it entirely and fell through to the raw path.
- Matching is deliberately exact aliases plus ONE narrow rule for Windows (`^windows +([0-9][0-9a-z.]*)$`), which is the only case where a producer folds the version into the type string while `osVersionName` carries the useless kernel number. An earlier draft used general prefix matching and was rejected in review: it would have read "Chrome OS Flex" as family-plus-version and suppressed the real version.
- That Java reports `os.name` "Windows 11" with `os.version` "10.0" was not measured on a Windows machine. The rule is a no-op if that is wrong, since it only fires on a numeric suffix and a bare "Windows" reaches the same output through the plain alias path.
- `humanizeIdentifier` preserves each token's tail characters on purpose. Lowercasing them would turn "FreeBSD" into "Freebsd"; the cost is that "HOME_ASSISTANT" stays uppercase.
- Worth a close look: `osDisplayName`'s `isAndroidFamily` flag now decides whether "(API n)" is appended. For legacy peers that identity comes from `androidVersionName` rather than `osType`, and the same flag also stops an Android version leaking into a non-Android label ("Linux 14").
