### PR TITLE
Update translations for Russian, Greek, and Polish

### DIFF
--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- The upgraded postfix on its own, colored in the upgrade screen title ("Octi <Pro>"). -->
     <string name="app_name_upgrade_postfix">Pro</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступен</string>
     <string name="upgrades_gplay_unavailable_error_description">Octi не может подключиться к Google Play. Установлен и обновлен ли Google Play? Вошли ли Вы в аккаунт Google? Попробуйте очистить кэш приложения Google Play и перезагрузить устройство.</string>
@@ -14,7 +13,6 @@
     <string name="upgrades_gplay_network_error_description">Не удалось подключиться к Google Play. Пожалуйста, проверьте подключение к интернету и повторите попытку.</string>
     <string name="upgrades_gplay_offer_unavailable_title">Предложение недоступно</string>
     <string name="upgrades_gplay_offer_unavailable_description">В настоящее время Google Play не предлагает эту опцию обновления. Пожалуйста, повторите попытку позже или проверьте Google Play Store.</string>
-    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, он отсутствует, отключен или недоступен на этом устройстве.</string>
     <string name="upgrades_dashcard_body">Обновитесь, чтобы разблокировать дополнительные функции и поддержать развитие!</string>
     <string name="upgrades_dashcard_upgrade_action">Обновить</string>
@@ -24,7 +22,6 @@
         <item quantity="many">Бесплатная версия ограничена %1$d устройствами.</item>
         <item quantity="other">Бесплатная версия ограничена %1$d устройствами.</item>
     </plurals>
-    <!-- %1$s is the full localized brand ("Octi Pro", composed from the app name + postfix) — translate the sentence around it, keep the placeholder. -->
     <string name="upgrade_screen_title_template">Получить %1$s</string>
     <string name="upgrade_screen_preamble">В Octi нет рекламы и Ваши пользовательские данные не продаются. Моя работа финансируется Вами ❤️.</string>
     <string name="upgrade_screen_benefits_title">Преимущества</string>
@@ -32,7 +29,6 @@
     <string name="upgrade_screen_subscription_trial_action">Начать 14-дневный бесплатный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться</string>
     <string name="upgrade_screen_iap_action">Разовая покупка</string>
-    <!-- Offers box -->
     <string name="upgrade_screen_offers_title">Варианты обновления</string>
     <string name="upgrade_screen_offers_unavailable_title">Цены недоступны</string>
     <string name="upgrade_screen_offers_unavailable_message">Не удалось загрузить цены. Проверьте Google Play и повторите попытку через некоторое время.</string>
@@ -49,48 +45,35 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизация Play Store может занять время. Попробуйте перезагрузить устройство, очистить кэш Google Play или просто подождите.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Несколько аккаунтов могут запутать Google Play. Выйдите из других аккаунтов или установите через сайт Google Play, чтобы привязаться к определенному аккаунту.</string>
     <string name="upgrade_screen_restore_success_message">Покупка восстановлена — спасибо!</string>
-    <!-- Restore section copy (plain acquisition + ownership recheck) and failed-restore dialog -->
     <string name="upgrade_screen_restore_body">Уже купили Pro на этом аккаунте? Попросите Google Play перепроверить покупку этого приложения.</string>
     <string name="upgrade_screen_restore_status_title">Статус покупки</string>
     <string name="upgrade_screen_restore_status_body">Повторная проверка Ваших покупок через Google Play, если Ваш Pro статус не работает.</string>
     <string name="upgrade_screen_restore_checked_message">Мы попросили Google Play перепроверить покупки этого приложения, но не смогли подтвердить их для текущего аккаунта.</string>
     <string name="upgrade_screen_restore_contact_hint">Всё ещё не получается? Обратитесь в службу поддержки и мы поможем разобраться.</string>
     <string name="upgrade_screen_restore_inconclusive_message">Проверка с Google Play не закончилась вовремя, поэтому статус покупки до сих пор неизвестен. В Вашей учетной записи ничего не изменилось.</string>
-    <!-- Pro status / ownership -->
     <string name="upgrade_screen_owned_iap_title">Единовременная покупка</string>
     <string name="upgrade_screen_owned_iap_body">У Вас есть единовременная покупка Pro. Она никогда не истекает.</string>
     <string name="upgrade_screen_owned_sub_renewing_body">Ваша подписка на Pro активна и обновляется автоматически.</string>
     <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша подписка на Pro активна, но она не продлевается. Она остается активной до конца текущего периода.</string>
     <string name="upgrade_screen_owned_both_warning">У Вас есть как подписка, так и единоразовая покупка. Чтобы избежать двойной оплаты, отмените подписку в Google Play — Вы обладатель Pro посредством покупки.</string>
-    <!-- Owned hero card (%1$s = "Octi Pro") -->
-    <!-- Replaces upgrade_screen_owned_hero_title, which told the user they *are* the product tier
-         ("You are Octi Pro") instead of that they own it. %1$s is the complete localized tier name,
-         already composed from the app name and the tier qualifier - never translate it here. Render
-         the sentence idiomatically if that reads better in your language ("%1$s is active", "Your
-         %1$s access is active"), as long as the placeholder survives. -->
     <string name="upgrade_screen_owned_hero_brand_title">У Вас есть %1$s 🎉</string>
     <string name="upgrade_screen_owned_hero_iap_body">Спасибо за покупку %1$s! Ваши функции Pro разблокированы и никогда не заканчиваются.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Спасибо за подписку на %1$s! Ваши функции Pro разблокированы.</string>
     <string name="upgrade_screen_manage_subscription_action">Управлять подпиской</string>
-    <!-- Switch subscription → one-time purchase -->
     <string name="upgrade_screen_switch_body">Предпочитайте платить один раз вместо подписки? Вы можете оформить единоразовую покупку Pro и остановить подписку.</string>
     <string name="upgrade_screen_switch_locked_note">Ваша подписка обновляется автоматически. Сначала отмените её в Google Play, а затем вернитесь к единоразовой покупке. Покупка здесь не аннулирует или не возвращает подписку — используйте тот же аккаунт Google.</string>
     <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка все ещё продлевается. Отмените её в Google Play, чтобы оплата не производилась дважды, а затем оформите единоразовую покупку. Это не возмещает оплату подписки.</string>
-    <string name="upgrade_screen_purchase_check_failed_message">Google Play не ответил вовремя, поэтому мы не можем безопасно подтвердить твой статус покупки. Попробуй ещё раз через некоторое время.</string>
-    <!-- Pending payment (Google Play is still processing a slow payment method) -->
+    <string name="upgrade_screen_purchase_check_failed_message">Google Play не ответил вовремя, поэтому мы не можем безопасно подтвердить Ваш статус покупки. Попробуйте ещё раз через некоторое время.</string>
     <string name="upgrade_screen_pending_card_title">Платёж обрабатывается</string>
-    <string name="upgrade_screen_pending_card_body">Google Play всё ещё обрабатывает твой платёж. Pro активируется автоматически, как только платёж пройдёт. Некоторые способы оплаты могут занять какое-то время. Больше ничего делать не нужно.</string>
+    <string name="upgrade_screen_pending_card_body">Google Play всё ещё обрабатывает Ваш платёж. Pro активируется автоматически, как только платёж пройдёт. Некоторые способы оплаты могут занять какое-то время. Больше ничего делать не нужно.</string>
     <string name="upgrade_screen_pending_dialog_message">Google Play обнаружил покупку с ожидающим платежом и всё ещё обрабатывает её. Pro активируется автоматически, как только платёж пройдёт.</string>
-    <!-- Grace period -->
     <string name="upgrade_screen_grace_title">Pro все ещё активен</string>
     <string name="upgrade_screen_grace_body">Мы подтверждаем Вашу покупку с помощью Google Play. Ваши Pro-функции будут разблокированы через некоторое время.</string>
     <string name="upgrade_screen_grace_diagnostics_body">Мы все еще не можем подтвердить покупку с помощью Google Play. Ваши Pro-функции пока не разблокированы. Попробуйте повторное подключение.</string>
     <string name="upgrade_screen_contact_support_action">Связаться с поддержкой</string>
-    <!-- Free status page (manage entry) -->
     <string name="upgrade_screen_free_status_title">Вы используете бесплатную версию</string>
     <string name="upgrade_screen_free_status_body">Обновитесь до Octi Pro, чтобы получить дополнительные функции и поддержать разработку.</string>
     <string name="upgrade_screen_see_options_action">Посмотреть варианты обновления</string>
-    <!-- Settings status row (gplay) -->
     <string name="settings_upgrade_status_desc">Смотрите Ваш статус Pro и управляйте обновлением</string>
 </resources>

--- a/modules-connectivity/src/main/res/values-el/strings.xml
+++ b/modules-connectivity/src/main/res/values-el/strings.xml
@@ -3,7 +3,7 @@
     <string name="module_connectivity_label">Μονάδα σύνδεσης</string>
     <string name="module_connectivity_desc">Τύπος σύνδεσης, δημόσια IP, λεπτομέρειες δικτύου</string>
     <string name="module_connectivity_type_wifi_label">WiFi</string>
-    <string name="module_connectivity_type_cellular_label">Κινητό</string>
+    <string name="module_connectivity_type_cellular_label">Δίκτυο κινητής</string>
     <string name="module_connectivity_type_ethernet_label">Ethernet</string>
     <string name="module_connectivity_type_none_label">Χωρίς σύνδεση</string>
     <string name="module_connectivity_unknown_public_ip_label">Άγνωστη δημόσια IP</string>
@@ -11,7 +11,7 @@
     <string name="module_connectivity_detail_local_ipv4_label">Τοπική IPv4</string>
     <string name="module_connectivity_detail_local_ipv6_label">Τοπική IPv6</string>
     <string name="module_connectivity_detail_gateway_label">Πύλη</string>
-    <string name="module_connectivity_detail_dns_label">DNS διακομιστές</string>
+    <string name="module_connectivity_detail_dns_label">Διακομιστές DNS</string>
     <string name="module_connectivity_detail_public_ip_label">Δημόσια IP</string>
     <string name="module_connectivity_detail_connection_type_label">Τύπος σύνδεσης</string>
     <string name="module_connectivity_status_connected_label">Συνδέθηκε</string>

--- a/modules-connectivity/src/main/res/values-pl/strings.xml
+++ b/modules-connectivity/src/main/res/values-pl/strings.xml
@@ -2,8 +2,8 @@
 <resources>
     <string name="module_connectivity_label">Moduł łączności</string>
     <string name="module_connectivity_desc">Typ połączenia, publiczny adres IP, szczegóły sieci</string>
-    <string name="module_connectivity_type_wifi_label">WiFi</string>
-    <string name="module_connectivity_type_cellular_label">Sieć komórkowa</string>
+    <string name="module_connectivity_type_wifi_label">Wi-Fi</string>
+    <string name="module_connectivity_type_cellular_label">Dane mobilne</string>
     <string name="module_connectivity_type_ethernet_label">Ethernet</string>
     <string name="module_connectivity_type_none_label">Brak połączenia</string>
     <string name="module_connectivity_unknown_public_ip_label">Nieznany publiczny adres IP</string>
@@ -15,7 +15,7 @@
     <string name="module_connectivity_detail_public_ip_label">Publiczny adres IP</string>
     <string name="module_connectivity_detail_connection_type_label">Typ połączenia</string>
     <string name="module_connectivity_status_connected_label">Połączony</string>
-    <string name="module_connectivity_status_disconnected_label">Rozłączono</string>
+    <string name="module_connectivity_status_disconnected_label">Rozłączony</string>
     <string name="module_connectivity_widget_description">Wyświetla informacje o sieci z synchronizowanych urządzeń.</string>
     <string name="module_connectivity_widget_copy_action">Kopiuj adresy sieciowe</string>
     <string name="module_connectivity_widget_copied_toast">Skopiowano adresy</string>

--- a/modules-files/src/main/res/values-el/strings.xml
+++ b/modules-files/src/main/res/values-el/strings.xml
@@ -11,7 +11,7 @@
     <string name="module_files_unavailable">Δεν είναι διαθέσιμο ακόμα</string>
     <string name="module_files_expired">Έληξε</string>
     <string name="module_files_upload_success">Το αρχείο κοινοποιήθηκε με επιτυχία</string>
-    <string name="module_files_upload_partial">Το αρχείο κοινοποιήθηκε σε ορισμένες συσκευές. Επανάληψη σε εξέλιξη…</string>
+    <string name="module_files_upload_partial">Το αρχείο κοινοποιήθηκε σε ορισμένες συσκευές. Επανάληψη σε εξέλιξη\u2026</string>
     <string name="module_files_upload_failed">Αποτυχία κοινοποίησης αρχείου</string>
     <string name="module_files_upload_source_unavailable">Δεν ήταν δυνατή η ανάγνωση του επιλεγμένου αρχείου — ενδέχεται να μετακινήθηκε ή να διαγράφηκε</string>
     <string name="module_files_upload_too_large">Το αρχείο είναι πολύ μεγάλο για κοινοποίηση (μέγ. %1$s)</string>
@@ -41,11 +41,11 @@
         <item quantity="other">%1$d σύνδεσμοι συγχρονισμού έχουν λιγότερο από 10%% ελεύθερο χώρο</item>
     </plurals>
     <string name="module_files_time_remaining">%1$s απομένει</string>
-    <string name="module_files_uploading">Ανέβασμα…</string>
+    <string name="module_files_uploading">Ανέβασμα\u2026</string>
     <string name="module_files_notification_channel_label">Εισερχόμενα Κοινοποιημένα Αρχεία</string>
     <string name="module_files_notification_incoming_title">%1$s κοινοποίησε ένα αρχείο</string>
     <string name="module_files_unavailable_title">Κοινή χρήση αρχείων μη διαθέσιμη</string>
-    <string name="module_files_unavailable_message">Καμία υπηρεσία συγχρονισμού σε αυτήν τη συσκευή δεν υποστηρίζει κοινή χρήση αρχείων. Ελέγξτε την προειδοποίηση στον πίνακα ελέγχου για περισσότερες λεπτομέρειες.</string>
+    <string name="module_files_unavailable_message">Καμία υπηρεσία συγχρονισμού σε αυτήν τη συσκευή δεν υποστηρίζει κοινή χρήση αρχείων. Ελέγξτε την προειδοποίηση στον πίνακα ελέγχου για λεπτομέρειες.</string>
     <string name="module_files_usage_hint_message">Για γρήγορα, μικρά αρχεία — διαμορφώσεις, PDF, έγγραφα κειμένου. Δεν έχει σχεδιαστεί για φωτογραφίες, βίντεο ή εγκαταστάσεις εφαρμογών.</string>
     <string name="module_files_hint_dismiss_action">Κλείσιμο</string>
     <string name="module_files_retry_action">Δοκιμάστε ξανά</string>
@@ -76,7 +76,7 @@
     <string name="module_files_open_failed">Αποτυχία ανοίγματος αρχείου</string>
     <string name="module_files_open_preparing">Προετοιμασία…</string>
     <string name="module_files_pending_delete_label">Εκκαθάριση σε εκκρεμότητα…</string>
-    <string name="module_files_delete_requested_label">Διαγραφή ζητήθηκε…</string>
+    <string name="module_files_delete_requested_label">Ζητήθηκε διαγραφή…</string>
     <string name="module_files_sheet_property_size">Μέγεθος</string>
     <string name="module_files_sheet_property_type">Τύπος</string>
     <string name="module_files_sheet_property_shared_by">Κοινοποιήθηκε από</string>
@@ -87,7 +87,7 @@
     <string name="module_files_sheet_dismiss_action">Κλείσιμο</string>
     <string name="module_files_share_unsupported">Αυτή η κοινή χρήση δεν είναι αρχείο</string>
     <string name="module_files_share_module_disabled">Η κοινή χρήση αρχείων είναι απενεργοποιημένη</string>
-    <string name="module_files_free_limit_reached_message">Η δωρεάν έκδοση περιορίζεται σε 1 κοινοποιημένο αρχείο κάθε φορά. Διαγράψτε το για να κοινοποιήσετε ένα άλλο, ή αναβαθμίστε για απεριόριστο (εντός του ορίου αποθήκευσης σας).</string>
+    <string name="module_files_free_limit_reached_message">Η δωρεάν έκδοση περιορίζεται σε 1 κοινοποιημένο αρχείο κάθε φορά. Διαγράψτε το για να κοινοποιήσετε ένα άλλο, ή αναβαθμίστε για απεριόριστα (εντός του ορίου αποθήκευσης σας).</string>
     <string name="module_files_free_limit_action_upgrade">Αναβάθμιση</string>
     <string name="module_files_free_limit_dropped_extras">%1$d επιπλέον αρχείο(α) παραλείφθηκε(αν) — το δωρεάν όριο είναι 1.</string>
     <string name="module_files_delete_confirm_title">Διαγραφή αρχείου;</string>

--- a/modules-files/src/main/res/values-pl/strings.xml
+++ b/modules-files/src/main/res/values-pl/strings.xml
@@ -3,7 +3,7 @@
     <string name="module_files_label">Udostępnianie plików</string>
     <string name="module_files_desc">Udostępniaj małe pliki między połączonymi urządzeniami</string>
     <string name="module_files_tile_empty">Brak plików</string>
-    <string name="module_files_tile_count">Udostępniono plików: %1$d</string>
+    <string name="module_files_tile_count">Udostępnione pliki: %1$d</string>
     <string name="module_files_list_title">Udostępnione pliki</string>
     <string name="module_files_share_action">Udostępnij plik</string>
     <string name="module_files_save_action">Zapisz</string>
@@ -19,7 +19,7 @@
     <string name="module_files_save_success">Plik zapisany</string>
     <string name="module_files_save_not_available">Plik nie jest dostępny w żadnej z połączonych usług</string>
     <string name="module_files_save_failed">Nie udało się zapisać pliku</string>
-    <string name="module_files_checksum_mismatch">Kontrola integralności pliku nie powiodła się</string>
+    <string name="module_files_checksum_mismatch">Kontrola integralności pliku się nie powiodła</string>
     <string name="module_files_delete_success">Plik usunięty</string>
     <string name="module_files_delete_requested">Zażądano usunięcia</string>
     <string name="module_files_delete_partial">Plik częściowo usunięty. Czyszczenie będzie kontynuowane w tle.</string>
@@ -27,7 +27,7 @@
     <string name="module_files_quota_header">Pamięć wewnętrzna</string>
     <string name="module_files_quota_item">%1$s: wykorzystano %2$s z %3$s</string>
     <string name="module_files_quota_label_gdrive">Dysk Google</string>
-    <string name="module_files_quota_label_gdrive_with_account">Google Drive (%1$s)</string>
+    <string name="module_files_quota_label_gdrive_with_account">Dysk Google (%1$s)</string>
     <string name="module_files_quota_label_octiserver_with_account">%1$s (%2$s)</string>
     <string name="module_files_quota_action">Szczegóły pamięci</string>
     <string name="module_files_quota_sheet_title">Pamięć wewnętrzna</string>
@@ -40,7 +40,7 @@
         <item quantity="one">%1$d usługa synchronizacji ma mniej niż 10%% wolnego miejsca</item>
         <item quantity="few">%1$d usługi synchronizacji mają mniej niż 10%% wolnego miejsca</item>
         <item quantity="many">%1$d usług synchronizacji ma mniej niż 10%% wolnego miejsca</item>
-        <item quantity="other">%1$d usługi synchronizacji ma mniej niż 10%% wolnego miejsca</item>
+        <item quantity="other">%1$d usług synchronizacji ma mniej niż 10%% wolnego miejsca</item>
     </plurals>
     <string name="module_files_time_remaining">Pozostało %1$s</string>
     <string name="module_files_uploading">Przesyłanie…</string>
@@ -66,7 +66,7 @@
     <string name="module_files_filter_devices_label">Urządzenia</string>
     <string name="module_files_sort_action">Sortuj</string>
     <string name="module_files_sync_now_action">Synchronizuj teraz</string>
-    <string name="module_files_sync_failed">Synchronizacja nie powiodła się</string>
+    <string name="module_files_sync_failed">Synchronizacja się nie powiodła</string>
     <string name="module_files_sort_by_date">Data</string>
     <string name="module_files_sort_by_name">Nazwa</string>
     <string name="module_files_sort_by_size">Rozmiar</string>
@@ -89,11 +89,11 @@
     <string name="module_files_sheet_dismiss_action">Zamknij</string>
     <string name="module_files_share_unsupported">To udostępnienie nie jest plikiem</string>
     <string name="module_files_share_module_disabled">Udostępnianie plików jest wyłączone</string>
-    <string name="module_files_free_limit_reached_message">Darmowa wersja umożliwia udostępnienie tylko 1 pliku naraz. Usuń go, aby udostępnić kolejny, albo uaktualnij, aby mieć nieograniczoną liczbę (w ramach limitu miejsca).</string>
-    <string name="module_files_free_limit_action_upgrade">Uaktualnij</string>
+    <string name="module_files_free_limit_reached_message">Darmowa wersja umożliwia udostępnienie tylko 1 pliku naraz. Usuń go, aby udostępnić kolejny, albo zaktualizuj, aby mieć nieograniczoną liczbę (w ramach limitu miejsca).</string>
+    <string name="module_files_free_limit_action_upgrade">Zaktualizuj</string>
     <string name="module_files_free_limit_dropped_extras">Pominięto %1$d dodatkowych plików — darmowy limit to 1.</string>
     <string name="module_files_delete_confirm_title">Usunąć plik?</string>
-    <string name="module_files_delete_confirm_own">%1$s zostanie usunięty ze wszystkich Twoich urządzeń.</string>
+    <string name="module_files_delete_confirm_own">%1$s zostanie usunięty ze wszystkich twoich urządzeń.</string>
     <string name="module_files_delete_confirm_peer">Poprosić %2$s o usunięcie %1$s? Zostanie usunięty po zsynchronizowaniu.</string>
     <string name="module_files_delete_confirm_action">Usuń</string>
     <string name="module_files_delete_cancel_action">Anuluj</string>

--- a/modules-files/src/main/res/values-ru/strings.xml
+++ b/modules-files/src/main/res/values-ru/strings.xml
@@ -17,7 +17,7 @@
     <string name="module_files_upload_too_large">Файл слишком велик для обмена (максимум %1$s)</string>
     <string name="module_files_upload_no_connectors">Нет доступной службы синхронизации для обмена файлами</string>
     <string name="module_files_save_success">Файл сохранён</string>
-    <string name="module_files_save_not_available">Файл недоступен ни на одной из ваших подключённых служб</string>
+    <string name="module_files_save_not_available">Файл недоступен ни на одной из Ваших подключённых служб</string>
     <string name="module_files_save_failed">Не удалось сохранить файл</string>
     <string name="module_files_checksum_mismatch">Ошибка проверки целостности файла</string>
     <string name="module_files_delete_success">Файл удалён</string>
@@ -89,11 +89,11 @@
     <string name="module_files_sheet_dismiss_action">Закрыть</string>
     <string name="module_files_share_unsupported">Это не файл</string>
     <string name="module_files_share_module_disabled">Обмен файлами отключён</string>
-    <string name="module_files_free_limit_reached_message">Бесплатная версия ограничена 1 общим файлом одновременно. Удалите его, чтобы поделиться другим, или обновите версию для неограниченного количества (в пределах вашей квоты хранилища).</string>
+    <string name="module_files_free_limit_reached_message">Бесплатная версия ограничена 1 общим файлом одновременно. Удалите его, чтобы поделиться другим, или обновите версию для неограниченного количества (в пределах Вашей квоты хранилища).</string>
     <string name="module_files_free_limit_action_upgrade">Обновить</string>
     <string name="module_files_free_limit_dropped_extras">%1$d дополнительных файлов пропущено — бесплатный лимит составляет 1.</string>
     <string name="module_files_delete_confirm_title">Удалить файл?</string>
-    <string name="module_files_delete_confirm_own">%1$s будет удалён со всех ваших устройств.</string>
+    <string name="module_files_delete_confirm_own">%1$s будет удалён со всех Ваших устройств.</string>
     <string name="module_files_delete_confirm_peer">Попросить %2$s удалить %1$s? Файл будет удалён после синхронизации.</string>
     <string name="module_files_delete_confirm_action">Удалить</string>
     <string name="module_files_delete_cancel_action">Отмена</string>

--- a/syncs-octiserver/src/main/res/values-ru/strings.xml
+++ b/syncs-octiserver/src/main/res/values-ru/strings.xml
@@ -38,7 +38,7 @@
     <string name="sync_octiserver_add_select_server_label">Выбрать сервер</string>
     <string name="sync_octiserver_add_custom_server_label">Пользовательский сервер</string>
     <string name="sync_octiserver_link_code_invalid_label">Код связи неполный</string>
-    <string name="sync_octiserver_link_code_invalid_description">Этот код связи неполный или был изменён при передаче. Скопируй код целиком с другого устройства и вставь его, не набирая вручную, либо отсканируй QR-код.</string>
+    <string name="sync_octiserver_link_code_invalid_description">Этот код связи неполный или был изменён при передаче. Скопируйте код целиком с другого устройства и вставьте его, не набирая вручную, либо отсканируйте QR-код.</string>
     <string name="sync_octiserver_link_code_copied_message">Код связи скопирован</string>
     <plurals name="sync_octiserver_link_code_character_count">
         <item quantity="one">%d символ</item>


### PR DESCRIPTION
## What changed

Refines Russian, Greek, and Polish translations across the connectivity and file-sync screens, the Octi Server sync messages, and the Google Play app text.

- Russian translations now consistently use the formal form of address throughout.
- Greek translations get word choice, word order, and grammatical agreement corrections.
- Polish translations get wording and grammar corrections, including plural agreement fixes.

## Technical Context

- Routine translation sync from Crowdin; no code changes.
- Entries reviewed for placeholder, escape, and encoding integrity.
