### PR TITLE
Fix mistranslated Open button in nine languages

### DIFF
--- a/modules-connectivity/src/main/res/values-sr/strings.xml
+++ b/modules-connectivity/src/main/res/values-sr/strings.xml
@@ -10,7 +10,7 @@
     <string name="module_connectivity_unknown_local_ip_label">Непозната локална IP адреса</string>
     <string name="module_connectivity_detail_local_ipv4_label">Локална IPv4</string>
     <string name="module_connectivity_detail_local_ipv6_label">Локална IPv6</string>
-    <string name="module_connectivity_detail_gateway_label">Gateway</string>
+    <string name="module_connectivity_detail_gateway_label">Мрежни пролаз</string>
     <string name="module_connectivity_detail_dns_label">DNS сервери</string>
     <string name="module_connectivity_detail_public_ip_label">Јавна IP адреса</string>
     <string name="module_connectivity_detail_connection_type_label">Тип повезивања</string>

--- a/modules-files/src/main/res/values-es/strings.xml
+++ b/modules-files/src/main/res/values-es/strings.xml
@@ -69,6 +69,7 @@
     <string name="module_files_sort_by_name">Nombre</string>
     <string name="module_files_sort_by_size">Tamaño</string>
     <string name="module_files_sort_by_device">Dispositivo</string>
+    <string name="module_files_action_open">Abrir</string>
     <string name="module_files_action_save_as">Guardar como…</string>
     <string name="module_files_open_chooser">Abrir con</string>
     <string name="module_files_open_no_app">Ninguna app de este dispositivo puede abrir este archivo</string>

--- a/modules-files/src/main/res/values-fi/strings.xml
+++ b/modules-files/src/main/res/values-fi/strings.xml
@@ -69,7 +69,7 @@
     <string name="module_files_sort_by_name">Nimi</string>
     <string name="module_files_sort_by_size">Koko</string>
     <string name="module_files_sort_by_device">Laite</string>
-    <string name="module_files_action_open">Auki</string>
+    <string name="module_files_action_open">Avaa</string>
     <string name="module_files_action_save_as">Tallenna nimellä…</string>
     <string name="module_files_open_chooser">Avaa sovelluksella</string>
     <string name="module_files_open_no_app">Mikään tämän laitteen sovellus ei voi avata tätä tiedostoa</string>

--- a/modules-files/src/main/res/values-hu/strings.xml
+++ b/modules-files/src/main/res/values-hu/strings.xml
@@ -69,7 +69,7 @@
     <string name="module_files_sort_by_name">Név</string>
     <string name="module_files_sort_by_size">Méret</string>
     <string name="module_files_sort_by_device">Eszköz</string>
-    <string name="module_files_action_open">Nyitva</string>
+    <string name="module_files_action_open">Megnyitás</string>
     <string name="module_files_action_save_as">Mentés másként…</string>
     <string name="module_files_open_chooser">Megnyitás ezzel</string>
     <string name="module_files_open_no_app">Egyetlen alkalmazás sem tudja megnyitni ezt a fájlt ezen az eszközön</string>

--- a/modules-files/src/main/res/values-it/strings.xml
+++ b/modules-files/src/main/res/values-it/strings.xml
@@ -69,6 +69,7 @@
     <string name="module_files_sort_by_name">Nome</string>
     <string name="module_files_sort_by_size">Dimensione</string>
     <string name="module_files_sort_by_device">Dispositivo</string>
+    <string name="module_files_action_open">Apri</string>
     <string name="module_files_action_save_as">Salva con nome…</string>
     <string name="module_files_open_chooser">Apri con</string>
     <string name="module_files_open_no_app">Nessuna app su questo dispositivo può aprire questo file</string>

--- a/modules-files/src/main/res/values-ja/strings.xml
+++ b/modules-files/src/main/res/values-ja/strings.xml
@@ -68,6 +68,7 @@
     <string name="module_files_sort_by_name">名前</string>
     <string name="module_files_sort_by_size">サイズ</string>
     <string name="module_files_sort_by_device">デバイス</string>
+    <string name="module_files_action_open">開く</string>
     <string name="module_files_action_save_as">名前を付けて保存…</string>
     <string name="module_files_open_chooser">別のアプリで開く</string>
     <string name="module_files_open_no_app">このデバイスでこのファイルを開くことができるアプリがありません</string>

--- a/modules-files/src/main/res/values-nb/strings.xml
+++ b/modules-files/src/main/res/values-nb/strings.xml
@@ -69,7 +69,7 @@
     <string name="module_files_sort_by_name">Navn</string>
     <string name="module_files_sort_by_size">Størrelse</string>
     <string name="module_files_sort_by_device">Enhet</string>
-    <string name="module_files_action_open">Åpen</string>
+    <string name="module_files_action_open">Åpne</string>
     <string name="module_files_action_save_as">Lagre som…</string>
     <string name="module_files_open_chooser">Åpne med</string>
     <string name="module_files_open_no_app">Ingen app på denne enheten kan åpne denne filen</string>

--- a/modules-files/src/main/res/values-pt-rBR/strings.xml
+++ b/modules-files/src/main/res/values-pt-rBR/strings.xml
@@ -69,6 +69,7 @@
     <string name="module_files_sort_by_name">Nome</string>
     <string name="module_files_sort_by_size">Tamanho</string>
     <string name="module_files_sort_by_device">Dispositivo</string>
+    <string name="module_files_action_open">Abrir</string>
     <string name="module_files_action_save_as">Salvar como…</string>
     <string name="module_files_open_chooser">Abrir com</string>
     <string name="module_files_open_no_app">Nenhum app neste dispositivo pode abrir este arquivo</string>

--- a/modules-files/src/main/res/values-sr/strings.xml
+++ b/modules-files/src/main/res/values-sr/strings.xml
@@ -70,7 +70,7 @@
     <string name="module_files_sort_by_name">Назив</string>
     <string name="module_files_sort_by_size">Величина</string>
     <string name="module_files_sort_by_device">Уређај</string>
-    <string name="module_files_action_open">Отворено</string>
+    <string name="module_files_action_open">Отвори</string>
     <string name="module_files_action_save_as">Сачувај као…</string>
     <string name="module_files_open_chooser">Отвори помоћу</string>
     <string name="module_files_open_no_app">Ниједна апликација на овом уређају не може да отвори ову датотеку</string>

--- a/modules-files/src/main/res/values-sv/strings.xml
+++ b/modules-files/src/main/res/values-sv/strings.xml
@@ -69,7 +69,7 @@
     <string name="module_files_sort_by_name">Namn</string>
     <string name="module_files_sort_by_size">Storlek</string>
     <string name="module_files_sort_by_device">Enhet</string>
-    <string name="module_files_action_open">Öppet</string>
+    <string name="module_files_action_open">Öppna</string>
     <string name="module_files_action_save_as">Spara som…</string>
     <string name="module_files_open_chooser">Öppna med</string>
     <string name="module_files_open_no_app">Ingen app på den här enheten kan öppna den här filen</string>

--- a/modules-meta/src/main/res/values-el/strings.xml
+++ b/modules-meta/src/main/res/values-el/strings.xml
@@ -8,7 +8,7 @@
     <string name="module_meta_detail_model_label">Μοντέλο</string>
     <string name="module_meta_detail_device_type_label">Τύπος συσκευής</string>
     <string name="module_meta_detail_device_type_phone">Τηλέφωνο</string>
-    <string name="module_meta_detail_device_type_tablet">Ταμπλέτα</string>
+    <string name="module_meta_detail_device_type_tablet">Tablet</string>
     <string name="module_meta_detail_device_type_desktop">Επιτραπέζιος Υπολογιστής</string>
     <string name="module_meta_detail_device_type_browser">Περιηγητής</string>
     <string name="module_meta_detail_device_type_server">Διακομιστής</string>


### PR DESCRIPTION
## What changed

The "Open" button in the file detail sheet read as a state ("opened", "is open") instead of an action in nine languages. It now reads as a proper button verb in Spanish, Italian, Japanese, Brazilian Portuguese, Finnish, Hungarian, Norwegian, Swedish and Serbian. The Serbian network gateway row is translated instead of showing the English word, and the Greek device type keeps "Tablet", which is what the Greek translator chose.

## Technical Context

- Root cause of the nine-language defect was pre-translation, not the translators: Crowdin matched the bare source word "Open" at 100% against CAPod's translation memory, which reached this project through global TM and supplied the adjective form. Every one of the nine was an unapproved machine pre-translation with no human work behind it.
- The corrections were made on Crowdin and pulled down, rather than patched locally. The previous pull fixed several of these in the working tree only, so they simply came back on this pull; anything repaired locally is not repaired at all.
- The source string now carries context marking it an imperative button label, plus a 15-character limit. One validator on this run cited that context as its reason for accepting the Finnish correction, so it is already steering translation rather than just documenting intent.
- Greek "Tablet" was a deliberate choice by a community translator that our validation kept reverting as "untranslated" on every pull. The source string now carries a context note permitting the English word where a language normally uses it, which stopped the revert on this run.
- The Hungarian low-quota banner had a bare `%` where the source has `%%`, which would throw when that banner renders. It had been repaired locally on two consecutive pulls without ever reaching Crowdin; the stored value is now correct, so the repair stops being needed.
