### PR TITLE
Add modules-connectivity and modules-files to Crowdin config

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -34,6 +34,7 @@ Each module has its own `strings.xml` managed by Crowdin:
 - `modules-apps/src/main/res/values/strings.xml`
 - `modules-clipboard/src/main/res/values/strings.xml`
 - `modules-connectivity/src/main/res/values/strings.xml`
+- `modules-files/src/main/res/values/strings.xml`
 - `sync-core/src/main/res/values/strings.xml`
 - `syncs-gdrive/src/main/res/values/strings.xml`
 - `syncs-octiserver/src/main/res/values/strings.xml`

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -115,6 +115,16 @@
     "translation": "/modules-clipboard/src/main/res/values-%android_code%/strings.xml",
     "languages_mapping": *stringmapping
   }, {
+    "source": "/modules-connectivity/src/main/res/values/strings.xml",
+    "dest": "/strings-modules-connectivity.xml",
+    "translation": "/modules-connectivity/src/main/res/values-%android_code%/strings.xml",
+    "languages_mapping": *stringmapping
+  }, {
+    "source": "/modules-files/src/main/res/values/strings.xml",
+    "dest": "/strings-modules-files.xml",
+    "translation": "/modules-files/src/main/res/values-%android_code%/strings.xml",
+    "languages_mapping": *stringmapping
+  }, {
     "source": "/modules-meta/src/main/res/values/strings.xml",
     "dest": "/strings-modules-meta.xml",
     "translation": "/modules-meta/src/main/res/values-%android_code%/strings.xml",


### PR DESCRIPTION
## What changed

Two modules that ship user-facing text were never registered with Crowdin, so none of their strings could be translated. `modules-files` is the larger gap: 92 strings, and the module has never had a single locale directory since it was added in "Add file sharing module with BlobStore abstraction". `modules-connectivity` adds another 19. Both now upload to Crowdin like every other module, and their translations download back into the usual `values-*/strings.xml` paths.

## Technical Context

- **`modules-connectivity` has pre-existing translations that Crowdin has never seen.** It already carries 29 `values-*/strings.xml` directories with 14 translated strings each, but `git log -S 'modules-connectivity' -- crowdin.yaml` returns nothing, so the module was never in this config and those files came from somewhere else. Crowdin holds no translation records for the new file, so the first `crowdin download` after this merges would overwrite all 29 files and drop that work. **Run `./crowdin.sh upload translations` before any download.** `modules-files` has no locale dirs at all, so it carries no such risk.
- The base file already drifted ahead of its translations: `values/strings.xml` has 19 strings, `values-de/strings.xml` has 14. After the upload, those 5 will correctly show as untranslated rather than silently missing.
- Entries are placed alphabetically between `modules-clipboard` and `modules-meta`, matching the existing ordering, and reuse the same `dest` naming (`/strings-modules-<name>.xml`) and shared `*stringmapping` anchor as every other entry. Verified no duplicate `dest` values across all 18 file entries.
- `.claude/rules/localization.md` already listed `modules-connectivity` as Crowdin-managed, which was false until this change; `modules-files` was missing from that list entirely. Both are now accurate.
- The new strings will land on Crowdin with default identifier context. Annotating them is a Crowdin-side action after the first source push, not part of this PR.