### PR TITLE
Release to Play at 100% instead of a 10% rollout

### DIFF
--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -44,10 +44,10 @@ bats tools/release/bump.bats
 
 | Tag suffix | FOSS APK | GitHub release | Fastlane lane | Play track | Rollout |
 |---|---|---|---|---|---|
-| `-beta*` | `assembleFossBeta` | pre-release | `beta` | `beta` | 10% |
-| `-rc*` (or anything else) | `assembleFossRelease` | full release | `production` | **`beta`** | 10% |
+| `-beta*` | `assembleFossBeta` | pre-release | `beta` | `beta` | 100% |
+| `-rc*` (or anything else) | `assembleFossRelease` | full release | `production` | **`beta`** | 100% |
 
-`lane :production` in `Fastfile` uploads to Play's **beta** track at 10% — manually promoted to production via Play Console. The lane is intentionally not renamed to preserve historical fastlane invocation surface.
+`lane :production` in `Fastfile` uploads to Play's **beta** track at 100% — manually promoted to production via Play Console. The lane is intentionally not renamed to preserve historical fastlane invocation surface.
 
 ## Rollback
 
@@ -55,7 +55,7 @@ bats tools/release/bump.bats
 |---|---|
 | Bump on `main`, downstream not started | `git push origin :refs/tags/v<bad>`, `git revert <bump-sha>`, push |
 | GitHub release created | Above + `gh release delete v<bad> --yes --cleanup-tag` |
-| Play upload completed | Above + halt rollout in Play Console (or `bundle exec fastlane supply --track beta --rollout 0 --version-code <bad-code>`) |
+| Play upload completed | Above + publish a fixed build with a higher `versionCode`. The lanes release at 100% (`completed`), so there is no staged rollout to halt: `supply --rollout` only accepts values greater than 0 and up to 1, and Play's halt action applies to in-progress rollouts. |
 | Job 2 ran but downstream rejected at env approval | Treat as first row — bump+tag are public on `main` regardless of downstream outcome |
 
 `bump.sh` enforces strict `versionCode` monotonicity, so re-using a code is impossible without manually editing `version.properties`.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,7 +25,7 @@ platform :android do
     sh "bash ./remove_unsupported_languages.sh"
   	supply(
         track: 'beta',
-        rollout: '0.10',
+        rollout: '1.0',
         package_name: 'eu.darken.octi',
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',
@@ -40,7 +40,7 @@ platform :android do
     sh "bash ./remove_unsupported_languages.sh"
     supply(
         track: 'beta',
-        rollout: '0.10',
+        rollout: '1.0',
         package_name: 'eu.darken.octi',
         skip_upload_changelogs: 'false',
         skip_upload_apk: 'true',


### PR DESCRIPTION
## What changed

Play Store releases now go out to everyone on the target track immediately instead of being staged to 10% of users. Applies to both the beta and production release lanes.

## Technical Context

- `supply` only treats a rollout value as a staged rollout when it is strictly between 0 and 1. At `1.0` the release keeps the default `completed` status and sends no `user_fraction`, which is a full release. Setting the value explicitly rather than dropping the key keeps the Fastfile matching the documented channel table.
- Both lanes always build and upload a fresh AAB, so `supply` takes the `update_track` path. The alternative `update_rollout` path, which can retroactively complete an older in-progress rollout, is unreachable from these lanes.
- The rollback table in `.claude/rules/release.md` documented halting the rollout, which stops being possible with a completed release: there is no staged rollout to halt and `supply --rollout 0` is rejected by its validator. That row now points at the higher-`versionCode` replacement path instead.