### PR TITLE
Show out-of-date devices in widgets and warn sooner

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -51,4 +51,8 @@ dependencies {
     // types without dragging the dependency into non-widget consumers of app-common. Each widget
     // module brings glance-appwidget at runtime itself.
     compileOnly("androidx.glance:glance-appwidget:1.2.0-rc01")
+
+    // WidgetTheme.deriveColors goes through androidx.core ColorUtils, which calls into
+    // android.graphics.Color — not available in the plain unit-test android.jar.
+    testImplementation("org.robolectric:robolectric:4.16.1")
 }

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetTheme.kt
@@ -21,6 +21,7 @@ enum class WidgetTheme(
     data class Colors(
         val containerBg: Int,
         val onContainer: Int,
+        val onContainerVariant: Int,
         val tileBg: Int,
         val onTile: Int,
         val onTileVariant: Int,
@@ -43,6 +44,7 @@ enum class WidgetTheme(
             return Colors(
                 containerBg = bg,
                 onContainer = onContainer,
+                onContainerVariant = ColorUtils.blendARGB(onContainer, bg, 0.38f),
                 tileBg = tileBg,
                 onTile = onTile,
                 onTileVariant = ColorUtils.blendARGB(onTile, tileBg, 0.38f),

--- a/app-common/src/main/java/eu/darken/octi/common/widget/WidgetThemeDefaults.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/widget/WidgetThemeDefaults.kt
@@ -9,6 +9,7 @@ import eu.darken.octi.common.R
 fun widgetDefaultColors(): WidgetTheme.Colors = WidgetTheme.Colors(
     containerBg = colorResource(R.color.widgetContainerBackground).toArgb(),
     onContainer = colorResource(R.color.widgetOnContainer).toArgb(),
+    onContainerVariant = colorResource(R.color.widgetOnContainerVariant).toArgb(),
     tileBg = colorResource(R.color.widgetTileBackground).toArgb(),
     onTile = colorResource(R.color.widgetOnTile).toArgb(),
     onTileVariant = colorResource(R.color.widgetOnTileVariant).toArgb(),

--- a/app-common/src/main/res/drawable/widget_warning_24.xml
+++ b/app-common/src/main/res/drawable/widget_warning_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/widgetOnAccent"
+        android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z" />
+</vector>

--- a/app-common/src/main/res/values-night-v31/colors.xml
+++ b/app-common/src/main/res/values-night-v31/colors.xml
@@ -3,6 +3,7 @@
     <!-- Material You dynamic colors for widget (Android 12+, dark mode) -->
     <color name="widgetContainerBackground">@android:color/system_accent1_700</color>
     <color name="widgetOnContainer">@android:color/system_accent1_50</color>
+    <color name="widgetOnContainerVariant">@android:color/system_accent1_200</color>
     <color name="widgetTileBackground">@android:color/system_accent2_600</color>
     <color name="widgetOnTile">@android:color/system_neutral1_50</color>
     <color name="widgetOnTileVariant">@android:color/system_neutral2_200</color>

--- a/app-common/src/main/res/values-night/colors.xml
+++ b/app-common/src/main/res/values-night/colors.xml
@@ -3,6 +3,7 @@
     <!-- Dark mode widget colors (pre-API 31) -->
     <color name="widgetContainerBackground">#FF11512E</color>
     <color name="widgetOnContainer">#FFE4F7E8</color>
+    <color name="widgetOnContainerVariant">#FF93B7A1</color>
     <color name="widgetTileBackground">#FF39634A</color>
     <color name="widgetOnTile">#FFE4F7E8</color>
     <color name="widgetOnTileVariant">#FFB4CCBA</color>

--- a/app-common/src/main/res/values-v31/colors.xml
+++ b/app-common/src/main/res/values-v31/colors.xml
@@ -3,6 +3,7 @@
     <!-- Material You dynamic colors for widget (Android 12+, light mode) -->
     <color name="widgetContainerBackground">@android:color/system_accent1_600</color>
     <color name="widgetOnContainer">@android:color/system_accent1_50</color>
+    <color name="widgetOnContainerVariant">@android:color/system_accent1_200</color>
     <color name="widgetTileBackground">@android:color/system_accent2_500</color>
     <color name="widgetOnTile">@android:color/system_neutral1_50</color>
     <color name="widgetOnTileVariant">@android:color/system_neutral2_200</color>

--- a/app-common/src/main/res/values/colors.xml
+++ b/app-common/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
     <!-- Light mode widget colors (pre-API 31) -->
     <color name="widgetContainerBackground">#FF2D6A44</color>
     <color name="widgetOnContainer">#FFFFFFFF</color>
+    <color name="widgetOnContainerVariant">#FFAFC6B7</color>
     <color name="widgetTileBackground">#FF4A7057</color>
     <color name="widgetOnTile">#FFF3FFF4</color>
     <color name="widgetOnTileVariant">#FFCEE0D2</color>

--- a/app-common/src/main/res/values/strings.xml
+++ b/app-common/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="widget_empty_label">No matching devices</string>
     <string name="widget_no_sync_devices_label">No sync devices yet</string>
     <string name="widget_more_items">+ %1$d more</string>
+    <string name="widget_stale_device_content_description">Device data is out of date</string>
     <!-- Replaces widget_upgrade_required_title, which named the Google Play tier in the FOSS build too.
          Keep it tier-free and short: it renders on a small widget surface, capped at one line. -->
     <string name="widget_upgrade_required_headline">Upgrade required</string>

--- a/app-common/src/test/java/eu/darken/octi/common/widget/WidgetThemeContrastTest.kt
+++ b/app-common/src/test/java/eu/darken/octi/common/widget/WidgetThemeContrastTest.kt
@@ -1,0 +1,59 @@
+package eu.darken.octi.common.widget
+
+import androidx.core.graphics.ColorUtils
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * The de-emphasized roles are what stale widget rows render in. They are derived by blending
+ * towards their own background, so a bad blend ratio produces text that is technically drawn
+ * but unreadable. This pins a floor over every colour combination a user can actually pick.
+ *
+ * 2.5 is measured, not aspirational: the worst swatch pair sits at 2.64 (onTileVariant) and
+ * 3.14 (onContainerVariant), the worst preset at 2.79 (ORANGE) and 2.96 (RED).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class WidgetThemeContrastTest {
+
+    private val minContrast = 2.5
+
+    private fun assertVariantContrast(bg: Int, accent: Int, label: String) {
+        val colors = WidgetTheme.deriveColors(bg, accent)
+
+        val tileContrast = ColorUtils.calculateContrast(colors.onTileVariant, colors.tileBg)
+        assertTrue(
+            "$label: onTileVariant vs tileBg contrast $tileContrast < $minContrast " +
+                "(bg=#${Integer.toHexString(bg)}, accent=#${Integer.toHexString(accent)})",
+            tileContrast >= minContrast,
+        )
+
+        val containerContrast = ColorUtils.calculateContrast(colors.onContainerVariant, colors.containerBg)
+        assertTrue(
+            "$label: onContainerVariant vs containerBg contrast $containerContrast < $minContrast " +
+                "(bg=#${Integer.toHexString(bg)}, accent=#${Integer.toHexString(accent)})",
+            containerContrast >= minContrast,
+        )
+    }
+
+    @Test
+    fun `every preset keeps the de-emphasized roles readable`() {
+        WidgetTheme.entries
+            .filter { it.presetBg != null && it.presetAccent != null }
+            .forEach { theme ->
+                assertVariantContrast(theme.presetBg!!, theme.presetAccent!!, theme.name)
+            }
+    }
+
+    @Test
+    fun `every swatch combination keeps the de-emphasized roles readable`() {
+        WidgetTheme.SWATCH_COLORS.forEach { bg ->
+            WidgetTheme.SWATCH_COLORS.forEach { accent ->
+                assertVariantContrast(bg, accent, "swatch")
+            }
+        }
+    }
+}

--- a/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
+++ b/modules-clipboard/src/main/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContent.kt
@@ -44,6 +44,7 @@ import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.clipboard.ClipboardInfo
 import eu.darken.octi.modules.clipboard.R
 import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.StalenessUtil
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.common.R as CommonR
 
@@ -99,13 +100,14 @@ internal object ClipboardWidgetSizing {
     )
 }
 
-private data class ClipboardDeviceRow(
+internal data class ClipboardDeviceRow(
     val deviceName: String,
     val lastSeen: CharSequence,
     val clipboardText: String?,
     val hasCopyableContent: Boolean,
     val deviceType: MetaInfo.DeviceType,
     val deviceId: String,
+    val isStale: Boolean,
 )
 
 private data class SelfClipboardDisplay(
@@ -235,7 +237,7 @@ private fun extractSelf(clipboardState: ModuleRepo.State<*>?): SelfClipboardDisp
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun buildDeviceRows(
+internal fun buildDeviceRows(
     metaState: ModuleRepo.State<*>?,
     clipboardState: ModuleRepo.State<*>?,
     selfDeviceId: String?,
@@ -268,10 +270,11 @@ private fun buildDeviceRows(
         )
         .map { (clipData, metaData) ->
             val preview = clipData.data.toWidgetPreview()
+            val lastActivity = maxOf(metaData.modifiedAt, clipData.modifiedAt)
             ClipboardDeviceRow(
                 deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
-                    metaData.modifiedAt.toEpochMilliseconds(),
+                    lastActivity.toEpochMilliseconds(),
                     System.currentTimeMillis(),
                     DateUtils.MINUTE_IN_MILLIS,
                     DateUtils.FORMAT_ABBREV_RELATIVE,
@@ -280,6 +283,7 @@ private fun buildDeviceRows(
                 hasCopyableContent = preview.hasCopyableContent,
                 deviceType = metaData.data.deviceType,
                 deviceId = clipData.deviceId.id,
+                isStale = StalenessUtil.isStale(lastActivity),
             )
         }
         .toList()
@@ -331,8 +335,23 @@ private fun ClipboardDeviceRowContent(
         actionRunCallback<NoOpClickCallback>()
     }
 
-    val titleColor = if (device.hasCopyableContent) primaryColor else secondaryColor
+    val titleColor = when {
+        device.isStale -> secondaryColor
+        device.hasCopyableContent -> primaryColor
+        else -> secondaryColor
+    }
     val bodyColor = secondaryColor
+
+    val copyLabel = context.getString(R.string.module_clipboard_copy_action)
+    val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
+    // The icon's content description is the row's only accessibility label and the row still
+    // copies while stale, so the affordance has to survive alongside the warning.
+    val iconDescription = when {
+        device.isStale && device.hasCopyableContent -> "$staleLabel. $copyLabel"
+        device.isStale -> staleLabel
+        device.hasCopyableContent -> copyLabel
+        else -> null
+    }
 
     Box(
         modifier = GlanceModifier
@@ -347,12 +366,14 @@ private fun ClipboardDeviceRowContent(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Image(
-                provider = ImageProvider(device.deviceType.widgetIconRes()),
-                contentDescription = if (device.hasCopyableContent) {
-                    context.getString(R.string.module_clipboard_copy_action)
-                } else {
-                    null
-                },
+                provider = ImageProvider(
+                    if (device.isStale) {
+                        CommonR.drawable.widget_warning_24
+                    } else {
+                        device.deviceType.widgetIconRes()
+                    },
+                ),
+                contentDescription = iconDescription,
                 modifier = GlanceModifier.size(18.dp),
                 colorFilter = ColorFilter.tint(titleColor),
             )
@@ -367,9 +388,11 @@ private fun ClipboardDeviceRowContent(
                 maxLines = 1,
             )
             Spacer(modifier = GlanceModifier.width(6.dp))
+            // This row computes an age but has nowhere to show it, so a stale row leads with it.
+            val detailPrefix = if (device.isStale) "${device.lastSeen} \u00b7 " else ""
             if (device.hasCopyableContent) {
                 Text(
-                    text = device.clipboardText ?: "",
+                    text = detailPrefix + (device.clipboardText ?: ""),
                     style = TextStyle(
                         fontSize = 10.sp,
                         color = bodyColor,
@@ -379,7 +402,7 @@ private fun ClipboardDeviceRowContent(
                 )
             } else {
                 Text(
-                    text = context.getString(R.string.module_clipboard_widget_no_data),
+                    text = detailPrefix + context.getString(R.string.module_clipboard_widget_no_data),
                     style = TextStyle(
                         fontSize = 10.sp,
                         fontStyle = FontStyle.Italic,

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
@@ -19,6 +19,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
@@ -34,8 +36,9 @@ class ClipboardWidgetContentGlanceTest {
     private fun clipboardModuleData(
         deviceId: DeviceId,
         info: ClipboardInfo,
+        modifiedAt: Instant = Clock.System.now(),
     ): ModuleData<ClipboardInfo> = ModuleData(
-        modifiedAt = Instant.fromEpochMilliseconds(0),
+        modifiedAt = modifiedAt,
         deviceId = deviceId,
         moduleId = clipboardModuleId,
         data = info,
@@ -44,8 +47,9 @@ class ClipboardWidgetContentGlanceTest {
     private fun metaModuleData(
         deviceId: DeviceId,
         label: String,
+        modifiedAt: Instant = Clock.System.now(),
     ): ModuleData<MetaInfo> = ModuleData(
-        modifiedAt = Instant.fromEpochMilliseconds(0),
+        modifiedAt = modifiedAt,
         deviceId = deviceId,
         moduleId = metaModuleId,
         data = MetaInfo(
@@ -67,13 +71,14 @@ class ClipboardWidgetContentGlanceTest {
         self: ClipboardInfo = ClipboardInfo(),
         remote: ClipboardInfo? = null,
         extraRemotes: List<Pair<DeviceId, ClipboardInfo>> = emptyList(),
+        remotesModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<ClipboardInfo> = BaseModuleRepo.State(
         moduleId = clipboardModuleId,
         self = clipboardModuleData(selfDeviceId, self),
         isOthersInitialized = true,
         others = buildList {
-            remote?.let { add(clipboardModuleData(remoteDeviceId, it)) }
-            extraRemotes.forEach { (id, info) -> add(clipboardModuleData(id, info)) }
+            remote?.let { add(clipboardModuleData(remoteDeviceId, it, remotesModifiedAt)) }
+            extraRemotes.forEach { (id, info) -> add(clipboardModuleData(id, info, remotesModifiedAt)) }
         },
     )
 
@@ -81,13 +86,14 @@ class ClipboardWidgetContentGlanceTest {
         selfLabel: String = "MyPhone",
         remoteLabel: String? = null,
         extraRemotes: List<Pair<DeviceId, String>> = emptyList(),
+        remotesModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
         moduleId = metaModuleId,
         self = metaModuleData(selfDeviceId, selfLabel),
         isOthersInitialized = true,
         others = buildList {
-            remoteLabel?.let { add(metaModuleData(remoteDeviceId, it)) }
-            extraRemotes.forEach { (id, label) -> add(metaModuleData(id, label)) }
+            remoteLabel?.let { add(metaModuleData(remoteDeviceId, it, remotesModifiedAt)) }
+            extraRemotes.forEach { (id, label) -> add(metaModuleData(id, label, remotesModifiedAt)) }
         },
     )
 
@@ -121,6 +127,77 @@ class ClipboardWidgetContentGlanceTest {
                 maxRows = 5,
             )
         }
+        onNode(hasContentDescription("Copy to clipboard")).assertExists()
+    }
+
+    @Test
+    fun `stale row keeps the copy affordance alongside the warning`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(
+                    remoteLabel = "Pixel 9",
+                    remotesModifiedAt = Clock.System.now() - 8.days,
+                ),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(
+                        type = ClipboardInfo.Type.SIMPLE_TEXT,
+                        data = "Hello".encodeUtf8(),
+                    ),
+                    remotesModifiedAt = Clock.System.now() - 8.days,
+                ),
+                themeColors = null,
+                maxRows = 5,
+            )
+        }
+        val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
+        val copyLabel = context.getString(R.string.module_clipboard_copy_action)
+        onNode(hasContentDescription("$staleLabel. $copyLabel")).assertExists()
+    }
+
+    @Test
+    fun `stale row without copyable content is labelled only as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(
+                    remoteLabel = "Pixel 9",
+                    remotesModifiedAt = Clock.System.now() - 8.days,
+                ),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(),
+                    remotesModifiedAt = Clock.System.now() - 8.days,
+                ),
+                themeColors = null,
+                maxRows = 5,
+            )
+        }
+        val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
+        onNode(hasContentDescription(staleLabel)).assertExists()
+        onNode(hasContentDescription("Copy to clipboard")).assertDoesNotExist()
+    }
+
+    @Test
+    fun `fresh row is not labelled as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        provideComposable {
+            ClipboardWidgetContent(
+                metaState = fakeMetaState(remoteLabel = "Pixel 9"),
+                clipboardState = fakeClipboardState(
+                    remote = ClipboardInfo(
+                        type = ClipboardInfo.Type.SIMPLE_TEXT,
+                        data = "Hello".encodeUtf8(),
+                    ),
+                ),
+                themeColors = null,
+                maxRows = 5,
+            )
+        }
+        val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
+        onNode(hasContentDescription(staleLabel)).assertDoesNotExist()
         onNode(hasContentDescription("Copy to clipboard")).assertExists()
     }
 

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetContentGlanceTest.kt
@@ -134,19 +134,20 @@ class ClipboardWidgetContentGlanceTest {
     fun `stale row keeps the copy affordance alongside the warning`() = runGlanceAppWidgetUnitTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         setContext(context)
+        val staleAt = Clock.System.now() - 8.days
+        val metaState = fakeMetaState(remoteLabel = "Pixel 9", remotesModifiedAt = staleAt)
+        val clipboardState = fakeClipboardState(
+            remote = ClipboardInfo(
+                type = ClipboardInfo.Type.SIMPLE_TEXT,
+                data = "Hello".encodeUtf8(),
+            ),
+            remotesModifiedAt = staleAt,
+        )
+        val expectedLastSeen = buildDeviceRows(metaState, clipboardState, selfDeviceId.id, null).single().lastSeen
         provideComposable {
             ClipboardWidgetContent(
-                metaState = fakeMetaState(
-                    remoteLabel = "Pixel 9",
-                    remotesModifiedAt = Clock.System.now() - 8.days,
-                ),
-                clipboardState = fakeClipboardState(
-                    remote = ClipboardInfo(
-                        type = ClipboardInfo.Type.SIMPLE_TEXT,
-                        data = "Hello".encodeUtf8(),
-                    ),
-                    remotesModifiedAt = Clock.System.now() - 8.days,
-                ),
+                metaState = metaState,
+                clipboardState = clipboardState,
                 themeColors = null,
                 maxRows = 5,
             )
@@ -154,29 +155,30 @@ class ClipboardWidgetContentGlanceTest {
         val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
         val copyLabel = context.getString(R.string.module_clipboard_copy_action)
         onNode(hasContentDescription("$staleLabel. $copyLabel")).assertExists()
+        onNode(hasText("$expectedLastSeen \u00b7 Hello")).assertExists()
     }
 
     @Test
     fun `stale row without copyable content is labelled only as out of date`() = runGlanceAppWidgetUnitTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         setContext(context)
+        val staleAt = Clock.System.now() - 8.days
+        val metaState = fakeMetaState(remoteLabel = "Pixel 9", remotesModifiedAt = staleAt)
+        val clipboardState = fakeClipboardState(remote = ClipboardInfo(), remotesModifiedAt = staleAt)
+        val expectedLastSeen = buildDeviceRows(metaState, clipboardState, selfDeviceId.id, null).single().lastSeen
         provideComposable {
             ClipboardWidgetContent(
-                metaState = fakeMetaState(
-                    remoteLabel = "Pixel 9",
-                    remotesModifiedAt = Clock.System.now() - 8.days,
-                ),
-                clipboardState = fakeClipboardState(
-                    remote = ClipboardInfo(),
-                    remotesModifiedAt = Clock.System.now() - 8.days,
-                ),
+                metaState = metaState,
+                clipboardState = clipboardState,
                 themeColors = null,
                 maxRows = 5,
             )
         }
         val staleLabel = context.getString(CommonR.string.widget_stale_device_content_description)
+        val noData = context.getString(R.string.module_clipboard_widget_no_data)
         onNode(hasContentDescription(staleLabel)).assertExists()
         onNode(hasContentDescription("Copy to clipboard")).assertDoesNotExist()
+        onNode(hasText("$expectedLastSeen \u00b7 $noData")).assertExists()
     }
 
     @Test

--- a/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetRowsTest.kt
+++ b/modules-clipboard/src/test/java/eu/darken/octi/modules/clipboard/ui/widget/ClipboardWidgetRowsTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.octi.modules.clipboard.ui.widget
+
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.clipboard.ClipboardInfo
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Robolectric because the builder formats `lastSeen` via `DateUtils.getRelativeTimeSpanString`,
+ * which is unavailable in the plain unit-test android.jar.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class ClipboardWidgetRowsTest {
+
+    private val selfDeviceId = DeviceId(id = "self-device")
+    private val peerDeviceId = DeviceId(id = "peer-device")
+    private val clipboardModuleId = ModuleId("eu.darken.octi.module.core.clipboard")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private val now = Clock.System.now()
+
+    private fun clipboardModuleData(deviceId: DeviceId, modifiedAt: Instant): ModuleData<ClipboardInfo> =
+        ModuleData(
+            modifiedAt = modifiedAt,
+            deviceId = deviceId,
+            moduleId = clipboardModuleId,
+            data = ClipboardInfo(),
+        )
+
+    private fun metaModuleData(deviceId: DeviceId, label: String, modifiedAt: Instant): ModuleData<MetaInfo> =
+        ModuleData(
+            modifiedAt = modifiedAt,
+            deviceId = deviceId,
+            moduleId = metaModuleId,
+            data = MetaInfo(
+                deviceLabel = label,
+                deviceId = deviceId,
+                octiVersionName = "test",
+                octiGitSha = "test",
+                deviceManufacturer = "test",
+                deviceName = label,
+                deviceType = MetaInfo.DeviceType.PHONE,
+                deviceBootedAt = now,
+                androidVersionName = "test",
+                androidApiLevel = 34,
+                androidSecurityPatch = null,
+            ),
+        )
+
+    private fun rowsFor(peerMetaAt: Instant, peerClipboardAt: Instant): List<ClipboardDeviceRow> {
+        val metaState = BaseModuleRepo.State(
+            moduleId = metaModuleId,
+            self = metaModuleData(selfDeviceId, "MyPhone", now),
+            isOthersInitialized = true,
+            others = listOf(metaModuleData(peerDeviceId, "Peer", peerMetaAt)),
+        )
+        val clipboardState = BaseModuleRepo.State(
+            moduleId = clipboardModuleId,
+            self = clipboardModuleData(selfDeviceId, now),
+            isOthersInitialized = true,
+            others = listOf(clipboardModuleData(peerDeviceId, peerClipboardAt)),
+        )
+        return buildDeviceRows(metaState, clipboardState, selfDeviceId.id, null)
+    }
+
+    private fun List<ClipboardDeviceRow>.peer() = single { it.deviceId == peerDeviceId.id }
+
+    @Test
+    fun `a fresh peer is not stale`() {
+        rowsFor(peerMetaAt = now, peerClipboardAt = now).peer().isStale shouldBe false
+    }
+
+    @Test
+    fun `an eight day old peer is stale`() {
+        val old = now - 8.days
+        rowsFor(peerMetaAt = old, peerClipboardAt = old).peer().isStale shouldBe true
+    }
+
+    @Test
+    fun `fresh clipboard data keeps a peer with old meta data current`() {
+        rowsFor(peerMetaAt = now - 8.days, peerClipboardAt = now).peer().isStale shouldBe false
+    }
+}

--- a/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
+++ b/modules-connectivity/src/main/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContent.kt
@@ -37,11 +37,13 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.widgetCornerRadius
+import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.connectivity.R
 import eu.darken.octi.modules.connectivity.core.ConnectivityInfo
 import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.StalenessUtil
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
 import eu.darken.octi.common.R as CommonR
 
@@ -111,13 +113,14 @@ internal object NetworkWidgetSizing {
     )
 }
 
-private data class NetworkDeviceTile(
+internal data class NetworkDeviceTile(
     val deviceId: String,
     val deviceName: String,
     val lastSeen: CharSequence,
     val connectionType: ConnectivityInfo.ConnectionType?,
     val localIp: String,
     val publicIp: String,
+    val isStale: Boolean,
 )
 
 @Composable
@@ -229,7 +232,7 @@ fun NetworkWidgetContent(
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun buildDeviceTiles(
+internal fun buildDeviceTiles(
     metaState: ModuleRepo.State<*>?,
     connectivityState: ModuleRepo.State<*>?,
     allowedDeviceIds: Set<String>?,
@@ -240,6 +243,9 @@ private fun buildDeviceTiles(
         ?: return emptyList()
     val connectivityAll = connectivityState.all as? Collection<ModuleData<ConnectivityInfo>>
         ?: return emptyList()
+    // Our own tile is stamped only when MetaInfo actually changes, so an idle long-running
+    // process would otherwise report the user's own device as out of date.
+    val selfDeviceId = (connectivityState as? BaseModuleRepo.State<*>)?.self?.deviceId
 
     val pairs = connectivityAll
         .mapNotNull { connData ->
@@ -261,11 +267,12 @@ private fun buildDeviceTiles(
             }.thenBy { it.second.deviceId.id }
         )
         .map { (connData, metaData) ->
+            val lastActivity = maxOf(metaData.modifiedAt, connData.modifiedAt)
             NetworkDeviceTile(
                 deviceId = connData.deviceId.id,
                 deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
-                    metaData.modifiedAt.toEpochMilliseconds(),
+                    lastActivity.toEpochMilliseconds(),
                     System.currentTimeMillis(),
                     DateUtils.MINUTE_IN_MILLIS,
                     DateUtils.FORMAT_ABBREV_RELATIVE,
@@ -273,6 +280,7 @@ private fun buildDeviceTiles(
                 connectionType = connData.data.connectionType,
                 localIp = connData.data.localAddressIpv4 ?: "\u2014",
                 publicIp = connData.data.publicIp ?: "\u2014",
+                isStale = connData.deviceId != selfDeviceId && StalenessUtil.isStale(lastActivity),
             )
         }
 }
@@ -330,9 +338,17 @@ private fun NetworkDeviceTileContent(
 ) {
     val context = LocalContext.current
     val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
-    val titleColor = colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
     val detailColor = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
-    val iconRes = connectionIconRes(device.connectionType)
+    val titleColor = if (device.isStale) {
+        detailColor
+    } else {
+        colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
+    }
+    val iconRes = if (device.isStale) {
+        CommonR.drawable.widget_warning_24
+    } else {
+        connectionIconRes(device.connectionType)
+    }
 
     val copyAction = actionRunCallback<CopyNetworkAddressesCallback>(
         actionParametersOf(CopyNetworkAddressesCallback.KEY_DEVICE_ID to device.deviceId),
@@ -354,7 +370,11 @@ private fun NetworkDeviceTileContent(
             ) {
                 Image(
                     provider = ImageProvider(iconRes),
-                    contentDescription = null,
+                    contentDescription = if (device.isStale) {
+                        context.getString(CommonR.string.widget_stale_device_content_description)
+                    } else {
+                        null
+                    },
                     modifier = GlanceModifier.size(16.dp),
                     colorFilter = ColorFilter.tint(titleColor),
                 )
@@ -373,6 +393,7 @@ private fun NetworkDeviceTileContent(
             Text(
                 text = "${connectionTypeLabel(context, device.connectionType)} \u00b7 ${device.lastSeen}",
                 style = TextStyle(
+                    fontWeight = if (device.isStale) FontWeight.Bold else null,
                     fontSize = 10.sp,
                     color = detailColor,
                 ),
@@ -458,10 +479,19 @@ private fun NetworkDeviceCompactRow(
     device: NetworkDeviceTile,
     themeColors: WidgetTheme.Colors?,
 ) {
+    val context = LocalContext.current
     val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
-    val titleColor = colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
     val detailColor = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
-    val iconRes = connectionIconRes(device.connectionType)
+    val titleColor = if (device.isStale) {
+        detailColor
+    } else {
+        colorOrDefault(themeColors?.onTile, CommonR.color.widgetOnTile)
+    }
+    val iconRes = if (device.isStale) {
+        CommonR.drawable.widget_warning_24
+    } else {
+        connectionIconRes(device.connectionType)
+    }
 
     val copyAction = actionRunCallback<CopyNetworkAddressesCallback>(
         actionParametersOf(CopyNetworkAddressesCallback.KEY_DEVICE_ID to device.deviceId),
@@ -481,7 +511,11 @@ private fun NetworkDeviceCompactRow(
         ) {
             Image(
                 provider = ImageProvider(iconRes),
-                contentDescription = null,
+                contentDescription = if (device.isStale) {
+                    context.getString(CommonR.string.widget_stale_device_content_description)
+                } else {
+                    null
+                },
                 modifier = GlanceModifier.size(16.dp),
                 colorFilter = ColorFilter.tint(titleColor),
             )
@@ -497,7 +531,13 @@ private fun NetworkDeviceCompactRow(
             )
             Spacer(modifier = GlanceModifier.width(6.dp))
             Text(
-                text = "${device.localIp} \u00b7 ${device.publicIp}",
+                // A week-old peer's addresses are almost certainly wrong, so the compact row
+                // trades them for the age that explains why the row is dimmed.
+                text = if (device.isStale) {
+                    device.lastSeen.toString()
+                } else {
+                    "${device.localIp} \u00b7 ${device.publicIp}"
+                },
                 style = TextStyle(
                     fontSize = 10.sp,
                     color = detailColor,

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.connectivity.ui.widget
 
 import android.content.Context
 import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.unit.hasContentDescription
 import androidx.glance.testing.unit.hasText
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.octi.common.R as CommonR
@@ -15,6 +16,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
@@ -41,15 +44,20 @@ class NetworkWidgetContentGlanceTest {
     private fun connectivityModuleData(
         deviceId: DeviceId,
         info: ConnectivityInfo = connectivityInfo(),
+        modifiedAt: Instant = Clock.System.now(),
     ): ModuleData<ConnectivityInfo> = ModuleData(
-        modifiedAt = Instant.fromEpochMilliseconds(0),
+        modifiedAt = modifiedAt,
         deviceId = deviceId,
         moduleId = connectivityModuleId,
         data = info,
     )
 
-    private fun metaModuleData(deviceId: DeviceId, label: String): ModuleData<MetaInfo> = ModuleData(
-        modifiedAt = Instant.fromEpochMilliseconds(0),
+    private fun metaModuleData(
+        deviceId: DeviceId,
+        label: String,
+        modifiedAt: Instant = Clock.System.now(),
+    ): ModuleData<MetaInfo> = ModuleData(
+        modifiedAt = modifiedAt,
         deviceId = deviceId,
         moduleId = metaModuleId,
         data = MetaInfo(
@@ -70,21 +78,23 @@ class NetworkWidgetContentGlanceTest {
     private fun connectivityState(
         selfInfo: ConnectivityInfo = connectivityInfo(),
         extras: List<Pair<DeviceId, ConnectivityInfo>> = emptyList(),
+        extrasModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<ConnectivityInfo> = BaseModuleRepo.State(
         moduleId = connectivityModuleId,
         self = connectivityModuleData(selfDeviceId, selfInfo),
         isOthersInitialized = true,
-        others = extras.map { (id, info) -> connectivityModuleData(id, info) },
+        others = extras.map { (id, info) -> connectivityModuleData(id, info, extrasModifiedAt) },
     )
 
     private fun metaState(
         selfLabel: String = "MyPhone",
         extras: List<Pair<DeviceId, String>> = emptyList(),
+        extrasModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
         moduleId = metaModuleId,
         self = metaModuleData(selfDeviceId, selfLabel),
         isOthersInitialized = true,
-        others = extras.map { (id, label) -> metaModuleData(id, label) },
+        others = extras.map { (id, label) -> metaModuleData(id, label, extrasModifiedAt) },
     )
 
     @Test
@@ -195,6 +205,86 @@ class NetworkWidgetContentGlanceTest {
         onNode(hasText("MyPhone")).assertDoesNotExist()
         onNode(hasText("Alpha")).assertDoesNotExist()
         onNode(hasText(context.getString(CommonR.string.widget_more_items, 3))).assertExists()
+    }
+
+    @Test
+    fun `stale tile is labelled as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val staleId = DeviceId("stale-device")
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(
+                    extras = listOf(staleId to "Old Tablet"),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                connectivityState = connectivityState(
+                    extras = listOf(staleId to connectivityInfo()),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                themeColors = null,
+                maxRows = 4,
+                widthDp = 300f,
+                heightDp = 200f,
+                allowedDeviceIds = setOf(staleId.id),
+            )
+        }
+        onNode(hasText("Old Tablet")).assertExists()
+        onNode(
+            hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
+        ).assertExists()
+    }
+
+    @Test
+    fun `fresh tile is not labelled as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val freshId = DeviceId("fresh-device")
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(extras = listOf(freshId to "New Tablet")),
+                connectivityState = connectivityState(extras = listOf(freshId to connectivityInfo())),
+                themeColors = null,
+                maxRows = 4,
+                widthDp = 300f,
+                heightDp = 200f,
+                allowedDeviceIds = setOf(freshId.id),
+            )
+        }
+        onNode(hasText("New Tablet")).assertExists()
+        onNode(
+            hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `stale compact row shows the age instead of the addresses`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val staleId = DeviceId("stale-device")
+        provideComposable {
+            NetworkWidgetContent(
+                metaState = metaState(
+                    extras = listOf(staleId to "Old Tablet"),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                connectivityState = connectivityState(
+                    extras = listOf(
+                        staleId to connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
+                    ),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                themeColors = null,
+                maxRows = 4,
+                widthDp = 150f,
+                heightDp = 200f,
+                allowedDeviceIds = setOf(staleId.id),
+            )
+        }
+        onNode(hasText("10.0.0.5 · 1.2.3.4")).assertDoesNotExist()
+        onNode(
+            hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
+        ).assertExists()
     }
 
     @Test

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentGlanceTest.kt
@@ -262,18 +262,26 @@ class NetworkWidgetContentGlanceTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         setContext(context)
         val staleId = DeviceId("stale-device")
+        val staleAt = Clock.System.now() - 8.days
+        val staleMetaState = metaState(
+            extras = listOf(staleId to "Old Tablet"),
+            extrasModifiedAt = staleAt,
+        )
+        val staleConnectivityState = connectivityState(
+            extras = listOf(
+                staleId to connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
+            ),
+            extrasModifiedAt = staleAt,
+        )
+        val expectedLastSeen = buildDeviceTiles(
+            staleMetaState,
+            staleConnectivityState,
+            setOf(staleId.id),
+        ).single().lastSeen
         provideComposable {
             NetworkWidgetContent(
-                metaState = metaState(
-                    extras = listOf(staleId to "Old Tablet"),
-                    extrasModifiedAt = Clock.System.now() - 8.days,
-                ),
-                connectivityState = connectivityState(
-                    extras = listOf(
-                        staleId to connectivityInfo(localIp = "10.0.0.5", publicIp = "1.2.3.4"),
-                    ),
-                    extrasModifiedAt = Clock.System.now() - 8.days,
-                ),
+                metaState = staleMetaState,
+                connectivityState = staleConnectivityState,
                 themeColors = null,
                 maxRows = 4,
                 widthDp = 150f,
@@ -285,6 +293,7 @@ class NetworkWidgetContentGlanceTest {
         onNode(
             hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
         ).assertExists()
+        onNode(hasText(expectedLastSeen.toString())).assertExists()
     }
 
     @Test

--- a/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentTest.kt
+++ b/modules-connectivity/src/test/java/eu/darken/octi/modules/connectivity/ui/widget/NetworkWidgetContentTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.octi.modules.connectivity.ui.widget
+
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.connectivity.core.ConnectivityInfo
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Robolectric because the builder formats `lastSeen` via `DateUtils.getRelativeTimeSpanString`,
+ * which is unavailable in the plain unit-test android.jar.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class NetworkWidgetContentTest {
+
+    private val selfDeviceId = DeviceId(id = "self-device")
+    private val peerDeviceId = DeviceId(id = "peer-device")
+    private val connectivityModuleId = ModuleId("eu.darken.octi.module.core.connectivity")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private val now = Clock.System.now()
+
+    private fun connectivityInfo() = ConnectivityInfo(
+        connectionType = ConnectivityInfo.ConnectionType.WIFI,
+        publicIp = "203.0.113.5",
+        localAddressIpv4 = "192.168.1.10",
+        localAddressIpv6 = null,
+        gatewayIp = null,
+        dnsServers = null,
+    )
+
+    private fun connectivityModuleData(deviceId: DeviceId, modifiedAt: Instant): ModuleData<ConnectivityInfo> =
+        ModuleData(
+            modifiedAt = modifiedAt,
+            deviceId = deviceId,
+            moduleId = connectivityModuleId,
+            data = connectivityInfo(),
+        )
+
+    private fun metaModuleData(deviceId: DeviceId, label: String, modifiedAt: Instant): ModuleData<MetaInfo> =
+        ModuleData(
+            modifiedAt = modifiedAt,
+            deviceId = deviceId,
+            moduleId = metaModuleId,
+            data = MetaInfo(
+                deviceLabel = label,
+                deviceId = deviceId,
+                octiVersionName = "test",
+                octiGitSha = "test",
+                deviceManufacturer = "test",
+                deviceName = label,
+                deviceType = MetaInfo.DeviceType.PHONE,
+                deviceBootedAt = now,
+                androidVersionName = "test",
+                androidApiLevel = 34,
+                androidSecurityPatch = null,
+            ),
+        )
+
+    private fun tilesFor(
+        selfMetaAt: Instant = now,
+        selfConnectivityAt: Instant = now,
+        peerMetaAt: Instant? = null,
+        peerConnectivityAt: Instant? = null,
+    ): List<NetworkDeviceTile> {
+        val metaState = BaseModuleRepo.State(
+            moduleId = metaModuleId,
+            self = metaModuleData(selfDeviceId, "MyPhone", selfMetaAt),
+            isOthersInitialized = true,
+            others = peerMetaAt?.let { listOf(metaModuleData(peerDeviceId, "Peer", it)) } ?: emptyList(),
+        )
+        val connectivityState = BaseModuleRepo.State(
+            moduleId = connectivityModuleId,
+            self = connectivityModuleData(selfDeviceId, selfConnectivityAt),
+            isOthersInitialized = true,
+            others = peerConnectivityAt?.let { listOf(connectivityModuleData(peerDeviceId, it)) } ?: emptyList(),
+        )
+        return buildDeviceTiles(metaState, connectivityState, null)
+    }
+
+    private fun List<NetworkDeviceTile>.tile(deviceId: DeviceId) = single { it.deviceId == deviceId.id }
+
+    @Test
+    fun `a fresh peer is not stale`() {
+        val tiles = tilesFor(peerMetaAt = now, peerConnectivityAt = now)
+        tiles.tile(peerDeviceId).isStale shouldBe false
+    }
+
+    @Test
+    fun `an eight day old peer is stale`() {
+        val old = now - 8.days
+        val tiles = tilesFor(peerMetaAt = old, peerConnectivityAt = old)
+        tiles.tile(peerDeviceId).isStale shouldBe true
+    }
+
+    @Test
+    fun `self is never stale even with an old timestamp`() {
+        val old = now - 30.days
+        val tiles = tilesFor(selfMetaAt = old, selfConnectivityAt = old)
+        tiles.tile(selfDeviceId).isStale shouldBe false
+    }
+
+    @Test
+    fun `fresh connectivity data keeps a peer with old meta data current`() {
+        val tiles = tilesFor(peerMetaAt = now - 8.days, peerConnectivityAt = now)
+        tiles.tile(peerDeviceId).isStale shouldBe false
+    }
+}

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContent.kt
@@ -38,12 +38,14 @@ import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.navigation.WidgetDeeplink
 import eu.darken.octi.common.widget.WidgetTheme
 import eu.darken.octi.common.widget.widgetCornerRadius
+import eu.darken.octi.module.core.BaseModuleRepo
 import eu.darken.octi.module.core.ModuleData
 import eu.darken.octi.module.core.ModuleRepo
 import eu.darken.octi.modules.meta.core.MetaInfo
 import eu.darken.octi.common.R as CommonR
 import eu.darken.octi.modules.power.R
 import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.sync.core.StalenessUtil
 import eu.darken.octi.sync.core.disambiguateDeviceLabels
 
 internal object BatteryWidgetSizing {
@@ -111,12 +113,13 @@ private val TAG = logTag("Module", "Power", "Widget", "Content")
 private fun colorOrDefault(value: Int?, @ColorRes defaultRes: Int): ColorProvider =
     value?.let { ColorProvider(Color(it)) } ?: ColorProvider(defaultRes)
 
-private data class BatteryDeviceRow(
+internal data class BatteryDeviceRow(
     val deviceId: String,
     val deviceName: String,
     val lastSeen: CharSequence,
     val percent: Int,
     val isCharging: Boolean,
+    val isStale: Boolean,
 )
 
 @Composable
@@ -212,7 +215,7 @@ fun BatteryWidgetContent(
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun buildDeviceRows(
+internal fun buildDeviceRows(
     metaState: ModuleRepo.State<*>?,
     powerState: ModuleRepo.State<*>?,
     allowedDeviceIds: Set<String>?,
@@ -221,6 +224,9 @@ private fun buildDeviceRows(
 
     val metaAll = metaState.all as? Collection<ModuleData<MetaInfo>> ?: return emptyList()
     val powerAll = powerState.all as? Collection<ModuleData<PowerInfo>> ?: return emptyList()
+    // Our own row is stamped only when MetaInfo actually changes, so an idle long-running
+    // process would otherwise report the user's own device as out of date.
+    val selfDeviceId = (powerState as? BaseModuleRepo.State<*>)?.self?.deviceId
 
     val pairs = powerAll
         .mapNotNull { powerData ->
@@ -244,17 +250,19 @@ private fun buildDeviceRows(
         .map { (powerData, metaData) ->
             val rawPercent = powerData.data.battery.percent
             val safePercent = if (rawPercent.isFinite()) (rawPercent * 100).toInt() else 0
+            val lastActivity = maxOf(metaData.modifiedAt, powerData.modifiedAt)
             BatteryDeviceRow(
                 deviceId = powerData.deviceId.id,
                 deviceName = labelsByDevice[metaData.deviceId] ?: metaData.data.labelOrFallback,
                 lastSeen = DateUtils.getRelativeTimeSpanString(
-                    metaData.modifiedAt.toEpochMilliseconds(),
+                    lastActivity.toEpochMilliseconds(),
                     System.currentTimeMillis(),
                     DateUtils.MINUTE_IN_MILLIS,
                     DateUtils.FORMAT_ABBREV_RELATIVE,
                 ),
                 percent = safePercent.coerceIn(0, 100),
                 isCharging = powerData.data.isCharging,
+                isStale = powerData.deviceId != selfDeviceId && StalenessUtil.isStale(lastActivity),
             )
         }
 }
@@ -271,6 +279,15 @@ private fun BatteryDeviceRowContent(
     val tileBg = colorOrDefault(themeColors?.tileBg, CommonR.color.widgetTileBackground)
     val accentContent = colorOrDefault(themeColors?.onAccent, CommonR.color.widgetOnAccent)
     val onContainer = colorOrDefault(themeColors?.onContainer, CommonR.color.widgetOnContainer)
+    val onTileVariant = colorOrDefault(themeColors?.onTileVariant, CommonR.color.widgetOnTileVariant)
+    val onContainerVariant = colorOrDefault(
+        themeColors?.onContainerVariant,
+        CommonR.color.widgetOnContainerVariant,
+    )
+
+    // A stale row drops the accent fill entirely, so its content sits on the plain tile.
+    val rowContent = if (device.isStale) onTileVariant else accentContent
+    val percentColor = if (device.isStale) onContainerVariant else onContainer
 
     val rowClick = WidgetDeeplink.buildIntent(context, device.deviceId, WidgetDeeplink.ModuleType.POWER)
         ?.let { actionStartActivity(it) }
@@ -291,7 +308,7 @@ private fun BatteryDeviceRowContent(
                     if (rowClick != null) GlanceModifier.clickable(rowClick) else GlanceModifier
                 ),
         ) {
-            val fillWidth = (barWidthDp * device.percent / 100f).coerceAtLeast(0f)
+            val fillWidth = if (device.isStale) 0f else (barWidthDp * device.percent / 100f).coerceAtLeast(0f)
             if (fillWidth > 0f) {
                 Box(
                     modifier = GlanceModifier
@@ -307,12 +324,19 @@ private fun BatteryDeviceRowContent(
             ) {
                 Image(
                     provider = ImageProvider(
-                        if (device.isCharging) R.drawable.widget_battery_charging_full_24
-                        else R.drawable.widget_battery_full_24,
+                        when {
+                            device.isStale -> CommonR.drawable.widget_warning_24
+                            device.isCharging -> R.drawable.widget_battery_charging_full_24
+                            else -> R.drawable.widget_battery_full_24
+                        },
                     ),
-                    contentDescription = null,
+                    contentDescription = if (device.isStale) {
+                        context.getString(CommonR.string.widget_stale_device_content_description)
+                    } else {
+                        null
+                    },
                     modifier = GlanceModifier.size(20.dp),
-                    colorFilter = ColorFilter.tint(accentContent),
+                    colorFilter = ColorFilter.tint(rowContent),
                 )
                 Spacer(modifier = GlanceModifier.width(4.dp))
                 Text(
@@ -320,7 +344,7 @@ private fun BatteryDeviceRowContent(
                     style = TextStyle(
                         fontWeight = FontWeight.Bold,
                         fontSize = 11.sp,
-                        color = accentContent,
+                        color = rowContent,
                     ),
                     maxLines = 1,
                 )
@@ -328,8 +352,9 @@ private fun BatteryDeviceRowContent(
                 Text(
                     text = "\u00b7 ${device.lastSeen}",
                     style = TextStyle(
+                        fontWeight = if (device.isStale) FontWeight.Bold else null,
                         fontSize = 11.sp,
-                        color = accentContent,
+                        color = rowContent,
                     ),
                     maxLines = 1,
                 )
@@ -341,7 +366,7 @@ private fun BatteryDeviceRowContent(
             style = TextStyle(
                 fontWeight = FontWeight.Bold,
                 fontSize = 13.sp,
-                color = onContainer,
+                color = percentColor,
             ),
             modifier = GlanceModifier.width(44.dp),
         )

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentGlanceTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentGlanceTest.kt
@@ -2,6 +2,7 @@ package eu.darken.octi.modules.power.ui.widget
 
 import android.content.Context
 import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.unit.hasContentDescription
 import androidx.glance.testing.unit.hasText
 import androidx.test.core.app.ApplicationProvider
 import eu.darken.octi.common.R as CommonR
@@ -15,6 +16,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
 @RunWith(RobolectricTestRunner::class)
@@ -37,16 +40,24 @@ class BatteryWidgetContentGlanceTest {
         ),
     )
 
-    private fun powerModuleData(deviceId: DeviceId, info: PowerInfo = powerInfo()): ModuleData<PowerInfo> =
+    private fun powerModuleData(
+        deviceId: DeviceId,
+        info: PowerInfo = powerInfo(),
+        modifiedAt: Instant = Clock.System.now(),
+    ): ModuleData<PowerInfo> =
         ModuleData(
-            modifiedAt = Instant.fromEpochMilliseconds(0),
+            modifiedAt = modifiedAt,
             deviceId = deviceId,
             moduleId = powerModuleId,
             data = info,
         )
 
-    private fun metaModuleData(deviceId: DeviceId, label: String): ModuleData<MetaInfo> = ModuleData(
-        modifiedAt = Instant.fromEpochMilliseconds(0),
+    private fun metaModuleData(
+        deviceId: DeviceId,
+        label: String,
+        modifiedAt: Instant = Clock.System.now(),
+    ): ModuleData<MetaInfo> = ModuleData(
+        modifiedAt = modifiedAt,
         deviceId = deviceId,
         moduleId = metaModuleId,
         data = MetaInfo(
@@ -67,21 +78,23 @@ class BatteryWidgetContentGlanceTest {
     private fun powerState(
         selfInfo: PowerInfo = powerInfo(),
         extras: List<Pair<DeviceId, PowerInfo>> = emptyList(),
+        extrasModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<PowerInfo> = BaseModuleRepo.State(
         moduleId = powerModuleId,
         self = powerModuleData(selfDeviceId, selfInfo),
         isOthersInitialized = true,
-        others = extras.map { (id, info) -> powerModuleData(id, info) },
+        others = extras.map { (id, info) -> powerModuleData(id, info, extrasModifiedAt) },
     )
 
     private fun metaState(
         selfLabel: String = "MyPhone",
         extras: List<Pair<DeviceId, String>> = emptyList(),
+        extrasModifiedAt: Instant = Clock.System.now(),
     ): BaseModuleRepo.State<MetaInfo> = BaseModuleRepo.State(
         moduleId = metaModuleId,
         self = metaModuleData(selfDeviceId, selfLabel),
         isOthersInitialized = true,
-        others = extras.map { (id, label) -> metaModuleData(id, label) },
+        others = extras.map { (id, label) -> metaModuleData(id, label, extrasModifiedAt) },
     )
 
     @Test
@@ -156,6 +169,52 @@ class BatteryWidgetContentGlanceTest {
         }
         onNode(hasText(context.getString(CommonR.string.widget_empty_label))).assertExists()
         onNode(hasText("MyPhone")).assertDoesNotExist()
+    }
+
+    @Test
+    fun `stale device row is labelled as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val staleId = DeviceId("stale-device")
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(
+                    extras = listOf(staleId to "Old Tablet"),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                powerState = powerState(
+                    extras = listOf(staleId to powerInfo()),
+                    extrasModifiedAt = Clock.System.now() - 8.days,
+                ),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf(staleId.id),
+            )
+        }
+        onNode(hasText("Old Tablet")).assertExists()
+        onNode(
+            hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
+        ).assertExists()
+    }
+
+    @Test
+    fun `fresh device row is not labelled as out of date`() = runGlanceAppWidgetUnitTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        setContext(context)
+        val freshId = DeviceId("fresh-device")
+        provideComposable {
+            BatteryWidgetContent(
+                metaState = metaState(extras = listOf(freshId to "New Tablet")),
+                powerState = powerState(extras = listOf(freshId to powerInfo())),
+                themeColors = null,
+                maxRows = 5,
+                allowedDeviceIds = setOf(freshId.id),
+            )
+        }
+        onNode(hasText("New Tablet")).assertExists()
+        onNode(
+            hasContentDescription(context.getString(CommonR.string.widget_stale_device_content_description))
+        ).assertDoesNotExist()
     }
 
     @Test

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/ui/widget/BatteryWidgetContentTest.kt
@@ -1,0 +1,120 @@
+package eu.darken.octi.modules.power.ui.widget
+
+import eu.darken.octi.module.core.BaseModuleRepo
+import eu.darken.octi.module.core.ModuleData
+import eu.darken.octi.module.core.ModuleId
+import eu.darken.octi.modules.meta.core.MetaInfo
+import eu.darken.octi.modules.power.core.PowerInfo
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Instant
+
+/**
+ * Robolectric because the builder formats `lastSeen` via `DateUtils.getRelativeTimeSpanString`,
+ * which is unavailable in the plain unit-test android.jar.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class BatteryWidgetContentTest {
+
+    private val selfDeviceId = DeviceId(id = "self-device")
+    private val peerDeviceId = DeviceId(id = "peer-device")
+    private val powerModuleId = ModuleId("eu.darken.octi.module.core.power")
+    private val metaModuleId = ModuleId("eu.darken.octi.module.core.meta")
+
+    private val now = Clock.System.now()
+
+    private fun powerInfo() = PowerInfo(
+        status = PowerInfo.Status.DISCHARGING,
+        battery = PowerInfo.Battery(level = 80, scale = 100, health = 1, temp = 25f),
+        chargeIO = PowerInfo.ChargeIO(
+            currentNow = null,
+            currenAvg = null,
+            fullSince = null,
+            fullAt = null,
+            emptyAt = null,
+        ),
+    )
+
+    private fun powerModuleData(deviceId: DeviceId, modifiedAt: Instant): ModuleData<PowerInfo> = ModuleData(
+        modifiedAt = modifiedAt,
+        deviceId = deviceId,
+        moduleId = powerModuleId,
+        data = powerInfo(),
+    )
+
+    private fun metaModuleData(deviceId: DeviceId, label: String, modifiedAt: Instant): ModuleData<MetaInfo> =
+        ModuleData(
+            modifiedAt = modifiedAt,
+            deviceId = deviceId,
+            moduleId = metaModuleId,
+            data = MetaInfo(
+                deviceLabel = label,
+                deviceId = deviceId,
+                octiVersionName = "test",
+                octiGitSha = "test",
+                deviceManufacturer = "test",
+                deviceName = label,
+                deviceType = MetaInfo.DeviceType.PHONE,
+                deviceBootedAt = now,
+                androidVersionName = "test",
+                androidApiLevel = 34,
+                androidSecurityPatch = null,
+            ),
+        )
+
+    private fun rowsFor(
+        selfMetaAt: Instant = now,
+        selfPowerAt: Instant = now,
+        peerMetaAt: Instant? = null,
+        peerPowerAt: Instant? = null,
+    ): List<BatteryDeviceRow> {
+        val metaState = BaseModuleRepo.State(
+            moduleId = metaModuleId,
+            self = metaModuleData(selfDeviceId, "MyPhone", selfMetaAt),
+            isOthersInitialized = true,
+            others = peerMetaAt?.let { listOf(metaModuleData(peerDeviceId, "Peer", it)) } ?: emptyList(),
+        )
+        val powerState = BaseModuleRepo.State(
+            moduleId = powerModuleId,
+            self = powerModuleData(selfDeviceId, selfPowerAt),
+            isOthersInitialized = true,
+            others = peerPowerAt?.let { listOf(powerModuleData(peerDeviceId, it)) } ?: emptyList(),
+        )
+        return buildDeviceRows(metaState, powerState, null)
+    }
+
+    private fun List<BatteryDeviceRow>.row(deviceId: DeviceId) = single { it.deviceId == deviceId.id }
+
+    @Test
+    fun `a fresh peer is not stale`() {
+        val rows = rowsFor(peerMetaAt = now, peerPowerAt = now)
+        rows.row(peerDeviceId).isStale shouldBe false
+    }
+
+    @Test
+    fun `an eight day old peer is stale`() {
+        val old = now - 8.days
+        val rows = rowsFor(peerMetaAt = old, peerPowerAt = old)
+        rows.row(peerDeviceId).isStale shouldBe true
+    }
+
+    @Test
+    fun `self is never stale even with an old timestamp`() {
+        val old = now - 30.days
+        val rows = rowsFor(selfMetaAt = old, selfPowerAt = old)
+        rows.row(selfDeviceId).isStale shouldBe false
+    }
+
+    @Test
+    fun `fresh power data keeps a peer with old meta data current`() {
+        val rows = rowsFor(peerMetaAt = now - 8.days, peerPowerAt = now)
+        rows.row(peerDeviceId).isStale shouldBe false
+    }
+}

--- a/sync-core/src/main/java/eu/darken/octi/sync/core/StalenessUtil.kt
+++ b/sync-core/src/main/java/eu/darken/octi/sync/core/StalenessUtil.kt
@@ -3,15 +3,18 @@ package eu.darken.octi.sync.core
 import android.content.Context
 import eu.darken.octi.sync.R
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Instant
 
 object StalenessUtil {
-    const val STALE_DEVICE_THRESHOLD_DAYS = 30L
+    const val STALE_DEVICE_THRESHOLD_DAYS = 7L
 
-    fun isStale(lastSyncTime: Instant?): Boolean {
+    fun isStale(lastSyncTime: Instant?): Boolean = isStale(lastSyncTime, Clock.System.now())
+
+    /** A device is stale once the age of its newest data reaches [STALE_DEVICE_THRESHOLD_DAYS]. */
+    internal fun isStale(lastSyncTime: Instant?, now: Instant): Boolean {
         if (lastSyncTime == null) return false
-        val daysSinceLastSync = (Clock.System.now() - lastSyncTime).inWholeDays
-        return daysSinceLastSync > STALE_DEVICE_THRESHOLD_DAYS
+        return (now - lastSyncTime) >= STALE_DEVICE_THRESHOLD_DAYS.days
     }
 
     fun SyncRead.Device.isStale(): Boolean {

--- a/sync-core/src/test/java/eu/darken/octi/sync/core/StalenessUtilTest.kt
+++ b/sync-core/src/test/java/eu/darken/octi/sync/core/StalenessUtilTest.kt
@@ -1,0 +1,59 @@
+package eu.darken.octi.sync.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
+
+class StalenessUtilTest : BaseTest() {
+
+    private val now = Instant.parse("2026-03-15T12:00:00Z")
+
+    @Nested
+    inner class `staleness boundary` {
+
+        @Test
+        fun `a device without any data is never stale`() {
+            StalenessUtil.isStale(null, now) shouldBe false
+        }
+
+        @Test
+        fun `six days old is fresh`() {
+            StalenessUtil.isStale(now - 6.days, now) shouldBe false
+        }
+
+        @Test
+        fun `just under seven days is fresh`() {
+            StalenessUtil.isStale(now - 6.days - 23.hours, now) shouldBe false
+        }
+
+        @Test
+        fun `exactly seven days is stale`() {
+            StalenessUtil.isStale(now - 7.days, now) shouldBe true
+        }
+
+        @Test
+        fun `just over seven days is stale`() {
+            StalenessUtil.isStale(now - 7.days - 1.hours, now) shouldBe true
+        }
+
+        @Test
+        fun `eight days old is stale`() {
+            StalenessUtil.isStale(now - 8.days, now) shouldBe true
+        }
+    }
+
+    @Nested
+    inner class `system clock delegation` {
+
+        @Test
+        fun `the public overload uses the system clock`() {
+            StalenessUtil.isStale(Clock.System.now() - 8.days) shouldBe true
+            StalenessUtil.isStale(Clock.System.now() - 1.days) shouldBe false
+        }
+    }
+}


### PR DESCRIPTION
## What changed

A device that has stopped syncing used to look identical to a live one on the battery, network and clipboard widgets. Now a device whose data has gone out of date is marked: its icon becomes a warning triangle, the row dims, and the age of the data is shown and emphasized.

The battery widget additionally drops the coloured charge bar for such a device and dims its percentage, because a week-old battery reading is not a number worth reading at a glance. The network widget's compact row and the clipboard row previously showed no age at all, so a dimmed row there would have had no visible explanation; both now show it. The clipboard widget in particular had been working out how old a device's data was and then never displaying it.

All of the marking derives from the widget's own colour theme, so it works on every preset and on custom colours, including Material You.

Separately, a device now counts as out of date after 7 days instead of 30. This threshold is shared with the dashboard, so the "Stale device" warning there will now appear for devices that were previously silent — expected, but it will look like a new warning arriving on its own.

## Technical Context

- Widgets reuse the existing `StalenessUtil` rather than introducing a second notion of staleness, so the dashboard and the widgets can never disagree. Its comparison also changes from `inWholeDays > threshold` to a `Duration` `>=`: the truncating form fired a day late, so the old 30 really meant 31 and a literal 7 would have meant 8.
- Staleness and the displayed age both come from the newest of the meta and module timestamps, matching the device-level rule `StalenessUtil` already applies. Using the meta timestamp alone would let a partial write render a warning next to a recent age.
- The local device is exempt. Battery and network render `State.all`, which includes self, and self's `ModuleData.modifiedAt` is only stamped when `MetaInfo` actually changes — an idle long-running process would otherwise flag its own row. The dashboard has always skipped self for the same reason.
- The new `onContainerVariant` role is defined in all four colour qualifier files. Omitting the `-v31` pair would have made Material You fall back to the hard-coded green on Android 12+, which is the case worth checking closely in this diff.
- `WidgetThemeContrastTest` pins a 2.5 contrast floor on both de-emphasis roles across every preset and all 576 swatch pairs. The floor is measured rather than chosen: the worst pair sits at 2.64 and the lowest preset at 2.79, so a 3.0 floor would fail the RED preset at 2.96.
