### PR TITLE
Enable code obfuscation for the Google Play build

### DIFF
--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -64,6 +64,21 @@ Only the 6 smoke locales (en-US, de-DE, ja-JP, ar, zh-CN, pt-BR) have `phoneScre
 - **Flavors**: `foss` (open source), `gplay` (Google Play with additional features)
 - **Build types**: `debug`, `beta`, `release`
 
+## R8 obfuscation
+
+- `gplay` beta/release are obfuscated. `foss` is not — `app/proguard-rules-foss.pro` applies `-dontobfuscate` to that flavor only.
+- Mapping file: `app/build/outputs/mapping/<variant>/mapping.txt`. It is embedded in the AAB and downloadable from the Play Console (App bundle explorer → Downloads).
+- Retrace a user-reported stack trace:
+  ```bash
+  $ANDROID_HOME/cmdline-tools/latest/bin/retrace mapping.txt stacktrace.txt
+  ```
+- Verify the setup after a release build:
+  ```bash
+  ./gradlew assembleGplayRelease assembleFossRelease bundleGplayRelease
+  bash tools/r8/verify-obfuscation.sh
+  ```
+- After the next Play upload, confirm the Console reports an obfuscation percentage above 25%.
+
 ## Version Management
 
 - `version.properties`: Source of truth for version numbers (major.minor.patch.build)

--- a/app-common/proguard-rules.pro
+++ b/app-common/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Error dialogs show the exception's simple name (LocalizedError). Names only; no shrinking impact.
+-keepnames class * extends java.lang.Throwable
+
+# ViewModel1 builds its log tag from the subclass name. Names only; no shrinking impact.
+-keepnames class * extends eu.darken.octi.common.uix.ViewModel1

--- a/app-common/src/main/java/eu/darken/octi/common/WebpageTool.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/WebpageTool.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import javax.inject.Inject
 
 @Reusable
@@ -25,9 +26,12 @@ class WebpageTool @Inject constructor(
             context.startActivity(intent)
             true
         } catch (e: Exception) {
-            log(ERROR) { "Failed to launch: ${e.asLog()}" }
+            log(TAG, ERROR) { "Failed to launch: ${e.asLog()}" }
             false
         }
     }
 
+    companion object {
+        private val TAG = logTag("WebpageTool")
+    }
 }

--- a/app-common/src/main/java/eu/darken/octi/common/debug/logging/Logging.kt
+++ b/app-common/src/main/java/eu/darken/octi/common/debug/logging/Logging.kt
@@ -11,6 +11,8 @@ import java.io.StringWriter
  */
 
 object Logging {
+    private val TAG = logTag("Logging")
+
     enum class Priority(
         val intValue: Int,
         val shortLabel: String
@@ -50,14 +52,14 @@ object Logging {
 
     fun install(logger: Logger) {
         synchronized(internalLoggers) { internalLoggers.add(logger) }
-        log { "Was installed $logger" }
+        log(TAG) { "Was installed $logger" }
     }
 
     fun remove(logger: Logger) {
         // Deregister first: a logger that is being torn down is still a receiver for anything we
         // log before that, and if it fails on that line it would stay installed forever.
         synchronized(internalLoggers) { internalLoggers.remove(logger) }
-        log { "Removed: $logger" }
+        log(TAG) { "Removed: $logger" }
     }
 
     fun logInternal(
@@ -80,23 +82,8 @@ object Logging {
     }
 
     fun clearAll() {
-        log { "Clearing all loggers" }
+        log(TAG) { "Clearing all loggers" }
         synchronized(internalLoggers) { internalLoggers.clear() }
-    }
-}
-
-inline fun Any.log(
-    priority: Logging.Priority = Logging.Priority.DEBUG,
-    metaData: Map<String, Any>? = null,
-    message: () -> String,
-) {
-    if (Logging.hasReceivers) {
-        Logging.logInternal(
-            tag = logTag(logTagViaCallSite()),
-            priority = priority,
-            metaData = metaData,
-            message = message(),
-        )
     }
 }
 
@@ -122,17 +109,4 @@ fun Throwable.asLog(): String {
     printStackTrace(printWriter)
     printWriter.flush()
     return stringWriter.toString()
-}
-
-@PublishedApi
-internal fun Any.logTagViaCallSite(): String {
-    val javaClass = this::class.java
-    val fullClassName = javaClass.name
-    val outerClassName = fullClassName.substringBefore('$')
-    val simplerOuterClassName = outerClassName.substringAfterLast('.')
-    return if (simplerOuterClassName.isEmpty()) {
-        fullClassName
-    } else {
-        simplerOuterClassName.removeSuffix("Kt")
-    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -52,10 +52,12 @@ android {
         create("foss") {
             dimension = "version"
             signingConfig = signingConfigs["releaseFoss"]
+            proguardFiles("proguard-rules-foss.pro")
         }
         create("gplay") {
             dimension = "version"
             signingConfig = signingConfigs["releaseGplay"]
+            proguardFiles("proguard-rules-gplay.pro")
         }
     }
 

--- a/app/proguard-rules-foss.pro
+++ b/app/proguard-rules-foss.pro
@@ -1,0 +1,2 @@
+# The open-source build keeps readable class and member names.
+-dontobfuscate

--- a/app/proguard-rules-gplay.pro
+++ b/app/proguard-rules-gplay.pro
@@ -1,0 +1,3 @@
+# Keep line tables so obfuscated stack traces retrace against mapping.txt.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/app/proguard/proguard-rules.pro
+++ b/app/proguard/proguard-rules.pro
@@ -1,6 +1,5 @@
 # Keep the BuildConfig
 -keep class eu.darken.octi.BuildConfig { *; }
--dontobfuscate
 
 -dontwarn org.bouncycastle.jsse.BCSSLParameters
 -dontwarn org.bouncycastle.jsse.BCSSLSocket

--- a/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/octi/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -8,6 +8,7 @@ import eu.darken.octi.R
 import eu.darken.octi.common.ca.toCaString
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.error.HasLocalizedError
 import eu.darken.octi.common.error.LocalizedError
 
@@ -44,10 +45,11 @@ class GplayServiceUnavailableException(cause: Throwable) :
     )
 
     private fun onLaunchFailed(e: Exception) {
-        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        log(TAG, ERROR) { "Can't launch settings intent for Google Play: $e" }
     }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"
+        private val TAG = logTag("Upgrade", "Gplay", "ServiceUnavailable")
     }
 }

--- a/app/src/main/java/eu/darken/octi/common/ButtonExtensions.kt
+++ b/app/src/main/java/eu/darken/octi/common/ButtonExtensions.kt
@@ -5,6 +5,9 @@ import android.widget.CompoundButton.OnCheckedChangeListener
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
+
+private val TAG = logTag("ButtonExtensions")
 
 fun CompoundButton.setChecked2(checked: Boolean, animate: Boolean = true) {
     val currentListener = getOnCheckedChangeListener()
@@ -20,6 +23,6 @@ fun CompoundButton.getOnCheckedChangeListener(): OnCheckedChangeListener? = try 
     val field = CompoundButton::class.getField("mOnCheckedChangeListener")
     field.get(this) as? OnCheckedChangeListener
 } catch (e: Exception) {
-    log(WARN) { "Failed to access CompoundButton.mOnCheckedChangeListener: ${e.asLog()}" }
+    log(TAG, WARN) { "Failed to access CompoundButton.mOnCheckedChangeListener: ${e.asLog()}" }
     null
 }

--- a/app/src/main/java/eu/darken/octi/main/core/updater/UpdaterExtensions.kt
+++ b/app/src/main/java/eu/darken/octi/main/core/updater/UpdaterExtensions.kt
@@ -13,7 +13,7 @@ fun UpdateChecker.Update.isNewer(): Boolean = try {
     val latest = Version.parse(versionName, strict = false)
     latest > current
 } catch (e: Exception) {
-    log(ERROR) { "Failed version check: ${e.asLog()}" }
+    log(TAG, ERROR) { "Failed version check: ${e.asLog()}" }
     false
 }
 

--- a/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
+++ b/app/src/main/java/eu/darken/octi/main/ui/dashboard/DashboardVM.kt
@@ -944,7 +944,7 @@ class DashboardVM @Inject constructor(
         ): List<ConnectorIssue> {
             return allIssues
                 .filter { it.deviceId == item.deviceId }
-                .sortedWith(compareBy({ if (it.severity == IssueSeverity.ERROR) 0 else 1 }, { it::class.simpleName }))
+                .sortedBy { if (it.severity == IssueSeverity.ERROR) 0 else 1 }
         }
 
         /**

--- a/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
+++ b/app/src/test/java/eu/darken/octi/main/ui/dashboard/DeviceInfoBuilderTest.kt
@@ -156,7 +156,7 @@ class DeviceInfoBuilderTest : BaseTest() {
             )
             val infos = DashboardVM.buildDeviceInfos(item, issues)
             infos shouldHaveSize 2
-            // StaleDevice is WARNING, ClockSkew is WARNING — both same severity, sorted by class name
+            // StaleDevice is WARNING, ClockSkew is WARNING — same severity keeps input order
             infos.all { it.severity == IssueSeverity.WARNING } shouldBe true
         }
     }

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/InstallerInfo.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/InstallerInfo.kt
@@ -9,7 +9,10 @@ import androidx.annotation.RequiresApi
 import eu.darken.octi.common.debug.logging.Logging.Priority.WARN
 import eu.darken.octi.common.debug.logging.asLog
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.hasApiLevel
+
+private val TAG = logTag("Module", "Apps", "InstallerInfo")
 
 data class InstallerInfo(
     val installingPkg: String? = null,
@@ -76,7 +79,7 @@ private fun PackageInfo.getInstallerInfoLegacy(packageManager: PackageManager): 
         @Suppress("DEPRECATION") // TODO Remove when minSdk >= 30
         packageManager.getInstallerPackageName(packageName)
     } catch (e: IllegalArgumentException) {
-        log(WARN) { "OS race condition, package ($packageName) was uninstalled?: ${e.asLog()}" }
+        log(TAG, WARN) { "OS race condition, package ($packageName) was uninstalled?: ${e.asLog()}" }
         null
     }
 

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/PackageEventListener.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/core/PackageEventListener.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.octi.common.coroutine.AppScope
 import eu.darken.octi.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.flow.replayingShare
 import eu.darken.octi.common.flow.setupCommonEventHandlers
 import kotlinx.coroutines.CoroutineScope
@@ -32,7 +33,7 @@ class PackageEventListener @Inject constructor(
     val events: Flow<Event> = callbackFlow {
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
-                log { "onReceive(context=$context, intent=$intent)" }
+                log(TAG) { "onReceive(context=$context, intent=$intent)" }
 
                 when (intent.action) {
                     Intent.ACTION_PACKAGE_ADDED -> {
@@ -43,7 +44,7 @@ class PackageEventListener @Inject constructor(
                         val pkgId = intent.data?.encodedSchemeSpecificPart
                         pkgId?.let { trySendBlocking(Event.PackageRemoved(it)) }
                     }
-                    else -> log(ERROR) { "Unknown intent: $intent" }
+                    else -> log(TAG, ERROR) { "Unknown intent: $intent" }
                 }
             }
 
@@ -58,11 +59,14 @@ class PackageEventListener @Inject constructor(
         context.registerReceiver(receiver, intentFilter)
 
         awaitClose {
-            log { "unregisterReceiver($receiver)" }
+            log(TAG) { "unregisterReceiver($receiver)" }
             context.unregisterReceiver(receiver)
         }
     }
         .setupCommonEventHandlers("PackageEventListener") { "events" }
         .replayingShare(appScope)
 
+    companion object {
+        private val TAG = logTag("Module", "Apps", "PackageEventListener")
+    }
 }

--- a/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/coil/AppIconFetcher.kt
+++ b/modules-apps/src/main/java/eu/darken/octi/modules/apps/ui/coil/AppIconFetcher.kt
@@ -11,6 +11,7 @@ import coil3.fetch.ImageFetchResult
 import coil3.request.Options
 import eu.darken.octi.modules.apps.R
 import eu.darken.octi.common.debug.logging.log
+import eu.darken.octi.common.debug.logging.logTag
 import eu.darken.octi.common.getIcon2
 import eu.darken.octi.modules.apps.core.AppsInfo
 import javax.inject.Inject
@@ -22,7 +23,7 @@ class AppIconFetcher @Inject constructor(
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult {
-        log { "Fetching $data" }
+        log(TAG) { "Fetching $data" }
         val baseIcon = packageManager.getIcon2(data.packageName)
             ?: ContextCompat.getDrawable(options.context, R.drawable.ic_baseline_apps_24)!!
 
@@ -42,5 +43,9 @@ class AppIconFetcher @Inject constructor(
             options: Options,
             imageLoader: ImageLoader,
         ): Fetcher = AppIconFetcher(packageManager, data, options)
+    }
+
+    companion object {
+        private val TAG = logTag("Module", "Apps", "IconFetcher")
     }
 }

--- a/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
+++ b/modules-power/src/main/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotifications.kt
@@ -68,12 +68,6 @@ class PowerAlertNotifications @Inject constructor(
         setDeleteIntent(deletePi)
     }
 
-    private val PowerAlertRule.notificationId: Int
-        get() {
-            val hash = (deviceId.toString() + this::class.java.simpleName).hashCode()
-            return NOTIFICATION_ID_RANGE_STATE + (hash.absoluteValue % 101)
-        }
-
     private val PowerAlertRule.pendingIntentRequestCode: Int
         get() = id.hashCode() and Int.MAX_VALUE
 
@@ -120,12 +114,12 @@ class PowerAlertNotifications @Inject constructor(
             }
         }
 
-        notificationManager.notify(rule.notificationId, builder.build())
+        notificationManager.notify(rule.notificationId(), builder.build())
     }
 
     suspend fun dismiss(alert: PowerAlertRule) {
         log(TAG) { "dismiss($alert)" }
-        notificationManager.cancel(alert.notificationId)
+        notificationManager.cancel(alert.notificationId())
     }
 
     companion object {
@@ -135,4 +129,15 @@ class PowerAlertNotifications @Inject constructor(
         private const val CHANNEL_ID = "eu.darken.octi.notification.channel.module.power.alerts"
         val TAG = logTag("Module", "Power", "Alert", "Notifications")
     }
+}
+
+// The literals pin the IDs of notifications already posted on user devices, renaming a rule
+// class must not shift them.
+internal fun PowerAlertRule.notificationId(): Int {
+    val typeKey = when (this) {
+        is BatteryLowAlertRule -> "BatteryLowAlertRule"
+        is BatteryHighAlertRule -> "BatteryHighAlertRule"
+    }
+    val hash = (deviceId.toString() + typeKey).hashCode()
+    return PowerAlertNotifications.NOTIFICATION_ID_RANGE_STATE + (hash.absoluteValue % 101)
 }

--- a/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotificationIdTest.kt
+++ b/modules-power/src/test/java/eu/darken/octi/modules/power/core/alert/PowerAlertNotificationIdTest.kt
@@ -1,0 +1,30 @@
+package eu.darken.octi.modules.power.core.alert
+
+import eu.darken.octi.modules.power.core.alert.PowerAlertNotifications.Companion.NOTIFICATION_ID_RANGE_STATE
+import eu.darken.octi.sync.core.DeviceId
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import kotlin.math.absoluteValue
+
+class PowerAlertNotificationIdTest : BaseTest() {
+
+    private val deviceId = DeviceId("00000000-0000-0000-0000-000000000022")
+
+    private fun expectedId(typeKey: String): Int {
+        val hash = (deviceId.toString() + typeKey).hashCode()
+        return NOTIFICATION_ID_RANGE_STATE + (hash.absoluteValue % 101)
+    }
+
+    @Test
+    fun `battery low notification id stays pinned to its type key`() {
+        BatteryLowAlertRule(deviceId = deviceId, threshold = 0.2f).notificationId() shouldBe
+            expectedId("BatteryLowAlertRule")
+    }
+
+    @Test
+    fun `battery high notification id stays pinned to its type key`() {
+        BatteryHighAlertRule(deviceId = deviceId, threshold = 0.8f).notificationId() shouldBe
+            expectedId("BatteryHighAlertRule")
+    }
+}

--- a/tools/r8/check-no-receiver-log.sh
+++ b/tools/r8/check-no-receiver-log.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fails if a call site uses the tagless `log { }` form, whose tag would have to
+# come from a runtime class name that R8 renames. Run from the repository root.
+set -euo pipefail
+
+hits=$(grep -rnE '(^|[^a-zA-Z._`])log(\((INFO|WARN|ERROR|VERBOSE|DEBUG)\))? \{' --include='*.kt' \
+    app/src app-common/src app-common-test/src module-core/src modules-*/src sync-core/src syncs-*/src \
+    | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(\*|//)' || true)
+
+if [ -n "$hits" ]; then
+    echo "Tagless log { } call sites found:"
+    echo "$hits"
+    exit 1
+fi
+echo "OK: every log call passes an explicit tag."

--- a/tools/r8/verify-obfuscation.sh
+++ b/tools/r8/verify-obfuscation.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Verifies that the gplay build is obfuscated and the foss build is not.
+#
+# Run from the repository root after:
+#   ./gradlew assembleGplayRelease assembleFossRelease bundleGplayRelease
+#
+# mapping.txt is ~87 MB, so every check streams it via grep/awk instead of
+# reading it into a variable.
+set -euo pipefail
+
+GPLAY_MAPPING_DIR="app/build/outputs/mapping/gplayRelease"
+FOSS_MAPPING_DIR="app/build/outputs/mapping/fossRelease"
+BUNDLE_GLOB="app/build/outputs/bundle/gplayRelease"
+
+MIN_RENAMED=500
+
+failures=0
+
+pass() {
+    echo "PASS: $1"
+}
+
+fail() {
+    echo "FAIL: $1"
+    failures=$((failures + 1))
+}
+
+require_file() {
+    if [ ! -f "$1" ]; then
+        fail "missing $1 (did you run the assemble/bundle tasks?)"
+        return 1
+    fi
+    return 0
+}
+
+check_dontobfuscate() {
+    local gplay_config="$GPLAY_MAPPING_DIR/configuration.txt"
+    local foss_config="$FOSS_MAPPING_DIR/configuration.txt"
+
+    require_file "$gplay_config" || return 0
+    require_file "$foss_config" || return 0
+
+    if grep -qE '^-dontobfuscate' "$gplay_config"; then
+        fail "gplayRelease configuration.txt contains -dontobfuscate"
+    else
+        pass "gplayRelease configuration.txt has no -dontobfuscate"
+    fi
+
+    if grep -qE '^-dontobfuscate' "$foss_config"; then
+        pass "fossRelease configuration.txt contains -dontobfuscate"
+    else
+        fail "fossRelease configuration.txt is missing -dontobfuscate"
+    fi
+}
+
+check_line_numbers() {
+    local gplay_config="$GPLAY_MAPPING_DIR/configuration.txt"
+
+    require_file "$gplay_config" || return 0
+
+    local match
+    match=$(grep -E '^-keepattributes.*LineNumberTable' "$gplay_config" | head -1 || true)
+    if [ -n "$match" ]; then
+        pass "gplayRelease keeps line numbers ($match)"
+    else
+        fail "gplayRelease configuration.txt has no -keepattributes ... LineNumberTable"
+    fi
+}
+
+# Prints "<renamed> <total>" for the given mapping file.
+count_renames() {
+    { grep -E '^eu\.darken\.octi\..* -> ' "$1" || true; } \
+        | { grep -v 'R8\$\$REMOVED' || true; } \
+        | awk -F' -> ' '{ total++; if ($1 ":" != $2) renamed++ } END { print renamed + 0, total + 0 }'
+}
+
+check_renames() {
+    local gplay_mapping="$GPLAY_MAPPING_DIR/mapping.txt"
+    local foss_mapping="$FOSS_MAPPING_DIR/mapping.txt"
+
+    require_file "$gplay_mapping" || return 0
+    require_file "$foss_mapping" || return 0
+
+    local gplay_renamed gplay_total gplay_pct
+    read -r gplay_renamed gplay_total < <(count_renames "$gplay_mapping")
+    if [ "$gplay_total" -eq 0 ]; then
+        fail "gplayRelease mapping.txt lists no eu.darken.octi classes"
+    else
+        gplay_pct=$((gplay_renamed * 100 / gplay_total))
+        if [ "$gplay_renamed" -ge "$MIN_RENAMED" ]; then
+            pass "gplayRelease renamed $gplay_renamed/$gplay_total ($gplay_pct%)"
+        else
+            fail "gplayRelease renamed $gplay_renamed/$gplay_total ($gplay_pct%), expected >= $MIN_RENAMED"
+        fi
+    fi
+
+    local foss_renamed foss_total foss_pct
+    read -r foss_renamed foss_total < <(count_renames "$foss_mapping")
+    foss_pct=0
+    if [ "$foss_total" -gt 0 ]; then
+        foss_pct=$((foss_renamed * 100 / foss_total))
+    fi
+    if [ "$foss_renamed" -eq 0 ]; then
+        pass "fossRelease renamed $foss_renamed/$foss_total ($foss_pct%)"
+    else
+        fail "fossRelease renamed $foss_renamed/$foss_total ($foss_pct%), expected 0"
+    fi
+}
+
+check_keep_targets() {
+    local gplay_mapping="$GPLAY_MAPPING_DIR/mapping.txt"
+
+    require_file "$gplay_mapping" || return 0
+
+    local keep_targets=(
+        "eu.darken.octi.BuildConfig"
+        "eu.darken.octi.main.ui.MainActivity"
+        "eu.darken.octi.sync.core.worker.SyncWorker"
+        "eu.darken.octi.main.ui.dashboard.DashboardVM"
+        "eu.darken.octi.main.ui.MainActivityVM"
+        "eu.darken.octi.modules.clipboard.ui.widget.CopyClipboardCallback"
+        "eu.darken.octi.modules.connectivity.ui.widget.CopyNetworkAddressesCallback"
+        "eu.darken.octi.syncs.octiserver.core.InvalidLinkCodeException"
+        "eu.darken.octi.modules.power.core.alert.PowerAlertNotificationReceiver"
+    )
+
+    local cls
+    for cls in "${keep_targets[@]}"; do
+        if grep -qF "$cls -> $cls:" "$gplay_mapping"; then
+            pass "kept name: $cls"
+        else
+            fail "not kept (or absent): $cls"
+        fi
+    done
+}
+
+check_bundle_mapping() {
+    local aab
+    aab=$(ls "$BUNDLE_GLOB"/*.aab 2>/dev/null | head -1 || true)
+    if [ -z "$aab" ]; then
+        fail "no .aab in $BUNDLE_GLOB (did you run bundleGplayRelease?)"
+        return 0
+    fi
+
+    if unzip -l "$aab" | grep -qF "BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map"; then
+        pass "$aab embeds proguard.map"
+    else
+        fail "$aab does not embed BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map"
+    fi
+}
+
+check_dontobfuscate
+check_line_numbers
+check_renames
+check_keep_targets
+check_bundle_mapping
+
+echo
+if [ "$failures" -eq 0 ]; then
+    echo "All obfuscation checks passed."
+else
+    echo "$failures obfuscation check(s) failed."
+    exit 1
+fi

--- a/tools/r8/verify-obfuscation.sh
+++ b/tools/r8/verify-obfuscation.sh
@@ -59,7 +59,7 @@ check_line_numbers() {
     require_file "$gplay_config" || return 0
 
     local match
-    match=$(grep -E '^-keepattributes.*LineNumberTable' "$gplay_config" | head -1 || true)
+    match=$(grep -m1 -E '^-keepattributes.*LineNumberTable' "$gplay_config" || true)
     if [ -n "$match" ]; then
         pass "gplayRelease keeps line numbers ($match)"
     else
@@ -142,7 +142,7 @@ check_bundle_mapping() {
         return 0
     fi
 
-    if unzip -l "$aab" | grep -qF "BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map"; then
+    if unzip -l "$aab" | grep -F "BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map" > /dev/null; then
         pass "$aab embeds proguard.map"
     else
         fail "$aab does not embed BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map"


### PR DESCRIPTION
## What changed

No user-facing behavior change. The Google Play build now ships with obfuscated class and member names, which Google Play Console started requiring (it flags the app at 0% obfuscation, enforced from February 2027). The open-source build keeps readable names. Error dialogs and debug logs still show real exception and screen names.

## Technical Context

- Root cause of the 0%: a `-dontobfuscate` line in the shared app rules file, applied to every build type. It now lives in a foss-only flavor file; the gplay flavor file keeps `SourceFile`/`LineNumberTable` so stack traces retrace against the mapping.
- Renaming hazards found in the audit: error dialog titles and ViewModel log tags are built from the runtime class name, so app-common's consumer rules now `-keepnames` Throwable and ViewModel1 subclasses. The tagless `log { }` overload, which derived its tag from the receiver's class, is removed and a script fails the build style check if it comes back.
- Power alert notification IDs hashed the rule class name; they now hash literal type keys equal to the old names, so IDs already posted on user devices stay identical (pinned by a unit test). Dashboard issue ordering no longer tiebreaks on class names.
- The mapping is embedded in the AAB, which is what Play scores, and is downloadable from the Play Console. `tools/r8/verify-obfuscation.sh` asserts the setup from build outputs (gplay renamed, foss not, keep targets identity-mapped, mapping in the bundle).
- Manual testing on an emulator with the obfuscated gplayRelease build covered onboarding, cache restore, back-stack restore after process death, readable log tags, Octi Server sync, the Upgrade screen, and debug-log recording. Worth close review: the flavor wiring in `app/build.gradle.kts`, the keepnames rules in `app-common/proguard-rules.pro`, and the notification-ID literals in `PowerAlertNotifications.kt`.
