### PR TITLE
Update app translations from Crowdin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,7 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "support-investigator@claude-code-cafe": true,
+    "support@claude-code-cafe": true,
     "google-play@claude-code-cafe": true,
     "devtools@claude-code-cafe": true
   }

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -82,7 +82,7 @@
          already composed from the app name and the tier qualifier - never translate it here. Render
          the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
          %1$s access is active"), as long as the placeholder survives. -->
-    <string name="upgrade_screen_owned_hero_brand_title">У вас есть %1$s 🎉</string>
+    <string name="upgrade_screen_owned_hero_brand_title">У Вас есть %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Спасибо за покупку %1$s! Ваши функции Pro разблокированы и никогда не заканчиваются.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Спасибо за подписку на %1$s! Ваши функции Pro разблокированы.</string>
     <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -203,7 +203,7 @@
          Keep it tier-free when translating: name no product edition. %1$d is the device limit. -->
     <plurals name="pro_device_limit_maximum_hint">
         <item quantity="one">Чтобы просматривать более %1$d устройства, обновитесь или удалите устройства.</item>
-        <item quantity="few">Чтобы просматривать более %1$d устройства, обновитесь или удалите устройства.</item>
+        <item quantity="few">Чтобы просматривать более %1$d устройств, обновитесь или удалите устройства.</item>
         <item quantity="many">Чтобы просматривать более %1$d устройств, обновитесь или удалите устройства.</item>
         <item quantity="other">Чтобы просматривать более %1$d устройств, обновитесь или удалите устройства.</item>
     </plurals>


### PR DESCRIPTION
## What changed

Updated Russian translations pulled from Crowdin: a formal-address capitalization fix on the upgrade screen's hero title, and a grammar correction to the device-limit plural string.

## Technical Context

- `upgrade_screen_owned_hero_brand_title` (ru): informal "you" capitalized to the formal form.
- `pro_device_limit_maximum_hint` (ru, `few` plural category): corrected to the grammatically proper genitive plural form.
- Also includes one unrelated commit renaming a Claude Code plugin reference in `.claude/settings.json` (`support-investigator` → `support`) — it was already uncommitted on this branch and folded in here rather than left dangling.
